### PR TITLE
fix: attach API key to localhost remember/recall (401 against authenticated local server)

### DIFF
--- a/integrations/claude-code/scripts/_recall_http.py
+++ b/integrations/claude-code/scripts/_recall_http.py
@@ -138,10 +138,9 @@ def do_recall(
     if context_profile:
         body["context_profile"] = context_profile
     headers = {"Content-Type": "application/json"}
-    # COGNEE_API_KEY is a *cloud* credential; the local single-user server needs no
-    # auth and ignores it. Only attach it for a remote/cloud target, so we don't send
-    # a meaningless (and confusing) cloud key to localhost.
-    if api_key and not _is_local(service_url):
+    # Attach the key whenever we have one. A local server that requires auth
+    # returns 401 without it; a server that needs no auth simply ignores it.
+    if api_key:
         headers["X-Api-Key"] = api_key
 
     req = urllib.request.Request(

--- a/integrations/claude-code/scripts/_remember_http.py
+++ b/integrations/claude-code/scripts/_remember_http.py
@@ -114,9 +114,9 @@ def do_remember(
         [("data", filename, content.encode("utf-8") if isinstance(content, str) else content)],
     )
     headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
-    # COGNEE_API_KEY is a cloud credential; local single-user servers need no
-    # auth and ignore it. Only attach it for a remote/cloud target.
-    if api_key and not _is_local(service_url):
+    # Attach the key whenever we have one. A local server that requires auth
+    # returns 401 without it; a server that needs no auth simply ignores it.
+    if api_key:
         headers["X-Api-Key"] = api_key
 
     req = urllib.request.Request(url, data=body, headers=headers, method="POST")

--- a/integrations/codex/plugins/cognee/scripts/_recall_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_recall_http.py
@@ -138,10 +138,9 @@ def do_recall(
     if context_profile:
         body["context_profile"] = context_profile
     headers = {"Content-Type": "application/json"}
-    # COGNEE_API_KEY is a *cloud* credential; the local single-user server needs no
-    # auth and ignores it. Only attach it for a remote/cloud target, so we don't send
-    # a meaningless (and confusing) cloud key to localhost.
-    if api_key and not _is_local(service_url):
+    # Attach the key whenever we have one. A local server that requires auth
+    # returns 401 without it; a server that needs no auth simply ignores it.
+    if api_key:
         headers["X-Api-Key"] = api_key
 
     req = urllib.request.Request(

--- a/integrations/codex/plugins/cognee/scripts/_remember_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_remember_http.py
@@ -114,9 +114,9 @@ def do_remember(
         [("data", filename, content.encode("utf-8") if isinstance(content, str) else content)],
     )
     headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
-    # COGNEE_API_KEY is a cloud credential; local single-user servers need no
-    # auth and ignore it. Only attach it for a remote/cloud target.
-    if api_key and not _is_local(service_url):
+    # Attach the key whenever we have one. A local server that requires auth
+    # returns 401 without it; a server that needs no auth simply ignores it.
+    if api_key:
         headers["X-Api-Key"] = api_key
 
     req = urllib.request.Request(url, data=body, headers=headers, method="POST")


### PR DESCRIPTION
## Problem

`_remember_http.py` and `_recall_http.py` strip the API key for localhost targets:

```python
if api_key and not _is_local(service_url):
    headers["X-Api-Key"] = api_key
```

The comment justifies it as "local single-user server needs no auth." That's not true when the local server has access control enabled — which is the **default in Cognee 1.0+** (`ENABLE_BACKEND_ACCESS_CONTROL`). A stock local server at `http://localhost:8011` returns **401 without the key**.

### Impact

Against an authenticated local server, every plugin `remember` and `search`/`recall` fails:

```
[cognee-remember] unauthorized (HTTP 401) — check COGNEE_API_KEY / credentials
[cognee-search]   unauthorized (HTTP 401) — check COGNEE_API_KEY / credentials
```

`sync` is unaffected because `_plugin_common.py` already attaches the key unconditionally (`if api_key:`) — which is exactly what proves the strip is the bug, not the server.

## Fix

Attach the key whenever we have one, matching the sync path. A server that needs no auth ignores it; a server that requires it now gets it.

Applied to both the `claude-code` and `codex` integration copies (2 files each).

## Verification

With a stock local server (auth on) and a valid `~/.cognee-plugin/api_key.json`:

- Before: `remember` / `search` → HTTP 401
- After:  `remember` → `{"ok": true}`, `search` → 200 with graph results

Direct curl with the same key returns 200, confirming the key is valid and the helper was the only thing dropping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)