### PR TITLE
feat(integrations): add compact status one-liner options to statuslin…

### DIFF
--- a/integrations/claude-code/scripts/cognee-statusline.sh
+++ b/integrations/claude-code/scripts/cognee-statusline.sh
@@ -5,4 +5,4 @@
 # We `exec` into the standalone Python renderer so it inherits that same stdin —
 # the renderer is pure-local (reads only ~/.cognee-plugin JSON files), never
 # imports the plugin runtime, and makes no network call, so it stays instant.
-exec python3 "$(dirname "$0")/cognee_statusline_render.py"
+exec python3 "$(dirname "$0")/cognee_statusline_render.py" "$@"

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -73,7 +73,77 @@ def _health_prefix() -> str:
     return ""
 
 
+def _active_url() -> str:
+    # 1. env var
+    url = os.environ.get("COGNEE_BASE_URL", "").strip()
+    # 2. config file
+    if not url:
+        try:
+            data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                url = str(data.get("base_url") or "").strip()
+        except Exception:
+            pass
+    return url or "http://localhost:8011"
+
+
+def _active_key() -> str:
+    # 1. env var
+    key = os.environ.get("COGNEE_API_KEY", "").strip()
+    if key:
+        return key
+    # 2. api_key.json cache
+    try:
+        api_key_cache_path = _SHARED_ROOT / "api_key.json"
+        if api_key_cache_path.exists():
+            data = json.loads(api_key_cache_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                key = str(data.get("api_key") or "").strip()
+                if key:
+                    return key
+    except Exception:
+        pass
+    # 3. config file
+    try:
+        data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            key = str(data.get("api_key") or "").strip()
+            if key:
+                return key
+    except Exception:
+        pass
+    return ""
+
+
+def _active_version() -> str:
+    # 1. server-ready.json
+    try:
+        if _SERVER_READY_PATH.exists():
+            data = json.loads(_SERVER_READY_PATH.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                v = str(data.get("version") or "").strip()
+                if v:
+                    return v
+    except Exception:
+        pass
+    # 2. venv-ready.json
+    try:
+        venv_ready_path = _SHARED_ROOT / "venv-ready.json"
+        if venv_ready_path.exists():
+            data = json.loads(venv_ready_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                v = str(data.get("cognee_version") or "").strip()
+                if v:
+                    return v
+    except Exception:
+        pass
+    return ""
+
+
 def main() -> None:
+    if "--compact" in sys.argv or "-c" in sys.argv:
+        sys.stdout.write(f"mode={_active_mode()} url={_active_url()} key={_active_key()} version={_active_version()}\n")
+        sys.exit(0)
     try:
         json.load(sys.stdin)  # consume stdin as required by Claude Code
     except Exception:

--- a/integrations/claude-code/tests/test_statusline.py
+++ b/integrations/claude-code/tests/test_statusline.py
@@ -1,0 +1,104 @@
+"""Unit tests for the compact statusline functionality in cognee_statusline_render.py.
+
+We patch the path constants and configuration loaders to test all resolution scenarios:
+- Local vs Cloud mode
+- URL fallback
+- API key sources (env vs cached files)
+- Version sources (server-ready vs venv-ready)
+"""
+
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import cognee_statusline_render as csr
+
+# Create an isolated temporary directory for plugin configuration paths
+_TMP = tempfile.mkdtemp(prefix="cognee-status-test-")
+csr._SHARED_ROOT = pathlib.Path(_TMP)
+csr._CONFIG_PATH = csr._SHARED_ROOT / "claude-code" / "config.json"
+csr._SERVER_READY_PATH = csr._SHARED_ROOT / "server-ready.json"
+csr._BREAKER_PATH = csr._SHARED_ROOT / "recall-breaker.json"
+
+@pytest.fixture(autouse=True)
+def clean_state():
+    # Reset files in temp directory
+    for p in csr._SHARED_ROOT.rglob("*"):
+        if p.is_file():
+            p.unlink()
+    # Reset environments
+    if "COGNEE_BASE_URL" in os.environ:
+        del os.environ["COGNEE_BASE_URL"]
+    if "COGNEE_API_KEY" in os.environ:
+        del os.environ["COGNEE_API_KEY"]
+    yield
+
+def test_resolved_default_local():
+    assert csr._active_mode() == "local"
+    assert csr._active_url() == "http://localhost:8011"
+    assert csr._active_key() == ""
+    assert csr._active_version() == ""
+
+def test_resolved_env_vars():
+    os.environ["COGNEE_BASE_URL"] = "https://my-custom.cognee.ai"
+    os.environ["COGNEE_API_KEY"] = "my-env-api-key"
+    
+    assert csr._active_mode() == "cloud"
+    assert csr._active_url() == "https://my-custom.cognee.ai"
+    assert csr._active_key() == "my-env-api-key"
+
+def test_resolved_config_file():
+    csr._CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    csr._CONFIG_PATH.write_text(json.dumps({
+        "base_url": "https://config-url.ai",
+        "api_key": "config-api-key"
+    }), encoding="utf-8")
+    
+    assert csr._active_mode() == "cloud"
+    assert csr._active_url() == "https://config-url.ai"
+    assert csr._active_key() == "config-api-key"
+
+def test_resolved_cached_api_key():
+    csr._SHARED_ROOT.mkdir(parents=True, exist_ok=True)
+    (csr._SHARED_ROOT / "api_key.json").write_text(json.dumps({
+        "api_key": "cached-api-key"
+    }), encoding="utf-8")
+    
+    assert csr._active_key() == "cached-api-key"
+
+def test_resolved_version_server_ready():
+    csr._SERVER_READY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    csr._SERVER_READY_PATH.write_text(json.dumps({
+        "version": "1.3.0-server"
+    }), encoding="utf-8")
+    
+    assert csr._active_version() == "1.3.0-server"
+
+def test_resolved_version_venv_ready():
+    csr._SHARED_ROOT.mkdir(parents=True, exist_ok=True)
+    (csr._SHARED_ROOT / "venv-ready.json").write_text(json.dumps({
+        "cognee_version": "1.2.2.dev0"
+    }), encoding="utf-8")
+    
+    assert csr._active_version() == "1.2.2.dev0"
+
+def test_main_compact(capsys):
+    os.environ["COGNEE_BASE_URL"] = "http://localhost:8011"
+    os.environ["COGNEE_API_KEY"] = "test-key"
+    csr._SHARED_ROOT.mkdir(parents=True, exist_ok=True)
+    (csr._SHARED_ROOT / "venv-ready.json").write_text(json.dumps({
+        "cognee_version": "1.2.2.dev0"
+    }), encoding="utf-8")
+    
+    sys.argv = ["cognee_statusline_render.py", "--compact"]
+    with pytest.raises(SystemExit) as excinfo:
+        csr.main()
+        
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    assert captured.out == "mode=local url=http://localhost:8011 key=test-key version=1.2.2.dev0\n"

--- a/integrations/codex/plugins/cognee/scripts/cognee-statusline.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-statusline.sh
@@ -6,4 +6,4 @@
 # the renderer is pure-local (reads only ~/.cognee-plugin/codex JSON files),
 # never imports the plugin runtime, and makes no network call, so it stays
 # instant.
-exec python3 "$(dirname "$0")/cognee_statusline_render.py"
+exec python3 "$(dirname "$0")/cognee_statusline_render.py" "$@"

--- a/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
@@ -73,12 +73,82 @@ def _health_prefix() -> str:
     return ""
 
 
+def _active_url() -> str:
+    # 1. env var
+    url = os.environ.get("COGNEE_BASE_URL", "").strip()
+    # 2. config file
+    if not url:
+        try:
+            data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                url = str(data.get("base_url") or "").strip()
+        except Exception:
+            pass
+    return url or "http://localhost:8011"
+
+
+def _active_key() -> str:
+    # 1. env var
+    key = os.environ.get("COGNEE_API_KEY", "").strip()
+    if key:
+        return key
+    # 2. api_key.json cache
+    try:
+        api_key_cache_path = _SHARED_ROOT / "api_key.json"
+        if api_key_cache_path.exists():
+            data = json.loads(api_key_cache_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                key = str(data.get("api_key") or "").strip()
+                if key:
+                    return key
+    except Exception:
+        pass
+    # 3. config file
+    try:
+        data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            key = str(data.get("api_key") or "").strip()
+            if key:
+                return key
+    except Exception:
+        pass
+    return ""
+
+
+def _active_version() -> str:
+    # 1. server-ready.json
+    try:
+        if _SERVER_READY_PATH.exists():
+            data = json.loads(_SERVER_READY_PATH.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                v = str(data.get("version") or "").strip()
+                if v:
+                    return v
+    except Exception:
+        pass
+    # 2. venv-ready.json
+    try:
+        venv_ready_path = _SHARED_ROOT / "venv-ready.json"
+        if venv_ready_path.exists():
+            data = json.loads(venv_ready_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                v = str(data.get("cognee_version") or "").strip()
+                if v:
+                    return v
+    except Exception:
+        pass
+    return ""
+
+
 def render_status_for_host(host_id: str) -> str:
     """Return the status string (host_id is unused; kept for call-site compat)."""
     return f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}"
 
 
 def main() -> None:
+    if "--compact" in sys.argv or "-c" in sys.argv:
+        sys.stdout.write(f"mode={_active_mode()} url={_active_url()} key={_active_key()} version={_active_version()}\n")
+        sys.exit(0)
     try:
         json.load(sys.stdin)  # consume stdin as required by the host
     except Exception:

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"


### PR DESCRIPTION
### Summary
This PR adds support for a compact status one-liner output to the statusline scripts of both the `claude-code` and `codex` integrations.

### Changes
1. **Bash Entrypoint Updates**:
   - Modified `cognee-statusline.sh` in both integrations to forward all command-line arguments (using `"$@"`) to the underlying Python renderer.
2. **Standalone Python Renderer Updates**:
   - Added support for `--compact` (`-c`) flags to print the resolved runtime state on one line and exit 0.
   - Added robust helper functions to resolve mode, URL, API key, and version from environment variables, configuration files, and caching states without importing heavy dependencies:
     - `mode`: Resolves to `local` or `cloud`.
     - `url`: Resolves via `COGNEE_BASE_URL`, config `base_url`, or the default local URL (`http://localhost:8011`).
     - `key`: Resolves via `COGNEE_API_KEY`, cached `api_key.json`, or config `api_key`.
     - `version`: Resolves via `server-ready.json` or `venv-ready.json`.
3. **Tests Added**:
   - Created a comprehensive test suite in `integrations/claude-code/tests/test_statusline.py` verifying all resolution combinations.

### How to Verify
Run the newly added unit tests:
```bash
uv run pytest integrations/claude-code/tests/test_statusline.py -v
Fixes Topoteretes/cognee#3552
<img width="912" height="266" alt="image" src="https://github.com/user-attachments/assets/bc352ccd-f47e-4300-b834-65bb19f45736" />
