### PR TITLE
docs: standardize documentation for cognee connection modes across al…

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -51,17 +51,30 @@ Key resolution order:
 2. `~/.cognee-plugin/api_key.json` (cached from a previous mint)
 3. Auto-mint from the default local user (local mode only), then cache to `api_key.json`
 
-## Mode selection rules
+## Modes
 
-At startup (`SessionStart`):
-- `COGNEE_BASE_URL` set → `managed_endpoint`, either local, or on Cognee Cloud (API key needed in cloud case)
-- otherwise → `integration_local` (local API bootstrap)
+The plugin connects to cognee in one of three modes. It picks the mode
+automatically from your config:
 
-At hook runtime:
-- hooks resolve mode through runtime endpoint auth (env + `api_key.json`), not only config intent
-- `http` mode skips local SDK initialization
+| Mode | When it's used | How it talks to cognee |
+| --- | --- | --- |
+| **local-server** (default) | no `COGNEE_BASE_URL`, `COGNEE_EMBEDDED` unset | ensures a local cognee server is running and connects as a thin client |
+| **remote** | `COGNEE_BASE_URL` is set | thin client to your managed / cloud cognee |
+| **embedded** | `COGNEE_EMBEDDED=true` | runs cognee in-process |
 
-The hooks emit `mode_decision` logs with `mode`, `service_url`, `url_source`, `key_source`, `api_key_present`.
+**Why local-server is the default.** cognee's local stores (SQLite, Kuzu/Ladybug,
+LanceDB) are single-writer. Driving them in-process from the agent's background
+threads — or from a second process sharing the same `data_root` — risks
+`database is locked` errors and corruption. A local cognee server is the single
+owner that serializes all access, so the agent just makes HTTP calls.
+**`embedded` is opt-in and is safe for single-process / offline use only.**
+
+**No silent fallbacks.** The plugin never downgrades modes behind your back. If
+`COGNEE_BASE_URL` is set but unreachable, or the local server fails to start,
+initialization raises rather than quietly switching to a different mode — silent
+fallback would either mask a config error (remote → local data divergence) or
+reintroduce the very DB-lock risk this design removes (local-server → embedded).
+To accept the single-process trade-off, set `COGNEE_EMBEDDED=true` explicitly.
 
 ## Sessions
 

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -65,17 +65,30 @@ Key resolution order:
 2. `~/.cognee-plugin/api_key.json` (cached from a previous mint)
 3. Auto-mint from the default local user (local mode only), then cache to `api_key.json`
 
-## Mode selection rules
+## Modes
 
-At startup (`SessionStart`):
-- `COGNEE_BASE_URL` set → `managed_endpoint`
-- otherwise → `integration_local` (local API bootstrap)
+The plugin connects to cognee in one of three modes. It picks the mode
+automatically from your config:
 
-At hook runtime:
-- hooks resolve mode through runtime endpoint auth (env + `api_key.json`), not only config intent
-- `http` mode skips local SDK initialization
+| Mode | When it's used | How it talks to cognee |
+| --- | --- | --- |
+| **local-server** (default) | no `COGNEE_BASE_URL`, `COGNEE_EMBEDDED` unset | ensures a local cognee server is running and connects as a thin client |
+| **remote** | `COGNEE_BASE_URL` is set | thin client to your managed / cloud cognee |
+| **embedded** | `COGNEE_EMBEDDED=true` | runs cognee in-process |
 
-The hooks emit `mode_decision` logs with `mode`, `service_url`, `url_source`, `key_source`, `api_key_present`.
+**Why local-server is the default.** cognee's local stores (SQLite, Kuzu/Ladybug,
+LanceDB) are single-writer. Driving them in-process from the agent's background
+threads — or from a second process sharing the same `data_root` — risks
+`database is locked` errors and corruption. A local cognee server is the single
+owner that serializes all access, so the agent just makes HTTP calls.
+**`embedded` is opt-in and is safe for single-process / offline use only.**
+
+**No silent fallbacks.** The plugin never downgrades modes behind your back. If
+`COGNEE_BASE_URL` is set but unreachable, or the local server fails to start,
+initialization raises rather than quietly switching to a different mode — silent
+fallback would either mask a config error (remote → local data divergence) or
+reintroduce the very DB-lock risk this design removes (local-server → embedded).
+To accept the single-process trade-off, set `COGNEE_EMBEDDED=true` explicitly.
 
 ## Sessions
 

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -50,7 +50,7 @@ secrets to `$HERMES_HOME/.env`.
 
 ### Modes
 
-The provider connects to cognee in one of three modes. It picks the mode
+The plugin connects to cognee in one of three modes. It picks the mode
 automatically from your config:
 
 | Mode | When it's used | How it talks to cognee |
@@ -61,13 +61,12 @@ automatically from your config:
 
 **Why local-server is the default.** cognee's local stores (SQLite, Kuzu/Ladybug,
 LanceDB) are single-writer. Driving them in-process from the agent's background
-threads — or from a second Hermes process sharing the same `data_root` — risks
+threads — or from a second process sharing the same `data_root` — risks
 `database is locked` errors and corruption. A local cognee server is the single
-owner that serializes all access, so the agent just makes HTTP calls. This is the
-same design the Claude Code and Codex plugins use. **`embedded` is opt-in and is
-safe for single-process / offline use only.**
+owner that serializes all access, so the agent just makes HTTP calls.
+**`embedded` is opt-in and is safe for single-process / offline use only.**
 
-**No silent fallbacks.** The provider never downgrades modes behind your back. If
+**No silent fallbacks.** The plugin never downgrades modes behind your back. If
 `COGNEE_BASE_URL` is set but unreachable, or the local server fails to start,
 initialization raises rather than quietly switching to a different mode — silent
 fallback would either mask a config error (remote → local data divergence) or

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -80,6 +80,31 @@ plugins:
 
 > `hooks.allowConversationAccess` -> OpenClaw ≥ 2026.4.27 blocks non-bundled plugins from registering the `agent_end` hook unless this flag is set. Without it, file sync memory operations after each agent turn is silently disabled. The gateway still loads the plugin, but file changes the agent makes won't reach Cognee until the next manual `openclaw cognee index` or gateway start. Restart the gateway after adding the flag: `openclaw gateway stop && openclaw gateway start`.
 
+## Modes
+
+The plugin connects to cognee in one of three modes. It picks the mode
+automatically from your config:
+
+| Mode | When it's used | How it talks to cognee |
+| --- | --- | --- |
+| **local-server** (default) | no `COGNEE_BASE_URL`, `COGNEE_EMBEDDED` unset | ensures a local cognee server is running and connects as a thin client |
+| **remote** | `COGNEE_BASE_URL` is set | thin client to your managed / cloud cognee |
+| **embedded** | `COGNEE_EMBEDDED=true` | runs cognee in-process |
+
+**Why local-server is the default.** cognee's local stores (SQLite, Kuzu/Ladybug,
+LanceDB) are single-writer. Driving them in-process from the agent's background
+threads — or from a second process sharing the same `data_root` — risks
+`database is locked` errors and corruption. A local cognee server is the single
+owner that serializes all access, so the agent just makes HTTP calls.
+**`embedded` is opt-in and is safe for single-process / offline use only.**
+
+**No silent fallbacks.** The plugin never downgrades modes behind your back. If
+`COGNEE_BASE_URL` is set but unreachable, or the local server fails to start,
+initialization raises rather than quietly switching to a different mode — silent
+fallback would either mask a config error (remote → local data divergence) or
+reintroduce the very DB-lock risk this design removes (local-server → embedded).
+To accept the single-process trade-off, set `COGNEE_EMBEDDED=true` explicitly.
+
 ### Cognee Cloud
 
 To use Cognee Cloud instead of a local instance, set `mode` to `"cloud"`:

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -22,6 +22,31 @@ export COGNEE_SERVICE_URL="http://localhost:8000"
 export COGNEE_API_KEY="your-api-key" # optional
 ```
 
+## Modes
+
+The plugin connects to cognee in one of three modes. It picks the mode
+automatically from your config:
+
+| Mode | When it's used | How it talks to cognee |
+| --- | --- | --- |
+| **local-server** (default) | no `COGNEE_BASE_URL`, `COGNEE_EMBEDDED` unset | ensures a local cognee server is running and connects as a thin client |
+| **remote** | `COGNEE_BASE_URL` is set | thin client to your managed / cloud cognee |
+| **embedded** | `COGNEE_EMBEDDED=true` | runs cognee in-process |
+
+**Why local-server is the default.** cognee's local stores (SQLite, Kuzu/Ladybug,
+LanceDB) are single-writer. Driving them in-process from the agent's background
+threads — or from a second process sharing the same `data_root` — risks
+`database is locked` errors and corruption. A local cognee server is the single
+owner that serializes all access, so the agent just makes HTTP calls.
+**`embedded` is opt-in and is safe for single-process / offline use only.**
+
+**No silent fallbacks.** The plugin never downgrades modes behind your back. If
+`COGNEE_BASE_URL` is set but unreachable, or the local server fails to start,
+initialization raises rather than quietly switching to a different mode — silent
+fallback would either mask a config error (remote → local data divergence) or
+reintroduce the very DB-lock risk this design removes (local-server → embedded).
+To accept the single-process trade-off, set `COGNEE_EMBEDDED=true` explicitly.
+
 ## Features
 
 - **Auto-capture**: Listens to `tool.execute.after` to store all completed tool execution parameters and outputs directly into Cognee.


### PR DESCRIPTION
Summary
Standardizes the three runtime modes (embedded / local-server / cloud) description — including the DB-safety rationale — across all five core integration READMEs. The Hermes integration already had a thorough version; this PR promotes that as the canonical shared text.

Problem
Each integration README described connection modes differently (or not at all):

Claude Code & Codex had a terse "Mode selection rules" section with implementation-level details but no user-facing rationale
OpenClaw had a "Cognee Cloud" subsection with config snippets but no explanation of why local-server is preferred
OpenCode had no modes section at all
Hermes had the most complete version with the DB-safety explanation
This inconsistency made it harder for users to understand the trade-offs when choosing a mode, and meant the safety rationale (single-writer DB locking) was only documented in one place.

Changes
All five READMEs now share byte-identical modes text covering:

Three-mode table — local-server (default), remote, and embedded — with triggers and behavior
DB-safety rationale — why local-server is the default (SQLite/Kuzu/LanceDB are single-writer; in-process use risks database is locked errors)
No-silent-fallback policy — the plugin never auto-downgrades modes; misconfiguration raises instead of silently diverging