### PR TITLE
feat: tunable per-op timeouts — COGNEE_REMEMBER_TIMEOUT / COGNEE_REGISTER_TIMEOUT

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -291,3 +291,6 @@ Config precedence:
 | idle watcher poll | `COGNEE_IDLE_POLL` | `10` | Idle watcher poll interval in seconds |
 | idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle sync fires |
 | idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `120` | Minimum seconds between idle sync runs |
+| recall timeout | `COGNEE_RECALL_TIMEOUT` | `20` | Recall (read) request timeout in seconds |
+| remember timeout | `COGNEE_REMEMBER_TIMEOUT` | `60` | Remember (write) request timeout in seconds |
+| register timeout | `COGNEE_REGISTER_TIMEOUT` | `15` | Agent-register request timeout in seconds |

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -18,6 +18,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+# Per-operation timeouts in seconds, tunable independently of recall
+# (COGNEE_RECALL_TIMEOUT). Each falls back to its prior default when unset.
+_REMEMBER_TIMEOUT = float(os.environ.get("COGNEE_REMEMBER_TIMEOUT", "30"))
+_REGISTER_TIMEOUT = float(os.environ.get("COGNEE_REGISTER_TIMEOUT", "15"))
+
 _PLUGIN_DIR = Path.home() / ".cognee-plugin" / "claude-code"
 _SHARED_PLUGIN_ROOT = Path.home() / ".cognee-plugin"
 _HOOK_LOG = _PLUGIN_DIR / "hook.log"
@@ -1060,7 +1065,7 @@ def remember_entry_via_http(
     session_id: str,
     entry: dict,
     *,
-    timeout: float = 30.0,
+    timeout: float = _REMEMBER_TIMEOUT,
 ) -> dict | None:
     """Store a typed QA/trace entry through the backend API.
 
@@ -1085,7 +1090,7 @@ def register_agent_via_http(
     agent_session_name: str,
     session_id: str = "",
     dataset_names: list[str] | None = None,
-    timeout: float = 15.0,
+    timeout: float = _REGISTER_TIMEOUT,
 ) -> tuple[bool, dict]:
     payload = {
         "agent_session_name": agent_session_name,

--- a/integrations/claude-code/scripts/_remember_http.py
+++ b/integrations/claude-code/scripts/_remember_http.py
@@ -29,6 +29,10 @@ import uuid
 
 UNREACHABLE = "UNREACHABLE"
 
+# Remember (write) timeout in seconds, tunable independently of recall
+# (COGNEE_RECALL_TIMEOUT). Falls back to the prior default when unset.
+_REMEMBER_TIMEOUT = float(os.environ.get("COGNEE_REMEMBER_TIMEOUT", "60"))
+
 
 def _is_local(url):
     """True for a localhost/loopback target (where a cloud API key is meaningless)."""
@@ -100,7 +104,7 @@ def do_remember(
     node_set,
     *,
     opener=urllib.request.urlopen,
-    timeout=60.0,
+    timeout=_REMEMBER_TIMEOUT,
 ):
     """POST content to the server. Return {"ok": true}, an error envelope, or UNREACHABLE."""
     url = service_url.rstrip("/") + "/api/v1/remember"

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -212,6 +212,9 @@ Config precedence:
 | idle watcher poll | `COGNEE_IDLE_POLL` | `10` | Idle watcher poll interval in seconds |
 | idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle sync fires |
 | idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `120` | Minimum seconds between idle sync runs |
+| recall timeout | `COGNEE_RECALL_TIMEOUT` | `20` | Recall (read) request timeout in seconds |
+| remember timeout | `COGNEE_REMEMBER_TIMEOUT` | `60` | Remember (write) request timeout in seconds |
+| register timeout | `COGNEE_REGISTER_TIMEOUT` | `15` | Agent-register request timeout in seconds |
 
 ## Troubleshooting
 

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -18,6 +18,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+# Per-operation timeouts in seconds, tunable independently of recall
+# (COGNEE_RECALL_TIMEOUT). Each falls back to its prior default when unset.
+_REMEMBER_TIMEOUT = float(os.environ.get("COGNEE_REMEMBER_TIMEOUT", "30"))
+_REGISTER_TIMEOUT = float(os.environ.get("COGNEE_REGISTER_TIMEOUT", "15"))
+
 _PLUGIN_DIR = Path.home() / ".cognee-plugin" / "codex"
 _SHARED_PLUGIN_ROOT = Path.home() / ".cognee-plugin"
 _HOOK_LOG = _PLUGIN_DIR / "hook.log"
@@ -1041,7 +1046,7 @@ def remember_entry_via_http(
     session_id: str,
     entry: dict,
     *,
-    timeout: float = 30.0,
+    timeout: float = _REMEMBER_TIMEOUT,
 ) -> dict | None:
     """Store a typed QA/trace entry through the backend API.
 
@@ -1066,7 +1071,7 @@ def register_agent_via_http(
     agent_session_name: str,
     session_id: str = "",
     dataset_names: list[str] | None = None,
-    timeout: float = 15.0,
+    timeout: float = _REGISTER_TIMEOUT,
 ) -> tuple[bool, dict]:
     payload = {
         "agent_session_name": agent_session_name,

--- a/integrations/codex/plugins/cognee/scripts/_remember_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_remember_http.py
@@ -29,6 +29,10 @@ import uuid
 
 UNREACHABLE = "UNREACHABLE"
 
+# Remember (write) timeout in seconds, tunable independently of recall
+# (COGNEE_RECALL_TIMEOUT). Falls back to the prior default when unset.
+_REMEMBER_TIMEOUT = float(os.environ.get("COGNEE_REMEMBER_TIMEOUT", "60"))
+
 
 def _is_local(url):
     """True for a localhost/loopback target (where a cloud API key is meaningless)."""
@@ -100,7 +104,7 @@ def do_remember(
     node_set,
     *,
     opener=urllib.request.urlopen,
-    timeout=60.0,
+    timeout=_REMEMBER_TIMEOUT,
 ):
     """POST content to the server. Return {"ok": true}, an error envelope, or UNREACHABLE."""
     url = service_url.rstrip("/") + "/api/v1/remember"


### PR DESCRIPTION
## What

`COGNEE_RECALL_TIMEOUT` already lets recall be tuned, but the **remember** and **register** write paths used hard-coded timeouts. This adds two env vars so they can be tuned independently of recall:

- `COGNEE_REMEMBER_TIMEOUT` — remember (write) requests
- `COGNEE_REGISTER_TIMEOUT` — agent-register requests

## How

Each operation reads its own env var and **falls back to the existing default when unset**, so behavior is unchanged unless you opt in:

| Operation | Function | Env var | Default (unset) |
|---|---|---|---|
| remember (content write) | `do_remember` — `_remember_http.py` | `COGNEE_REMEMBER_TIMEOUT` | 60s |
| remember (session entry) | `remember_entry_via_http` — `_plugin_common.py` | `COGNEE_REMEMBER_TIMEOUT` | 30s |
| register | `register_agent_via_http` — `_plugin_common.py` | `COGNEE_REGISTER_TIMEOUT` | 15s |

This mirrors the existing `COGNEE_RECALL_TIMEOUT` pattern in `_cognee_client.py`. Applied to **both** the `claude-code` and `codex` integrations, and all three timeout vars are now documented in both READMEs' Configuration reference.

## Testing

- All existing unit tests pass (run directly — the repo has no pytest dependency): `test_remember_http`, `test_cognee_client`, `test_recall_http`, `test_memory_preference`, `test_session_id`.
- Verified env override end-to-end: unset → `60 / 30 / 15` (unchanged); `COGNEE_REMEMBER_TIMEOUT=7 COGNEE_REGISTER_TIMEOUT=3` → effective defaults become `7 / 7 / 3`.

Resolves topoteretes/cognee#3543
