### PR TITLE
feat: Add `remember` and `recall` operations to n8n node

### DIFF
--- a/integrations/n8n/README.md
+++ b/integrations/n8n/README.md
@@ -50,9 +50,67 @@ Create credentials of type `Cognee API` in n8n. The node uses these values to au
 
 ## Operations
 
-The node exposes five resources. Each operation maps to a Cognee API endpoint.
+The node exposes six resources. Each operation maps to a Cognee API endpoint.
 
-> **Two API surfaces.** The **Add Data / Cognify / Search / Delete** resources call Cognee Cloud's `/api/*` endpoints. The **Skill** resource (self-improving loop) calls the `/api/v1/*` endpoints — available on a self-hosted cognee server today, and on Cognee Cloud as its `/api/v1` surface rolls out. Point the credential **Base URL** at whichever backend exposes the routes you need (e.g. `http://localhost:8000` for a self-hosted server). The connection test hits `GET /health`.
+> **Two API surfaces.** The **Add Data / Cognify / Search / Delete** resources call Cognee Cloud's `/api/*` endpoints. The **Memory** and **Skill** resources call the `/api/v1/*` endpoints — available on a self-hosted cognee server today, and on Cognee Cloud as its `/api/v1` surface rolls out. Point the credential **Base URL** at whichever backend exposes the routes you need (e.g. `http://localhost:8000` for a self-hosted server). The connection test hits `GET /health`.
+
+### Resource: Memory
+
+#### Operation: Recall
+
+- **Endpoint**: `POST /api/v1/recall`
+- **Description**: Query the Cognee knowledge graph and/or session cache with natural language. A memory-oriented alias for search, supporting all search types.
+- **Fields**:
+  - Query (`recallQuery`, required): Natural-language question to ask.
+  - Datasets (`recallDatasets`, optional, multiple): Dataset names to search. Leave empty to search all accessible datasets.
+  - Search Type (`recallSearchType`, options, default `GRAPH_COMPLETION`): One of `GRAPH_COMPLETION`, `GRAPH_COMPLETION_COT`, `RAG_COMPLETION`, `CHUNKS`, `SUMMARIES`.
+  - Top K (`recallTopK`, number, default `15`): Maximum results to return.
+  - Session ID (`recallSessionId`, optional): Session whose cached QA/trace entries should be searched.
+
+Example body sent by the node:
+
+```json
+{
+  "query": "What are our company's data retention policies?",
+  "datasets": ["company-docs"],
+  "search_type": "GRAPH_COMPLETION",
+  "top_k": 15
+}
+```
+
+Example response (list of result objects):
+
+```json
+[
+  {
+    "id": "...",
+    "text": "Data is retained for 7 years per regulatory requirements...",
+    "confidence": 0.91
+  }
+]
+```
+
+#### Operation: Remember
+
+- **Endpoint**: `POST /api/v1/remember`
+- **Description**: Ingest text into a Cognee dataset and build the knowledge graph in a single call (add + cognify in one request).
+- **Fields**:
+  - Dataset Name (`rememberDatasetName`, required): Target dataset name (created if it does not exist).
+  - Text (`rememberText`, required): The text content to ingest.
+  - Session ID (`rememberSessionId`, optional): Session to attribute this memory to. When set, data is stored in the session cache and bridged into the permanent graph in the background.
+  - Run in Background (`rememberRunInBackground`, boolean, default `false`): When `true`, returns immediately with pipeline metadata; poll `GET /api/v1/datasets/status` for completion.
+
+> **Text-only limitation.** `POST /api/v1/remember` is a `multipart/form-data` endpoint designed primarily for file uploads. Through this node, only inline text ingestion is supported (the text is sent via the `skills_text` form field and processed server-side). To upload binary files or documents, use the Cognee Python SDK or REST API directly.
+
+Example response:
+
+```json
+{
+  "status": "completed",
+  "pipeline_run_id": "3fa85f64-...",
+  "items_processed": 1
+}
+```
 
 ### Resource: Add Data
 
@@ -187,6 +245,8 @@ The node depends on `n8n-workflow` at runtime (peer dependency). It should work 
 - [Package homepage](https://github.com/topoteretes/cognee-n8n)
 
 ## Version history
+
+- **0.6.0**: Add the **Memory** resource with `recall` (`POST /api/v1/recall`) and `remember` (`POST /api/v1/remember`, text-only) operations targeting the `/api/v1` API. Both operations follow the same declarative routing pattern as all existing operations.
 
 - **0.5.0**: Add the **Skill** resource (self-improving skill loop) targeting the `/api/v1` API: Ingest Skill, Review Skill (agentic), Propose Improvement, Apply Improvement, Get Skill, Get Proposal. Existing Add/Cognify/Search/Delete operations are unchanged.
 

--- a/integrations/n8n/nodes/Cognee/Cognee.node.ts
+++ b/integrations/n8n/nodes/Cognee/Cognee.node.ts
@@ -167,6 +167,7 @@ export class Cognee implements INodeType {
           { name: 'Add Data', value: 'addData' },
           { name: 'Cognify', value: 'cognify' },
           { name: 'Delete', value: 'delete' },
+          { name: 'Memory', value: 'memory' },
           { name: 'Search', value: 'search' },
           { name: 'Skill', value: 'skill' },
         ],
@@ -321,6 +322,56 @@ export class Cognee implements INodeType {
           },
         ],
         default: 'deleteDataset',
+      },
+      {
+        displayName: 'Operation',
+        name: 'operation',
+        type: 'options',
+        noDataExpression: true,
+        displayOptions: {
+          show: {
+            resource: ['memory'],
+          },
+        },
+        options: [
+          {
+            name: 'Recall',
+            value: 'recall',
+            action: 'Recall information from the knowledge graph',
+            description: 'Query the Cognee knowledge graph and/or session cache with natural language (POST /api/v1/recall)',
+            routing: {
+              request: {
+                method: 'POST',
+                url: '/v1/recall',
+                headers: {
+                  'Content-Type': 'application/json',
+                },
+                timeout: 300000, // 5 minutes
+              },
+            },
+          },
+          {
+            name: 'Remember',
+            value: 'remember',
+            action: 'Ingest text and build the knowledge graph',
+            // POST /api/v1/remember is a multipart/form-data endpoint (supports file uploads
+            // via the SDK). Through the n8n node, only the text-only path is exposed:
+            // the text is sent as a plain-text form field and the server stores it inline.
+            // File uploads require direct SDK or API usage.
+            description: 'Ingest text into a Cognee dataset and build the knowledge graph (POST /api/v1/remember, text-only; file uploads require the SDK)',
+            routing: {
+              request: {
+                method: 'POST',
+                url: '/v1/remember',
+                headers: {
+                  'Content-Type': 'multipart/form-data',
+                },
+                timeout: 600000, // 10 minutes
+              },
+            },
+          },
+        ],
+        default: 'recall',
       },
       {
         displayName: 'Operation',
@@ -642,6 +693,207 @@ export class Cognee implements INodeType {
           request: {
             body: {
               topK: '={{$value}}',
+            },
+          },
+        },
+      },
+      // Memory — Recall fields
+      {
+        displayName: 'Query',
+        name: 'recallQuery',
+        type: 'string',
+        default: '',
+        required: true,
+        description: 'The natural-language question or query to run against the knowledge graph',
+        displayOptions: {
+          show: {
+            resource: ['memory'],
+            operation: ['recall'],
+          },
+        },
+        routing: {
+          request: {
+            body: {
+              query: '={{$value}}',
+            },
+          },
+        },
+      },
+      {
+        displayName: 'Datasets',
+        name: 'recallDatasets',
+        type: 'string',
+        typeOptions: {
+          multipleValues: true,
+        },
+        default: [],
+        description: 'Dataset names to search within. Leave empty to search all datasets you have access to',
+        displayOptions: {
+          show: {
+            resource: ['memory'],
+            operation: ['recall'],
+          },
+        },
+        routing: {
+          request: {
+            body: {
+              datasets: '={{$value.length ? $value : undefined}}',
+            },
+          },
+        },
+      },
+      {
+        displayName: 'Search Type',
+        name: 'recallSearchType',
+        type: 'options',
+        options: [
+          { name: 'Graph Completion', value: 'GRAPH_COMPLETION' },
+          { name: 'Chain of Thought', value: 'GRAPH_COMPLETION_COT' },
+          { name: 'RAG Completion', value: 'RAG_COMPLETION' },
+          { name: 'Chunks', value: 'CHUNKS' },
+          { name: 'Summaries', value: 'SUMMARIES' },
+        ],
+        default: 'GRAPH_COMPLETION',
+        description: 'Search strategy to use when querying the knowledge graph',
+        displayOptions: {
+          show: {
+            resource: ['memory'],
+            operation: ['recall'],
+          },
+        },
+        routing: {
+          request: {
+            body: {
+              search_type: '={{$value}}',
+            },
+          },
+        },
+      },
+      {
+        displayName: 'Top K',
+        name: 'recallTopK',
+        type: 'number',
+        default: 15,
+        description: 'Maximum number of results to return',
+        displayOptions: {
+          show: {
+            resource: ['memory'],
+            operation: ['recall'],
+          },
+        },
+        routing: {
+          request: {
+            body: {
+              top_k: '={{$value}}',
+            },
+          },
+        },
+      },
+      {
+        displayName: 'Session ID',
+        name: 'recallSessionId',
+        type: 'string',
+        default: '',
+        description: 'Session ID whose cached QA and trace entries should be included in the search (optional)',
+        displayOptions: {
+          show: {
+            resource: ['memory'],
+            operation: ['recall'],
+          },
+        },
+        routing: {
+          request: {
+            body: {
+              session_id: '={{$value || undefined}}',
+            },
+          },
+        },
+      },
+      // Memory — Remember fields
+      {
+        displayName: 'Dataset Name',
+        name: 'rememberDatasetName',
+        type: 'string',
+        default: '',
+        required: true,
+        description: 'Name of the target dataset (created if it does not exist)',
+        placeholder: 'e.g. my-project',
+        displayOptions: {
+          show: {
+            resource: ['memory'],
+            operation: ['remember'],
+          },
+        },
+        routing: {
+          request: {
+            body: {
+              datasetName: '={{$value}}',
+            },
+          },
+        },
+      },
+      {
+        displayName: 'Text',
+        name: 'rememberText',
+        type: 'string',
+        typeOptions: {
+          rows: 6,
+        },
+        default: '',
+        required: true,
+        // Sent as a plain-text form field (skills_text path of the remember endpoint).
+        // The server writes it to a temporary file and runs the normal add+cognify pipeline.
+        description: 'Text content to ingest. Sent as inline text via the multipart form; file uploads require direct SDK or API usage',
+        displayOptions: {
+          show: {
+            resource: ['memory'],
+            operation: ['remember'],
+          },
+        },
+        routing: {
+          request: {
+            body: {
+              skills_text: '={{$value}}',
+            },
+          },
+        },
+      },
+      {
+        displayName: 'Session ID',
+        name: 'rememberSessionId',
+        type: 'string',
+        default: '',
+        description: 'Session to attribute this memory to (optional). When set, data is stored in the session cache and bridged into the permanent graph in the background',
+        displayOptions: {
+          show: {
+            resource: ['memory'],
+            operation: ['remember'],
+          },
+        },
+        routing: {
+          request: {
+            body: {
+              session_id: '={{$value || undefined}}',
+            },
+          },
+        },
+      },
+      {
+        displayName: 'Run in Background',
+        name: 'rememberRunInBackground',
+        type: 'boolean',
+        default: false,
+        description: 'Whether to run ingestion asynchronously. When enabled, the request returns immediately; poll GET /api/v1/datasets/status for completion',
+        displayOptions: {
+          show: {
+            resource: ['memory'],
+            operation: ['remember'],
+          },
+        },
+        routing: {
+          request: {
+            body: {
+              run_in_background: '={{$value}}',
             },
           },
         },


### PR DESCRIPTION
### Description
Adds the new **Memory** resource to the n8n Cognee node, exposing the `/api/v1/remember` and `/api/v1/recall` endpoints.

Closes  topoteretes/cognee#3560 from (https://github.com/topoteretes/cognee/issues/3560)

**Code Changes (`integrations/n8n/nodes/Cognee/Cognee.node.ts`):**
- **Added Memory Resource:** Included `memory` in the resource dropdown.
- **Added Recall Operation:** Maps to `POST /api/v1/recall` (JSON). Added UI fields for `query`, `datasets`, `search_type`, `top_k`, and `session_id`. 
- **Added Remember Operation:** Maps to `POST /api/v1/remember` (multipart/form-data). Added UI fields for `datasetName`, `skills_text` (inline text ingestion), `session_id`, and `run_in_background`.
- 
**Documentation Changes (`integrations/n8n/README.md`):**
- Added the **Resource: Memory** section detailing the new endpoints, request/response formats, and the inline-text limitation for `remember` via the n8n UI. 
- Updated version history to `0.6.0`.