### PR TITLE
feat(claude-code): show "plugin update available" in the status line

### DIFF
--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -20,6 +20,7 @@ _SHARED_ROOT = Path.home() / ".cognee-plugin"
 _CONFIG_PATH = _SHARED_ROOT / "claude-code" / "config.json"
 _SERVER_READY_PATH = _SHARED_ROOT / "server-ready.json"
 _BREAKER_PATH = _SHARED_ROOT / "recall-breaker.json"
+_UPDATE_CHECK_PATH = _SHARED_ROOT / "update-check.json"
 _DEFAULT_DATASET = "agent_sessions"
 
 
@@ -73,12 +74,34 @@ def _health_prefix() -> str:
     return ""
 
 
+def _update_suffix() -> str:
+    """A compact 'update available' badge, read from the cached version check.
+
+    Pure-local: the network check runs elsewhere (version_check.py, spawned at
+    SessionStart) and writes update-check.json; here we only read it.
+    """
+    if os.environ.get("COGNEE_UPDATE_CHECK", "").strip().lower() in {"0", "false", "no", "off"}:
+        return ""
+    try:
+        data = json.loads(_UPDATE_CHECK_PATH.read_text(encoding="utf-8"))
+        if isinstance(data, dict) and data.get("update_available"):
+            latest = str(data.get("latest") or "").strip()
+            if latest:
+                return f" · ⬆ v{latest} available — /plugin update"
+            return " · ⬆ update available"
+    except Exception:
+        pass
+    return ""
+
+
 def main() -> None:
     try:
         json.load(sys.stdin)  # consume stdin as required by Claude Code
     except Exception:
         pass
-    sys.stdout.write(f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}")
+    sys.stdout.write(
+        f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}{_update_suffix()}"
+    )
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -63,6 +63,7 @@ _WATCHER_PID = _STATE_DIR / "watcher.pid"
 _WATCHER_STOP = _STATE_DIR / "watcher.stop"
 _WATCHER_SCRIPT = Path(__file__).with_name("idle-watcher.py")
 _EXIT_WATCHER_SCRIPT = Path(__file__).with_name("exit-watcher.py")
+_VERSION_CHECK_SCRIPT = Path(__file__).with_name("version_check.py")
 _EXIT_WATCHERS_DIR = _STATE_DIR / "exit-watchers"
 _LOCAL_SERVICE_URL = "http://localhost:8011"
 _HEALTH_URL = f"{_LOCAL_SERVICE_URL}/health"
@@ -678,6 +679,28 @@ def _spawn_idle_watcher(
         print("cognee-plugin: idle watcher started", file=sys.stderr)
     except Exception as e:
         print(f"cognee-plugin: idle watcher launch failed ({e})", file=sys.stderr)
+
+
+def _spawn_version_check() -> None:
+    """Fire-and-forget the plugin-update check (detached, never blocks).
+
+    version_check.py is TTL-gated + fail-silent internally (so this runs at most
+    once per interval and a network error is a no-op); here we only launch it.
+    Opt out with COGNEE_UPDATE_CHECK=false.
+    """
+    if os.environ.get("COGNEE_UPDATE_CHECK", "").strip().lower() in ("0", "false", "no", "off"):
+        return
+    try:
+        subprocess.Popen(
+            [sys.executable, str(_VERSION_CHECK_SCRIPT), os.environ.get("CLAUDE_PLUGIN_ROOT", "")],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except Exception as exc:
+        hook_log("version_check_spawn_failed", {"error": str(exc)[:200]})
 
 
 def _find_claude_parent_pid() -> int:
@@ -1317,6 +1340,9 @@ async def _start(payload: dict | None = None) -> dict:
         api_key=agent_api_key,
         service_url=str(config.get("base_url", "") or ""),
     )
+
+    # Background, TTL-gated check for a newer plugin version (status line shows a badge).
+    _spawn_version_check()
 
     mode = "cloud" if config.get("base_url") else "local"
     print(

--- a/integrations/claude-code/scripts/version_check.py
+++ b/integrations/claude-code/scripts/version_check.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Background check for a newer published plugin version.
+
+Spawned detached from SessionStart so it never blocks the session. It compares
+the installed plugin version (``CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json``)
+against the latest published version in the marketplace manifest on GitHub, and
+writes the result to ``~/.cognee-plugin/update-check.json`` for the (pure-local,
+no-network) status line to read.
+
+Deliberately standalone + stdlib-only (runs under the system ``python3`` without
+the plugin venv). TTL-gated and fail-silent: a recent check or a network error is
+a no-op — never a false "update available", never a stack trace in a hook.
+
+Env knobs:
+  COGNEE_UPDATE_CHECK=false            disable the check entirely
+  COGNEE_UPDATE_CHECK_INTERVAL_HOURS   re-check interval (default 24)
+"""
+
+import json
+import os
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+_STATE_PATH = Path.home() / ".cognee-plugin" / "update-check.json"
+_MARKETPLACE_URL = (
+    "https://raw.githubusercontent.com/topoteretes/cognee-integrations/"
+    "main/.claude-plugin/marketplace.json"
+)
+_PLUGIN_NAME = "cognee-memory"
+_DEFAULT_TTL_HOURS = 24.0
+
+
+def _enabled() -> bool:
+    return os.environ.get("COGNEE_UPDATE_CHECK", "").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def _ttl_hours() -> float:
+    try:
+        raw = os.environ.get("COGNEE_UPDATE_CHECK_INTERVAL_HOURS", "").strip()
+        return float(raw) if raw else _DEFAULT_TTL_HOURS
+    except (TypeError, ValueError):
+        return _DEFAULT_TTL_HOURS
+
+
+def _installed_version(plugin_root: str) -> str:
+    try:
+        manifest = Path(plugin_root) / ".claude-plugin" / "plugin.json"
+        return str(json.loads(manifest.read_text(encoding="utf-8")).get("version") or "").strip()
+    except Exception:
+        return ""
+
+
+def _latest_version(timeout: float) -> str:
+    """Latest published version of THIS plugin from the marketplace manifest.
+
+    Reads ``plugins[].version`` for the matching plugin name only — NOT the
+    marketplace's own ``metadata.version`` (a different, unrelated number).
+    """
+    req = urllib.request.Request(_MARKETPLACE_URL, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+    for plugin in data.get("plugins", []) or []:
+        if isinstance(plugin, dict) and plugin.get("name") == _PLUGIN_NAME:
+            return str(plugin.get("version") or "").strip()
+    return ""
+
+
+def _parse(version: str) -> tuple:
+    """Parse 'X.Y.Z' to a comparable tuple. Tolerates a leading 'v' and a
+    pre-release suffix (e.g. '1.2.3-rc1' -> (1, 2, 3))."""
+    parts = []
+    for chunk in str(version).strip().lstrip("vV").split("."):
+        digits = ""
+        for ch in chunk:
+            if ch.isdigit():
+                digits += ch
+            else:
+                break  # stop at the first non-digit (drops '-rc1', '+build', etc.)
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts)
+
+
+def is_newer(latest: str, installed: str) -> bool:
+    """True only when both versions parse and latest > installed."""
+    if not latest or not installed:
+        return False
+    return _parse(latest) > _parse(installed)
+
+
+def _recently_checked() -> bool:
+    try:
+        prev = json.loads(_STATE_PATH.read_text(encoding="utf-8"))
+        return (time.time() - float(prev.get("checked_at", 0) or 0)) < _ttl_hours() * 3600.0
+    except Exception:
+        return False
+
+
+def _previous_latest() -> str:
+    try:
+        return str(json.loads(_STATE_PATH.read_text(encoding="utf-8")).get("latest") or "").strip()
+    except Exception:
+        return ""
+
+
+def run(plugin_root: str = "", *, timeout: float = 4.0, force: bool = False) -> None:
+    if not _enabled():
+        return
+    if not force and _recently_checked():
+        return
+
+    installed = _installed_version(plugin_root or os.environ.get("CLAUDE_PLUGIN_ROOT", ""))
+    try:
+        latest = _latest_version(timeout)
+    except Exception:
+        # Network/parse failure: keep the last known 'latest' so a transient
+        # outage doesn't clear a real notification, and refresh the timestamp so
+        # we don't hammer the network on every session.
+        latest = _previous_latest()
+
+    record = {
+        "checked_at": time.time(),
+        "installed": installed,
+        "latest": latest,
+        "update_available": is_newer(latest, installed),
+    }
+    try:
+        _STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _STATE_PATH.write_text(json.dumps(record), encoding="utf-8")
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    root = next((a for a in args if not a.startswith("-")), "")
+    run(root, force="--force" in args)

--- a/integrations/claude-code/tests/test_version_check.py
+++ b/integrations/claude-code/tests/test_version_check.py
@@ -1,0 +1,154 @@
+"""Unit tests for the plugin-update check (version_check.py) and the status-line badge.
+
+Covers:
+  * version comparison (only a strictly-newer published version triggers an update);
+  * the TTL gate (a recent check is a no-op — no network);
+  * a network failure preserves the last known 'latest' instead of clearing it;
+  * the status line renders the badge only when update_available is set.
+
+Run: python integrations/claude-code/tests/test_version_check.py (or via pytest).
+"""
+
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import cognee_statusline_render as sl  # noqa: E402
+import version_check as vc  # noqa: E402
+
+
+def _tmp_state():
+    return pathlib.Path(tempfile.mkdtemp()) / "update-check.json"
+
+
+# ---- version comparison ----
+
+
+def test_is_newer():
+    assert vc.is_newer("0.3.0", "0.2.0")
+    assert vc.is_newer("0.2.1", "0.2.0")
+    assert vc.is_newer("1.0.0", "0.9.9")
+    assert not vc.is_newer("0.2.0", "0.2.0")  # equal → no update
+    assert not vc.is_newer("0.1.0", "0.2.0")  # older → no update
+    assert not vc.is_newer("", "0.2.0")  # unknown latest → no false badge
+    assert not vc.is_newer("0.2.0", "")  # unknown installed → no false badge
+
+
+def test_parse_tolerates_v_and_prerelease():
+    assert vc._parse("v0.3.0") == (0, 3, 0)
+    assert vc._parse("1.2.3-rc1") == (1, 2, 3)
+    assert vc.is_newer("v1.2.3", "v1.2.2")
+
+
+# ---- run() behavior ----
+
+
+def test_run_writes_update_available():
+    vc._STATE_PATH = _tmp_state()
+    vc._latest_version = lambda timeout: "0.3.0"
+    vc._installed_version = lambda root: "0.2.0"
+    os.environ.pop("COGNEE_UPDATE_CHECK", None)
+    vc.run("/fake/root", force=True)
+    rec = json.loads(vc._STATE_PATH.read_text())
+    assert rec["update_available"] is True
+    assert rec["latest"] == "0.3.0"
+    assert rec["installed"] == "0.2.0"
+
+
+def test_run_no_update_when_equal():
+    vc._STATE_PATH = _tmp_state()
+    vc._latest_version = lambda timeout: "0.2.0"
+    vc._installed_version = lambda root: "0.2.0"
+    vc.run("/fake/root", force=True)
+    assert json.loads(vc._STATE_PATH.read_text())["update_available"] is False
+
+
+def test_ttl_gate_skips_when_recent():
+    vc._STATE_PATH = _tmp_state()
+    vc._STATE_PATH.write_text(json.dumps({"checked_at": time.time(), "latest": "9.9.9"}))
+    called = {"n": 0}
+
+    def _boom(timeout):
+        called["n"] += 1
+        raise AssertionError("should not hit the network within the TTL")
+
+    vc._latest_version = _boom
+    vc.run("/fake/root")  # not forced → recent check → skip
+    assert called["n"] == 0
+
+
+def test_network_failure_preserves_previous_latest():
+    vc._STATE_PATH = _tmp_state()
+    # a prior run found 0.4.0 available
+    vc._STATE_PATH.write_text(
+        json.dumps({"checked_at": 0, "installed": "0.2.0", "latest": "0.4.0"})
+    )
+    vc._installed_version = lambda root: "0.2.0"
+
+    def _fail(timeout):
+        raise OSError("network down")
+
+    vc._latest_version = _fail
+    vc.run("/fake/root", force=True)
+    rec = json.loads(vc._STATE_PATH.read_text())
+    assert rec["latest"] == "0.4.0"  # preserved, not cleared
+    assert rec["update_available"] is True
+
+
+def test_disabled_is_noop():
+    vc._STATE_PATH = _tmp_state()
+    os.environ["COGNEE_UPDATE_CHECK"] = "false"
+    try:
+        vc._latest_version = lambda timeout: "9.9.9"
+        vc.run("/fake/root", force=True)
+        assert not vc._STATE_PATH.exists()  # nothing written
+    finally:
+        os.environ.pop("COGNEE_UPDATE_CHECK", None)
+
+
+# ---- status-line badge ----
+
+
+def test_statusline_shows_badge_when_update_available():
+    p = _tmp_state()
+    p.write_text(json.dumps({"update_available": True, "latest": "0.3.0"}))
+    sl._UPDATE_CHECK_PATH = p
+    os.environ.pop("COGNEE_UPDATE_CHECK", None)
+    suffix = sl._update_suffix()
+    assert "⬆" in suffix and "0.3.0" in suffix
+
+
+def test_statusline_no_badge_when_up_to_date():
+    p = _tmp_state()
+    p.write_text(json.dumps({"update_available": False, "latest": "0.2.0"}))
+    sl._UPDATE_CHECK_PATH = p
+    assert sl._update_suffix() == ""
+
+
+def test_statusline_badge_respects_opt_out():
+    p = _tmp_state()
+    p.write_text(json.dumps({"update_available": True, "latest": "0.3.0"}))
+    sl._UPDATE_CHECK_PATH = p
+    os.environ["COGNEE_UPDATE_CHECK"] = "off"
+    try:
+        assert sl._update_suffix() == ""
+    finally:
+        os.environ.pop("COGNEE_UPDATE_CHECK", None)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## What

Tells the user, right in the Cognee status line, when a newer plugin version is published — so they know to run `/plugin update`.

```
up to date :  cognee: agent_sessions · local
update     :  cognee: agent_sessions · local · ⬆ v0.3.0 available — /plugin update
```

## How

The status line is intentionally **pure-local** (it renders on every redraw and must do no network I/O). So the network check runs elsewhere and writes a cache file the renderer reads:

- **`version_check.py`** (new) — spawned **detached** from SessionStart so it never blocks. It's **TTL-gated** (default 24h) and **fail-silent**: a recent check or a network error is a no-op. Compares the installed plugin version (`CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json`) against the published `plugins[].version` in the marketplace manifest on GitHub, and writes `~/.cognee-plugin/update-check.json`. Reads only **this plugin's** `plugins[].version` — *not* the marketplace's own `metadata.version` (a different number that would otherwise trigger a false update).
- **`cognee_statusline_render.py`** — appends the badge when the cache says an update is available. No network, no `_plugin_common` import (unchanged design constraints).
- **`session-start.py`** — `_spawn_version_check()`: fire-and-forget, detached, mirrors the existing watcher-spawn pattern.

## Safety / UX
- **No false badge:** only a strictly-newer published version shows. Today `installed 0.2.0 == published 0.2.0`, so it's **dormant** until maintainers bump the version — verified live against GitHub.
- **Network outage doesn't clear a real notification:** a failed fetch preserves the last known `latest` and just refreshes the timestamp (no hammering).
- **Opt out:** `COGNEE_UPDATE_CHECK=false`. **Cadence:** `COGNEE_UPDATE_CHECK_INTERVAL_HOURS` (default 24).

## Tests
`tests/test_version_check.py` (new, 10 cases): version comparison (incl. `v` prefix + pre-release suffix), the TTL gate (no network within interval), network-failure preserves last known latest, disabled-is-noop, and the status-line badge / opt-out. All pass; existing suite unaffected; `ruff check` + `format --check` clean.

## Scope
claude-code only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)