### PR TITLE
Add config precedence tests for integrations

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -277,6 +277,8 @@ Config precedence:
 2. `~/.cognee-plugin/claude-code/config.json`
 3. defaults
 
+Precedence is covered by `tests/test_config_precedence.py`.
+
 | Key | Env var(s) | Default | Notes |
 |---|---|---|---|
 | `dataset` | `COGNEE_PLUGIN_DATASET` | `agent_sessions` | Dataset for writes and recall |

--- a/integrations/claude-code/tests/test_config_precedence.py
+++ b/integrations/claude-code/tests/test_config_precedence.py
@@ -1,0 +1,204 @@
+"""Config precedence matrix: env > config file > defaults (config.py).
+
+Run: python integrations/claude-code/tests/test_config_precedence.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load_config_module():
+    spec = importlib.util.spec_from_file_location("cc_config", _SCRIPTS / "config.py")
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# (config_key, env_var, file_value, env_value, default_value, extra_env, file_extra)
+PRECEDENCE_MATRIX = [
+    ("dataset", "COGNEE_PLUGIN_DATASET", "file_dataset", "env_dataset", "agent_sessions", {}, {}),
+    ("agent_name", "COGNEE_AGENT_NAME", "file_agent", "env_agent", "claude-code-agent", {}, {}),
+    (
+        "session_strategy",
+        "COGNEE_SESSION_STRATEGY",
+        "git-branch",
+        "static",
+        "per-directory",
+        {},
+        {},
+    ),
+    ("session_prefix", "COGNEE_SESSION_PREFIX", "file_prefix", "env_prefix", "claude", {}, {}),
+    (
+        "base_url",
+        "COGNEE_BASE_URL",
+        "http://file:9000",
+        "http://env:8000",
+        "",
+        {"COGNEE_CLAUDE_BACKEND": "http"},
+        {},
+    ),
+    (
+        "api_key",
+        "COGNEE_API_KEY",
+        "file-key",
+        "env-key",
+        "",
+        {"COGNEE_CLAUDE_BACKEND": "http", "COGNEE_BASE_URL": "http://env:8000"},
+        {"base_url": "http://file:9000", "backend": "http"},
+    ),
+    ("user_email", "COGNEE_USER_EMAIL", "file@example.com", "env@example.com", "default_user@example.com", {}, {}),
+    (
+        "user_password",
+        "COGNEE_USER_PASSWORD",
+        "file-pass",
+        "env-pass",
+        "default_password",
+        {},
+        {},
+    ),
+    ("llm_api_key", "LLM_API_KEY", "file-llm", "env-llm", "", {}, {}),
+    ("llm_model", "LLM_MODEL", "file-model", "env-model", "", {}, {}),
+    (
+        "prefer_cognee_memory",
+        "COGNEE_PREFER_MEMORY",
+        "false",
+        "true",
+        True,
+        {},
+        {},
+    ),
+    (
+        "cognify_poll_interval",
+        "COGNEE_COGNIFY_POLL_INTERVAL",
+        "5.0",
+        "9.0",
+        3.0,
+        {},
+        {},
+    ),
+    (
+        "bridge_poll_deadline",
+        "COGNEE_BRIDGE_POLL_DEADLINE",
+        "100.0",
+        "200.0",
+        600.0,
+        {},
+        {},
+    ),
+    (
+        "bridge_submit_timeout",
+        "COGNEE_BRIDGE_SUBMIT_TIMEOUT",
+        "15.0",
+        "25.0",
+        30.0,
+        {},
+        {},
+    ),
+    (
+        "remember_wait_seconds",
+        "COGNEE_REMEMBER_WAIT_SECONDS",
+        "4.0",
+        "6.0",
+        8.0,
+        {},
+        {},
+    ),
+    (
+        "status_request_timeout",
+        "COGNEE_STATUS_REQUEST_TIMEOUT",
+        "12.0",
+        "18.0",
+        10.0,
+        {},
+        {},
+    ),
+    (
+        "_static_session_id",
+        "COGNEE_SESSION_ID",
+        "file-session",
+        "env-session",
+        None,
+        {},
+        {},
+    ),
+    ("backend", "COGNEE_CLAUDE_BACKEND", "http", "cloud", "auto", {}, {}),
+]
+
+
+def _coerce(actual, expected):
+    if isinstance(expected, bool) and isinstance(actual, str):
+        return str(actual).lower() in {"1", "true", "yes", "on"} if expected else str(actual).lower() in {
+            "0",
+            "false",
+            "no",
+            "off",
+        }
+    if isinstance(expected, float) and isinstance(actual, str):
+        return float(actual) == expected
+    if expected is None:
+        return actual is None or actual == ""
+    return actual == expected
+
+
+def test_precedence_matrix():
+    mod = _load_config_module()
+    config_file = pathlib.Path(tempfile.mktemp(suffix=".json"))
+    mod._CONFIG_FILE = config_file
+
+    all_env_keys = {row[1] for row in PRECEDENCE_MATRIX}
+    all_env_keys.update(
+        key for row in PRECEDENCE_MATRIX for key in row[5].keys()
+    )
+
+    saved_env = {key: os.environ.get(key) for key in all_env_keys}
+    try:
+        for config_key, env_var, file_val, env_val, default_val, extra_env, file_extra in PRECEDENCE_MATRIX:
+            for key in all_env_keys:
+                os.environ.pop(key, None)
+
+            config_file.write_text(json.dumps({}), encoding="utf-8")
+            cfg = mod.load_config()
+            assert _coerce(cfg.get(config_key), default_val), (
+                f"{config_key}: expected default {default_val!r}, got {cfg.get(config_key)!r}"
+            )
+
+            file_payload = {config_key: file_val, **file_extra}
+            config_file.write_text(json.dumps(file_payload), encoding="utf-8")
+            cfg = mod.load_config()
+            assert _coerce(cfg.get(config_key), file_val), (
+                f"{config_key}: expected file value {file_val!r}, got {cfg.get(config_key)!r}"
+            )
+
+            os.environ[env_var] = env_val
+            for extra_key, extra_val in extra_env.items():
+                os.environ[extra_key] = extra_val
+            cfg = mod.load_config()
+            assert _coerce(cfg.get(config_key), env_val), (
+                f"{config_key}: expected env value {env_val!r}, got {cfg.get(config_key)!r}"
+            )
+    finally:
+        for key, value in saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        if config_file.exists():
+            config_file.unlink()
+
+
+if __name__ == "__main__":
+    try:
+        test_precedence_matrix()
+        print("PASS test_precedence_matrix")
+    except AssertionError as exc:
+        print("FAIL test_precedence_matrix", exc)
+        sys.exit(1)

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -199,6 +199,8 @@ Config precedence:
 2. `~/.cognee-plugin/config.json`
 3. defaults
 
+Precedence is covered by `plugins/cognee/tests/test_config_precedence.py`.
+
 | Key | Env var(s) | Default | Notes |
 |---|---|---|---|
 | `dataset` | `COGNEE_PLUGIN_DATASET` | `agent_sessions` | Dataset for writes and recall |

--- a/integrations/codex/plugins/cognee/tests/test_config_precedence.py
+++ b/integrations/codex/plugins/cognee/tests/test_config_precedence.py
@@ -1,0 +1,138 @@
+"""Config precedence matrix: env > config file > defaults (config.py).
+
+Run: python integrations/codex/plugins/cognee/tests/test_config_precedence.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load_config_module():
+    spec = importlib.util.spec_from_file_location("codex_config", _SCRIPTS / "config.py")
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+PRECEDENCE_MATRIX = [
+    ("dataset", "COGNEE_PLUGIN_DATASET", "file_dataset", "env_dataset", "agent_sessions", {}, {}),
+    ("agent_name", "COGNEE_AGENT_NAME", "file_agent", "env_agent", "codex-agent", {}, {}),
+    (
+        "session_strategy",
+        "COGNEE_SESSION_STRATEGY",
+        "git-branch",
+        "static",
+        "per-directory",
+        {},
+        {},
+    ),
+    ("session_prefix", "COGNEE_SESSION_PREFIX", "file_prefix", "env_prefix", "codex", {}, {}),
+    (
+        "base_url",
+        "COGNEE_BASE_URL",
+        "http://file:9000",
+        "http://env:8000",
+        "",
+        {"COGNEE_CODEX_BACKEND": "http"},
+        {},
+    ),
+    (
+        "api_key",
+        "COGNEE_API_KEY",
+        "file-key",
+        "env-key",
+        "",
+        {"COGNEE_CODEX_BACKEND": "http", "COGNEE_BASE_URL": "http://env:8000"},
+        {"base_url": "http://file:9000", "backend": "http"},
+    ),
+    ("user_email", "COGNEE_USER_EMAIL", "file@example.com", "env@example.com", "default_user@example.com", {}, {}),
+    (
+        "user_password",
+        "COGNEE_USER_PASSWORD",
+        "file-pass",
+        "env-pass",
+        "default_password",
+        {},
+        {},
+    ),
+    ("llm_api_key", "LLM_API_KEY", "file-llm", "env-llm", "", {}, {}),
+    ("llm_model", "LLM_MODEL", "file-model", "env-model", "", {}, {}),
+    (
+        "_static_session_id",
+        "COGNEE_SESSION_ID",
+        "file-session",
+        "env-session",
+        None,
+        {},
+        {},
+    ),
+    ("backend", "COGNEE_CODEX_BACKEND", "http", "cloud", "auto", {}, {}),
+]
+
+
+def _coerce(actual, expected):
+    if expected is None:
+        return actual is None or actual == ""
+    return actual == expected
+
+
+def test_precedence_matrix():
+    mod = _load_config_module()
+    config_file = pathlib.Path(tempfile.mktemp(suffix=".json"))
+    mod._CONFIG_FILE = config_file
+
+    all_env_keys = {row[1] for row in PRECEDENCE_MATRIX}
+    all_env_keys.update(key for row in PRECEDENCE_MATRIX for key in row[5].keys())
+
+    saved_env = {key: os.environ.get(key) for key in all_env_keys}
+    try:
+        for config_key, env_var, file_val, env_val, default_val, extra_env, file_extra in PRECEDENCE_MATRIX:
+            for key in all_env_keys:
+                os.environ.pop(key, None)
+
+            config_file.write_text(json.dumps({}), encoding="utf-8")
+            cfg = mod.load_config()
+            assert _coerce(cfg.get(config_key), default_val), (
+                f"{config_key}: expected default {default_val!r}, got {cfg.get(config_key)!r}"
+            )
+
+            file_payload = {config_key: file_val, **file_extra}
+            config_file.write_text(json.dumps(file_payload), encoding="utf-8")
+            cfg = mod.load_config()
+            assert _coerce(cfg.get(config_key), file_val), (
+                f"{config_key}: expected file value {file_val!r}, got {cfg.get(config_key)!r}"
+            )
+
+            os.environ[env_var] = env_val
+            for extra_key, extra_val in extra_env.items():
+                os.environ[extra_key] = extra_val
+            cfg = mod.load_config()
+            assert _coerce(cfg.get(config_key), env_val), (
+                f"{config_key}: expected env value {env_val!r}, got {cfg.get(config_key)!r}"
+            )
+    finally:
+        for key, value in saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        if config_file.exists():
+            config_file.unlink()
+
+
+if __name__ == "__main__":
+    try:
+        test_precedence_matrix()
+        print("PASS test_precedence_matrix")
+    except AssertionError as exc:
+        print("FAIL test_precedence_matrix", exc)
+        sys.exit(1)

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -48,6 +48,14 @@ cognee = "cognee_integration_hermes"
 The setup wizard writes non-secret settings to `$HERMES_HOME/cognee.json` and
 secrets to `$HERMES_HOME/.env`.
 
+Config precedence:
+
+1. environment variables
+2. `$HERMES_HOME/cognee.json`
+3. defaults
+
+Precedence is covered by `tests/test_config_precedence.py`.
+
 ### Modes
 
 The provider connects to cognee in one of three modes. It picks the mode

--- a/integrations/hermes-agent/cognee_integration_hermes/config.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/config.py
@@ -11,6 +11,54 @@ DEFAULT_DATASET = "hermes"
 DEFAULT_IDENTITY_EMAIL = "hermes-agent@cognee.local"
 DEFAULT_IDENTITY_PASSWORD = "hermes-agent-plugin"
 
+_DEFAULTS: dict[str, Any] = {
+    "llm_api_key": "",
+    "llm_model": "",
+    "service_url": "",
+    "api_key": "",
+    "embedded": False,
+    "local_port": 8000,
+    "server_boot_timeout": 30,
+    "dataset": DEFAULT_DATASET,
+    "top_k": 5,
+    "auto_route": True,
+    "improve_on_end": True,
+    "improve_background": "",
+    "session_prefix": "hermes",
+    "data_root": "",
+    "system_root": "",
+    "identity_email": DEFAULT_IDENTITY_EMAIL,
+    "identity_password": DEFAULT_IDENTITY_PASSWORD,
+    "recall_timeout": 60,
+    "write_timeout": 120,
+    "improve_timeout": 300,
+}
+
+# Env var overrides (env var name → config key). COGNEE_SERVICE_URL is handled
+# separately as a deprecated alias for COGNEE_BASE_URL.
+_ENV_MAP: dict[str, str] = {
+    "LLM_API_KEY": "llm_api_key",
+    "LLM_MODEL": "llm_model",
+    "COGNEE_BASE_URL": "service_url",
+    "COGNEE_API_KEY": "api_key",
+    "COGNEE_EMBEDDED": "embedded",
+    "COGNEE_LOCAL_PORT": "local_port",
+    "COGNEE_SERVER_BOOT_TIMEOUT": "server_boot_timeout",
+    "COGNEE_DATASET": "dataset",
+    "COGNEE_TOP_K": "top_k",
+    "COGNEE_AUTO_ROUTE": "auto_route",
+    "COGNEE_IMPROVE_ON_END": "improve_on_end",
+    "COGNEE_IMPROVE_BACKGROUND": "improve_background",
+    "COGNEE_SESSION_PREFIX": "session_prefix",
+    "COGNEE_DATA_ROOT": "data_root",
+    "COGNEE_SYSTEM_ROOT": "system_root",
+    "COGNEE_HERMES_USER_EMAIL": "identity_email",
+    "COGNEE_HERMES_USER_PASSWORD": "identity_password",
+    "COGNEE_RECALL_TIMEOUT": "recall_timeout",
+    "COGNEE_WRITE_TIMEOUT": "write_timeout",
+    "COGNEE_IMPROVE_TIMEOUT": "improve_timeout",
+}
+
 
 def str_to_bool(value: Any, default: bool = False) -> bool:
     if isinstance(value, bool):
@@ -48,53 +96,20 @@ def config_path(hermes_home: str | Path | None = None) -> Path | None:
     return home / "cognee.json" if home else None
 
 
-def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
-    """Load plugin config from environment variables and HERMES_HOME/cognee.json."""
-    # COGNEE_BASE_URL is the canonical name; COGNEE_SERVICE_URL is a deprecated alias
-    # kept for backward compatibility. A set service_url selects remote/cloud mode.
-    service_url = os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_SERVICE_URL", "")
-    config: dict[str, Any] = {
-        "llm_api_key": os.environ.get("LLM_API_KEY", ""),
-        "llm_model": os.environ.get("LLM_MODEL", ""),
-        "service_url": service_url,
-        "api_key": os.environ.get("COGNEE_API_KEY", ""),
-        # Connection mode knobs (see provider.initialize / README "Modes").
-        # embedded=true runs cognee in-process (single-process/offline only);
-        # otherwise local mode ensures a local server on local_port (DB-safe).
-        "embedded": str_to_bool(os.environ.get("COGNEE_EMBEDDED"), False),
-        "local_port": str_to_int(os.environ.get("COGNEE_LOCAL_PORT"), 8000),
-        "server_boot_timeout": str_to_int(os.environ.get("COGNEE_SERVER_BOOT_TIMEOUT"), 30),
-        "dataset": os.environ.get("COGNEE_DATASET", DEFAULT_DATASET),
-        "top_k": str_to_int(os.environ.get("COGNEE_TOP_K"), 5),
-        "auto_route": str_to_bool(os.environ.get("COGNEE_AUTO_ROUTE"), True),
-        "improve_on_end": str_to_bool(os.environ.get("COGNEE_IMPROVE_ON_END"), True),
-        # Tri-state: "" = auto (background only in server/remote mode, where the
-        # server outlives this process; synchronous in embedded). Set to force.
-        "improve_background": os.environ.get("COGNEE_IMPROVE_BACKGROUND", ""),
-        "session_prefix": os.environ.get("COGNEE_SESSION_PREFIX", "hermes"),
-        "data_root": os.environ.get("COGNEE_DATA_ROOT", ""),
-        "system_root": os.environ.get("COGNEE_SYSTEM_ROOT", ""),
-        "identity_email": os.environ.get("COGNEE_HERMES_USER_EMAIL", DEFAULT_IDENTITY_EMAIL),
-        "identity_password": os.environ.get(
-            "COGNEE_HERMES_USER_PASSWORD",
-            DEFAULT_IDENTITY_PASSWORD,
-        ),
-        "recall_timeout": str_to_int(os.environ.get("COGNEE_RECALL_TIMEOUT"), 60),
-        "write_timeout": str_to_int(os.environ.get("COGNEE_WRITE_TIMEOUT"), 120),
-        "improve_timeout": str_to_int(os.environ.get("COGNEE_IMPROVE_TIMEOUT"), 300),
-    }
+def _apply_env_overrides(config: dict[str, Any]) -> None:
+    for env_key, config_key in _ENV_MAP.items():
+        val = os.environ.get(env_key, "")
+        if val:
+            config[config_key] = val
 
-    path = config_path(hermes_home)
-    if path and path.exists():
-        try:
-            file_config = json.loads(path.read_text(encoding="utf-8"))
-            if isinstance(file_config, dict):
-                config.update(
-                    {key: value for key, value in file_config.items() if value is not None}
-                )
-        except Exception:
-            pass
+    # Deprecated alias — only when canonical COGNEE_BASE_URL is unset.
+    if not os.environ.get("COGNEE_BASE_URL", ""):
+        legacy = os.environ.get("COGNEE_SERVICE_URL", "")
+        if legacy:
+            config["service_url"] = legacy
 
+
+def _normalize_config(config: dict[str, Any]) -> dict[str, Any]:
     config["top_k"] = max(1, str_to_int(config.get("top_k"), 5))
     config["recall_timeout"] = max(1, str_to_int(config.get("recall_timeout"), 60))
     config["write_timeout"] = max(1, str_to_int(config.get("write_timeout"), 120))
@@ -105,6 +120,29 @@ def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
     config["improve_on_end"] = str_to_bool(config.get("improve_on_end"), True)
     config["embedded"] = str_to_bool(config.get("embedded"), False)
     return config
+
+
+def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
+    """Load merged config: defaults → file → env vars."""
+    config = dict(_DEFAULTS)
+
+    path = config_path(hermes_home)
+    if path and path.exists():
+        try:
+            file_config = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(file_config, dict):
+                config.update(
+                    {
+                        key: value
+                        for key, value in file_config.items()
+                        if value is not None and value != ""
+                    }
+                )
+        except Exception:
+            pass
+
+    _apply_env_overrides(config)
+    return _normalize_config(config)
 
 
 def save_config(values: dict[str, Any], hermes_home: str | Path) -> Path:

--- a/integrations/hermes-agent/tests/test_config_precedence.py
+++ b/integrations/hermes-agent/tests/test_config_precedence.py
@@ -1,0 +1,101 @@
+"""Config precedence matrix: env > config file > defaults (config.py)."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from cognee_integration_hermes.config import _DEFAULTS, _ENV_MAP, load_config, save_config
+
+PRECEDENCE_MATRIX = [
+    ("dataset", "COGNEE_DATASET", "file_dataset", "env_dataset"),
+    ("top_k", "COGNEE_TOP_K", "7", "9"),
+    ("auto_route", "COGNEE_AUTO_ROUTE", "false", "true"),
+    ("improve_on_end", "COGNEE_IMPROVE_ON_END", "false", "true"),
+    ("improve_background", "COGNEE_IMPROVE_BACKGROUND", "false", "true"),
+    ("session_prefix", "COGNEE_SESSION_PREFIX", "file_prefix", "env_prefix"),
+    ("service_url", "COGNEE_BASE_URL", "https://file.example", "https://env.example"),
+    ("api_key", "COGNEE_API_KEY", "file-key", "env-key"),
+    ("llm_api_key", "LLM_API_KEY", "file-llm", "env-llm"),
+    ("llm_model", "LLM_MODEL", "file-model", "env-model"),
+    ("embedded", "COGNEE_EMBEDDED", "false", "true"),
+    ("local_port", "COGNEE_LOCAL_PORT", "9001", "9002"),
+    ("server_boot_timeout", "COGNEE_SERVER_BOOT_TIMEOUT", "45", "55"),
+    ("data_root", "COGNEE_DATA_ROOT", "/file/data", "/env/data"),
+    ("system_root", "COGNEE_SYSTEM_ROOT", "/file/system", "/env/system"),
+    (
+        "identity_email",
+        "COGNEE_HERMES_USER_EMAIL",
+        "file@example.com",
+        "env@example.com",
+    ),
+    (
+        "identity_password",
+        "COGNEE_HERMES_USER_PASSWORD",
+        "file-pass",
+        "env-pass",
+    ),
+    ("recall_timeout", "COGNEE_RECALL_TIMEOUT", "70", "80"),
+    ("write_timeout", "COGNEE_WRITE_TIMEOUT", "130", "140"),
+    ("improve_timeout", "COGNEE_IMPROVE_TIMEOUT", "310", "320"),
+]
+
+
+def _coerce_boolish(actual, expected_str: str) -> bool:
+    if isinstance(actual, bool):
+        return str(actual).lower() == expected_str.lower()
+    return str(actual).lower() == expected_str.lower()
+
+
+@pytest.mark.parametrize(
+    "config_key,env_var,file_val,env_val",
+    PRECEDENCE_MATRIX,
+    ids=[row[0] for row in PRECEDENCE_MATRIX],
+)
+def test_precedence_matrix(config_key, env_var, file_val, env_val, tmp_path, monkeypatch):
+    for key in _ENV_MAP:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv("COGNEE_SERVICE_URL", raising=False)
+
+    cfg = load_config(tmp_path)
+    assert cfg[config_key] == _DEFAULTS[config_key]
+
+    save_config({config_key: file_val}, tmp_path)
+    cfg = load_config(tmp_path)
+    expected_file = file_val
+    if config_key in {"top_k", "local_port", "server_boot_timeout", "recall_timeout", "write_timeout", "improve_timeout"}:
+        expected_file = int(file_val)
+    elif config_key in {"auto_route", "improve_on_end", "embedded"}:
+        assert _coerce_boolish(cfg[config_key], file_val)
+        monkeypatch.setenv(env_var, env_val)
+        cfg = load_config(tmp_path)
+        assert _coerce_boolish(cfg[config_key], env_val)
+        return
+
+    assert cfg[config_key] == expected_file
+
+    monkeypatch.setenv(env_var, env_val)
+    cfg = load_config(tmp_path)
+    if config_key in {"top_k", "local_port", "server_boot_timeout", "recall_timeout", "write_timeout", "improve_timeout"}:
+        assert cfg[config_key] == int(env_val)
+    else:
+        assert cfg[config_key] == env_val
+
+
+def test_env_overrides_file_service_url(tmp_path, monkeypatch):
+    monkeypatch.delenv("COGNEE_SERVICE_URL", raising=False)
+    monkeypatch.setenv("COGNEE_BASE_URL", "https://from-env.example")
+    save_config({"service_url": "https://from-file.example"}, tmp_path)
+    assert load_config(tmp_path)["service_url"] == "https://from-env.example"
+
+
+def test_base_url_preferred_over_service_url(tmp_path, monkeypatch):
+    monkeypatch.delenv("COGNEE_BASE_URL", raising=False)
+    monkeypatch.setenv("COGNEE_SERVICE_URL", "https://legacy.example")
+    save_config({"service_url": "https://file.example"}, tmp_path)
+    assert load_config(tmp_path)["service_url"] == "https://legacy.example"
+
+    monkeypatch.setenv("COGNEE_BASE_URL", "https://canonical.example")
+    assert load_config(tmp_path)["service_url"] == "https://canonical.example"

--- a/integrations/hermes-agent/tests/test_smoke.py
+++ b/integrations/hermes-agent/tests/test_smoke.py
@@ -61,10 +61,11 @@ def test_save_and_load_config(tmp_path, monkeypatch):
     assert config["auto_route"] is False
 
 
-def test_empty_service_url_clears_remote_mode(tmp_path, monkeypatch):
+def test_env_overrides_file_service_url(tmp_path, monkeypatch):
     from cognee_integration_hermes.config import load_config, save_config
 
-    monkeypatch.setenv("COGNEE_SERVICE_URL", "https://remote.example")
-    save_config({"service_url": ""}, tmp_path)
+    monkeypatch.delenv("COGNEE_SERVICE_URL", raising=False)
+    monkeypatch.setenv("COGNEE_BASE_URL", "https://from-env.example")
+    save_config({"service_url": "https://from-file.example"}, tmp_path)
 
-    assert load_config(tmp_path)["service_url"] == ""
+    assert load_config(tmp_path)["service_url"] == "https://from-env.example"

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -184,6 +184,14 @@ This lets the agent distinguish between personal context, shared knowledge, and 
 
 ## Configuration Options
 
+Config precedence:
+
+1. environment variables
+2. plugin config in `openclaw.json` / gateway config
+3. defaults
+
+Precedence is covered by `npm run test:config-precedence` (`__tests__/test_configPrecedence.ts`).
+
 ### Connection
 
 | Option | Type | Default | Description |

--- a/integrations/openclaw/__tests__/test_configPrecedence.ts
+++ b/integrations/openclaw/__tests__/test_configPrecedence.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import {
+  DEFAULT_AUTO_RECALL,
+  DEFAULT_BASE_URL,
+  DEFAULT_DATASET_NAME,
+  DEFAULT_MAX_RESULTS,
+  DEFAULT_MIN_SCORE,
+  resolveConfig,
+} from "../src/config";
+import type { CogneePluginConfig } from "../src/types";
+
+type MatrixRow = {
+  configKey: keyof ReturnType<typeof resolveConfig>;
+  envVar: string;
+  fileValue: unknown;
+  envValue: string;
+  defaultValue: unknown;
+  fileConfig?: CogneePluginConfig;
+};
+
+const PRECEDENCE_MATRIX: MatrixRow[] = [
+  {
+    configKey: "baseUrl",
+    envVar: "COGNEE_BASE_URL",
+    fileValue: "http://file:9000",
+    envValue: "http://env:8000",
+    defaultValue: DEFAULT_BASE_URL,
+    fileConfig: { baseUrl: "http://file:9000" },
+  },
+  {
+    configKey: "datasetName",
+    envVar: "COGNEE_PLUGIN_DATASET",
+    fileValue: "file-dataset",
+    envValue: "env-dataset",
+    defaultValue: DEFAULT_DATASET_NAME,
+    fileConfig: { datasetName: "file-dataset" },
+  },
+  {
+    configKey: "maxResults",
+    envVar: "COGNEE_MAX_RESULTS",
+    fileValue: 7,
+    envValue: "9",
+    defaultValue: DEFAULT_MAX_RESULTS,
+    fileConfig: { maxResults: 7 },
+  },
+  {
+    configKey: "minScore",
+    envVar: "COGNEE_MIN_SCORE",
+    fileValue: 0.5,
+    envValue: "0.8",
+    defaultValue: DEFAULT_MIN_SCORE,
+    fileConfig: { minScore: 0.5 },
+  },
+  {
+    configKey: "autoRecall",
+    envVar: "COGNEE_AUTO_RECALL",
+    fileValue: false,
+    envValue: "true",
+    defaultValue: DEFAULT_AUTO_RECALL,
+    fileConfig: { autoRecall: false },
+  },
+  {
+    configKey: "mode",
+    envVar: "COGNEE_MODE",
+    fileValue: "local",
+    envValue: "cloud",
+    defaultValue: "local",
+    fileConfig: { mode: "local" },
+  },
+  {
+    configKey: "username",
+    envVar: "COGNEE_USERNAME",
+    fileValue: "file-user",
+    envValue: "env-user",
+    defaultValue: "",
+    fileConfig: { username: "file-user" },
+  },
+  {
+    configKey: "agentId",
+    envVar: "OPENCLAW_AGENT_ID",
+    fileValue: "file-agent",
+    envValue: "env-agent",
+    defaultValue: "default",
+    fileConfig: { agentId: "file-agent" },
+  },
+  {
+    configKey: "searchType",
+    envVar: "COGNEE_SEARCH_TYPE",
+    fileValue: "CHUNKS",
+    envValue: "RAG_COMPLETION",
+    defaultValue: "GRAPH_COMPLETION",
+    fileConfig: { searchType: "CHUNKS" },
+  },
+  {
+    configKey: "deleteMode",
+    envVar: "COGNEE_DELETE_MODE",
+    fileValue: "soft",
+    envValue: "hard",
+    defaultValue: "soft",
+    fileConfig: { deleteMode: "soft" },
+  },
+];
+
+function clearEnv(keys: string[]) {
+  for (const key of keys) {
+    delete process.env[key];
+  }
+}
+
+function expectEnvValue(
+  configKey: keyof ReturnType<typeof resolveConfig>,
+  envValue: string,
+  defaultValue: unknown,
+  actual: ReturnType<typeof resolveConfig>,
+) {
+  if (typeof defaultValue === "number") {
+    assert.equal(actual[configKey], Number(envValue));
+    return;
+  }
+  if (typeof defaultValue === "boolean") {
+    assert.equal(actual[configKey], envValue === "true" || envValue === "1");
+    return;
+  }
+  if (configKey === "mode") {
+    assert.equal(actual.mode, envValue);
+    return;
+  }
+  assert.equal(actual[configKey], envValue);
+}
+
+export function runConfigPrecedenceTests(): void {
+  const envKeys = PRECEDENCE_MATRIX.map((row) => row.envVar);
+
+  for (const row of PRECEDENCE_MATRIX) {
+    clearEnv(envKeys);
+
+    const defaultsOnly = resolveConfig({});
+    assert.equal(defaultsOnly[row.configKey], row.defaultValue);
+
+    const fromFile = resolveConfig(row.fileConfig ?? {});
+    assert.equal(
+      fromFile[row.configKey],
+      row.fileConfig?.[row.configKey as keyof CogneePluginConfig] ?? row.defaultValue,
+    );
+
+    process.env[row.envVar] = row.envValue;
+    const fromEnv = resolveConfig(row.fileConfig ?? {});
+    expectEnvValue(row.configKey, row.envValue, row.defaultValue, fromEnv);
+    clearEnv(envKeys);
+  }
+
+  process.env.COGNEE_API_KEY = "env-key";
+  assert.equal(resolveConfig({ apiKey: "file-key" }).apiKey, "env-key");
+  delete process.env.COGNEE_API_KEY;
+}
+
+function isDirectRun(): boolean {
+  const entry = process.argv[1]?.replace(/\\/g, "/") ?? "";
+  return entry.endsWith("test_configPrecedence.ts");
+}
+
+if (isDirectRun()) {
+  runConfigPrecedenceTests();
+  console.log("PASS config precedence matrix");
+}
+
+const jestDescribe = (globalThis as { describe?: typeof describe }).describe;
+if (jestDescribe) {
+  jestDescribe("resolveConfig precedence (env > plugin config > defaults)", () => {
+  const envKeys = PRECEDENCE_MATRIX.map((row) => row.envVar);
+
+  afterEach(() => {
+    clearEnv(envKeys);
+    delete process.env.COGNEE_API_KEY;
+  });
+
+  it.each(PRECEDENCE_MATRIX)(
+    "$configKey uses default, then file, then env",
+    ({ configKey, envVar, envValue, defaultValue, fileConfig }) => {
+      clearEnv(envKeys);
+
+      const defaultsOnly = resolveConfig({});
+      expect(defaultsOnly[configKey]).toEqual(defaultValue);
+
+      const fromFile = resolveConfig(fileConfig ?? {});
+      expect(fromFile[configKey]).toEqual(
+        fileConfig?.[configKey as keyof CogneePluginConfig] ?? defaultValue,
+      );
+
+      process.env[envVar] = envValue;
+      const fromEnv = resolveConfig(fileConfig ?? {});
+      if (typeof defaultValue === "number") {
+        expect(fromEnv[configKey]).toEqual(Number(envValue));
+      } else if (typeof defaultValue === "boolean") {
+        expect(fromEnv[configKey]).toBe(envValue === "true" || envValue === "1");
+      } else if (configKey === "mode") {
+        expect(fromEnv.mode).toBe(envValue);
+      } else {
+        expect(fromEnv[configKey]).toBe(envValue);
+      }
+    },
+  );
+
+  it("COGNEE_API_KEY overrides plugin apiKey", () => {
+    process.env.COGNEE_API_KEY = "env-key";
+    const cfg = resolveConfig({ apiKey: "file-key" });
+    expect(cfg.apiKey).toBe("env-key");
+  });
+  });
+}

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -20,7 +20,8 @@
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
-    "test": "jest"
+    "test": "jest",
+    "test:config-precedence": "npx tsx __tests__/test_configPrecedence.ts"
   },
   "jest": {
     "preset": "ts-jest",

--- a/integrations/openclaw/src/config.ts
+++ b/integrations/openclaw/src/config.ts
@@ -35,6 +35,14 @@ export const DEFAULT_SCOPE_ROUTING: ScopeRoute[] = [
 /** Glob patterns for memory files, relative to workspace root. */
 export const MEMORY_FILE_PATTERNS = ["MEMORY.md", "memory"];
 
+const VALID_RECALL_POSITIONS = [
+  "prependSystemContext",
+  "appendSystemContext",
+  "prependContext",
+] as const;
+
+const VALID_WRITE_SCOPES: MemoryScope[] = ["company", "user", "agent"];
+
 // ---------------------------------------------------------------------------
 // Env var resolution
 // ---------------------------------------------------------------------------
@@ -49,8 +57,157 @@ export function resolveEnvVars(value: string): string {
   });
 }
 
+function envTrim(key: string): string | undefined {
+  const value = process.env[key]?.trim();
+  return value ? value : undefined;
+}
+
+function pickString(options: {
+  envKeys?: string | string[];
+  file?: string | undefined;
+  defaultValue: string;
+}): string {
+  const keys = options.envKeys
+    ? Array.isArray(options.envKeys)
+      ? options.envKeys
+      : [options.envKeys]
+    : [];
+  for (const key of keys) {
+    const env = envTrim(key);
+    if (env !== undefined) return env;
+  }
+  const file = options.file?.trim();
+  if (file) return file;
+  return options.defaultValue;
+}
+
+function pickOptionalString(options: {
+  envKeys?: string | string[];
+  file?: string | undefined;
+}): string {
+  const keys = options.envKeys
+    ? Array.isArray(options.envKeys)
+      ? options.envKeys
+      : [options.envKeys]
+    : [];
+  for (const key of keys) {
+    const env = envTrim(key);
+    if (env !== undefined) return env;
+  }
+  return options.file?.trim() || "";
+}
+
+function pickBool(options: {
+  envKey?: string;
+  file?: boolean | undefined;
+  defaultValue: boolean;
+}): boolean {
+  if (options.envKey) {
+    const env = process.env[options.envKey];
+    if (env !== undefined && env !== "") {
+      return env === "true" || env === "1";
+    }
+  }
+  if (typeof options.file === "boolean") return options.file;
+  return options.defaultValue;
+}
+
+function pickNumber(options: {
+  envKey?: string;
+  file?: number | undefined;
+  defaultValue: number;
+}): number {
+  if (options.envKey) {
+    const env = process.env[options.envKey];
+    if (env !== undefined && env !== "") {
+      const parsed = Number(env);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  if (typeof options.file === "number") return options.file;
+  return options.defaultValue;
+}
+
+function pickMode(raw: CogneePluginConfig): CogneeMode {
+  const env = envTrim("COGNEE_MODE");
+  if (env === "cloud" || env === "local") return env;
+  return raw.mode === "cloud" ? "cloud" : "local";
+}
+
+function pickDeleteMode(raw: CogneePluginConfig): "soft" | "hard" {
+  const env = envTrim("COGNEE_DELETE_MODE");
+  if (env === "hard") return "hard";
+  if (env === "soft") return "soft";
+  return raw.deleteMode === "hard" ? "hard" : DEFAULT_DELETE_MODE;
+}
+
+function pickSearchType(raw: CogneePluginConfig): CogneeSearchType {
+  const env = envTrim("COGNEE_SEARCH_TYPE");
+  if (env) return env as CogneeSearchType;
+  return raw.searchType || DEFAULT_SEARCH_TYPE;
+}
+
+function pickRecallInjectionPosition(
+  raw: CogneePluginConfig,
+): (typeof VALID_RECALL_POSITIONS)[number] {
+  const env = envTrim("COGNEE_RECALL_INJECTION_POSITION");
+  if (env && VALID_RECALL_POSITIONS.includes(env as (typeof VALID_RECALL_POSITIONS)[number])) {
+    return env as (typeof VALID_RECALL_POSITIONS)[number];
+  }
+  if (
+    raw.recallInjectionPosition &&
+    VALID_RECALL_POSITIONS.includes(raw.recallInjectionPosition)
+  ) {
+    return raw.recallInjectionPosition;
+  }
+  return DEFAULT_RECALL_INJECTION_POSITION;
+}
+
+function pickWriteScope(raw: CogneePluginConfig): MemoryScope {
+  const env = envTrim("COGNEE_DEFAULT_WRITE_SCOPE");
+  if (env && VALID_WRITE_SCOPES.includes(env as MemoryScope)) {
+    return env as MemoryScope;
+  }
+  return raw.defaultWriteScope || DEFAULT_WRITE_SCOPE;
+}
+
+function pickRecallScopes(raw: CogneePluginConfig): MemoryScope[] {
+  const env = envTrim("COGNEE_RECALL_SCOPES");
+  if (env) {
+    try {
+      const parsed = JSON.parse(env);
+      if (Array.isArray(parsed)) return parsed as MemoryScope[];
+    } catch {
+      // fall through to file/default
+    }
+  }
+  return Array.isArray(raw.recallScopes) ? raw.recallScopes : DEFAULT_RECALL_SCOPES;
+}
+
+function pickScopeRouting(raw: CogneePluginConfig): ScopeRoute[] {
+  const env = envTrim("COGNEE_SCOPE_ROUTING");
+  if (env) {
+    try {
+      const parsed = JSON.parse(env);
+      if (Array.isArray(parsed)) return parsed as ScopeRoute[];
+    } catch {
+      // fall through to file/default
+    }
+  }
+  return Array.isArray(raw.scopeRouting) ? raw.scopeRouting : DEFAULT_SCOPE_ROUTING;
+}
+
+function resolveApiKey(raw: CogneePluginConfig): string {
+  const env = envTrim("COGNEE_API_KEY");
+  if (env !== undefined) return env;
+  if (raw.apiKey && raw.apiKey.length > 0) {
+    return resolveEnvVars(raw.apiKey);
+  }
+  return "";
+}
+
 // ---------------------------------------------------------------------------
-// Config resolution
+// Config resolution (precedence: env > plugin config file > defaults)
 // ---------------------------------------------------------------------------
 
 export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> {
@@ -59,66 +216,152 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
       ? (rawConfig as CogneePluginConfig)
       : {};
 
-  const mode: CogneeMode = raw.mode === "cloud" || process.env.COGNEE_MODE === "cloud" ? "cloud" : "local";
-  const baseUrl = raw.baseUrl?.trim() || process.env.COGNEE_BASE_URL?.trim() || DEFAULT_BASE_URL;
-  const datasetName = raw.datasetName?.trim() || DEFAULT_DATASET_NAME;
-  const searchType = raw.searchType || DEFAULT_SEARCH_TYPE;
-  const searchPrompt = raw.searchPrompt || "";
-  const deleteMode = raw.deleteMode === "hard" ? "hard" : DEFAULT_DELETE_MODE;
-  const maxResults = typeof raw.maxResults === "number" ? raw.maxResults : DEFAULT_MAX_RESULTS;
-  const minScore = typeof raw.minScore === "number" ? raw.minScore : DEFAULT_MIN_SCORE;
-  const maxTokens = typeof raw.maxTokens === "number" ? raw.maxTokens : DEFAULT_MAX_TOKENS;
-  const autoRecall = typeof raw.autoRecall === "boolean" ? raw.autoRecall : DEFAULT_AUTO_RECALL;
-  const autoIndex = typeof raw.autoIndex === "boolean" ? raw.autoIndex : DEFAULT_AUTO_INDEX;
-  const autoCognify = typeof raw.autoCognify === "boolean" ? raw.autoCognify : DEFAULT_AUTO_COGNIFY;
-  const autoMemify = typeof raw.autoMemify === "boolean" ? raw.autoMemify : DEFAULT_AUTO_MEMIFY;
-  const improveOnSessionEnd = typeof raw.improveOnSessionEnd === "boolean" ? raw.improveOnSessionEnd : DEFAULT_IMPROVE_ON_SESSION_END;
-  const requestTimeoutMs = typeof raw.requestTimeoutMs === "number" ? raw.requestTimeoutMs : DEFAULT_REQUEST_TIMEOUT_MS;
-  const ingestionTimeoutMs = typeof raw.ingestionTimeoutMs === "number" ? raw.ingestionTimeoutMs : DEFAULT_INGESTION_TIMEOUT_MS;
+  const mode = pickMode(raw);
+  const baseUrl = pickString({
+    envKeys: "COGNEE_BASE_URL",
+    file: raw.baseUrl,
+    defaultValue: DEFAULT_BASE_URL,
+  });
+  const datasetName = pickString({
+    envKeys: ["COGNEE_PLUGIN_DATASET", "COGNEE_DATASET"],
+    file: raw.datasetName,
+    defaultValue: DEFAULT_DATASET_NAME,
+  });
+  const searchType = pickSearchType(raw);
+  const searchPrompt = pickOptionalString({ envKeys: "COGNEE_SEARCH_PROMPT", file: raw.searchPrompt });
+  const deleteMode = pickDeleteMode(raw);
+  const maxResults = pickNumber({
+    envKey: "COGNEE_MAX_RESULTS",
+    file: raw.maxResults,
+    defaultValue: DEFAULT_MAX_RESULTS,
+  });
+  const minScore = pickNumber({
+    envKey: "COGNEE_MIN_SCORE",
+    file: raw.minScore,
+    defaultValue: DEFAULT_MIN_SCORE,
+  });
+  const maxTokens = pickNumber({
+    envKey: "COGNEE_MAX_TOKENS",
+    file: raw.maxTokens,
+    defaultValue: DEFAULT_MAX_TOKENS,
+  });
+  const autoRecall = pickBool({
+    envKey: "COGNEE_AUTO_RECALL",
+    file: raw.autoRecall,
+    defaultValue: DEFAULT_AUTO_RECALL,
+  });
+  const autoIndex = pickBool({
+    envKey: "COGNEE_AUTO_INDEX",
+    file: raw.autoIndex,
+    defaultValue: DEFAULT_AUTO_INDEX,
+  });
+  const autoCognify = pickBool({
+    envKey: "COGNEE_AUTO_COGNIFY",
+    file: raw.autoCognify,
+    defaultValue: DEFAULT_AUTO_COGNIFY,
+  });
+  const autoMemify = pickBool({
+    envKey: "COGNEE_AUTO_MEMIFY",
+    file: raw.autoMemify,
+    defaultValue: DEFAULT_AUTO_MEMIFY,
+  });
+  const improveOnSessionEnd = pickBool({
+    envKey: "COGNEE_IMPROVE_ON_SESSION_END",
+    file: raw.improveOnSessionEnd,
+    defaultValue: DEFAULT_IMPROVE_ON_SESSION_END,
+  });
+  const requestTimeoutMs = pickNumber({
+    envKey: "COGNEE_REQUEST_TIMEOUT_MS",
+    file: raw.requestTimeoutMs,
+    defaultValue: DEFAULT_REQUEST_TIMEOUT_MS,
+  });
+  const ingestionTimeoutMs = pickNumber({
+    envKey: "COGNEE_INGESTION_TIMEOUT_MS",
+    file: raw.ingestionTimeoutMs,
+    defaultValue: DEFAULT_INGESTION_TIMEOUT_MS,
+  });
 
-  const apiKey =
-    raw.apiKey && raw.apiKey.length > 0 ? resolveEnvVars(raw.apiKey)
-    : mode === "cloud" ? process.env.COGNEE_API_KEY || ""
-    : "";
-  const username = raw.username?.trim() || process.env.COGNEE_USERNAME || "";
-  const password = raw.password?.trim() || process.env.COGNEE_PASSWORD || "";
+  const apiKey = resolveApiKey(raw);
+  const username = pickOptionalString({ envKeys: "COGNEE_USERNAME", file: raw.username });
+  const password = pickOptionalString({ envKeys: "COGNEE_PASSWORD", file: raw.password });
 
-  // Multi-scope
-  const companyDataset = raw.companyDataset?.trim() || "";
-  const userDatasetPrefix = raw.userDatasetPrefix?.trim() || "";
-  const agentDatasetPrefix = raw.agentDatasetPrefix?.trim() || "";
-  const agentDatasetTemplate = raw.agentDatasetTemplate?.trim() || "";
-  const userId = raw.userId?.trim() || process.env.OPENCLAW_USER_ID || "";
-  const agentId = raw.agentId?.trim() || process.env.OPENCLAW_AGENT_ID || "default";
-  const recallScopes = Array.isArray(raw.recallScopes) ? raw.recallScopes : DEFAULT_RECALL_SCOPES;
-  const defaultWriteScope = raw.defaultWriteScope || DEFAULT_WRITE_SCOPE;
-  const scopeRouting = Array.isArray(raw.scopeRouting) ? raw.scopeRouting : DEFAULT_SCOPE_ROUTING;
+  const companyDataset = pickOptionalString({
+    envKeys: "COGNEE_COMPANY_DATASET",
+    file: raw.companyDataset,
+  });
+  const userDatasetPrefix = pickOptionalString({
+    envKeys: "COGNEE_USER_DATASET_PREFIX",
+    file: raw.userDatasetPrefix,
+  });
+  const agentDatasetPrefix = pickOptionalString({
+    envKeys: "COGNEE_AGENT_DATASET_PREFIX",
+    file: raw.agentDatasetPrefix,
+  });
+  const agentDatasetTemplate = pickOptionalString({
+    envKeys: "COGNEE_AGENT_DATASET_TEMPLATE",
+    file: raw.agentDatasetTemplate,
+  });
+  const userId = pickOptionalString({ envKeys: "OPENCLAW_USER_ID", file: raw.userId });
+  const agentId = pickString({
+    envKeys: "OPENCLAW_AGENT_ID",
+    file: raw.agentId,
+    defaultValue: "default",
+  });
+  const recallScopes = pickRecallScopes(raw);
+  const defaultWriteScope = pickWriteScope(raw);
+  const scopeRouting = pickScopeRouting(raw);
 
-  // Per-agent memory: opt-in. Explicit config wins. When unset, it defaults to
-  // false here and is auto-enabled in plugin.ts only when the gateway hosts
-  // multiple agents (agents.list.length > 1) — so single-agent installs keep
-  // the legacy shared behavior and are unaffected by the upgrade.
-  const perAgentMemory = typeof raw.perAgentMemory === "boolean" ? raw.perAgentMemory : false;
+  const perAgentMemory = pickBool({
+    envKey: "COGNEE_PER_AGENT_MEMORY",
+    file: raw.perAgentMemory,
+    defaultValue: false,
+  });
 
-  // Recall injection
-  const validPositions = ["prependSystemContext", "appendSystemContext", "prependContext"] as const;
-  const recallInjectionPosition = raw.recallInjectionPosition && validPositions.includes(raw.recallInjectionPosition)
-    ? raw.recallInjectionPosition
-    : DEFAULT_RECALL_INJECTION_POSITION;
+  const recallInjectionPosition = pickRecallInjectionPosition(raw);
 
-  // Session
-  const enableSessions = typeof raw.enableSessions === "boolean" ? raw.enableSessions : true;
-  const persistSessionsAfterEnd = typeof raw.persistSessionsAfterEnd === "boolean" ? raw.persistSessionsAfterEnd : true;
+  const enableSessions = pickBool({
+    envKey: "COGNEE_ENABLE_SESSIONS",
+    file: raw.enableSessions,
+    defaultValue: true,
+  });
+  const persistSessionsAfterEnd = pickBool({
+    envKey: "COGNEE_PERSIST_SESSIONS_AFTER_END",
+    file: raw.persistSessionsAfterEnd,
+    defaultValue: true,
+  });
 
   return {
-    mode, baseUrl, apiKey, username, password, datasetName,
-    companyDataset, userDatasetPrefix, agentDatasetPrefix, agentDatasetTemplate, userId, agentId,
-    recallScopes, defaultWriteScope, scopeRouting, perAgentMemory,
+    mode,
+    baseUrl,
+    apiKey,
+    username,
+    password,
+    datasetName,
+    companyDataset,
+    userDatasetPrefix,
+    agentDatasetPrefix,
+    agentDatasetTemplate,
+    userId,
+    agentId,
+    recallScopes,
+    defaultWriteScope,
+    scopeRouting,
+    perAgentMemory,
     recallInjectionPosition,
-    enableSessions, persistSessionsAfterEnd,
-    searchType, searchPrompt, deleteMode,
-    maxResults, minScore, maxTokens,
-    autoRecall, autoIndex, autoCognify, autoMemify, improveOnSessionEnd,
-    requestTimeoutMs, ingestionTimeoutMs,
+    enableSessions,
+    persistSessionsAfterEnd,
+    searchType,
+    searchPrompt,
+    deleteMode,
+    maxResults,
+    minScore,
+    maxTokens,
+    autoRecall,
+    autoIndex,
+    autoCognify,
+    autoMemify,
+    improveOnSessionEnd,
+    requestTimeoutMs,
+    ingestionTimeoutMs,
   };
 }


### PR DESCRIPTION
Adds config precedence coverage (env > config file > defaults) across the four scoped integrations and fixes inverted precedence in Hermes and OpenClaw.

Hermes (cognee_integration_hermes/config.py): restructured loader to defaults → cognee.json → env (previously file overwrote env)
OpenClaw (src/config.ts): resolveConfig now applies env overrides before plugin config; added env var support for settings that previously only had file/default resolution
Claude Code & Codex: loaders were already correct; added precedence matrix tests and README pointers
Tests: new test_config_precedence suite in each integration, asserting default → file → env for every overridable setting
Docs: precedence sections updated in all four READMEs
Test plan

 Claude Code: python integrations/claude-code/tests/test_config_precedence.py

 Codex: python integrations/codex/plugins/cognee/tests/test_config_precedence.py

 Hermes: pytest integrations/hermes-agent/tests/test_config_precedence.py -q

 OpenClaw: cd integrations/openclaw && npm run test:config-precedence

 OpenClaw typecheck: cd integrations/openclaw && npx tsc --noEmit

 Hermes smoke: confirm test_env_overrides_file_service_url passes (replaces old inverted-precedence test)
Closes #3559                                          