### PR TITLE
feat: Add cold-start warmup ping for remote sessions

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -138,6 +138,20 @@ in the launching shell, if your Claude Code version supports it).
 |---|---|---|
 | `COGNEE_PREFER_MEMORY` | `true` | Inject SessionStart steer asserting Cognee as the preferred memory |
 
+## Cold-start warmup
+
+When COGNEE_BASE_URL points at a cloud tenant that scales to zero, enable
+the warmup ping so the tenant begins waking up before the user's first recall:
+
+    export COGNEE_WARMUP=true
+
+The ping is non-blocking and fails silently. Off by default. No-op in local mode.
+
+| Env var                | Default | Effect                                                      |
+|------------------------|---------|-------------------------------------------------------------|
+| COGNEE_WARMUP          | false   | Fire background GET /health at SessionStart                 |
+| COGNEE_WARMUP_TIMEOUT  | 5       | Timeout in seconds for the warmup ping (non-blocking)       |
+
 ## Session sync and watchers
 
 An idle watcher runs in the background for the lifetime of each launch. It polls activity every `COGNEE_IDLE_POLL` seconds and persists the session cache when the session has been quiet for `COGNEE_IDLE_THRESHOLD` seconds, then waits at least `COGNEE_IMPROVE_COOLDOWN` seconds before the next run.
@@ -291,3 +305,5 @@ Config precedence:
 | idle watcher poll | `COGNEE_IDLE_POLL` | `10` | Idle watcher poll interval in seconds |
 | idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle sync fires |
 | idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `120` | Minimum seconds between idle sync runs |
+| warmup ping    | COGNEE_WARMUP         | false | Fire background GET /health to pre-warm a cold cloud tenant |
+| warmup timeout | COGNEE_WARMUP_TIMEOUT | 5     | Timeout in seconds for the warmup ping (non-blocking)       |

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -85,6 +85,34 @@ _LAZY_BOOTSTRAP = os.environ.get("COGNEE_LAZY_BOOTSTRAP", "1").strip().lower() n
     "no",
 )
 
+_WARMUP_ENABLED: bool = os.environ.get("COGNEE_WARMUP", "false").strip().lower() in (
+    "1", "true", "yes", "on"
+)
+_WARMUP_TIMEOUT_SECONDS: float = float(
+    os.environ.get("COGNEE_WARMUP_TIMEOUT", "5").strip() or "5"
+)
+
+def _fire_warmup_ping(service_url: str) -> None:
+    """Fire a background GET /health to pre-warm a cold cloud tenant.
+
+    No-op when COGNEE_WARMUP is not set. Runs in a daemon thread so it
+    never consumes any part of the SessionStart hook budget. All errors
+    are swallowed — a failed or slow ping must never block the session.
+    """
+    if not _WARMUP_ENABLED or not service_url:
+        return
+    url = _health_url(service_url)
+    def _ping() -> None:
+        try:
+            with urllib.request.urlopen(url, timeout=_WARMUP_TIMEOUT_SECONDS):
+                pass
+        except Exception:
+            pass
+        finally:
+            hook_log("warmup_ping_fired", {"url": url})
+    import threading
+    threading.Thread(target=_ping, daemon=True, name="cognee-warmup").start()
+
 # --- Self-managed cognee install ---------------------------------------------
 # uv is kept self-contained under ~/.cognee-plugin so we never touch the user's
 # Python or PATH. A uv-managed Python guarantees a cognee-compatible runtime
@@ -1215,6 +1243,9 @@ async def _start(payload: dict | None = None) -> dict:
     os.environ["COGNEE_BASE_URL"] = target_url
     if api_key:
         os.environ["COGNEE_API_KEY"] = api_key
+
+    if configured_url:
+        _fire_warmup_ping(configured_url)
 
     # The host (Claude) session id is a local correlation key only: it keeps every
     # hook process of this launch resolving the SAME Cognee session id (via the

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -130,6 +130,20 @@ Data added outside of Claude to the dataset (via SDK or the server for example) 
 | `PreCompact` | memory anchor build before compaction |
 | `SessionEnd` | trigger detached final sync worker |
 
+## Cold-start warmup
+
+When COGNEE_BASE_URL points at a cloud tenant that scales to zero, enable
+the warmup ping so the tenant begins waking up before the user's first recall:
+
+    export COGNEE_WARMUP=true
+
+The ping is non-blocking and fails silently. Off by default. No-op in local mode.
+
+| Env var                | Default | Effect                                                      |
+|------------------------|---------|-------------------------------------------------------------|
+| COGNEE_WARMUP          | false   | Fire background GET /health at SessionStart                 |
+| COGNEE_WARMUP_TIMEOUT  | 5       | Timeout in seconds for the warmup ping (non-blocking)       |
+
 ## Session sync and watchers
 
 An idle watcher runs in the background for the lifetime of each launch. It polls activity every `COGNEE_IDLE_POLL` seconds and persists the session cache when the session has been quiet for `COGNEE_IDLE_THRESHOLD` seconds, then waits at least `COGNEE_IMPROVE_COOLDOWN` seconds before the next run.
@@ -212,6 +226,8 @@ Config precedence:
 | idle watcher poll | `COGNEE_IDLE_POLL` | `10` | Idle watcher poll interval in seconds |
 | idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle sync fires |
 | idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `120` | Minimum seconds between idle sync runs |
+| warmup ping    | COGNEE_WARMUP         | false | Fire background GET /health to pre-warm a cold cloud tenant |
+| warmup timeout | COGNEE_WARMUP_TIMEOUT | 5     | Timeout in seconds for the warmup ping (non-blocking)       |
 
 ## Troubleshooting
 

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -84,6 +84,34 @@ _LAZY_BOOTSTRAP = os.environ.get("COGNEE_LAZY_BOOTSTRAP", "1").strip().lower() n
     "no",
 )
 
+_WARMUP_ENABLED: bool = os.environ.get("COGNEE_WARMUP", "false").strip().lower() in (
+    "1", "true", "yes", "on"
+)
+_WARMUP_TIMEOUT_SECONDS: float = float(
+    os.environ.get("COGNEE_WARMUP_TIMEOUT", "5").strip() or "5"
+)
+
+def _fire_warmup_ping(service_url: str) -> None:
+    """Fire a background GET /health to pre-warm a cold cloud tenant.
+
+    No-op when COGNEE_WARMUP is not set. Runs in a daemon thread so it
+    never consumes any part of the SessionStart hook budget. All errors
+    are swallowed — a failed or slow ping must never block the session.
+    """
+    if not _WARMUP_ENABLED or not service_url:
+        return
+    url = _health_url(service_url)
+    def _ping() -> None:
+        try:
+            with urllib.request.urlopen(url, timeout=_WARMUP_TIMEOUT_SECONDS):
+                pass
+        except Exception:
+            pass
+        finally:
+            hook_log("warmup_ping_fired", {"url": url})
+    import threading
+    threading.Thread(target=_ping, daemon=True, name="cognee-warmup").start()
+
 # --- Self-managed cognee install (SHARED with the Claude Code plugin) --------
 # uv + a uv-managed Python guarantee a cognee-compatible runtime (3.10-3.14)
 # regardless of what's on the machine. All paths sit under the shared
@@ -1097,6 +1125,9 @@ async def _start(payload: dict | None = None) -> dict:
     os.environ["COGNEE_BASE_URL"] = target_url
     if api_key:
         os.environ["COGNEE_API_KEY"] = api_key
+
+    if configured_url:
+        _fire_warmup_ping(configured_url)
 
     # The host (Codex) session id is a local correlation key only: it keeps every
     # hook process of this launch resolving the SAME Cognee session id (via the


### PR DESCRIPTION
## Summary
Adds an opt-in background warmup ping to pre-warm scale-to-zero cloud tenants during `SessionStart`.

Closes topoteretes/cognee#3541

## Changes
- Introduces `COGNEE_WARMUP` and `COGNEE_WARMUP_TIMEOUT` environment variables (default `false` / `5`s).
- Fires a non-blocking `GET /health` request in a background daemon thread when connecting to a remote endpoint. 
- Silently catches all exceptions to ensure a failed or slow ping never consumes the hook budget or blocks the session.
- Applied symmetrically to both the Claude Code and Codex plugins.
- Updated README documentation for both plugins.
