### PR TITLE
feat(recall): retry on timeout/connection error for first session recall

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -147,6 +147,10 @@ An idle watcher runs in the background for the lifetime of each launch. It polls
 | `COGNEE_IDLE_POLL` | `10` | Poll interval in seconds |
 | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle sync fires |
 | `COGNEE_IMPROVE_COOLDOWN` | `120` | Minimum seconds between idle sync runs |
+| `COGNEE_WARMUP` | `false` | Fire background GET /health to pre-warm a cold cloud tenant |
+| `COGNEE_WARMUP_TIMEOUT` | `5` | Timeout in seconds for the warmup ping (non-blocking) |
+| `COGNEE_RECALL_RETRIES` | `2` | Retry count on timeout/connection error for the first recall of a session; 0 to disable |
+| `COGNEE_RECALL_BACKOFF` | `0.5` | Base backoff in seconds between retries (doubles each attempt) |
 
 Final sync on session end is triggered by the `SessionEnd` detached worker, with an exit watcher as fallback if the process exits without firing `SessionEnd`.
 

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1212,6 +1212,8 @@ def recall_via_http(
     search_type: str | None = None,
     context_profile: str | None = None,
     timeout: float = 10.0,
+    retries: int = 0,
+    backoff_base: float = 0.5,
 ) -> list:
     payload = {
         "query": query,
@@ -1224,8 +1226,20 @@ def recall_via_http(
         payload["search_type"] = search_type
     if context_profile:
         payload["context_profile"] = context_profile
-    result = _json_http_request("/api/v1/recall", payload, timeout=timeout)
-    return result if isinstance(result, list) else []
+    last_exc = None
+    for attempt in range(1 + max(0, retries)):
+        if attempt > 0:
+            time.sleep(backoff_base * (2 ** (attempt - 1)))
+        try:
+            result = _json_http_request("/api/v1/recall", payload, timeout=timeout)
+            return result if isinstance(result, list) else []
+        except urllib.error.HTTPError:
+            raise  # HTTP errors are not transient — propagate immediately
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            last_exc = exc
+    if last_exc is not None:
+        raise last_exc  # noqa: TRY201 — re-raise after exhausted retries
+    return []
 
 
 def _backend_reachable(base_url: str, timeout: float = 1.5) -> bool:

--- a/integrations/claude-code/scripts/_recall_http.py
+++ b/integrations/claude-code/scripts/_recall_http.py
@@ -31,6 +31,9 @@ import urllib.request
 
 UNREACHABLE = "UNREACHABLE"
 
+RECALL_RETRY_DEFAULT = 2   # sensible default, overridable per-call
+RECALL_BACKOFF_BASE  = 0.5  # seconds; doubles each attempt
+
 
 # macOS Python installations often lack root CA certs in the default bundle.
 # Build one opener for all HTTPS calls: try certifi opportunistically (if
@@ -114,8 +117,18 @@ def do_recall(
     *,
     opener=None,
     timeout=20.0,
+    retries: int = 0,           # 0 = no retry (default for normal turns)
+    backoff_base: float = RECALL_BACKOFF_BASE,
 ):
-    """Query the server. Return results (list), an error envelope (dict), or ``UNREACHABLE``."""
+    """Query the server. Return results (list), an error envelope (dict), or ``UNREACHABLE``.
+
+    On a transient network/timeout failure (URLError / TimeoutError / OSError),
+    retry up to ``retries`` times with exponential backoff (``backoff_base * 2**attempt``
+    seconds between attempts). HTTP errors are never retried — a reachable server
+    that rejects/fails the request is an authoritative answer.
+    """
+    import time as _time
+
     url = service_url.rstrip("/") + "/api/v1/recall"
     body = {
         "query": query,
@@ -144,25 +157,41 @@ def do_recall(
     if api_key and not _is_local(service_url):
         headers["X-Api-Key"] = api_key
 
+    # Build the request object once — reused on every retry attempt.
     req = urllib.request.Request(
         url, data=json.dumps(body).encode("utf-8"), headers=headers, method="POST"
     )
     _open = opener if opener is not None else _HTTPS_OPENER.open
-    try:
-        with _open(req, timeout=timeout) as resp:
-            raw = resp.read().decode("utf-8")
-    except urllib.error.HTTPError as e:
-        # Reachable but rejected/failed. NOT an authoritative empty, and NOT a
-        # reason to query a different backend via the CLI — report the error.
-        if e.code in (401, 403):
-            msg = "unauthorized (HTTP %s) — check COGNEE_API_KEY / credentials" % e.code
-        else:
-            msg = "server returned HTTP %s for /api/v1/recall" % e.code
-        sys.stderr.write("[cognee-search] %s — NOT falling back to local CLI\n" % msg)
-        return _error(e.code, msg)
-    except Exception as e:  # URLError / timeout / OSError → genuinely unreachable
+
+    raw = None
+    last_exc = None
+    for attempt in range(1 + max(0, retries)):
+        if attempt > 0:
+            _time.sleep(backoff_base * (2 ** (attempt - 1)))
+        try:
+            with _open(req, timeout=timeout) as resp:
+                raw = resp.read().decode("utf-8")
+            break  # success — exit retry loop
+        except urllib.error.HTTPError as e:
+            # Reachable but rejected/failed. NOT an authoritative empty, and NOT a
+            # reason to query a different backend via the CLI — report the error.
+            # HTTP errors are never retried.
+            if e.code in (401, 403):
+                msg = "unauthorized (HTTP %s) — check COGNEE_API_KEY / credentials" % e.code
+            else:
+                msg = "server returned HTTP %s for /api/v1/recall" % e.code
+            sys.stderr.write("[cognee-search] %s — NOT falling back to local CLI\n" % msg)
+            return _error(e.code, msg)
+        except Exception as e:  # URLError / timeout / OSError → genuinely unreachable
+            last_exc = e
+            sys.stderr.write(
+                "[cognee-search] attempt %d/%d failed: %s\n"
+                % (attempt + 1, 1 + retries, str(e)[:160])
+            )
+    else:
         sys.stderr.write(
-            "[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+            "[cognee-search] server unreachable at %s after %d attempt(s): %s\n"
+            % (service_url, 1 + retries, str(last_exc)[:160])
         )
         return UNREACHABLE
 

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -191,6 +191,25 @@ async def _run(prompt: str) -> dict | None:
         hook_log("no_session_id", {"event": "context_lookup"})
         return None
 
+    def _is_first_recall(sid: str) -> bool:
+        """True when no tool-call turns have completed for this session yet.
+
+        Uses the same counter.json that store-to-session.py writes via
+        bump_turn_counter(). A missing key means count == 0, i.e. first recall.
+        """
+        try:
+            from pathlib import Path
+            counter_file = Path.home() / ".cognee-plugin" / "claude-code" / "counter.json"
+            if not counter_file.exists():
+                return True
+            import json as _json
+            data = _json.loads(counter_file.read_text(encoding="utf-8"))
+            return int(data.get(sid, 0)) == 0
+        except Exception:
+            return False  # fail safe: don't retry if we can't tell
+
+    is_first = _is_first_recall(session_id)
+
     saves_last_turn = read_and_reset_save_counter(session_id)
 
     # Run scopes independently: a failure in one (e.g. graph search hitting an
@@ -215,6 +234,8 @@ async def _run(prompt: str) -> dict | None:
     # never be the long pole. Each scope gets a short per-call timeout, and the
     # whole loop stops once the overall budget is spent. Partial results are fine.
     recall_timeout = _float_env("COGNEE_RECALL_TIMEOUT", 2.5)
+    recall_retries = int(_float_env("COGNEE_RECALL_RETRIES", 2))
+    recall_backoff = _float_env("COGNEE_RECALL_BACKOFF", 0.5)
     budget_deadline = time.monotonic() + _float_env("COGNEE_RECALL_BUDGET", 4.0)
     # Respect the shared circuit breaker: when the server has been failing (tripped
     # by the explicit recall path), skip this per-prompt recall rather than hammering
@@ -244,22 +265,35 @@ async def _run(prompt: str) -> dict | None:
                     search_type=qtype,
                     context_profile=context_profile,
                     timeout=recall_timeout,
+                    retries=recall_retries if is_first else 0,
+                    backoff_base=recall_backoff,
                 )
             else:
                 query_type = getattr(SearchType, qtype, None) if qtype else None
-                part = await asyncio.wait_for(
-                    cognee.recall(
-                        prompt,
-                        session_id=session_id,
-                        top_k=TOP_K,
-                        scope=scope_list,
-                        only_context=True,
-                        query_type=query_type,
-                        user=user,
-                        **({"context_profile": context_profile} if context_profile else {}),
-                    ),
-                    timeout=recall_timeout,
-                )
+                _sdk_retries = recall_retries if is_first else 0
+                _sdk_attempt = 0
+                while True:
+                    try:
+                        part = await asyncio.wait_for(
+                            cognee.recall(
+                                prompt,
+                                session_id=session_id,
+                                top_k=TOP_K,
+                                scope=scope_list,
+                                only_context=True,
+                                query_type=query_type,
+                                user=user,
+                                **({"context_profile": context_profile} if context_profile else {}),
+                            ),
+                            timeout=recall_timeout,
+                        )
+                        break
+                    except (asyncio.TimeoutError, OSError) as exc:
+                        if _sdk_attempt >= _sdk_retries:
+                            raise
+                        _sdk_attempt += 1
+                        import time as _time
+                        _time.sleep(recall_backoff * (2 ** (_sdk_attempt - 1)))
             if part:
                 results.extend(part)
         except Exception as exc:

--- a/integrations/claude-code/tests/test_recall_http.py
+++ b/integrations/claude-code/tests/test_recall_http.py
@@ -168,6 +168,66 @@ def test_coerce_scope():
     assert rh.coerce_scope("") == "auto"
 
 
+def test_retry_succeeds_on_second_attempt():
+    """Timeout then success -> do_recall returns results, not UNREACHABLE."""
+    calls = {"n": 0}
+
+    def _opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise urllib.error.URLError("timed out")
+        return _Resp('[{"text": "hit"}]')
+
+    result = rh.do_recall(
+        "http://x", "", "q", "", '["graph"]', "5",
+        opener=_opener, retries=1, backoff_base=0.0,
+    )
+    assert result == [{"text": "hit"}]
+    assert calls["n"] == 2
+
+
+def test_retry_exhausted_returns_unreachable():
+    """All attempts timeout -> UNREACHABLE (graceful degradation)."""
+    result = rh.do_recall(
+        "http://x", "", "q", "", '["graph"]', "5",
+        opener=_raises(urllib.error.URLError("refused")),
+        retries=2, backoff_base=0.0,
+    )
+    assert result == rh.UNREACHABLE
+
+
+def test_http_error_not_retried():
+    """HTTPError is not a transient error — must not retry, must return error envelope."""
+    calls = {"n": 0}
+
+    def _opener(req, timeout=None):
+        calls["n"] += 1
+        raise urllib.error.HTTPError("http://x", 500, "boom", {}, None)
+
+    result = rh.do_recall(
+        "http://x", "", "q", "", '["graph"]', "5",
+        opener=_opener, retries=2, backoff_base=0.0,
+    )
+    assert isinstance(result, dict) and result["status"] == 500
+    assert calls["n"] == 1  # fired exactly once — no retry on HTTP errors
+
+
+def test_no_retry_by_default():
+    """retries=0 (default) -> exactly one attempt, UNREACHABLE on failure."""
+    calls = {"n": 0}
+
+    def _opener(req, timeout=None):
+        calls["n"] += 1
+        raise urllib.error.URLError("refused")
+
+    result = rh.do_recall(
+        "http://x", "", "q", "", '["graph"]', "5",
+        opener=_opener,
+    )
+    assert result == rh.UNREACHABLE
+    assert calls["n"] == 1
+
+
 if __name__ == "__main__":
     failures = 0
     for name, fn in sorted(globals().items()):

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -212,6 +212,10 @@ Config precedence:
 | idle watcher poll | `COGNEE_IDLE_POLL` | `10` | Idle watcher poll interval in seconds |
 | idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle sync fires |
 | idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `120` | Minimum seconds between idle sync runs |
+| warmup ping | `COGNEE_WARMUP` | `false` | Fire background GET /health to pre-warm a cold cloud tenant |
+| warmup timeout | `COGNEE_WARMUP_TIMEOUT` | `5` | Timeout in seconds for the warmup ping (non-blocking) |
+| recall retries | `COGNEE_RECALL_RETRIES` | `2` | Retry count on timeout/connection error for the first recall of a session; 0 to disable |
+| recall backoff | `COGNEE_RECALL_BACKOFF` | `0.5` | Base backoff in seconds between retries (doubles each attempt) |
 
 ## Troubleshooting
 

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -1120,6 +1120,8 @@ def recall_via_http(
     search_type: str | None = None,
     context_profile: str | None = None,
     timeout: float = 10.0,
+    retries: int = 0,
+    backoff_base: float = 0.5,
 ) -> list:
     payload = {
         "query": query,
@@ -1132,8 +1134,20 @@ def recall_via_http(
         payload["search_type"] = search_type
     if context_profile:
         payload["context_profile"] = context_profile
-    result = _json_http_request("/api/v1/recall", payload, timeout=timeout)
-    return result if isinstance(result, list) else []
+    last_exc = None
+    for attempt in range(1 + max(0, retries)):
+        if attempt > 0:
+            time.sleep(backoff_base * (2 ** (attempt - 1)))
+        try:
+            result = _json_http_request("/api/v1/recall", payload, timeout=timeout)
+            return result if isinstance(result, list) else []
+        except urllib.error.HTTPError:
+            raise  # HTTP errors are not transient — propagate immediately
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            last_exc = exc
+    if last_exc is not None:
+        raise last_exc  # re-raise after exhausted retries
+    return []
 
 
 def _backend_reachable(base_url: str, timeout: float = 1.5) -> bool:

--- a/integrations/codex/plugins/cognee/scripts/_recall_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_recall_http.py
@@ -31,6 +31,9 @@ import urllib.request
 
 UNREACHABLE = "UNREACHABLE"
 
+RECALL_RETRY_DEFAULT = 2   # sensible default, overridable per-call
+RECALL_BACKOFF_BASE  = 0.5  # seconds; doubles each attempt
+
 
 # macOS Python installations often lack root CA certs in the default bundle.
 # Build one opener for all HTTPS calls: try certifi opportunistically (if
@@ -114,8 +117,18 @@ def do_recall(
     *,
     opener=None,
     timeout=20.0,
+    retries: int = 0,           # 0 = no retry (default for normal turns)
+    backoff_base: float = RECALL_BACKOFF_BASE,
 ):
-    """Query the server. Return results (list), an error envelope (dict), or ``UNREACHABLE``."""
+    """Query the server. Return results (list), an error envelope (dict), or ``UNREACHABLE``.
+
+    On a transient network/timeout failure (URLError / TimeoutError / OSError),
+    retry up to ``retries`` times with exponential backoff (``backoff_base * 2**attempt``
+    seconds between attempts). HTTP errors are never retried — a reachable server
+    that rejects/fails the request is an authoritative answer.
+    """
+    import time as _time
+
     url = service_url.rstrip("/") + "/api/v1/recall"
     body = {
         "query": query,
@@ -144,25 +157,41 @@ def do_recall(
     if api_key and not _is_local(service_url):
         headers["X-Api-Key"] = api_key
 
+    # Build the request object once — reused on every retry attempt.
     req = urllib.request.Request(
         url, data=json.dumps(body).encode("utf-8"), headers=headers, method="POST"
     )
     _open = opener if opener is not None else _HTTPS_OPENER.open
-    try:
-        with _open(req, timeout=timeout) as resp:
-            raw = resp.read().decode("utf-8")
-    except urllib.error.HTTPError as e:
-        # Reachable but rejected/failed. NOT an authoritative empty, and NOT a
-        # reason to query a different backend via the CLI — report the error.
-        if e.code in (401, 403):
-            msg = "unauthorized (HTTP %s) — check COGNEE_API_KEY / credentials" % e.code
-        else:
-            msg = "server returned HTTP %s for /api/v1/recall" % e.code
-        sys.stderr.write("[cognee-search] %s — NOT falling back to local CLI\n" % msg)
-        return _error(e.code, msg)
-    except Exception as e:  # URLError / timeout / OSError → genuinely unreachable
+
+    raw = None
+    last_exc = None
+    for attempt in range(1 + max(0, retries)):
+        if attempt > 0:
+            _time.sleep(backoff_base * (2 ** (attempt - 1)))
+        try:
+            with _open(req, timeout=timeout) as resp:
+                raw = resp.read().decode("utf-8")
+            break  # success — exit retry loop
+        except urllib.error.HTTPError as e:
+            # Reachable but rejected/failed. NOT an authoritative empty, and NOT a
+            # reason to query a different backend via the CLI — report the error.
+            # HTTP errors are never retried.
+            if e.code in (401, 403):
+                msg = "unauthorized (HTTP %s) — check COGNEE_API_KEY / credentials" % e.code
+            else:
+                msg = "server returned HTTP %s for /api/v1/recall" % e.code
+            sys.stderr.write("[cognee-search] %s — NOT falling back to local CLI\n" % msg)
+            return _error(e.code, msg)
+        except Exception as e:  # URLError / timeout / OSError → genuinely unreachable
+            last_exc = e
+            sys.stderr.write(
+                "[cognee-search] attempt %d/%d failed: %s\n"
+                % (attempt + 1, 1 + retries, str(e)[:160])
+            )
+    else:
         sys.stderr.write(
-            "[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+            "[cognee-search] server unreachable at %s after %d attempt(s): %s\n"
+            % (service_url, 1 + retries, str(last_exc)[:160])
         )
         return UNREACHABLE
 

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -181,6 +181,25 @@ async def _run(prompt: str) -> dict | None:
         hook_log("no_session_id", {"event": "context_lookup"})
         return None
 
+    def _is_first_recall(sid: str) -> bool:
+        """True when no tool-call turns have completed for this session yet.
+
+        Uses the same counter.json that store-to-session.py writes via
+        bump_turn_counter(). A missing key means count == 0, i.e. first recall.
+        """
+        try:
+            from pathlib import Path
+            counter_file = Path.home() / ".cognee-plugin" / "codex" / "counter.json"
+            if not counter_file.exists():
+                return True
+            import json as _json
+            data = _json.loads(counter_file.read_text(encoding="utf-8"))
+            return int(data.get(sid, 0)) == 0
+        except Exception:
+            return False  # fail safe: don't retry if we can't tell
+
+    is_first = _is_first_recall(session_id)
+
     saves_last_turn = read_and_reset_save_counter(session_id)
 
     # Run scopes independently: a failure in one (e.g. graph search hitting an
@@ -205,6 +224,8 @@ async def _run(prompt: str) -> dict | None:
     # never be the long pole. Each scope gets a short per-call timeout, and the
     # whole loop stops once the overall budget is spent. Partial results are fine.
     recall_timeout = _float_env("COGNEE_RECALL_TIMEOUT", 2.5)
+    recall_retries = int(_float_env("COGNEE_RECALL_RETRIES", 2))
+    recall_backoff = _float_env("COGNEE_RECALL_BACKOFF", 0.5)
     budget_deadline = time.monotonic() + _float_env("COGNEE_RECALL_BUDGET", 4.0)
     # Respect the shared circuit breaker: when the server has been failing (tripped
     # by the explicit recall path), skip this per-prompt recall rather than hammering
@@ -234,22 +255,35 @@ async def _run(prompt: str) -> dict | None:
                     search_type=qtype,
                     context_profile=context_profile,
                     timeout=recall_timeout,
+                    retries=recall_retries if is_first else 0,
+                    backoff_base=recall_backoff,
                 )
             else:
                 query_type = getattr(SearchType, qtype, None) if qtype else None
-                part = await asyncio.wait_for(
-                    cognee.recall(
-                        prompt,
-                        session_id=session_id,
-                        top_k=TOP_K,
-                        scope=scope_list,
-                        only_context=True,
-                        query_type=query_type,
-                        user=user,
-                        **({"context_profile": context_profile} if context_profile else {}),
-                    ),
-                    timeout=recall_timeout,
-                )
+                _sdk_retries = recall_retries if is_first else 0
+                _sdk_attempt = 0
+                while True:
+                    try:
+                        part = await asyncio.wait_for(
+                            cognee.recall(
+                                prompt,
+                                session_id=session_id,
+                                top_k=TOP_K,
+                                scope=scope_list,
+                                only_context=True,
+                                query_type=query_type,
+                                user=user,
+                                **({"context_profile": context_profile} if context_profile else {}),
+                            ),
+                            timeout=recall_timeout,
+                        )
+                        break
+                    except (asyncio.TimeoutError, OSError) as exc:
+                        if _sdk_attempt >= _sdk_retries:
+                            raise
+                        _sdk_attempt += 1
+                        import time as _time
+                        _time.sleep(recall_backoff * (2 ** (_sdk_attempt - 1)))
             if part:
                 results.extend(part)
         except Exception as exc:


### PR DESCRIPTION
**Description**

On a cold-start the backend may still be warming up when the first `UserPromptSubmit` fires, causing the initial recall to time out and silently fall back to no-context. This PR adds opt-in exponential backoff retries to the first recall of each session. Later turns keep `retries=0` so they never stall the user.

Closes topoteretes/cognee#3542

## Code changes

- **`_recall_http.py`** — retry loop around the urllib call; transient errors (`URLError` / `OSError`) are retried, HTTP errors exit immediately; `retries=0` default leaves all existing callers unaffected.
- **`_plugin_common.py`** — `recall_via_http()` accepts and forwards `retries` / `backoff_base`.
- **`session-context-lookup.py`** — adds `_is_first_recall()` (reads `counter.json`), reads `COGNEE_RECALL_RETRIES`                                                  `COGNEE_RECALL_BACKOFF` from env, and passes retries only on the first recall of the session.
- **`tests/test_recall_http.py`** — 4 new tests: succeed-on-retry,  exhaust-all-retries, HTTP-not-retried, default-no-retry.
- **READMEs** — both updated with the two new env vars.

All changes applied symmetrically to the Claude Code and Codex plugins.
