### PR TITLE
feat: cognee plugin status one-liner fix

### DIFF
--- a/integrations/claude-code/scripts/status.py
+++ b/integrations/claude-code/scripts/status.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""
+cognee-plugin status
+Prints resolved runtime state on one line and exits 0.
+Output: mode=... url=... key=... version=...
+"""
+import json
+import sys
+from pathlib import Path
+
+# Add scripts dir to path so we can import _plugin_common
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _plugin_common import (
+    _api_key_with_source,
+    _local_api_url_with_source,
+)
+
+
+def main() -> None:
+    # --- version: read from .claude-plugin/plugin.json ---
+    plugin_json = Path(__file__).parent.parent / ".claude-plugin" / "plugin.json"
+    try:
+        version = json.loads(plugin_json.read_text(encoding="utf-8")).get("version", "unknown")
+    except Exception:
+        version = "unknown"
+
+    # --- url + mode: reuse existing resolver from _plugin_common ---
+    url, _ = _local_api_url_with_source()
+    url = url.rstrip("/")
+
+    is_local = (
+        not url
+        or "localhost" in url
+        or "127.0.0.1" in url
+    )
+    mode = "local" if is_local else "cloud"
+
+    # --- key: reuse existing resolver from _plugin_common ---
+    api_key, _ = _api_key_with_source(url)
+    key = "configured" if api_key else "missing"
+
+    print(f"mode={mode} url={url} key={key} version={version}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/codex/plugins/cognee/scripts/status.py
+++ b/integrations/codex/plugins/cognee/scripts/status.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+cognee-plugin status
+Prints resolved runtime state on one line and exits 0.
+Output: mode=... url=... key=... version=...
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _plugin_common import _api_key, _local_api_url
+
+
+def main() -> None:
+    # --- version: read from .cognee-plugin/plugin.json ---
+    plugin_json = Path(__file__).parent.parent / ".cognee-plugin" / "plugin.json"
+    try:
+        version = json.loads(plugin_json.read_text(encoding="utf-8")).get("version", "unknown")
+    except Exception:
+        version = "unknown"
+
+    # --- url + mode ---
+    url = _local_api_url().rstrip("/")
+    is_local = not url or "localhost" in url or "127.0.0.1" in url
+    mode = "local" if is_local else "cloud"
+
+    # --- key ---
+    api_key = _api_key()
+    key = "configured" if api_key else "missing"
+
+    print(f"mode={mode} url={url} key={key} version={version}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #3552

## What
Adds `status` one-liner to claude-code and codex integrations.

## Files
- integrations/claude-code/scripts/status.py
- integrations/codex/plugins/cognee/scripts/status.py

## How to test
cd integrations/claude-code/scripts
python status.py
# Expected: mode=local url=http://localhost:8011 key=missing version=0.2.0
# Exit code: 0