### PR TITLE
feat(integrations): add cloud cold-start warmup ping for plugin sessions

### DIFF
--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -1325,6 +1325,18 @@ async def _start(payload: dict | None = None) -> dict:
         file=sys.stderr,
     )
 
+    # Cloud cold-start warmup: fire a non-blocking GET /health when
+    # COGNEE_WARMUP is enabled so scale-to-zero tenants are warm
+    # before the first real request. Fails silently — never blocks
+    # the session or errors on timeout/unreachable.
+    if os.environ.get("COGNEE_WARMUP", "").strip().lower() in ("1", "true", "yes"):
+        import threading
+
+        warmup_url = _health_url(target_url)
+        threading.Thread(
+            target=_health_ok, args=(warmup_url, 2.0), daemon=True, name="cognee-warmup"
+        ).start()
+
     ready = server_live or server_ready_hint(str(config.get("base_url", "") or ""))
     return _session_start_guidance(mode, dataset, session_id, ready)
 

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -1204,6 +1204,18 @@ async def _start(payload: dict | None = None) -> dict:
         file=sys.stderr,
     )
 
+    # Cloud cold-start warmup: fire a non-blocking GET /health when
+    # COGNEE_WARMUP is enabled so scale-to-zero tenants are warm
+    # before the first real request. Fails silently — never blocks
+    # the session or errors on timeout/unreachable.
+    if os.environ.get("COGNEE_WARMUP", "").strip().lower() in ("1", "true", "yes"):
+        import threading
+
+        warmup_url = _health_url(target_url)
+        threading.Thread(
+            target=_health_ok, args=(warmup_url, 2.0), daemon=True, name="cognee-warmup"
+        ).start()
+
     status_line = render_status_for_host(session_key)
     return {
         "hookSpecificOutput": {


### PR DESCRIPTION
## Summary

Add a non-blocking health-check warmup ping when `COGNEE_WARMUP=true` is set, so scale-to-zero cloud tenants are warm before the first real user request. Eliminates cold-start latency that would otherwise land on the first query.

## Changes

- `integrations/claude-code/scripts/session-start.py`: fire a daemon-thread GET /health after session-ready, gated behind `COGNEE_WARMUP` env flag
- `integrations/codex/plugins/cognee/scripts/session-start.py`: identical mirror for the Codex integration

## Test Plan

1. **Default (no flag)**: start Claude/Codex with cognee plugin — no warmup thread, session-start behavior unchanged
2. **Warmup enabled**: `COGNEE_WARMUP=true` — a daemon thread fires GET /health after "session ready", fails silently
3. **Unreachable server**: set `COGNEE_WARMUP=true` with no server running — thread times out in 2s, session-start returns normally, no errors

Fixes https://github.com/topoteretes/cognee/issues/3541