### PR TITLE
feat(claude-code): show plugin version in statusline

### DIFF
--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -3,10 +3,12 @@
 
 Invoked by Claude Code's ``statusLine`` (via ``cognee-statusline.sh``), which
 pipes a JSON context on stdin. Deliberately standalone and pure-local: reads
-only env vars and ``~/.cognee-plugin/config.json`` — no network calls, no
-``_plugin_common`` import.
+only environment variables, ``~/.cognee-plugin/config.json``, and the plugin
+manifest under ``CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json`` — no network
+calls, no ``_plugin_common`` import.
 
-Output: ``cognee: <dataset-name> · local`` or ``cognee: <dataset-name> · cloud``
+Output: ``cognee: <dataset-name> · local · v0.3.0`` or
+``cognee: <dataset-name> · cloud · v0.3.0``
 """
 
 import json
@@ -73,12 +75,35 @@ def _health_prefix() -> str:
     return ""
 
 
+def _plugin_version() -> str:
+    root = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
+    if not root:
+        return ""
+    try:
+        manifest = Path(root, ".claude-plugin", "plugin.json")
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            v = str(data.get("version") or "").strip()
+            if v:
+                return v
+    except Exception:
+        pass
+    return ""
+
+
+def _version_suffix() -> str:
+    version = _plugin_version()
+    return f" · v{version}" if version else ""
+
+
 def main() -> None:
     try:
         json.load(sys.stdin)  # consume stdin as required by Claude Code
     except Exception:
         pass
-    sys.stdout.write(f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}")
+    sys.stdout.write(
+        f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}{_version_suffix()}"
+    )
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/tests/test_statusline_render.py
+++ b/integrations/claude-code/tests/test_statusline_render.py
@@ -1,0 +1,104 @@
+"""Unit tests for the pure-local Cognee statusline renderer.
+
+Run: python integrations/claude-code/tests/test_statusline_render.py
+(or via pytest).
+"""
+
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import cognee_statusline_render as sr  # noqa: E402
+
+
+def _with_plugin_root(manifest):
+    tmp = tempfile.TemporaryDirectory(prefix="cognee-statusline-test-")
+    root = pathlib.Path(tmp.name)
+    plugin_dir = root / ".claude-plugin"
+    plugin_dir.mkdir()
+    if manifest is not None:
+        (plugin_dir / "plugin.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return tmp, root
+
+
+def test_reads_plugin_version_from_claude_plugin_root():
+    tmp, root = _with_plugin_root({"version": "0.3.0"})
+    old = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    os.environ["CLAUDE_PLUGIN_ROOT"] = str(root)
+    try:
+        assert sr._plugin_version() == "0.3.0"
+    finally:
+        if old is None:
+            os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+        else:
+            os.environ["CLAUDE_PLUGIN_ROOT"] = old
+        tmp.cleanup()
+
+
+def test_missing_plugin_root_hides_plugin_version():
+    old = os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+    try:
+        assert sr._plugin_version() == ""
+    finally:
+        if old is not None:
+            os.environ["CLAUDE_PLUGIN_ROOT"] = old
+
+
+def test_missing_manifest_hides_plugin_version():
+    tmp, root = _with_plugin_root(None)
+    old = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    os.environ["CLAUDE_PLUGIN_ROOT"] = str(root)
+    try:
+        assert sr._plugin_version() == ""
+    finally:
+        if old is None:
+            os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+        else:
+            os.environ["CLAUDE_PLUGIN_ROOT"] = old
+        tmp.cleanup()
+
+
+def test_bad_manifest_hides_plugin_version():
+    tmp, root = _with_plugin_root(None)
+    old = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    os.environ["CLAUDE_PLUGIN_ROOT"] = str(root)
+    (root / ".claude-plugin" / "plugin.json").write_text("{", encoding="utf-8")
+    try:
+        assert sr._plugin_version() == ""
+    finally:
+        if old is None:
+            os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+        else:
+            os.environ["CLAUDE_PLUGIN_ROOT"] = old
+        tmp.cleanup()
+
+
+def test_missing_version_hides_plugin_version():
+    tmp, root = _with_plugin_root({})
+    old = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    os.environ["CLAUDE_PLUGIN_ROOT"] = str(root)
+    try:
+        assert sr._plugin_version() == ""
+    finally:
+        if old is None:
+            os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+        else:
+            os.environ["CLAUDE_PLUGIN_ROOT"] = old
+        tmp.cleanup()
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
### Summary

Adds the installed Claude Code plugin version to the Cognee statusline.
Closes https://github.com/topoteretes/cognee/issues/3675

### Changes

- Reads the version from `CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json`.
- Appends it compactly as `· v<version>` after the existing dataset and mode.
- Keeps the renderer pure-local and fail-silent when the manifest is missing, malformed, unreadable, or has no `version`.

### Tests

Added `test_statusline_render.py` covering:
- successful version read
- missing `CLAUDE_PLUGIN_ROOT`
- missing manifest
- malformed manifest
- missing `version`

### Tests passed

- `python integrations/claude-code/tests/test_statusline_render.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest integrations/claude-code/tests/test_statusline_render.py`
- `python -m ruff check integrations/claude-code/scripts/cognee_statusline_render.py integrations/claude-code/tests/test_statusline_render.py`
- `python -m ruff format --check integrations/claude-code/scripts/cognee_statusline_render.py integrations/claude-code/tests/test_statusline_render.py`