### PR TITLE
feat(openclaw): display plugin version in status surface

### DIFF
--- a/integrations/openclaw/__mocks__/version.ts
+++ b/integrations/openclaw/__mocks__/version.ts
@@ -1,0 +1,16 @@
+// ---------------------------------------------------------------------------
+// Test stub for src/version.ts
+//
+// Returned by the Jest moduleNameMapper when tests import ./version (or any
+// path ending in /version). This avoids ts-jest encountering import.meta.url,
+// which is a SyntaxError in the CJS context Jest uses even with useESM:true.
+//
+// The values are read from the real package.json via plain require(), which
+// is available in Jest's CJS runtime without any special configuration.
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const _pkg = require("../package.json") as { name: string; version: string };
+
+export const PLUGIN_NAME: string = _pkg.name;
+export const PLUGIN_VERSION: string = _pkg.version;

--- a/integrations/openclaw/__tests__/test_pluginAgentEndWorkspace.ts
+++ b/integrations/openclaw/__tests__/test_pluginAgentEndWorkspace.ts
@@ -46,4 +46,10 @@ describe("cognee-openclaw memory flush registration", () => {
       "memory/2026-04-03.md",
     );
   });
+  it("logs the plugin version on registration", () => {
+    const api = createApi();
+    expect(api.logger.info).toHaveBeenCalledWith(
+      expect.stringMatching(/cognee-openclaw: plugin version \d{4}\.\d+\.\d+/),
+    );
+  });
 });

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -34,6 +34,7 @@
       ]
     },
     "moduleNameMapper": {
+      "^(.*[\\/])version(?:\\.js)?$": "<rootDir>/__mocks__/version.ts",
       "^(\\.\\.?/.*)\\.js$": "$1"
     }
   },

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -23,6 +23,7 @@ import {
 } from "./persistence.js";
 import { cogneeSessionId, datasetNameForScope, isMultiScopeEnabled, normalizeAgentId, routeFileToScope } from "./scope.js";
 import { syncFiles, syncFilesScoped } from "./sync.js";
+import { PLUGIN_NAME, PLUGIN_VERSION } from "./version.js";
 
 /** Expand a leading `~` in a workspace path to the user's home directory. */
 function expandHome(p: string | undefined): string | undefined {
@@ -53,6 +54,7 @@ const memoryCogneePlugin = {
   kind: "memory" as const,
   register(api: OpenClawPluginApi) {
     const cfg = resolveConfig(api.pluginConfig);
+    api.logger.info?.(`cognee-openclaw: plugin version ${PLUGIN_VERSION}`);
 
     // Auto-enable per-agent memory when the gateway hosts more than one agent,
     // unless the plugin config set `perAgentMemory` explicitly. This keeps
@@ -436,6 +438,7 @@ const memoryCogneePlugin = {
         .description("Show Cognee sync state")
         .action(async () => {
           await stateReady;
+          console.log(`Plugin: ${PLUGIN_NAME} v${PLUGIN_VERSION}`);
           const files = await collectMemoryFiles(cliWorkspaceDir);
 
           if (multiScope) {

--- a/integrations/openclaw/src/version.ts
+++ b/integrations/openclaw/src/version.ts
@@ -1,0 +1,24 @@
+// ---------------------------------------------------------------------------
+// Plugin version — read from package.json once at module-load time.
+//
+// Using createRequire(import.meta.url) is the idiomatic way to load JSON in
+// an ESM-first project without toggling resolveJsonModule in tsconfig. The
+// result is computed once and re-used by every caller; there is no run-time
+// overhead beyond a single synchronous file read at module initialisation.
+//
+// Note for contributors: the Jest test runner uses a moduleNameMapper entry
+// in package.json that redirects imports of this module to
+// __mocks__/version.ts, avoiding the import.meta SyntaxError that occurs
+// when ts-jest compiles ESM source to CJS for its test VM context.
+// ---------------------------------------------------------------------------
+
+import { createRequire } from "node:module";
+
+const _require = createRequire(import.meta.url);
+const _pkg = _require("../package.json") as { name: string; version: string };
+
+/** Installed plugin name (e.g. "@cognee/cognee-openclaw"). */
+export const PLUGIN_NAME: string = _pkg.name;
+
+/** Installed plugin version string (e.g. "2026.6.11"). */
+export const PLUGIN_VERSION: string = _pkg.version;


### PR DESCRIPTION
## Summary

Implements issue #3688 by displaying the installed Cognee OpenClaw plugin version in the `openclaw cognee status` CLI.

### Changes

- Add `src/version.ts` to expose the plugin name and version from `package.json`.
- Display the plugin version at the top of the `cognee status` output.
- Log the plugin version during plugin registration.
- Add tests covering version logging.
- Add a Jest mock for the version module.

### Validation

- ✅ npm test
- ✅ npm run build

Closes #3688