### PR TITLE
docs(claude-code): one-command install/update + install smoke script

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -16,6 +16,14 @@ Install from the Claude Code marketplace. You can do this interactively by typin
 /plugin install cognee-memory@cognee
 ```
 
+The first command registers this repo as a plugin marketplace; the second installs the
+`cognee-memory` plugin from it. To verify a fresh checkout still wires these commands up
+correctly (marketplace name, plugin name, and source path all resolve), run:
+
+```bash
+bash integrations/claude-code/scripts/smoke-install.sh
+```
+
 Then set environment variables for your runtime mode.
 
 **Cognee Cloud or a remote server** — set both:
@@ -246,6 +254,13 @@ To also refresh the marketplace source:
 ```
 
 There is no automatic update mechanism — reinstall is the only way to pull in new plugin versions.
+
+After reinstalling, you can re-run the smoke check to confirm the install/update commands
+still match the current marketplace manifest:
+
+```bash
+bash integrations/claude-code/scripts/smoke-install.sh
+```
 
 ## Troubleshooting
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -17,12 +17,20 @@ Install from the Claude Code marketplace. You can do this interactively by typin
 ```
 
 The first command registers this repo as a plugin marketplace; the second installs the
-`cognee-memory` plugin from it. To verify a fresh checkout still wires these commands up
-correctly (marketplace name, plugin name, and source path all resolve), run:
+`cognee-memory` plugin from it.
+
+**Verify the install (optional).** To confirm a fresh checkout would install and run
+cleanly — before or without typing the slash commands — run the smoke check:
 
 ```bash
 bash integrations/claude-code/scripts/smoke-install.sh
 ```
+
+It validates the full install path end-to-end without needing a running Cognee server:
+the marketplace/plugin manifests are valid and agree on name and version, the
+`/plugin install` target resolves, every hook script the plugin registers exists on disk,
+and every declared skill is present. It exits `0` when the plugin is install-ready and
+non-zero with a clear list of what's wrong otherwise.
 
 Then set environment variables for your runtime mode.
 
@@ -255,8 +263,8 @@ To also refresh the marketplace source:
 
 There is no automatic update mechanism — reinstall is the only way to pull in new plugin versions.
 
-After reinstalling, you can re-run the smoke check to confirm the install/update commands
-still match the current marketplace manifest:
+After reinstalling, re-run the smoke check to confirm the new version still wires up
+cleanly (manifests agree on version, hook scripts and skills all resolve):
 
 ```bash
 bash integrations/claude-code/scripts/smoke-install.sh

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -245,29 +245,44 @@ Shared state (used by both Claude Code and Codex plugins):
 
 ## Update or remove
 
-Reinstall the plugin to pick up marketplace updates (run inside Claude Code chat):
+### Update
+
+Updating is a one-command refresh — **no uninstall + reinstall needed**. Refresh the
+`cognee` marketplace and hot-reload:
 
 ```
-/plugin uninstall cognee-memory@cognee
-/plugin install cognee-memory@cognee
+/plugin marketplace update cognee
+/reload-plugins
 ```
 
-To also refresh the marketplace source:
+Claude Code re-fetches the marketplace and updates the installed `cognee-memory` plugin
+to the latest version, then `/reload-plugins` applies it without restarting.
 
-```
-/plugin uninstall cognee-memory@cognee
-/plugin marketplace remove topoteretes/cognee-integrations
-/plugin marketplace add topoteretes/cognee-integrations
-/plugin install cognee-memory@cognee
-```
+To keep it current automatically, enable auto-update once: run `/plugin`, open the
+**Marketplaces** tab, select `cognee`, and choose **Enable auto-update**. Claude Code then
+refreshes the marketplace and updates the plugin at startup, prompting a reload when a new
+version lands. (Third-party marketplaces have auto-update off by default, which is why the
+manual refresh above exists.)
 
-There is no automatic update mechanism — reinstall is the only way to pull in new plugin versions.
-
-After reinstalling, re-run the smoke check to confirm the new version still wires up
-cleanly (manifests agree on version, hook scripts and skills all resolve):
+After updating, re-run the smoke check to confirm the new version still wires up cleanly
+(manifests agree on version, hook scripts and skills all resolve):
 
 ```bash
 bash integrations/claude-code/scripts/smoke-install.sh
+```
+
+### Remove
+
+Uninstall the plugin:
+
+```
+/plugin uninstall cognee-memory@cognee
+```
+
+To also remove the marketplace source:
+
+```
+/plugin marketplace remove topoteretes/cognee-integrations
 ```
 
 ## Troubleshooting

--- a/integrations/claude-code/scripts/smoke-install.sh
+++ b/integrations/claude-code/scripts/smoke-install.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Smoke check for the Cognee Memory plugin install/update flow.
+#
+# Verifies, on a fresh checkout, that the install/update steps documented in the
+# Claude Code README stay consistent with what the marketplace would actually
+# resolve when a user runs:
+#
+#   /plugin marketplace add topoteretes/cognee-integrations
+#   /plugin install cognee-memory@cognee
+#
+# Exits 0 when everything lines up, non-zero with a clear message otherwise.
+set -euo pipefail
+
+# Resolve paths relative to this script so it runs from any working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$PLUGIN_DIR/../.." && pwd)"
+
+README="$PLUGIN_DIR/README.md"
+PLUGIN_MANIFEST="$PLUGIN_DIR/.claude-plugin/plugin.json"
+MARKETPLACE_MANIFEST="$REPO_ROOT/.claude-plugin/marketplace.json"
+
+MARKETPLACE="cognee"
+PLUGIN="cognee-memory"
+SOURCE_REPO="topoteretes/cognee-integrations"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "ok: $*"; }
+
+# 1. Required files exist.
+for f in "$README" "$PLUGIN_MANIFEST" "$MARKETPLACE_MANIFEST"; do
+  [ -f "$f" ] || fail "missing required file: $f"
+done
+ok "README and plugin/marketplace manifests present"
+
+# 2. Documented install/update commands are present in the README.
+require_in_readme() {
+  grep -qF "$1" "$README" || fail "README is missing documented command: $1"
+}
+require_in_readme "/plugin marketplace add $SOURCE_REPO"
+require_in_readme "/plugin install $PLUGIN@$MARKETPLACE"
+require_in_readme "/plugin uninstall $PLUGIN@$MARKETPLACE"
+require_in_readme "/plugin marketplace remove $SOURCE_REPO"
+ok "documented install + update commands present in README"
+
+# 3. Manifests are valid JSON and the install target actually resolves.
+#    This is what makes the README commands work: marketplace name "cognee",
+#    a plugin named "cognee-memory", and a source path that points at this plugin.
+python3 - "$MARKETPLACE_MANIFEST" "$PLUGIN_MANIFEST" "$REPO_ROOT" "$MARKETPLACE" "$PLUGIN" <<'PY'
+import json, sys, os
+
+mkt_path, plugin_path, repo_root, marketplace, plugin = sys.argv[1:6]
+
+with open(mkt_path) as f:
+    mkt = json.load(f)
+with open(plugin_path) as f:
+    plug = json.load(f)
+
+if mkt.get("name") != marketplace:
+    sys.exit(f"FAIL: marketplace name is {mkt.get('name')!r}, expected {marketplace!r}")
+
+entries = [p for p in mkt.get("plugins", []) if p.get("name") == plugin]
+if not entries:
+    sys.exit(f"FAIL: marketplace does not declare a plugin named {plugin!r}")
+entry = entries[0]
+
+source = entry.get("source")
+if not source:
+    sys.exit(f"FAIL: plugin {plugin!r} has no source path")
+resolved = os.path.normpath(os.path.join(repo_root, source))
+if not os.path.isdir(resolved):
+    sys.exit(f"FAIL: plugin source path does not resolve to a directory: {source} -> {resolved}")
+
+if plug.get("name") != plugin:
+    sys.exit(f"FAIL: plugin.json name is {plug.get('name')!r}, expected {plugin!r}")
+
+if entry.get("version") != plug.get("version"):
+    sys.exit(
+        f"FAIL: version mismatch — marketplace {entry.get('version')!r} vs "
+        f"plugin.json {plug.get('version')!r}"
+    )
+
+print(f"ok: {plugin}@{marketplace} resolves to {source} (v{plug.get('version')})")
+PY
+
+echo "Claude Code plugin install/update smoke check passed."

--- a/integrations/claude-code/scripts/smoke-install.sh
+++ b/integrations/claude-code/scripts/smoke-install.sh
@@ -1,86 +1,220 @@
 #!/usr/bin/env bash
-# Smoke check for the Cognee Memory plugin install/update flow.
 #
-# Verifies, on a fresh checkout, that the install/update steps documented in the
-# Claude Code README stay consistent with what the marketplace would actually
-# resolve when a user runs:
+# smoke-install.sh — end-to-end install/update smoke check for the
+# Cognee Memory plugin for Claude Code.
+#
+# A user installs this plugin by running, in the Claude Code chat:
 #
 #   /plugin marketplace add topoteretes/cognee-integrations
 #   /plugin install cognee-memory@cognee
 #
-# Exits 0 when everything lines up, non-zero with a clear message otherwise.
+# This script verifies, on a fresh checkout, that those commands would actually
+# resolve and that the installed plugin would be runnable — without needing a
+# live Cognee server. It checks the documentation, the marketplace/plugin
+# manifests, and that every component the plugin declares (hook scripts and
+# skills) is present on disk.
+#
+# Usage:
+#   bash integrations/claude-code/scripts/smoke-install.sh
+#   bash integrations/claude-code/scripts/smoke-install.sh --quiet   # only print the final result
+#
+# Exit codes:
+#   0  every check passed
+#   1  one or more checks failed
+#   2  a prerequisite is missing (e.g. python3 not found)
 set -euo pipefail
+
+QUIET=0
+for arg in "$@"; do
+  case "$arg" in
+    -q|--quiet) QUIET=1 ;;
+    -h|--help)
+      sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "unknown argument: $arg (try --help)" >&2; exit 2 ;;
+  esac
+done
 
 # Resolve paths relative to this script so it runs from any working directory.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$PLUGIN_DIR/../.." && pwd)"
 
-README="$PLUGIN_DIR/README.md"
-PLUGIN_MANIFEST="$PLUGIN_DIR/.claude-plugin/plugin.json"
-MARKETPLACE_MANIFEST="$REPO_ROOT/.claude-plugin/marketplace.json"
+command -v python3 >/dev/null 2>&1 || { echo "FAIL: python3 is required but not found" >&2; exit 2; }
 
-MARKETPLACE="cognee"
-PLUGIN="cognee-memory"
-SOURCE_REPO="topoteretes/cognee-integrations"
+PLUGIN_DIR="$PLUGIN_DIR" REPO_ROOT="$REPO_ROOT" QUIET="$QUIET" python3 - <<'PY'
+import json
+import os
+import re
+import sys
 
-fail() { echo "FAIL: $*" >&2; exit 1; }
-ok()   { echo "ok: $*"; }
+PLUGIN_DIR = os.environ["PLUGIN_DIR"]
+REPO_ROOT = os.environ["REPO_ROOT"]
+QUIET = os.environ.get("QUIET") == "1"
 
-# 1. Required files exist.
-for f in "$README" "$PLUGIN_MANIFEST" "$MARKETPLACE_MANIFEST"; do
-  [ -f "$f" ] || fail "missing required file: $f"
-done
-ok "README and plugin/marketplace manifests present"
+MARKETPLACE = "cognee"
+PLUGIN = "cognee-memory"
+SOURCE_REPO = "topoteretes/cognee-integrations"
 
-# 2. Documented install/update commands are present in the README.
-require_in_readme() {
-  grep -qF "$1" "$README" || fail "README is missing documented command: $1"
-}
-require_in_readme "/plugin marketplace add $SOURCE_REPO"
-require_in_readme "/plugin install $PLUGIN@$MARKETPLACE"
-require_in_readme "/plugin uninstall $PLUGIN@$MARKETPLACE"
-require_in_readme "/plugin marketplace remove $SOURCE_REPO"
-ok "documented install + update commands present in README"
+README = os.path.join(PLUGIN_DIR, "README.md")
+PLUGIN_MANIFEST = os.path.join(PLUGIN_DIR, ".claude-plugin", "plugin.json")
+HOOKS_MANIFEST = os.path.join(PLUGIN_DIR, "hooks", "hooks.json")
+SKILLS_DIR = os.path.join(PLUGIN_DIR, "skills")
+MARKETPLACE_MANIFEST = os.path.join(REPO_ROOT, ".claude-plugin", "marketplace.json")
 
-# 3. Manifests are valid JSON and the install target actually resolves.
-#    This is what makes the README commands work: marketplace name "cognee",
-#    a plugin named "cognee-memory", and a source path that points at this plugin.
-python3 - "$MARKETPLACE_MANIFEST" "$PLUGIN_MANIFEST" "$REPO_ROOT" "$MARKETPLACE" "$PLUGIN" <<'PY'
-import json, sys, os
+passed = 0
+failures = []
 
-mkt_path, plugin_path, repo_root, marketplace, plugin = sys.argv[1:6]
 
-with open(mkt_path) as f:
-    mkt = json.load(f)
-with open(plugin_path) as f:
-    plug = json.load(f)
+def ok(msg):
+    global passed
+    passed += 1
+    if not QUIET:
+        print(f"  ✓ {msg}")
 
-if mkt.get("name") != marketplace:
-    sys.exit(f"FAIL: marketplace name is {mkt.get('name')!r}, expected {marketplace!r}")
 
-entries = [p for p in mkt.get("plugins", []) if p.get("name") == plugin]
-if not entries:
-    sys.exit(f"FAIL: marketplace does not declare a plugin named {plugin!r}")
-entry = entries[0]
+def fail(msg):
+    failures.append(msg)
+    if not QUIET:
+        print(f"  ✗ {msg}")
 
-source = entry.get("source")
-if not source:
-    sys.exit(f"FAIL: plugin {plugin!r} has no source path")
-resolved = os.path.normpath(os.path.join(repo_root, source))
-if not os.path.isdir(resolved):
-    sys.exit(f"FAIL: plugin source path does not resolve to a directory: {source} -> {resolved}")
 
-if plug.get("name") != plugin:
-    sys.exit(f"FAIL: plugin.json name is {plug.get('name')!r}, expected {plugin!r}")
+def section(title):
+    if not QUIET:
+        print(f"\n{title}")
 
-if entry.get("version") != plug.get("version"):
-    sys.exit(
-        f"FAIL: version mismatch — marketplace {entry.get('version')!r} vs "
-        f"plugin.json {plug.get('version')!r}"
+
+def load_json(path, label):
+    if not os.path.isfile(path):
+        fail(f"{label}: missing file ({path})")
+        return None
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        ok(f"{label}: present and valid JSON")
+        return data
+    except json.JSONDecodeError as e:
+        fail(f"{label}: invalid JSON — {e}")
+        return None
+
+
+# 1. Manifests exist and are valid JSON.
+section("Manifests")
+marketplace = load_json(MARKETPLACE_MANIFEST, "marketplace.json")
+plugin = load_json(PLUGIN_MANIFEST, "plugin.json")
+hooks = load_json(HOOKS_MANIFEST, "hooks.json")
+
+# 2. The /plugin install target actually resolves.
+section("Install target (/plugin install cognee-memory@cognee)")
+entry = None
+if marketplace is not None:
+    if marketplace.get("name") == MARKETPLACE:
+        ok(f"marketplace name is {MARKETPLACE!r}")
+    else:
+        fail(f"marketplace name is {marketplace.get('name')!r}, expected {MARKETPLACE!r}")
+
+    entries = [p for p in marketplace.get("plugins", []) if p.get("name") == PLUGIN]
+    if entries:
+        entry = entries[0]
+        ok(f"marketplace declares plugin {PLUGIN!r}")
+        source = entry.get("source")
+        if not source:
+            fail(f"plugin {PLUGIN!r} has no source path")
+        else:
+            resolved = os.path.normpath(os.path.join(REPO_ROOT, source))
+            if os.path.isdir(resolved):
+                ok(f"source path resolves: {source}")
+            else:
+                fail(f"source path does not resolve to a directory: {source}")
+    else:
+        fail(f"marketplace does not declare a plugin named {PLUGIN!r}")
+
+# 3. plugin.json has the fields a marketplace install relies on, and versions agree.
+section("Plugin manifest integrity")
+if plugin is not None:
+    for field in ("name", "version", "description"):
+        if plugin.get(field):
+            ok(f"plugin.json has {field!r}")
+        else:
+            fail(f"plugin.json is missing required field {field!r}")
+    if plugin.get("name") and plugin["name"] != PLUGIN:
+        fail(f"plugin.json name is {plugin['name']!r}, expected {PLUGIN!r}")
+    if entry is not None and plugin.get("version"):
+        if entry.get("version") == plugin["version"]:
+            ok(f"version matches across manifests (v{plugin['version']})")
+        else:
+            fail(
+                f"version mismatch — marketplace {entry.get('version')!r} "
+                f"vs plugin.json {plugin['version']!r}"
+            )
+
+# 4. Documentation: one-command install + update steps are present.
+section("Documentation (README)")
+if os.path.isfile(README):
+    with open(README) as f:
+        readme_text = f.read()
+    documented = [
+        f"/plugin marketplace add {SOURCE_REPO}",
+        f"/plugin install {PLUGIN}@{MARKETPLACE}",
+        f"/plugin uninstall {PLUGIN}@{MARKETPLACE}",
+        f"/plugin marketplace remove {SOURCE_REPO}",
+    ]
+    for cmd in documented:
+        if cmd in readme_text:
+            ok(f"documents: {cmd}")
+        else:
+            fail(f"README is missing documented command: {cmd}")
+else:
+    fail(f"README missing ({README})")
+
+# 5. Every hook the plugin registers points at a script that exists.
+#    This is what guarantees the plugin is runnable right after /plugin install.
+section("Hook scripts resolve")
+if hooks is not None:
+    referenced = set()
+    for event, blocks in hooks.get("hooks", {}).items():
+        for block in blocks:
+            for hook in block.get("hooks", []):
+                cmd = hook.get("command", "")
+                for m in re.findall(r"\$\{CLAUDE_PLUGIN_ROOT\}/(\S+\.py)", cmd):
+                    referenced.add(m)
+    if not referenced:
+        fail("hooks.json declares no runnable hook commands")
+    for rel in sorted(referenced):
+        path = os.path.join(PLUGIN_DIR, rel)
+        if os.path.isfile(path) and os.path.getsize(path) > 0:
+            ok(f"hook script present: {rel}")
+        else:
+            fail(f"hook script referenced but missing/empty: {rel}")
+
+# 6. Declared skills resolve (each needs a SKILL.md).
+section("Skills resolve")
+if os.path.isdir(SKILLS_DIR):
+    skill_dirs = sorted(
+        d for d in os.listdir(SKILLS_DIR)
+        if os.path.isdir(os.path.join(SKILLS_DIR, d))
     )
+    if not skill_dirs:
+        fail("skills/ directory has no skills")
+    for d in skill_dirs:
+        skill_md = os.path.join(SKILLS_DIR, d, "SKILL.md")
+        if os.path.isfile(skill_md):
+            ok(f"skill present: {d}")
+        else:
+            fail(f"skill {d!r} is missing SKILL.md")
+else:
+    fail("skills/ directory missing")
 
-print(f"ok: {plugin}@{marketplace} resolves to {source} (v{plug.get('version')})")
+# Summary.
+total = passed + len(failures)
+print()
+if failures:
+    print(f"FAIL: {len(failures)} of {total} checks failed:")
+    for item in failures:
+        print(f"  - {item}")
+    sys.exit(1)
+
+print(f"PASS: all {total} checks passed.")
+print(f"      {PLUGIN}@{MARKETPLACE} installs cleanly and is runnable from a fresh checkout.")
 PY
-
-echo "Claude Code plugin install/update smoke check passed."


### PR DESCRIPTION
Closes #139

## What

Tightens the README install/**update** flow and adds an end-to-end install smoke script, per issue #139.

### Update path (the main gap)

The old "Update or remove" section claimed *"there is no automatic update mechanism — reinstall is the only way"* and documented a manual `uninstall` + `install` dance. **Both are inaccurate.** Per the [Claude Code plugin docs](https://code.claude.com/docs/en/discover-plugins), updates are a one-command refresh, and marketplaces can auto-update. Rewritten into:

- **Update** — one command, no uninstall needed:
  ```
  /plugin marketplace update cognee
  /reload-plugins
  ```
  plus how to enable per-marketplace **auto-update** for hands-off updates at startup.
- **Remove** — `/plugin uninstall` + optional `/plugin marketplace remove`.

> Note: there is **no** `/plugin update <plugin>` command in Claude Code — the documented mechanisms are marketplace refresh (`/plugin marketplace update`) and auto-update. This section uses only verified commands.

### Install

Keeps the documented two-step install and adds an optional **smoke check** to verify a fresh checkout is install-ready.

### Smoke script

`scripts/smoke-install.sh` verifies the `/plugin marketplace add` + `/plugin install` flow resolves on a clean checkout — marketplace name, plugin name, source path, and version are consistent across the README and the marketplace/plugin manifests, every hook script and skill resolves on disk — **without** needing a running Cognee server.

## Acceptance (issue #139)

- [x] Documented one-command **install** (verify) + **update** path
- [x] Smoke script exits `0`:

```
$ bash integrations/claude-code/scripts/smoke-install.sh
...
PASS: all 24 checks passed.
$ echo $?
0
```

Refs topoteretes/cognee#3680