### PR TITLE
docs: add CHANGELOG and release checklist for claude-code and codex

### DIFF
--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to the Cognee Memory plugin for Claude Code are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0] - 2026-06-27
+
+Initial public release of the Cognee Memory plugin for Claude Code. The notes
+below are seeded from the project's git history.
+
+### Added
+
+- Claude Code plugin built on the Cognee V2 API, with session hooks and agent identity.
+- Session memory capture for prompts, tool traces, and assistant responses, plus context injection on prompt submit and graph sync on session end.
+- Cognee as the default memory over the native `MEMORY.md`.
+- Background `remember` and `cognify` status polling so the graph build runs without blocking the session.
+- Resilient recall client with a circuit breaker and bounded timeouts; HTTP-first lookups that no longer trust empty CLI output.
+- Automatic Cognee installation and the Claude Code marketplace entry.
+- Automatic local API server handling with a separate, non-blocking bootstrap process.
+- `cognee-statusline.sh` with automatic status line setup and a per-turn audit log.
+- Typed memory entries, an idle watcher, and auto-improve.
+- Standardized Cognee session names as `{agent}_{native_session_id}`.
+
+### Changed
+
+- Use datasets instead of sessions as the primary point of contact with agents; removed session switching and ad-hoc agent creation.
+- Renamed `service` config to `base_url`.
+- Tightened the over-budget poll and made the bridge return a uniform `parse_error` shape.
+- Pinned the Cognee dependency to a known-good version.
+
+### Fixed
+
+- Enforce an overall poll deadline, retry on parse errors, and return uniform error shapes.
+- Catch network and HTTP errors in the bridge POST and apply a spin-loop floor.
+- Resolve the SSL certificate issue on local connections.
+- Make pending prompts and the bridge cache concurrency-safe; fix concurrent startup races with lazy bootstrap.
+- Fix database setup for fresh environments.
+- Fix persistence of duplicated files and the graph-context exit/compaction hooks.
+
+[Unreleased]: https://github.com/topoteretes/cognee-integrations/compare/claude-code-v0.2.0...HEAD
+[0.2.0]: https://github.com/topoteretes/cognee-integrations/releases/tag/claude-code-v0.2.0

--- a/integrations/claude-code/RELEASING.md
+++ b/integrations/claude-code/RELEASING.md
@@ -1,0 +1,33 @@
+# Releasing the Cognee Memory plugin for Claude Code
+
+This checklist covers cutting a new release of the Claude Code integration.
+Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and
+tags use the `claude-code-v*` prefix (for example, `claude-code-v0.2.0`).
+
+## Release checklist
+
+1. **Bump the version.**
+   - Update `version` in `integrations/claude-code/.claude-plugin/plugin.json`.
+
+2. **Update the changelog.**
+   - Move the relevant entries from `[Unreleased]` into a new version section in `CHANGELOG.md`.
+   - Set the release date (`YYYY-MM-DD`) and keep the Added / Changed / Fixed grouping.
+   - Update the comparison links at the bottom of the file.
+
+3. **Sync the marketplace version.**
+   - Update the `cognee-memory` plugin `version` in the root [`.claude-plugin/marketplace.json`](../../.claude-plugin/marketplace.json) so it matches `plugin.json`.
+
+4. **Open a release PR.**
+   - Commit the version bump, changelog, and marketplace sync together.
+   - Merge once CI is green.
+
+5. **Tag the release.**
+   - After merging to `main`:
+     ```bash
+     git tag claude-code-v<version>
+     git push origin claude-code-v<version>
+     ```
+
+6. **Verify.**
+   - Confirm `plugin.json` and `marketplace.json` report the same version.
+   - Install the plugin from the marketplace and confirm the new version loads.

--- a/integrations/codex/CHANGELOG.md
+++ b/integrations/codex/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to the Cognee Codex plugin are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.3-local] - 2026-06-25
+
+Initial public release of the Cognee Codex plugin. The notes below are seeded
+from the project's git history.
+
+### Added
+
+- Codex CLI plugin that captures session memory: prompts, tool traces, and assistant responses.
+- Context injection on prompt submit and graph sync on session end.
+- Automatic installation and the Codex marketplace entry.
+- Automatic local API server handling: start the server on session start, kill it on session end, with a separate non-blocking bootstrap process.
+- Cloud connection support with an API-endpoint-compatible Codex client.
+- Multiple agent sessions, including reuse of the same agent name across sessions.
+- Per-session exit watcher and session-distillation logic.
+- Resilient recall client with a circuit breaker and bounded timeouts; HTTP-first lookups that no longer trust empty CLI output.
+- `auto_feedback` environment variable (defaults to true).
+- Standardized Cognee session names as `{agent}_{native_session_id}`.
+
+### Changed
+
+- Use datasets instead of sessions as the primary point of contact with agents; removed session switching and ad-hoc agent creation.
+- Default to a single dataset shared across Claude and Codex.
+- Renamed `service` config to `base_url`.
+- Pinned the Cognee dependency to a known-good version.
+
+### Fixed
+
+- Resolve the SSL certificate issue on local connections.
+- Make pending prompts and the bridge cache concurrency-safe; fix concurrent startup races with lazy bootstrap.
+- Recreate the agent correctly when the API key is stale.
+- Fix mode resolution and connecting to an existing dataset.
+- Fix recall dataset targeting and the `base_url` resolution bug.
+- Background graph build that no longer treats write timeouts as unreachable.
+
+[Unreleased]: https://github.com/topoteretes/cognee-integrations/compare/codex-v1.0.3-local...HEAD
+[1.0.3-local]: https://github.com/topoteretes/cognee-integrations/releases/tag/codex-v1.0.3-local

--- a/integrations/codex/RELEASING.md
+++ b/integrations/codex/RELEASING.md
@@ -1,0 +1,33 @@
+# Releasing the Cognee Codex plugin
+
+This checklist covers cutting a new release of the Codex integration.
+Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and
+tags use the `codex-v*` prefix (for example, `codex-v1.0.3-local`).
+
+## Release checklist
+
+1. **Bump the version.**
+   - Update `version` in `integrations/codex/plugins/cognee/.codex-plugin/plugin.json`.
+
+2. **Update the changelog.**
+   - Move the relevant entries from `[Unreleased]` into a new version section in `CHANGELOG.md`.
+   - Set the release date (`YYYY-MM-DD`) and keep the Added / Changed / Fixed grouping.
+   - Update the comparison links at the bottom of the file.
+
+3. **Sync the marketplace version.**
+   - Confirm the plugin entry in [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json) points at the released plugin. If the marketplace ever pins an explicit version, update it to match `plugin.json`.
+
+4. **Open a release PR.**
+   - Commit the version bump, changelog, and any marketplace changes together.
+   - Merge once CI is green.
+
+5. **Tag the release.**
+   - After merging to `main`:
+     ```bash
+     git tag codex-v<version>
+     git push origin codex-v<version>
+     ```
+
+6. **Verify.**
+   - Confirm `plugin.json` reports the new version.
+   - Install the plugin from the Codex marketplace and confirm the new version loads.


### PR DESCRIPTION
Closes #137

## What

Adds release documentation for the two shipped plugins.

**claude-code**
- `CHANGELOG.md` — Keep-a-Changelog format, seeded from git history, with the current `0.2.0` release and an `[Unreleased]` section.
- `RELEASING.md` — bump → changelog → sync marketplace version → tag `claude-code-v*`.

**codex**
- `CHANGELOG.md` — Keep-a-Changelog format, seeded from git history, with the current `1.0.3-local` release and an `[Unreleased]` section.
- `RELEASING.md` — bump → changelog → sync marketplace → tag `codex-v*`.

## Notes

- No tags existed yet, so each changelog opens with the version recorded in the plugin manifest (`plugin.json`) dated to the latest commit on that integration.
- Changelog entries are curated from `git log` rather than a raw dump, grouped into Added / Changed / Fixed.
- Docs-only change; the Lint workflow only runs on Python files, so CI is unaffected.

## Test plan

- [ ] Confirm both `CHANGELOG.md` files render and follow Keep-a-Changelog.
- [ ] Confirm `RELEASING.md` steps match the actual manifest paths and tag scheme.