### PR TITLE
feat(claude-code): add elapsed_ms to recall, bridge, and improve hook events

### DIFF
--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1092,20 +1092,20 @@ def wait_for_cognify(
         f"&pipeline={urllib.parse.quote(pipeline)}"
     )
     deadline = time.monotonic() + max(0.0, deadline_seconds)
+    _poll_start = time.monotonic()
     while True:
         try:
             result = _json_http_request(path, None, method="GET", timeout=request_timeout)
         except urllib.error.HTTPError as exc:
             if exc.code == 404:
-                # Older server without the status route — can't confirm, don't loop.
                 return "unknown"
             hook_log(
                 "cognify_poll_transient",
-                {"dataset_id": dataset_id, "error": f"HTTP {exc.code}"},
+                {"dataset_id": dataset_id, "error": f"HTTP {exc.code}", "elapsed_ms": round((time.monotonic() - _poll_start) * 1000)},
             )
             result = None
         except (urllib.error.URLError, TimeoutError, OSError) as exc:
-            hook_log("cognify_poll_transient", {"dataset_id": dataset_id, "error": str(exc)[:120]})
+            hook_log("cognify_poll_transient", {"dataset_id": dataset_id, "error": str(exc)[:120], "elapsed_ms": round((time.monotonic() - _poll_start) * 1000)})
             result = None
 
         status = ""
@@ -1113,19 +1113,21 @@ def wait_for_cognify(
             raw = result.get(str(dataset_id))
             if raw is None and len(result) == 1:
                 raw = next(iter(result.values()))
-            # A multi-pipeline response nests {pipeline: status}; unwrap if needed.
             if isinstance(raw, dict):
                 raw = raw.get(pipeline)
             status = str(raw or "").upper()
 
         if status.endswith("COMPLETED"):
+            hook_log("cognify_poll_completed", {"dataset_id": dataset_id, "elapsed_ms": round((time.monotonic() - _poll_start) * 1000)})
             return "completed"
         if status.endswith("ERRORED"):
+            hook_log("cognify_poll_errored", {"dataset_id": dataset_id, "elapsed_ms": round((time.monotonic() - _poll_start) * 1000)})
             return "errored"
 
         if time.monotonic() >= deadline:
+            hook_log("cognify_poll_timeout", {"dataset_id": dataset_id, "elapsed_ms": round((time.monotonic() - _poll_start) * 1000)})
             return "timeout"
-        time.sleep(max(0.1, interval_seconds))  # floor avoids a tight spin if misconfigured to 0
+        time.sleep(max(0.1, interval_seconds))
 
 
 def remember_entry_via_http(

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -216,6 +216,7 @@ async def _run(prompt: str) -> dict | None:
     # whole loop stops once the overall budget is spent. Partial results are fine.
     recall_timeout = _float_env("COGNEE_RECALL_TIMEOUT", 2.5)
     budget_deadline = time.monotonic() + _float_env("COGNEE_RECALL_BUDGET", 4.0)
+    _recall_start = time.monotonic()
     # Respect the shared circuit breaker: when the server has been failing (tripped
     # by the explicit recall path), skip this per-prompt recall rather than hammering
     # a down backend on every keystroke. HTTP/cloud mode only.
@@ -358,16 +359,17 @@ async def _run(prompt: str) -> dict | None:
             section_lines.append(_format_entry(e))
             section_lines.append("")
 
+    elapsed_ms = round((time.monotonic() - _recall_start) * 1000)
     if total > 0:
         full_context = (
             f"{header}\n\nRelevant context from this session's memory:\n\n"
             + "\n".join(section_lines).strip()
         )
-        hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
+        hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn, "elapsed_ms": elapsed_ms})
         notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
     else:
         full_context = f"{header}\n\n(no memory matches for this prompt)"
-        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
+        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn, "elapsed_ms": elapsed_ms})
         notify(f"no recall matches; saves last turn {saves_last_turn}")
 
     # Audit log: persist full recall details per turn. The hook output stays a

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -245,6 +245,7 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
         _load_resolved()
     )
     target_sessions = [session_id] if session_id else []
+    _sync_start = time.monotonic()
     hook_log(
         "sync_start",
         {
@@ -284,6 +285,7 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
                             "dataset": dataset,
                             "via": "http_remember",
                             "wrote": wrote,
+                            "elapsed_ms": round((time.monotonic() - _sync_start) * 1000),
                         },
                     )
                     print(
@@ -307,6 +309,7 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
                         "user_id": str(getattr(user, "id", "")),
                         "wrote": wrote,
                         "graph_synced": graph_result.get("synced", 0),
+                        "elapsed_ms": round((time.monotonic() - _sync_start) * 1000),
                     },
                 )
                 print(
@@ -412,9 +415,10 @@ def main():
             return
         except Exception as exc:
             # Non-fatal: session sync failure should not crash Codex.
+            _elapsed = round((time.monotonic() - _sync_start) * 1000) if '_sync_start' in dir() else 0
             hook_log(
                 "sync_failed",
-                {"attempt": attempt, "attempts": attempts, "error": str(exc)[:300]},
+                {"attempt": attempt, "attempts": attempts, "error": str(exc)[:300], "elapsed_ms": _elapsed},
             )
             print(f"cognee-sync: failed ({exc})", file=sys.stderr)
             if attempt < attempts:


### PR DESCRIPTION
## Summary

Adds `elapsed_ms` timing to key hook log events using `time.monotonic()`:

- **Recall** (`session-context-lookup.py`): `context_lookup_hit`, `context_lookup_empty` now carry `elapsed_ms`
- **Bridge** (`_plugin_common.py` `wait_for_cognify`): `cognify_poll_completed`, `cognify_poll_errored`, `cognify_poll_timeout` now carry `elapsed_ms`
- **Sync** (`sync-session-to-graph.py`): `sync_bridge_done` and `sync_failed` now carry `elapsed_ms`

## Testing

- All existing tests pass
- No behavior change — timing is purely additive to `hook_log` detail dicts

Closes #3676