### PR TITLE
feat(claude-code): show installed plugin version in status line

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -176,14 +176,14 @@ risk a duplicate). Only a genuine connection failure falls back.
 
 ## Status line
 
-The status line displays `cognee: <dataset> · <mode>`, for example:
+The status line displays `cognee: <dataset> · <mode> · v<version>`, for example:
 
 ```
-cognee: agent_sessions · local
-cognee: my-project · cloud
+cognee: agent_sessions · local · v0.2.0
+cognee: my-project · cloud · v0.2.0
 ```
 
-`<dataset>` is the active Cognee dataset. `<mode>` is `local` when no `COGNEE_BASE_URL` is set or when it points to localhost, and `cloud` when it points to a remote host.
+`<dataset>` is the active Cognee dataset. `<mode>` is `local` when no `COGNEE_BASE_URL` is set or when it points to localhost, and `cloud` when it points to a remote host. `<version>` is the installed plugin version, read locally from `$CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json`; if that manifest is missing or unreadable, the version suffix is simply omitted.
 
 It is configured automatically on first launch — no manual steps needed. SessionStart writes the correct path into `~/.claude/settings.json` and Claude Code hot-reloads it, so the status line appears from your first interaction onward.
 

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -6,7 +6,8 @@ pipes a JSON context on stdin. Deliberately standalone and pure-local: reads
 only env vars and ``~/.cognee-plugin/config.json`` — no network calls, no
 ``_plugin_common`` import.
 
-Output: ``cognee: <dataset-name> · local`` or ``cognee: <dataset-name> · cloud``
+Output: ``cognee: <dataset-name> · local`` or ``cognee: <dataset-name> · cloud``,
+optionally suffixed with `` · v<version>`` when the plugin manifest is readable.
 """
 
 import json
@@ -73,12 +74,35 @@ def _health_prefix() -> str:
     return ""
 
 
+def _plugin_version() -> str:
+    # Read the installed plugin version from the manifest Claude Code points at.
+    # Pure-local and fail-silent: a missing env var or unreadable/malformed
+    # manifest yields "" (no version shown), never an exception.
+    root = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
+    if not root:
+        return ""
+    try:
+        manifest = Path(root) / ".claude-plugin" / "plugin.json"
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            v = str(data.get("version") or "").strip()
+            if v:
+                return v
+    except Exception:
+        pass
+    return ""
+
+
 def main() -> None:
     try:
         json.load(sys.stdin)  # consume stdin as required by Claude Code
     except Exception:
         pass
-    sys.stdout.write(f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}")
+    version = _plugin_version()
+    suffix = f" · v{version}" if version else ""
+    sys.stdout.write(
+        f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}{suffix}"
+    )
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/tests/test_statusline_version.py
+++ b/integrations/claude-code/tests/test_statusline_version.py
@@ -1,0 +1,107 @@
+"""Tests for the status-line plugin-version read (`_plugin_version`).
+
+The status line appends `· v<version>` read from the installed plugin manifest
+at `$CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json`. The read must be pure-local
+and fail-silent: any missing env var or unreadable/malformed manifest yields ""
+(no version shown) rather than raising.
+
+Run: python integrations/claude-code/tests/test_statusline_version.py
+"""
+
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import cognee_statusline_render as sr  # noqa: E402
+
+
+def _write_manifest(root, contents):
+    """Create <root>/.claude-plugin/plugin.json holding `contents` (raw text)."""
+    manifest_dir = pathlib.Path(root) / ".claude-plugin"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "plugin.json").write_text(contents, encoding="utf-8")
+
+
+def test_reads_version_from_manifest():
+    with tempfile.TemporaryDirectory() as root:
+        _write_manifest(root, json.dumps({"name": "cognee-memory", "version": "0.2.0"}))
+        os.environ["CLAUDE_PLUGIN_ROOT"] = root
+        try:
+            assert sr._plugin_version() == "0.2.0"
+        finally:
+            os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+
+
+def test_no_env_var_yields_empty():
+    os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+    assert sr._plugin_version() == ""
+
+
+def test_missing_manifest_yields_empty():
+    with tempfile.TemporaryDirectory() as root:
+        # root exists but no .claude-plugin/plugin.json inside it
+        os.environ["CLAUDE_PLUGIN_ROOT"] = root
+        try:
+            assert sr._plugin_version() == ""
+        finally:
+            os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+
+
+def test_malformed_manifest_yields_empty():
+    with tempfile.TemporaryDirectory() as root:
+        _write_manifest(root, "{ not valid json ")
+        os.environ["CLAUDE_PLUGIN_ROOT"] = root
+        try:
+            assert sr._plugin_version() == ""
+        finally:
+            os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+
+
+def test_manifest_without_version_key_yields_empty():
+    with tempfile.TemporaryDirectory() as root:
+        _write_manifest(root, json.dumps({"name": "cognee-memory"}))
+        os.environ["CLAUDE_PLUGIN_ROOT"] = root
+        try:
+            assert sr._plugin_version() == ""
+        finally:
+            os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+
+
+def test_full_line_includes_version_suffix():
+    """End-to-end: main() appends the suffix when a manifest is present."""
+    import io
+    from contextlib import redirect_stdout
+
+    with tempfile.TemporaryDirectory() as root:
+        _write_manifest(root, json.dumps({"version": "9.9.9"}))
+        os.environ["CLAUDE_PLUGIN_ROOT"] = root
+        # Force a deterministic local line (no env-driven dataset/mode).
+        os.environ.pop("COGNEE_PLUGIN_DATASET", None)
+        os.environ.pop("COGNEE_BASE_URL", None)
+        stdin_backup = sys.stdin
+        sys.stdin = io.StringIO("{}")
+        out = io.StringIO()
+        try:
+            with redirect_stdout(out):
+                sr.main()
+            assert out.getvalue().endswith("· v9.9.9")
+        finally:
+            sys.stdin = stdin_backup
+            os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
Closes #134

## What

The status line showed `cognee: <dataset> · <mode>` but not the plugin version. This adds it:

```
cognee: agent_sessions · local · v0.2.0
```

## How

- New `_plugin_version()` helper in `integrations/claude-code/scripts/cognee_statusline_render.py` reads `version` from `$CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json`.
- Pure-local and fail-silent, mirroring the existing `_active_dataset` / `_health_prefix` style: a missing env var or unreadable/malformed manifest yields `""`, so the suffix is simply omitted — no crash, no version shown.
- `main()` appends ` · v<version>` only when a version is found.
- README "Status line" section updated to document the suffix and its source.

## Tests

`integrations/claude-code/tests/test_statusline_version.py` covers:
- reads version from a valid manifest
- no `CLAUDE_PLUGIN_ROOT` → `""`
- missing manifest file → `""`
- malformed JSON → `""`
- manifest without a `version` key → `""`
- end-to-end: rendered line ends with `· v<version>`

```
$ python integrations/claude-code/tests/test_statusline_version.py
PASS test_full_line_includes_version_suffix
PASS test_malformed_manifest_yields_empty
PASS test_manifest_without_version_key_yields_empty
PASS test_missing_manifest_yields_empty
PASS test_no_env_var_yields_empty
PASS test_reads_version_from_manifest
```

Part of the Q3 integrations roadmap (WS2).