### PR TITLE
fix(claude-code,codex): send X-Api-Key to localhost so local remember/recall don't 401

### DIFF
--- a/integrations/claude-code/scripts/_recall_http.py
+++ b/integrations/claude-code/scripts/_recall_http.py
@@ -138,10 +138,10 @@ def do_recall(
     if context_profile:
         body["context_profile"] = context_profile
     headers = {"Content-Type": "application/json"}
-    # COGNEE_API_KEY is a *cloud* credential; the local single-user server needs no
-    # auth and ignores it. Only attach it for a remote/cloud target, so we don't send
-    # a meaningless (and confusing) cloud key to localhost.
-    if api_key and not _is_local(service_url):
+    # Attach the API key whenever we have one. The bundled local server *requires*
+    # X-Api-Key (returns 401 without it); a server that needs no auth ignores the
+    # extra header. Previously stripped for loopback, which broke local writes (#106).
+    if api_key:
         headers["X-Api-Key"] = api_key
 
     req = urllib.request.Request(

--- a/integrations/claude-code/scripts/_remember_http.py
+++ b/integrations/claude-code/scripts/_remember_http.py
@@ -135,7 +135,7 @@ def _poll_status(
         + "&pipeline=cognify_pipeline"
     )
     headers = {}
-    if api_key and not _is_local(service_url):
+    if api_key:  # local status endpoint also requires the key (see issue #106)
         headers["X-Api-Key"] = api_key
     deadline = time.monotonic() + max(0.0, deadline_seconds)
     while True:
@@ -189,9 +189,10 @@ def do_remember(
         [("data", filename, content.encode("utf-8") if isinstance(content, str) else content)],
     )
     headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
-    # COGNEE_API_KEY is a cloud credential; local single-user servers need no
-    # auth and ignore it. Only attach it for a remote/cloud target.
-    if api_key and not _is_local(service_url):
+    # Attach the API key whenever we have one. The bundled local server *requires*
+    # X-Api-Key (returns 401 without it); a server that needs no auth ignores the
+    # extra header. Previously stripped for loopback, which broke local writes (#106).
+    if api_key:
         headers["X-Api-Key"] = api_key
 
     req = urllib.request.Request(url, data=body, headers=headers, method="POST")

--- a/integrations/claude-code/tests/test_localhost_auth.py
+++ b/integrations/claude-code/tests/test_localhost_auth.py
@@ -1,0 +1,126 @@
+"""Regression tests for issue #106: the X-Api-Key header must be sent to a
+localhost server when a key is present.
+
+The client used to strip ``X-Api-Key`` for loopback targets (``if api_key and
+not _is_local(...)``) on the assumption that the local single-user server needs
+no auth. The bundled local server *does* require the header and returns HTTP 401
+without it, so every ``cognee-remember`` write failed. The fix attaches the key
+whenever one is present; a server that ignores auth simply ignores the header.
+
+These tests capture the outgoing ``urllib.request.Request`` via the injectable
+``opener`` and assert the header is present for a ``localhost`` URL.
+
+Run: python integrations/claude-code/tests/test_localhost_auth.py (or via pytest).
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _recall_http as recall  # noqa: E402
+import _remember_http as remember  # noqa: E402
+
+# urllib capitalizes header keys, so "X-Api-Key" is stored as "X-api-key".
+_HEADER = "X-api-key"
+_LOCAL = "http://localhost:8011"
+_KEY = "ck_secret_local"
+
+
+class _Resp:
+    def __init__(self, body=b"{}"):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def _capturing_opener(captured, body=b"{}"):
+    def _open(req, timeout=None):
+        # Record every request issued (POST then any status GETs).
+        captured.setdefault("reqs", []).append(req)
+        captured["req"] = req
+        return _Resp(body)
+
+    return _open
+
+
+# --- remember (write) path -------------------------------------------------
+
+
+def test_remember_attaches_key_on_localhost():
+    """The core bug: a write to localhost must carry X-Api-Key when a key is set."""
+    cap = {}
+    remember.do_remember(_LOCAL, _KEY, "content", "ds", "user_context", opener=_capturing_opener(cap))
+    assert cap["req"].get_header(_HEADER) == _KEY
+
+
+def test_remember_no_key_sends_no_header():
+    """No key configured → no header (unchanged behavior, no accidental empty header)."""
+    cap = {}
+    remember.do_remember(_LOCAL, "", "content", "ds", "user_context", opener=_capturing_opener(cap))
+    assert cap["req"].get_header(_HEADER) is None
+
+
+def test_remember_attaches_key_on_remote():
+    """Cloud/remote target keeps working — key still attached."""
+    cap = {}
+    remember.do_remember(
+        "https://api.cognee.ai", _KEY, "content", "ds", "user_context", opener=_capturing_opener(cap)
+    )
+    assert cap["req"].get_header(_HEADER) == _KEY
+
+
+def test_remember_status_poll_attaches_key_on_localhost():
+    """The status-poll GET (cognify confirmation) must also be authenticated on localhost."""
+    cap = {}
+    # A response carrying dataset_id triggers the bounded status poll.
+    body = b'{"status":"running","dataset_id":"d1","pipeline_run_id":"p1"}'
+    import os
+
+    os.environ["COGNEE_REMEMBER_WAIT_SECONDS"] = "0.05"
+    os.environ["COGNEE_COGNIFY_POLL_INTERVAL"] = "0.01"
+    try:
+        remember.do_remember(_LOCAL, _KEY, "c", "ds", "uc", opener=_capturing_opener(cap, body))
+    finally:
+        os.environ.pop("COGNEE_REMEMBER_WAIT_SECONDS", None)
+        os.environ.pop("COGNEE_COGNIFY_POLL_INTERVAL", None)
+    methods = [getattr(r, "method", None) or r.get_method() for r in cap["reqs"]]
+    assert "GET" in methods, "expected a status-poll GET to be issued"
+    for r in cap["reqs"]:
+        assert r.get_header(_HEADER) == _KEY
+
+
+# --- recall (read) path ----------------------------------------------------
+
+
+def test_recall_attaches_key_on_localhost():
+    """Recall against an authenticated localhost server must carry the key too."""
+    cap = {}
+    recall.do_recall(_LOCAL, _KEY, "q", "", '["graph"]', "5", opener=_capturing_opener(cap, b"[]"))
+    assert cap["req"].get_header(_HEADER) == _KEY
+
+
+def test_recall_no_key_sends_no_header():
+    cap = {}
+    recall.do_recall(_LOCAL, "", "q", "", '["graph"]', "5", opener=_capturing_opener(cap, b"[]"))
+    assert cap["req"].get_header(_HEADER) is None
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/claude-code/tests/test_recall_http.py
+++ b/integrations/claude-code/tests/test_recall_http.py
@@ -115,17 +115,19 @@ def test_malformed_json_is_error_not_unreachable():
     assert out != rh.UNREACHABLE
 
 
-def test_no_cloud_key_sent_to_localhost():
+def test_key_attached_to_localhost_and_remote():
+    # Issue #106: the bundled local server requires X-Api-Key (401 without it), so
+    # the key must be attached for localhost too — not just remote/cloud targets.
     captured = {}
 
     def _capture(req, timeout=None):
         captured["xapikey"] = req.get_header("X-api-key")  # urllib title-cases header names
         return _Resp("[]")
 
-    # localhost target → cloud key must NOT be attached
-    rh.do_recall("http://localhost:8011", "cloud-key", "q", "", '["graph"]', "5", opener=_capture)
-    assert captured["xapikey"] is None
-    # remote target → key IS attached
+    # localhost target → key IS attached (previously stripped, which broke local auth)
+    rh.do_recall("http://localhost:8011", "local-key", "q", "", '["graph"]', "5", opener=_capture)
+    assert captured["xapikey"] == "local-key"
+    # remote target → key IS attached (unchanged)
     rh.do_recall(
         "https://tenant.cognee.ai", "cloud-key", "q", "", '["graph"]', "5", opener=_capture
     )

--- a/integrations/codex/plugins/cognee/scripts/_recall_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_recall_http.py
@@ -138,10 +138,10 @@ def do_recall(
     if context_profile:
         body["context_profile"] = context_profile
     headers = {"Content-Type": "application/json"}
-    # COGNEE_API_KEY is a *cloud* credential; the local single-user server needs no
-    # auth and ignores it. Only attach it for a remote/cloud target, so we don't send
-    # a meaningless (and confusing) cloud key to localhost.
-    if api_key and not _is_local(service_url):
+    # Attach the API key whenever we have one. The bundled local server *requires*
+    # X-Api-Key (returns 401 without it); a server that needs no auth ignores the
+    # extra header. Previously stripped for loopback, which broke local writes (#106).
+    if api_key:
         headers["X-Api-Key"] = api_key
 
     req = urllib.request.Request(

--- a/integrations/codex/plugins/cognee/scripts/_remember_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_remember_http.py
@@ -114,9 +114,10 @@ def do_remember(
         [("data", filename, content.encode("utf-8") if isinstance(content, str) else content)],
     )
     headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
-    # COGNEE_API_KEY is a cloud credential; local single-user servers need no
-    # auth and ignore it. Only attach it for a remote/cloud target.
-    if api_key and not _is_local(service_url):
+    # Attach the API key whenever we have one. The bundled local server *requires*
+    # X-Api-Key (returns 401 without it); a server that needs no auth ignores the
+    # extra header. Previously stripped for loopback, which broke local writes (#106).
+    if api_key:
         headers["X-Api-Key"] = api_key
 
     req = urllib.request.Request(url, data=body, headers=headers, method="POST")


### PR DESCRIPTION
Closes #106

## Problem

`cognee-remember` always returned **HTTP 401** against a local server (`http://localhost:8011`). The HTTP clients deliberately stripped `X-Api-Key` for loopback targets:

```python
# old
if api_key and not _is_local(service_url):
    headers["X-Api-Key"] = api_key
```

The assumption ("local single-user server needs no auth") is false for the **bundled** local server — it returns 401 when `X-Api-Key` is missing. `curl` confirms the header is the only difference between a 401 and a 200 on `/api/v1/remember`.

## Fix

Attach the key whenever one is present. A server that genuinely ignores auth ignores the extra header; the bundled local server that requires it now works.

```python
# new
if api_key:
    headers["X-Api-Key"] = api_key
```

Applied **consistently across both mirrored clients**:

| File | Site fixed |
| --- | --- |
| `claude-code/.../_remember_http.py` | remember `POST` **+** cognify status-poll `GET` (`_poll_status`) |
| `claude-code/.../_recall_http.py` | recall `POST` |
| `codex/.../_remember_http.py` | remember `POST` |
| `codex/.../_recall_http.py` | recall `POST` |

> Note: I also fixed the **status-poll GET** in `_poll_status`, so background-write confirmation is authenticated against the local server too — not just the initial POST.

No behavior change for remote/cloud targets (the key was, and still is, attached there).

## Tests

- **New** `tests/test_localhost_auth.py` — asserts `X-Api-Key` is attached for `localhost` on remember (POST **and** status poll) and recall; no header when no key is set; remote still authenticated. (6 tests)
- **Updated** `tests/test_recall_http.py::test_no_cloud_key_sent_to_localhost` → `test_key_attached_to_localhost_and_remote`; the old test asserted the buggy "strip on loopback" behavior.

```
$ python integrations/claude-code/tests/test_localhost_auth.py   # 6 PASS
$ for t in integrations/claude-code/tests/test_*.py; do python "$t"; done   # all green
```

All four changed scripts byte-compile.