### PR TITLE
docs: add CHANGELOG.md and release checklist per integration (#3678)

### DIFF
--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to the Cognee Claude Code plugin are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-06-29
+
+### Added
+- Status line shows installed plugin version (e.g. `· v0.2.0`)
+- Observability: `elapsed_ms` added to `context_lookup_hit`, `context_lookup_empty`, `cognify_poll_*`, and `sync_bridge_done` hook log events
+- Per-operation timeouts: `COGNEE_REMEMBER_TIMEOUT`, `COGNEE_REGISTER_TIMEOUT` env vars
+- Cloud cold-start warmup ping on `SessionStart` (gated by `COGNEE_WARMUP`)
+- Background remember with cognify status polling and `dataset_id` tracking
+- `improve()` (memify) support for post-ingestion enrichment
+- `cognee-plugin status` one-liner (runtime mode, URL, API key presence, version)
+- "Cognee preferred memory" SessionStart steer instruction
+- Circuit breaker for recall: threshold-based cooldown on repeated failures
+- Session-context distillation via improve step
+
+### Changed
+- Remember API uses `run_in_background=true` by default (`COGNEE_REMEMBER_BACKGROUND`)
+- Write timeouts no longer trigger CLI fallback (avoids duplicates)
+- HTTP errors (4xx/5xx) from server are authoritative — no CLI fallback
+- Recall routes through `_cognee_client.py` with breaker + timeout policy
+- Runtime state resolution via API endpoints instead of local files
+- Version consistency enforced across `inventory.yml`, `plugin.json`, `marketplace.json`
+
+### Fixed
+- Stale readiness marker no longer blocks recall after server restart
+- Idle watcher double-write race on concurrent agent sessions
+- Bridge poll no longer spins on zero interval
+- SSL cert loading on macOS without certifi
+- Server-first recall for cloud mode (removes local SDK dependency)
+
+## [0.1.0] - 2026-06-01
+
+### Added
+- Initial Claude Code marketplace plugin
+- Session-aware memory capture (prompt, trace, answer hooks)
+- Context injection on every `UserPromptSubmit` via `session-context-lookup`
+- Session-to-graph sync on `SessionEnd`
+- Local Cognee API bootstrap mode
+- Cloud/remote managed endpoint mode
+- Status line: `cognee: <dataset> · <mode>`
+- Idle watcher for periodic session persistence
+- Configuration via env vars and `~/.cognee-plugin/claude-code/config.json`

--- a/integrations/claude-code/RELEASING.md
+++ b/integrations/claude-code/RELEASING.md
@@ -1,0 +1,60 @@
+# Releasing
+
+This document describes how to release a new version of the Cognee Claude Code plugin.
+
+## Release checklist
+
+1. **Create a release branch**
+   ```bash
+   git checkout -b release/claude-code-v0.x.x
+   ```
+
+2. **Update the version**
+   - `integrations/claude-code/.claude-plugin/plugin.json` — bump `version`
+   - `integrations/inventory.yml` — bump `current_version` for `slug: claude-code`
+   - `.claude-plugin/marketplace.json` — bump `version` for plugin `cognee-memory`
+
+3. **Update the changelog**
+   - Move items from "Unreleased" to a new dated section in `CHANGELOG.md`
+   - Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format
+
+4. **Run version consistency check**
+   ```bash
+   python3 scripts/check_version_consistency.py
+   ```
+   Must exit 0.
+
+5. **Run tests**
+   ```bash
+   cd integrations/claude-code
+   uv sync --locked --dev
+   uv run pytest tests/ -v
+   ```
+
+6. **Commit and tag**
+   ```bash
+   git add -A
+   git commit -s -m "chore(claude-code): release v0.x.x"
+   git tag claude-code-v0.x.x
+   git push origin release/claude-code-v0.x.x --tags
+   ```
+
+7. **Open a pull request**
+   - Open a PR against `main`
+   - Title: `chore(claude-code): release v0.x.x`
+   - Include changelog summary in the PR description
+
+8. **After merge, sync the marketplace version**
+   - The marketplace source (`marketplace.json`) is consumed by Claude Code's plugin system.
+   - Once the PR merges, run inside Claude Code to pick up the update:
+     ```
+     /plugin uninstall cognee-memory@cognee
+     /plugin install cognee-memory@cognee
+     ```
+   - Or for a full refresh:
+     ```
+     /plugin uninstall cognee-memory@cognee
+     /plugin marketplace remove topoteretes/cognee-integrations
+     /plugin marketplace add topoteretes/cognee-integrations
+     /plugin install cognee-memory@cognee
+     ```

--- a/integrations/codex/CHANGELOG.md
+++ b/integrations/codex/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to the Cognee Codex plugin are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.3-local] - 2026-06-24
+
+### Added
+- CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and UI launch
+- Automatic session memory capture via Codex hooks (SessionStart, UserPromptSubmit, PostToolUse, Stop)
+- Context injection from session and graph memory on every prompt
+- Session-to-graph sync on session end
+- Local Cognee API bootstrap mode
+- Cloud/remote managed endpoint mode
+- Cognee preferred memory steering
+
+### Changed
+- Version consistency enforced across inventory.yml and plugin.json
+
+## [1.0.0] - 2026-06-01
+
+### Added
+- Initial Codex plugin with Cognee CLI skills
+- Setup, memory, codebase ingestion, and UI launch commands


### PR DESCRIPTION
Adds CHANGELOG.md (Keep a Changelog format) for:
- claude-code integration (seeded from git history: 0.1.0 initial → 0.2.0 current)
- codex integration (seeded from git history: 1.0.0 → 1.0.3-local)

Adds RELEASING.md covering the full workflow: bump → changelog → tag `claude-code-v*` → merge → sync marketplace version.

Closes #3678