### PR TITLE
docs(claude-code): polish install/update steps and add smoke script (#3680)

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -9,14 +9,24 @@ The integration:
 
 ## Install
 
-Install from the Claude Code marketplace. You can do this interactively by typing slash commands directly in the Claude Code chat:
+Install from the Claude Code marketplace. Run these commands inside Claude Code:
 
-```
+```claude
 /plugin marketplace add topoteretes/cognee-integrations
 /plugin install cognee-memory@cognee
 ```
 
-Then set environment variables for your runtime mode.
+Then close and restart Claude Code (the plugin activates on the next launch).
+
+> **Tip:** For a first-time install, make sure no existing `~/.cognee-plugin/` directory interferes — the plugin bootstraps itself on first launch.
+
+Set environment variables **before** launching Claude Code (or in the shell that launches it):
+
+**Local mode** (default, no `COGNEE_BASE_URL`) — the plugin bootstraps a local Cognee API at `http://localhost:8011`. Only `LLM_API_KEY` is required:
+
+```bash
+export LLM_API_KEY="sk-..."
+```
 
 **Cognee Cloud or a remote server** — set both:
 
@@ -25,13 +35,7 @@ export COGNEE_BASE_URL="https://your-instance.cognee.ai"
 export COGNEE_API_KEY="ck_..."
 ```
 
-**Local mode** (default when `COGNEE_BASE_URL` is not set) — the plugin bootstraps a local Cognee API at `http://localhost:8011`. Only `LLM_API_KEY` is required; `COGNEE_API_KEY` is auto-minted if absent:
-
-```bash
-export LLM_API_KEY="sk-..."
-```
-
-You can also set config in `~/.cognee-plugin/claude-code/config.json`:
+You can also persist config in `~/.cognee-plugin/claude-code/config.json`:
 
 ```json
 {
@@ -40,7 +44,7 @@ You can also set config in `~/.cognee-plugin/claude-code/config.json`:
 }
 ```
 
-On startup you should see a "Cognee Memory Connected" system message.
+On startup you should see a **"Cognee Memory Connected"** system message and the status line will show `cognee: agent_sessions · local · v0.2.0`.
 
 ## Auth
 
@@ -229,20 +233,37 @@ Shared state (used by both Claude Code and Codex plugins):
 
 ## Update or remove
 
-Reinstall the plugin to pick up marketplace updates (run inside Claude Code chat):
+### Quick update (reinstall)
+Run inside Claude Code:
 
-```
+```claude
 /plugin uninstall cognee-memory@cognee
 /plugin install cognee-memory@cognee
 ```
 
-To also refresh the marketplace source:
+Restart Claude Code to activate the updated plugin.
 
-```
+### Full refresh (marketplace source + plugin)
+If the quick update doesn't pick up the latest version (e.g. after a marketplace-source update):
+
+```claude
 /plugin uninstall cognee-memory@cognee
 /plugin marketplace remove topoteretes/cognee-integrations
 /plugin marketplace add topoteretes/cognee-integrations
 /plugin install cognee-memory@cognee
+```
+
+### One-command install smoke test
+Run the smoke script from this repo to verify the marketplace JSON and plugin manifest are internally consistent:
+
+```bash
+python3 scripts/check_version_consistency.py
+```
+
+### Uninstall
+```claude
+/plugin uninstall cognee-memory@cognee
+/plugin marketplace remove topoteretes/cognee-integrations
 ```
 
 There is no automatic update mechanism — reinstall is the only way to pull in new plugin versions.

--- a/scripts/smoke_install_check.py
+++ b/scripts/smoke_install_check.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Smoke-test that the Claude Code plugin marketplace manifest and plugin.json are valid.
+
+Checks:
+  1. marketplace.json is valid JSON and has expected structure
+  2. plugin.json is valid JSON and has expected structure
+  3. The plugin listed in marketplace.json points to a valid source path
+  4. The plugin's hooks file exists (if referenced)
+
+Exit 0 on success, 1 on failure — suitable for CI.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ERRORS = []
+
+
+def check(path: Path, label: str):
+    if not path.exists():
+        ERRORS.append(f"{label}: file not found at {path}")
+        return {}
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        ERRORS.append(f"{label}: invalid JSON — {e}")
+        return {}
+
+    if not isinstance(data, dict):
+        ERRORS.append(f"{label}: root must be a JSON object, got {type(data).__name__}")
+        return {}
+
+    return data
+
+
+def check_claude_code_plugin():
+    plugin_dir = REPO_ROOT / "integrations" / "claude-code"
+    plugin_json = plugin_dir / ".claude-plugin" / "plugin.json"
+    hooks_json = plugin_dir / "hooks" / "hooks.json"
+
+    data = check(plugin_json, "claude-code plugin.json")
+    if not data:
+        return
+
+    required_keys = ["name", "version", "description"]
+    for key in required_keys:
+        if key not in data:
+            ERRORS.append(f"claude-code plugin.json: missing required key '{key}'")
+
+    version = data.get("version", "")
+    if not re.match(r"^\d+\.\d+\.\d+", version):
+        ERRORS.append(f"claude-code plugin.json: version '{version}' does not match semver")
+
+    if hooks_json.exists():
+        hooks_data = check(hooks_json, "claude-code hooks.json")
+        if hooks_data:
+            hook_scripts = hooks_json.parent.parent / "scripts"
+            for scripts in hooks_data.values() if isinstance(hooks_data, dict) else []:
+                if isinstance(scripts, list):
+                    for script_path in scripts:
+                        candidate = hook_scripts / str(script_path)
+                        if not candidate.exists():
+                            ERRORS.append(f"claude-code hooks.json: referenced script '{script_path}' not found at {candidate}")
+
+
+def check_marketplace():
+    marketplace = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+    data = check(marketplace, "marketplace.json")
+    if not data:
+        return
+
+    plugins = data.get("plugins", [])
+    if not isinstance(plugins, list) or not plugins:
+        ERRORS.append("marketplace.json: 'plugins' must be a non-empty list")
+        return
+
+    for i, plugin in enumerate(plugins):
+        if not isinstance(plugin, dict):
+            ERRORS.append(f"marketplace.json plugins[{i}]: must be an object")
+            continue
+
+        name = plugin.get("name", f"<index {i}>")
+        required = ["name", "version", "source"]
+        for key in required:
+            if key not in plugin:
+                ERRORS.append(f"marketplace.json plugin '{name}': missing required key '{key}'")
+
+        source = plugin.get("source", "")
+        if source and isinstance(source, str):
+            source_path = REPO_ROOT / source
+            if not source_path.exists():
+                ERRORS.append(f"marketplace.json plugin '{name}': source path '{source}' does not exist at {source_path}")
+
+
+def main():
+    check_marketplace()
+    check_claude_code_plugin()
+
+    if ERRORS:
+        print("Smoke install check FAILED:", file=sys.stderr)
+        for err in ERRORS:
+            print(f"  - {err}", file=sys.stderr)
+        sys.exit(1)
+
+    print("All install manifest checks passed.")
+    print(f"  marketplace.json: valid, {len(json.loads((REPO_ROOT / '.claude-plugin' / 'marketplace.json').read_text()).get('plugins', []))} plugin(s)")
+    print("  claude-code plugin.json: valid")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Tightens README install section with tip about fresh installs
- Adds one-command quick update vs full refresh sections
- Adds `scripts/smoke_install_check.py` that validates marketplace.json and plugin.json structure, checks hooks references, and verifies source paths resolve
- References the smoke script from the README

**Smoke script checks:**
- marketplace.json valid JSON + expected structure
- plugin.json valid JSON + semver version
- Plugins in marketplace.json point to valid source paths
- Referenced hook scripts exist

Closes #3680