### PR TITLE
[codex] show installed plugin version in Claude status line

### DIFF
--- a/integrations/claude-code/scripts/EVENTS.md
+++ b/integrations/claude-code/scripts/EVENTS.md
@@ -1,0 +1,43 @@
+# Hook event taxonomy
+
+The hook logger normalizes structured event names before writing them to `hook.log`.
+
+## Namespaced events
+
+- `agent.register_failed`
+- `agent.unregister_failed`
+- `bridge.deadline_exceeded`
+- `bridge.done`
+- `bridge.failed`
+- `bridge.no_dataset_id`
+- `bridge.parse_error`
+- `bridge.skipped_empty_cache`
+- `bridge.skipped_no_api_key`
+- `cognify.poll_failed`
+- `cognify.poll_transient`
+- `fs.activity_log_write_failed`
+- `fs.activity_touch_failed`
+- `fs.json_load_failed`
+- `fs.json_write_failed`
+- `fs.save_counter_read_failed`
+- `fs.save_counter_reset_read_failed`
+- `fs.save_counter_reset_write_failed`
+- `fs.save_counter_write_failed`
+- `fs.turn_counter_write_failed`
+- `host.find_parent_failed`
+- `process.venv_reexec_failed`
+- `runtime.connection_lookup_failed`
+- `runtime.resolve_user_failed`
+- `runtime.server_ready_clear_failed`
+- `runtime.server_ready_mark_failed`
+- `runtime.users_me_failed`
+- `session.map_create_failed`
+- `session.map_read_failed`
+- `session.sync_lock_busy`
+- `session.sync_lock_read_failed`
+- `session.sync_lock_release_failed`
+- `session.sync_lock_unlink_failed`
+- `statusline.configured`
+- `statusline.setup_failed`
+- `statusline.setup_skipped`
+

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -56,6 +56,50 @@ AUTO_IMPROVE_EVERY_DEFAULT = 30
 SYNC_LOCK_STALE_SECONDS = 15 * 60
 _DEFAULT_LOCAL_SERVICE_URL = "http://localhost:8011"
 
+_EVENT_NAME_MAP = {
+    "session_map_read_failed": "session.map_read_failed",
+    "map_create_failed": "session.map_create_failed",
+    "runtime_state_users_me_failed": "runtime.users_me_failed",
+    "runtime_state_connection_lookup_failed": "runtime.connection_lookup_failed",
+    "json_load_failed": "fs.json_load_failed",
+    "json_write_failed": "fs.json_write_failed",
+    "resolve_user_failed": "runtime.resolve_user_failed",
+    "venv_reexec_failed": "process.venv_reexec_failed",
+    "activity_log_write_failed": "fs.activity_log_write_failed",
+    "save_counter_read_failed": "fs.save_counter_read_failed",
+    "save_counter_write_failed": "fs.save_counter_write_failed",
+    "save_counter_reset_read_failed": "fs.save_counter_reset_read_failed",
+    "save_counter_reset_write_failed": "fs.save_counter_reset_write_failed",
+    "turn_counter_write_failed": "fs.turn_counter_write_failed",
+    "activity_touch_failed": "fs.activity_touch_failed",
+    "sync_lock_read_failed": "session.sync_lock_read_failed",
+    "sync_lock_unlink_failed": "session.sync_lock_unlink_failed",
+    "sync_lock_busy": "session.sync_lock_busy",
+    "sync_lock_release_failed": "session.sync_lock_release_failed",
+    "server_ready_mark_failed": "runtime.server_ready_mark_failed",
+    "server_ready_clear_failed": "runtime.server_ready_clear_failed",
+    "find_claude_parent_failed": "host.find_parent_failed",
+    "statusline_setup_skipped": "statusline.setup_skipped",
+    "statusline_configured": "statusline.configured",
+    "statusline_setup_failed": "statusline.setup_failed",
+    "cognify_poll_failed": "cognify.poll_failed",
+    "cognify_poll_transient": "cognify.poll_transient",
+    "agent_register_failed": "agent.register_failed",
+    "agent_unregister_failed": "agent.unregister_failed",
+    "http_bridge_skipped_no_api_key": "bridge.skipped_no_api_key",
+    "http_bridge_skipped_empty_cache": "bridge.skipped_empty_cache",
+    "http_bridge_done": "bridge.done",
+    "http_bridge_failed": "bridge.failed",
+    "http_bridge_deadline_exceeded": "bridge.deadline_exceeded",
+    "http_bridge_parse_error": "bridge.parse_error",
+    "http_bridge_no_dataset_id": "bridge.no_dataset_id",
+}
+
+
+def _normalize_event_name(event: str) -> str:
+    event = str(event or "").strip()
+    return _EVENT_NAME_MAP.get(event, event)
+
 # --- Self-managed cognee runtime ---------------------------------------------
 # The plugin owns an isolated virtualenv for cognee under ~/.cognee-plugin/venv
 # (disposable: rebuilt/upgraded freely), while all persistent data lives under
@@ -535,7 +579,7 @@ def hook_log(event: str, detail: Optional[dict] = None) -> None:
         line = {
             "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
             "pid": os.getpid(),
-            "event": event,
+            "event": _normalize_event_name(event),
         }
         if detail:
             line["detail"] = detail

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -3,7 +3,7 @@
 
 Invoked by Claude Code's ``statusLine`` (via ``cognee-statusline.sh``), which
 pipes a JSON context on stdin. Deliberately standalone and pure-local: reads
-only env vars and ``~/.cognee-plugin/config.json`` — no network calls, no
+only env vars and ``~/.cognee-plugin/config.json`` - no network calls, no
 ``_plugin_common`` import.
 
 Output: ``cognee: <dataset-name> · local`` or ``cognee: <dataset-name> · cloud``
@@ -20,6 +20,9 @@ _SHARED_ROOT = Path.home() / ".cognee-plugin"
 _CONFIG_PATH = _SHARED_ROOT / "claude-code" / "config.json"
 _SERVER_READY_PATH = _SHARED_ROOT / "server-ready.json"
 _BREAKER_PATH = _SHARED_ROOT / "recall-breaker.json"
+_PLUGIN_MANIFEST_PATH = (
+    Path(os.environ.get("CLAUDE_PLUGIN_ROOT", "")) / ".claude-plugin" / "plugin.json"
+)
 _DEFAULT_DATASET = "agent_sessions"
 
 
@@ -73,12 +76,29 @@ def _health_prefix() -> str:
     return ""
 
 
+def _installed_version() -> str:
+    try:
+        raw = json.loads(_PLUGIN_MANIFEST_PATH.read_text(encoding="utf-8"))
+        if isinstance(raw, dict):
+            return str(raw.get("version") or "").strip()
+    except Exception:
+        pass
+    return ""
+
+
+def _version_suffix() -> str:
+    version = _installed_version()
+    return f" · v{version}" if version else ""
+
+
 def main() -> None:
     try:
         json.load(sys.stdin)  # consume stdin as required by Claude Code
     except Exception:
         pass
-    sys.stdout.write(f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}")
+    sys.stdout.write(
+        f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}{_version_suffix()}"
+    )
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/tests/test_events.py
+++ b/integrations/claude-code/tests/test_events.py
@@ -1,0 +1,72 @@
+import pathlib
+import re
+
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+EVENTS_MD = SCRIPT_DIR / "EVENTS.md"
+PLUGIN_COMMON = SCRIPT_DIR / "_plugin_common.py"
+
+
+def _documented_events() -> set[str]:
+    lines = EVENTS_MD.read_text(encoding="utf-8").splitlines()
+    return {line.strip()[2:-1] for line in lines if re.match(r"^- `.+`$", line.strip())}
+
+
+def _mapped_events() -> set[str]:
+    text = PLUGIN_COMMON.read_text(encoding="utf-8")
+    start = text.index("_EVENT_NAME_MAP = {")
+    end = text.index("}\n\n\ndef _normalize_event_name")
+    block = text[start:end]
+    events = set()
+    for line in block.splitlines():
+        line = line.strip()
+        if not line.startswith('"'):
+            continue
+        key = line.split('"', 2)[1]
+        events.add(key)
+    return {_normalize(key) for key in events}
+
+
+def _normalize(event: str) -> str:
+    return {
+        "session_map_read_failed": "session.map_read_failed",
+        "map_create_failed": "session.map_create_failed",
+        "runtime_state_users_me_failed": "runtime.users_me_failed",
+        "runtime_state_connection_lookup_failed": "runtime.connection_lookup_failed",
+        "json_load_failed": "fs.json_load_failed",
+        "json_write_failed": "fs.json_write_failed",
+        "resolve_user_failed": "runtime.resolve_user_failed",
+        "venv_reexec_failed": "process.venv_reexec_failed",
+        "activity_log_write_failed": "fs.activity_log_write_failed",
+        "save_counter_read_failed": "fs.save_counter_read_failed",
+        "save_counter_write_failed": "fs.save_counter_write_failed",
+        "save_counter_reset_read_failed": "fs.save_counter_reset_read_failed",
+        "save_counter_reset_write_failed": "fs.save_counter_reset_write_failed",
+        "turn_counter_write_failed": "fs.turn_counter_write_failed",
+        "activity_touch_failed": "fs.activity_touch_failed",
+        "sync_lock_read_failed": "session.sync_lock_read_failed",
+        "sync_lock_unlink_failed": "session.sync_lock_unlink_failed",
+        "sync_lock_busy": "session.sync_lock_busy",
+        "sync_lock_release_failed": "session.sync_lock_release_failed",
+        "server_ready_mark_failed": "runtime.server_ready_mark_failed",
+        "server_ready_clear_failed": "runtime.server_ready_clear_failed",
+        "find_claude_parent_failed": "host.find_parent_failed",
+        "statusline_setup_skipped": "statusline.setup_skipped",
+        "statusline_configured": "statusline.configured",
+        "statusline_setup_failed": "statusline.setup_failed",
+        "cognify_poll_failed": "cognify.poll_failed",
+        "cognify_poll_transient": "cognify.poll_transient",
+        "agent_register_failed": "agent.register_failed",
+        "agent_unregister_failed": "agent.unregister_failed",
+        "http_bridge_skipped_no_api_key": "bridge.skipped_no_api_key",
+        "http_bridge_skipped_empty_cache": "bridge.skipped_empty_cache",
+        "http_bridge_done": "bridge.done",
+        "http_bridge_failed": "bridge.failed",
+        "http_bridge_deadline_exceeded": "bridge.deadline_exceeded",
+        "http_bridge_parse_error": "bridge.parse_error",
+        "http_bridge_no_dataset_id": "bridge.no_dataset_id",
+    }[event]
+
+
+def test_documented_events_match_map():
+    assert _documented_events() == _mapped_events()

--- a/integrations/claude-code/tests/test_statusline_version.py
+++ b/integrations/claude-code/tests/test_statusline_version.py
@@ -1,0 +1,29 @@
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import cognee_statusline_render as sl  # noqa: E402
+
+
+def test_installed_version_reads_manifest(monkeypatch, tmp_path):
+    root = tmp_path / "plugin-root"
+    manifest = root / ".claude-plugin" / "plugin.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(json.dumps({"version": "0.3.0"}), encoding="utf-8")
+
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+    monkeypatch.setattr(sl, "_PLUGIN_MANIFEST_PATH", manifest)
+
+    assert sl._installed_version() == "0.3.0"
+    assert sl._version_suffix() == " · v0.3.0"
+
+
+def test_installed_version_is_fail_silent(monkeypatch, tmp_path):
+    missing = tmp_path / "missing" / ".claude-plugin" / "plugin.json"
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path / "missing"))
+    monkeypatch.setattr(sl, "_PLUGIN_MANIFEST_PATH", missing)
+
+    assert sl._installed_version() == ""
+    assert sl._version_suffix() == ""


### PR DESCRIPTION
## Summary
- show the installed Claude Code plugin version in the status line
- keep the renderer fail-silent if the manifest is missing, unreadable, or malformed
- add focused unit coverage for the manifest read and fallback behavior

## Verification
- direct Python smoke check of `_installed_version()` and `_version_suffix()`
- `python -m compileall` was attempted, but Windows hit a transient `__pycache__` rename permission error
