### PR TITLE
feat(integrations): add elapsed_ms timing to recall, bridge, and improve hook events

### DIFF
--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1465,7 +1465,7 @@ def persist_session_cache_to_graph_via_http(
                 wrote = True
             hook_log(
                 "http_bridge_poll",
-                {"dataset": dataset, "kind": kind, "outcome": outcome, "dataset_id": dataset_id},
+                {"dataset": dataset, "kind": kind, "outcome": outcome, "dataset_id": dataset_id, "elapsed_ms": round((time.monotonic() - overall_start) * 1000, 1)},
             )
         if isinstance(bridge_cache, dict):
             bridge_cache["_state"] = state

--- a/integrations/claude-code/scripts/idle-watcher.py
+++ b/integrations/claude-code/scripts/idle-watcher.py
@@ -84,6 +84,7 @@ def _install_signal_handlers() -> None:
 
 async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
     """Fire one session bridge cycle. Returns True on success."""
+    overall_start = time.monotonic()
     sys.path.insert(0, os.path.dirname(__file__))
     try:
         from _plugin_common import (  # type: ignore
@@ -127,6 +128,7 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
                     dataset=dataset,
                     via="http_remember",
                     wrote=wrote,
+                    elapsed_ms=round((time.monotonic() - overall_start) * 1000, 1),
                 )
                 return True
 
@@ -147,6 +149,7 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
                     user_id=str(user.id),
                     wrote=wrote,
                     graph_synced=graph_result.get("synced", 0),
+                    elapsed_ms=round((time.monotonic() - overall_start) * 1000, 1),
                 )
             return True
         except Exception as exc:

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -157,6 +157,7 @@ async def _recent_trace_fallback(session_id: str, user_id: str, top_k: int) -> l
 
 
 async def _run(prompt: str) -> dict | None:
+    overall_start = time.monotonic()
     config = load_config()
     runtime = resolve_runtime_mode()
     cloud_mode = runtime["mode"] == "http"
@@ -363,11 +364,11 @@ async def _run(prompt: str) -> dict | None:
             f"{header}\n\nRelevant context from this session's memory:\n\n"
             + "\n".join(section_lines).strip()
         )
-        hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
+        hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn, "elapsed_ms": round((time.monotonic() - overall_start) * 1000, 1)})
         notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
     else:
         full_context = f"{header}\n\n(no memory matches for this prompt)"
-        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
+        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn, "elapsed_ms": round((time.monotonic() - overall_start) * 1000, 1)})
         notify(f"no recall matches; saves last turn {saves_last_turn}")
 
     # Audit log: persist full recall details per turn. The hook output stays a

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import os
 import sys
+import time
 
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
@@ -57,12 +58,13 @@ _MAX_ASSISTANT_BYTES = 8000
 
 async def _fire_improve_background(dataset: str, session_id: str, user, reason: str) -> None:
     """Fire-and-forget session bridge; failures are logged but never raised."""
+    overall_start = time.monotonic()
     try:
         if http_api_ready():
             wrote = persist_session_cache_to_graph_via_http(dataset, session_id)
             hook_log(
                 "auto_bridge_fired",
-                {"reason": reason, "session": session_id, "via": "http_remember", "wrote": wrote},
+                {"reason": reason, "session": session_id, "via": "http_remember", "wrote": wrote, "elapsed_ms": round((time.monotonic() - overall_start) * 1000, 1)},
             )
             if wrote:
                 notify(f"session bridge persisted ({reason})")
@@ -78,6 +80,7 @@ async def _fire_improve_background(dataset: str, session_id: str, user, reason: 
                 "session": session_id,
                 "wrote": wrote,
                 "graph_synced": graph_result.get("synced", 0),
+                "elapsed_ms": round((time.monotonic() - overall_start) * 1000, 1),
             },
         )
         notify(f"session bridge persisted ({reason})")

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -1238,6 +1238,7 @@ def persist_session_cache_to_graph_via_http(
     shadow and this function posts that text to the backend remember
     endpoint as permanent graph data.
     """
+    overall_start = time.monotonic()
     base_url = _local_api_url()
     if not _backend_reachable(base_url):
         return False
@@ -1274,7 +1275,7 @@ def persist_session_cache_to_graph_via_http(
             _write_json_file(bridge_path, bridge_cache)
         hook_log(
             "http_bridge_done",
-            {"dataset": dataset, "session": session_id, "wrote": wrote},
+            {"dataset": dataset, "session": session_id, "wrote": wrote, "elapsed_ms": round((time.monotonic() - overall_start) * 1000, 1)},
         )
         return wrote
     except (urllib.error.URLError, TimeoutError, OSError) as exc:

--- a/integrations/codex/plugins/cognee/scripts/idle-watcher.py
+++ b/integrations/codex/plugins/cognee/scripts/idle-watcher.py
@@ -84,6 +84,7 @@ def _install_signal_handlers() -> None:
 
 async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
     """Fire one session bridge cycle. Returns True on success."""
+    overall_start = time.monotonic()
     sys.path.insert(0, os.path.dirname(__file__))
     try:
         from _plugin_common import (  # type: ignore
@@ -127,6 +128,7 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
                     dataset=dataset,
                     via="http_remember",
                     wrote=wrote,
+                    elapsed_ms=round((time.monotonic() - overall_start) * 1000, 1),
                 )
                 return True
 
@@ -147,6 +149,7 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
                     user_id=str(user.id),
                     wrote=wrote,
                     graph_synced=graph_result.get("synced", 0),
+                    elapsed_ms=round((time.monotonic() - overall_start) * 1000, 1),
                 )
             return True
         except Exception as exc:

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -158,6 +158,7 @@ async def _recent_trace_fallback(session_id: str, user_id: str, top_k: int) -> l
 
 
 async def _run(prompt: str) -> dict | None:
+    overall_start = time.monotonic()
     config = load_config()
     runtime = resolve_runtime_mode()
     cloud_mode = runtime["mode"] == "http"
@@ -355,11 +356,11 @@ async def _run(prompt: str) -> dict | None:
             f"{header}\n\nRelevant context from this session's memory:\n\n"
             + "\n".join(section_lines).strip()
         )
-        hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
+        hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn, "elapsed_ms": round((time.monotonic() - overall_start) * 1000, 1)})
         notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
     else:
         full_context = f"{header}\n\n(no memory matches for this prompt)"
-        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
+        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn, "elapsed_ms": round((time.monotonic() - overall_start) * 1000, 1)})
         notify(f"no recall matches; saves last turn {saves_last_turn}")
 
     # Audit log: persist full recall details per turn. The hook output stays a

--- a/integrations/codex/plugins/cognee/scripts/store-to-session.py
+++ b/integrations/codex/plugins/cognee/scripts/store-to-session.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import os
 import sys
+import time
 
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
@@ -57,12 +58,13 @@ _MAX_ASSISTANT_BYTES = 8000
 
 async def _fire_improve_background(dataset: str, session_id: str, user, reason: str) -> None:
     """Fire-and-forget session bridge; failures are logged but never raised."""
+    overall_start = time.monotonic()
     try:
         if http_api_ready():
             wrote = persist_session_cache_to_graph_via_http(dataset, session_id)
             hook_log(
                 "auto_bridge_fired",
-                {"reason": reason, "session": session_id, "via": "http_remember", "wrote": wrote},
+                {"reason": reason, "session": session_id, "via": "http_remember", "wrote": wrote, "elapsed_ms": round((time.monotonic() - overall_start) * 1000, 1)},
             )
             if wrote:
                 notify(f"session bridge persisted ({reason})")
@@ -78,6 +80,7 @@ async def _fire_improve_background(dataset: str, session_id: str, user, reason: 
                 "session": session_id,
                 "wrote": wrote,
                 "graph_synced": graph_result.get("synced", 0),
+                "elapsed_ms": round((time.monotonic() - overall_start) * 1000, 1),
             },
         )
         notify(f"session bridge persisted ({reason})")


### PR DESCRIPTION
## Summary

Add `elapsed_ms` timing field to hook log entries for recall, bridge, and improve operations so latency is directly observable in `hook.log`.

## Changes

- **Recall** (`session-context-lookup.py`): `context_lookup_hit` / `context_lookup_empty` now carry `elapsed_ms`
- **Bridge** (`_plugin_common.py`): `http_bridge_poll` (claude-code) / `http_bridge_done` (codex) now carry `elapsed_ms`
- **Improve** (`store-to-session.py` + `idle-watcher.py`): `auto_bridge_fired` / `session_bridge_done` now carry `elapsed_ms`
- Mirrored across both `claude-code` and `codex` integrations

## Test Plan

1. Start cognee plugin normally — `hook.log` entries carry `elapsed_ms` field
2. Verify elapsed_ms is a positive float (ms precision)
3. Verify no behavior change — all existing hook events still fire, `elapsed_ms` is purely additive

Fixes https://github.com/topoteretes/cognee-integrations/issues/135