### PR TITLE
[codex] validate integration inventory versions

### DIFF
--- a/.github/scripts/check_inventory_versions.py
+++ b/.github/scripts/check_inventory_versions.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Fail CI when inventory.yml drifts from integration plugin manifests."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+INVENTORY = ROOT / "integrations" / "inventory.yml"
+
+
+def _plugin_version_for_slug(slug: str) -> str | None:
+    if slug == "claude-code":
+        path = ROOT / "integrations" / "claude-code" / ".claude-plugin" / "plugin.json"
+    elif slug == "codex":
+        path = ROOT / "integrations" / "codex" / "plugins" / "cognee" / ".codex-plugin" / "plugin.json"
+    else:
+        return None
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return str(data.get("version") or "").strip()
+
+
+def main() -> int:
+    text = INVENTORY.read_text(encoding="utf-8")
+    mismatches: list[str] = []
+
+    current_slug = ""
+    for line in text.splitlines():
+        match = re.match(r"^\s*-\s*slug:\s*(.+)\s*$", line)
+        if match:
+            current_slug = match.group(1).strip().strip('"')
+            continue
+
+        match = re.match(r'^\s*current_version:\s*"?(.*?)"?\s*$', line)
+        if not match or not current_slug:
+            continue
+
+        expected = match.group(1).strip()
+        actual = _plugin_version_for_slug(current_slug)
+        if actual is None:
+            continue
+        if expected != actual:
+            mismatches.append(f"{current_slug}: inventory={expected} manifest={actual}")
+
+    if mismatches:
+        for line in mismatches:
+            print(line)
+        return 1
+
+    print("inventory versions match plugin manifests")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
 
           echo "Changed dirs: $CHANGED_DIRS"
 
+      - name: Check manifest version consistency
+        run: python3 .github/scripts/check_inventory_versions.py
+
   test-python:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.python != '[]' }}

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -34,7 +34,7 @@ integrations:
     registry: none
     package_name: null
     cognee_dependency: sdk
-    current_version: "0.1.0"
+    current_version: "0.2.0"
     migration_status: done
     notes: "Claude Code plugin – session storage via hooks, recall via context lookup, session-to-graph sync"
 


### PR DESCRIPTION
## Summary
- fix the stale Claude Code version in `integrations/inventory.yml`
- add a dependency-free CI check that compares inventory versions against installed plugin manifests
- keep the check scoped to the actual local manifests already present in the repo

## Verification
- `python .github/scripts/check_inventory_versions.py`
- `python -m compileall .github/scripts/check_inventory_versions.py`
