### PR TITLE
[codex] add release docs and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this repository will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+the project uses semantic versioning where practical.
+
+## [Unreleased]
+
+### Added
+- Claude Code plugin status line now shows the installed plugin version.
+- Claude Code observability logs now include `elapsed_ms` for recall, bridge, and improve paths.
+- A release inventory consistency check that compares `integrations/inventory.yml` with installed plugin manifests.
+- Repo release guidance for changelog and version bump workflow.
+
+### Changed
+- Cognee hook events in Claude Code are now normalized to a namespaced taxonomy.
+- The Claude Code status line and hook scripts now prefer fail-silent local reads for version metadata.
+
+## [0.2.0] - 2026-06-30
+
+### Added
+- Initial plugin manifests and release metadata for the Claude Code and Codex integrations.
+
+### Changed
+- Codex plugin status line now shows the installed plugin version.
+
+### Fixed
+- Inventory version metadata now matches the installed plugin manifests for Claude Code and Codex.
+

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,29 @@
+# Releasing Cognee Integrations
+
+Use this short checklist for each integration release.
+
+## Before tagging
+
+1. Bump the integration version in the plugin manifest.
+2. Update `integrations/inventory.yml` so `current_version` matches the manifest.
+3. Add a note to `CHANGELOG.md` under `Unreleased`.
+4. Run the relevant integration tests and any release checks.
+
+## Tagging
+
+1. Create the integration tag that matches the released package or plugin.
+2. For Claude Code, use tags like `claude-code-v*`.
+3. For other integrations, follow the package-specific tag pattern already used in that integration's release flow.
+
+## After tagging
+
+1. Sync the marketplace or package registry metadata if the integration publishes there.
+2. Confirm the published version matches the manifest.
+3. Update the changelog with the released version and date.
+
+## Notes
+
+- Keep release notes short and user-facing.
+- If a release changes a manifest version, update the inventory check in the same PR.
+- If a release adds a new integration, add it to `integrations/inventory.yml` and the changelog together.
+


### PR DESCRIPTION
## Summary
- add a repo-level Keep-a-Changelog file seeded from recent integration work
- add a short release checklist for bumping manifests, updating inventory, tagging, and syncing

## Verification
- docs-only change
