### PR TITLE
feat(integrations): retry first recall on cold-start timeout

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -291,3 +291,5 @@ Config precedence:
 | idle watcher poll | `COGNEE_IDLE_POLL` | `10` | Idle watcher poll interval in seconds |
 | idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle sync fires |
 | idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `120` | Minimum seconds between idle sync runs |
+| cold-start retries | `COGNEE_RECALL_COLDSTART_RETRIES` | `2` | Extra retries for the **first** recall of a session when it times out on a warming server (`0` disables). Later recalls never retry. |
+| cold-start backoff | `COGNEE_RECALL_COLDSTART_BACKOFF` | `0.5` | Base seconds for the first-recall retry backoff (jittered, exponential, capped by the recall budget) |

--- a/integrations/claude-code/scripts/_cognee_client.py
+++ b/integrations/claude-code/scripts/_cognee_client.py
@@ -98,15 +98,7 @@ def retry_cold_start(
     rng=None,
     monotonic=None,
 ):
-    """Retry ``attempt`` on a cold-start miss, with jittered exponential backoff.
-
-    ``attempt`` returns ``(ok, value)``: ``ok=False`` marks a retryable cold-start
-    failure (unreachable / timeout). Retries up to ``retries`` extra times. Sleeps
-    a jittered exponential backoff between tries and NEVER sleeps past ``deadline``
-    (a ``monotonic()`` value); once the budget is spent it stops. Returns the final
-    ``(ok, value)``. Injectable ``sleep``/``rng``/``monotonic`` keep it deterministic
-    in tests.
-    """
+    """Retry ``attempt`` on a cold-start miss, with jittered exponential backoff"""
     _sleep = sleep or time.sleep
     _rand = rng or random.random
     _now = monotonic or time.monotonic
@@ -192,11 +184,6 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
             service_url, api_key, query, session_id, scope, top_k, dataset, timeout=_timeout
         )
 
-    # Only the FIRST recall of a session retries a warming/unreachable backend;
-    # every later recall is single-shot. The whole retry burst is ONE breaker
-    # event: the accounting below runs once on the final result, so a slow cold
-    # start can't prematurely trip the circuit. Only UNREACHABLE is retryable —
-    # an error envelope (4xx/5xx/auth) is terminal and must fail fast.
     if session_id and is_first_recall(session_id):
 
         def _attempt():

--- a/integrations/claude-code/scripts/_cognee_client.py
+++ b/integrations/claude-code/scripts/_cognee_client.py
@@ -18,6 +18,7 @@ uses) would not survive between calls. State lives in the plugin state dir.
 import json
 import os
 import pathlib
+import random
 import sys
 import time
 
@@ -27,6 +28,101 @@ from _recall_http import UNREACHABLE, _error, do_recall
 _THRESHOLD = int(os.environ.get("COGNEE_BREAKER_THRESHOLD", "5"))
 _COOLDOWN = float(os.environ.get("COGNEE_BREAKER_COOLDOWN", "120"))
 _RECALL_TIMEOUT = float(os.environ.get("COGNEE_RECALL_TIMEOUT", "20"))
+
+_COLDSTART_SEEN_MAX = 256  # bound the marker file's session list
+
+
+def coldstart_config() -> tuple[int, float]:
+    """(extra_retries, base_backoff_seconds) for the first-recall cold-start path.
+
+    Read live so runtime/test env changes take effect. Named ``COLDSTART`` to
+    signal these apply only to the first recall of a session, not every recall.
+    """
+    try:
+        retries = int(os.environ.get("COGNEE_RECALL_COLDSTART_RETRIES", "2"))
+    except (TypeError, ValueError):
+        retries = 2
+    try:
+        backoff = float(os.environ.get("COGNEE_RECALL_COLDSTART_BACKOFF", "0.5"))
+    except (TypeError, ValueError):
+        backoff = 0.5
+    return max(0, retries), max(0.0, backoff)
+
+
+def _coldstart_state_path() -> pathlib.Path:
+    base = os.environ.get("COGNEE_PLUGIN_STATE_DIR") or os.path.expanduser("~/.cognee-plugin")
+    return pathlib.Path(base) / "recall-coldstart.json"
+
+
+def _coldstart_seen() -> list:
+    try:
+        data = json.loads(_coldstart_state_path().read_text(encoding="utf-8"))
+        seen = data.get("seen") if isinstance(data, dict) else None
+        return seen if isinstance(seen, list) else []
+    except Exception:
+        return []
+
+
+def is_first_recall(session_id: str) -> bool:
+    """True until ``mark_recall_seen`` records this session (unknown -> treat as first)."""
+    if not session_id:
+        return False
+    return session_id not in _coldstart_seen()
+
+
+def mark_recall_seen(session_id: str) -> None:
+    """Record that this session's first recall has resolved (success or exhausted)."""
+    if not session_id:
+        return
+    seen = _coldstart_seen()
+    if session_id in seen:
+        return
+    seen.append(session_id)
+    if len(seen) > _COLDSTART_SEEN_MAX:
+        seen = seen[-_COLDSTART_SEEN_MAX:]
+    try:
+        path = _coldstart_state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"seen": seen}), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def retry_cold_start(
+    attempt,
+    *,
+    retries: int,
+    backoff: float,
+    deadline=None,
+    sleep=None,
+    rng=None,
+    monotonic=None,
+):
+    """Retry ``attempt`` on a cold-start miss, with jittered exponential backoff.
+
+    ``attempt`` returns ``(ok, value)``: ``ok=False`` marks a retryable cold-start
+    failure (unreachable / timeout). Retries up to ``retries`` extra times. Sleeps
+    a jittered exponential backoff between tries and NEVER sleeps past ``deadline``
+    (a ``monotonic()`` value); once the budget is spent it stops. Returns the final
+    ``(ok, value)``. Injectable ``sleep``/``rng``/``monotonic`` keep it deterministic
+    in tests.
+    """
+    _sleep = sleep or time.sleep
+    _rand = rng or random.random
+    _now = monotonic or time.monotonic
+    ok, value = attempt()
+    tries = 0
+    while not ok and tries < retries:
+        if deadline is not None and (deadline - _now()) <= 0:
+            break
+        delay = backoff * (2**tries) * (0.5 + _rand())  # jitter in [0.5, 1.5)
+        if deadline is not None:
+            delay = min(delay, max(0.0, deadline - _now()))
+        if delay > 0:
+            _sleep(delay)
+        ok, value = attempt()
+        tries += 1
+    return ok, value
 
 
 def _state_path():
@@ -89,16 +185,30 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
         # which would just hammer the same down server).
         return _error(503, "cognee temporarily unavailable (circuit open, retry in ~%ds)" % retry)
 
-    result = do_recall(
-        service_url,
-        api_key,
-        query,
-        session_id,
-        scope,
-        top_k,
-        dataset,
-        timeout=timeout or _RECALL_TIMEOUT,
-    )
+    _timeout = timeout or _RECALL_TIMEOUT
+
+    def _once():
+        return do_recall(
+            service_url, api_key, query, session_id, scope, top_k, dataset, timeout=_timeout
+        )
+
+    # Only the FIRST recall of a session retries a warming/unreachable backend;
+    # every later recall is single-shot. The whole retry burst is ONE breaker
+    # event: the accounting below runs once on the final result, so a slow cold
+    # start can't prematurely trip the circuit. Only UNREACHABLE is retryable —
+    # an error envelope (4xx/5xx/auth) is terminal and must fail fast.
+    if session_id and is_first_recall(session_id):
+
+        def _attempt():
+            r = _once()
+            return (r != UNREACHABLE, r)  # ok unless the server was unreachable
+
+        retries, backoff = coldstart_config()
+        _ok, result = retry_cold_start(_attempt, retries=retries, backoff=backoff)
+        mark_recall_seen(session_id)
+    else:
+        result = _once()
+
     if result == UNREACHABLE:
         record_failure("unreachable")
     elif isinstance(result, dict) and int(result.get("status") or 0) >= 500:

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -264,9 +264,6 @@ async def _run(prompt: str) -> dict | None:
                         timeout=recall_timeout,
                     )
 
-                # Retry only the first scope of the first recall, and only on a
-                # cold-start error (timeout / connection). An HTTPError is reachable
-                # but rejected, so it fails fast. Backoff is bounded by the budget.
                 if coldstart_first and idx == 0 and cs_retries > 0:
 
                     def _attempt():
@@ -306,8 +303,6 @@ async def _run(prompt: str) -> dict | None:
         except Exception as exc:
             hook_log("recall_error", {"scope": scope_list, "error": str(exc)[:200]})
 
-    # First recall resolved (success or exhausted): mark the session warm so later
-    # recalls take the fast, no-retry path and steady-state latency is unchanged.
     if coldstart_first and session_id:
         mark_recall_seen(session_id)
 

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -16,6 +16,7 @@ import json
 import os
 import sys
 import time
+import urllib.error
 
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
@@ -219,32 +220,72 @@ async def _run(prompt: str) -> dict | None:
     # Respect the shared circuit breaker: when the server has been failing (tripped
     # by the explicit recall path), skip this per-prompt recall rather than hammering
     # a down backend on every keystroke. HTTP/cloud mode only.
+    # Cold-start: only the first recall of a session retries a warming backend.
+    coldstart_first = False
+    cs_retries, cs_backoff = 0, 0.0
     if cloud_mode:
         try:
-            from _cognee_client import breaker_open
-
-            _bopen, _bretry = breaker_open()
+            from _cognee_client import (
+                breaker_open,
+                coldstart_config,
+                is_first_recall,
+                mark_recall_seen,
+                retry_cold_start,
+            )
         except Exception:
-            _bopen, _bretry = False, 0
-        if _bopen:
-            hook_log("recall_breaker_open", {"retry_in": _bretry})
-            scope_specs = []
-    for scope_list, qtype, context_profile in scope_specs:
+            breaker_open = None
+        if breaker_open is not None:
+            try:
+                _bopen, _bretry = breaker_open()
+            except Exception:
+                _bopen, _bretry = False, 0
+            if _bopen:
+                hook_log("recall_breaker_open", {"retry_in": _bretry})
+                scope_specs = []
+            elif session_id and is_first_recall(session_id):
+                coldstart_first = True
+                cs_retries, cs_backoff = coldstart_config()
+    for idx, (scope_list, qtype, context_profile) in enumerate(scope_specs):
         if time.monotonic() >= budget_deadline:
             hook_log("recall_budget_exceeded", {"collected": len(results)})
             break
         try:
             if cloud_mode:
-                part = recall_via_http(
-                    prompt,
-                    session_id=session_id,
-                    top_k=TOP_K,
-                    scope=scope_list,
-                    only_context=True,
-                    search_type=qtype,
-                    context_profile=context_profile,
-                    timeout=recall_timeout,
-                )
+
+                def _do_recall_call(_scope=scope_list, _qtype=qtype, _profile=context_profile):
+                    return recall_via_http(
+                        prompt,
+                        session_id=session_id,
+                        top_k=TOP_K,
+                        scope=_scope,
+                        only_context=True,
+                        search_type=_qtype,
+                        context_profile=_profile,
+                        timeout=recall_timeout,
+                    )
+
+                # Retry only the first scope of the first recall, and only on a
+                # cold-start error (timeout / connection). An HTTPError is reachable
+                # but rejected, so it fails fast. Backoff is bounded by the budget.
+                if coldstart_first and idx == 0 and cs_retries > 0:
+
+                    def _attempt():
+                        try:
+                            return True, _do_recall_call()
+                        except urllib.error.HTTPError:
+                            raise
+                        except (TimeoutError, urllib.error.URLError, OSError) as exc:
+                            hook_log("recall_coldstart_retry", {"error": str(exc)[:160]})
+                            return False, []
+
+                    _ok, part = retry_cold_start(
+                        _attempt,
+                        retries=cs_retries,
+                        backoff=cs_backoff,
+                        deadline=budget_deadline,
+                    )
+                else:
+                    part = _do_recall_call()
             else:
                 query_type = getattr(SearchType, qtype, None) if qtype else None
                 part = await asyncio.wait_for(
@@ -264,6 +305,11 @@ async def _run(prompt: str) -> dict | None:
                 results.extend(part)
         except Exception as exc:
             hook_log("recall_error", {"scope": scope_list, "error": str(exc)[:200]})
+
+    # First recall resolved (success or exhausted): mark the session warm so later
+    # recalls take the fast, no-retry path and steady-state latency is unchanged.
+    if coldstart_first and session_id:
+        mark_recall_seen(session_id)
 
     # Bucket results by _source for human-readable output.
     # Local SDK mode returns Pydantic models (ResponseQAEntry, etc.); cloud

--- a/integrations/claude-code/tests/test_coldstart_retry.py
+++ b/integrations/claude-code/tests/test_coldstart_retry.py
@@ -1,0 +1,167 @@
+"""Unit tests for cold-start recall retry (issue #3542).
+
+The first recall of a session often lands while the server is still warming, so
+it times out even though a retry a moment later succeeds. These tests cover the
+pure retry core (`retry_cold_start`) plus its integration into `_cognee_client.recall`:
+first-recall gating, graceful degrade, no-retry on 4xx, budget-bounded backoff,
+and breaker coherence (a retry burst is one failure).
+
+State is file-based, so we point COGNEE_PLUGIN_STATE_DIR at a temp dir and patch
+the transport (`do_recall`).
+
+Run: `pytest integrations/claude-code/tests/test_coldstart_retry.py`
+(or `python integrations/claude-code/tests/test_coldstart_retry.py` standalone).
+"""
+
+import pathlib
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import os  # noqa: E402
+
+_TMP = tempfile.mkdtemp(prefix="cognee-coldstart-test-")
+os.environ["COGNEE_PLUGIN_STATE_DIR"] = _TMP
+# Keep tests fast and deterministic: zero base backoff => no real sleeping.
+os.environ["COGNEE_RECALL_COLDSTART_BACKOFF"] = "0"
+os.environ["COGNEE_RECALL_COLDSTART_RETRIES"] = "2"
+
+import _cognee_client as cc  # noqa: E402
+from _recall_http import UNREACHABLE  # noqa: E402
+
+_STATE = pathlib.Path(_TMP)
+
+
+def _reset():
+    for name in ("recall-breaker.json", "recall-coldstart.json"):
+        p = _STATE / name
+        if p.exists():
+            p.unlink()
+
+
+def _seq_transport(values):
+    """Return a do_recall stub that yields `values` in order, plus a call counter."""
+    calls = {"n": 0}
+
+    def _stub(*a, **k):
+        i = calls["n"]
+        calls["n"] += 1
+        return values[i] if i < len(values) else values[-1]
+
+    return _stub, calls
+
+
+# ── pure retry core ────────────────────────────────────────────────────────
+
+
+def test_core_timeout_then_success():
+    seq = iter([(False, "x"), (True, "hit")])
+    ok, value = cc.retry_cold_start(lambda: next(seq), retries=2, backoff=0, sleep=lambda _d: None)
+    assert ok is True and value == "hit"
+
+
+def test_core_exhausts_and_returns_last():
+    calls = {"n": 0}
+
+    def _attempt():
+        calls["n"] += 1
+        return (False, "down")
+
+    ok, value = cc.retry_cold_start(_attempt, retries=2, backoff=0, sleep=lambda _d: None)
+    assert ok is False and value == "down"
+    assert calls["n"] == 3  # 1 initial + 2 retries
+
+
+def test_core_backoff_never_exceeds_budget():
+    """With a fake clock advanced by sleep, total backoff stays within the deadline."""
+    clock = {"t": 0.0}
+    slept = []
+
+    def _sleep(d):
+        slept.append(d)
+        clock["t"] += d
+
+    ok, _ = cc.retry_cold_start(
+        lambda: (False, None),
+        retries=10,
+        backoff=0.4,
+        deadline=1.0,
+        sleep=_sleep,
+        rng=lambda: 0.5,  # jitter factor 1.0
+        monotonic=lambda: clock["t"],
+    )
+    assert ok is False
+    assert sum(slept) <= 1.0 + 1e-9  # never sleeps past the budget
+    assert clock["t"] <= 1.0 + 1e-9
+
+
+# ── recall() integration ───────────────────────────────────────────────────
+
+
+def test_first_recall_retries_then_returns_context():
+    _reset()
+    stub, calls = _seq_transport([UNREACHABLE, [{"text": "hit"}]])
+    cc.do_recall = stub
+    out = cc.recall("http://x", "", "q", "sess-A", '["graph"]', "5")
+    assert out == [{"text": "hit"}]  # ultimately returns context
+    assert calls["n"] == 2  # retried once
+    assert cc.breaker_open()[0] is False  # success cleared the breaker
+
+
+def test_exhausted_degrades_to_unreachable_no_error():
+    _reset()
+    stub, calls = _seq_transport([UNREACHABLE])
+    cc.do_recall = stub
+    out = cc.recall("http://x", "", "q", "sess-B", '["graph"]', "5")
+    assert out == UNREACHABLE  # graceful degrade, no exception raised
+    assert calls["n"] == 3  # 1 + 2 retries
+
+
+def test_retry_burst_is_one_breaker_failure():
+    _reset()
+    stub, _ = _seq_transport([UNREACHABLE])
+    cc.do_recall = stub
+    cc.recall("http://x", "", "q", "sess-C", '["graph"]', "5")
+    # Three transport calls, but the burst must count as a single failure.
+    assert int(cc._read().get("failures") or 0) == 1
+
+
+def test_4xx_envelope_is_not_retried():
+    _reset()
+    stub, calls = _seq_transport([{"error": "unauthorized", "status": 403, "authoritative": False}])
+    cc.do_recall = stub
+    out = cc.recall("http://x", "k", "q", "sess-D", '["graph"]', "5")
+    assert isinstance(out, dict) and out["status"] == 403
+    assert calls["n"] == 1  # reachable-but-rejected fails fast
+
+
+def test_second_recall_same_session_does_not_retry():
+    _reset()
+    stub, calls = _seq_transport([UNREACHABLE, [{"text": "hit"}]])
+    cc.do_recall = stub
+    cc.recall("http://x", "", "q", "sess-E", '["graph"]', "5")  # first: retries
+    first_calls = calls["n"]
+    cc.recall("http://x", "", "q", "sess-E", '["graph"]', "5")  # second: single-shot
+    assert calls["n"] == first_calls + 1  # exactly one more call, no retry
+
+
+def test_no_session_id_is_single_shot():
+    _reset()
+    stub, calls = _seq_transport([UNREACHABLE])
+    cc.do_recall = stub
+    cc.recall("http://x", "", "q", "", '["graph"]', "5")
+    assert calls["n"] == 1  # no session id => steady-state path, no retry
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print("PASS", name)
+            except AssertionError as e:
+                failures += 1
+                print("FAIL", name, e)
+    sys.exit(1 if failures else 0)

--- a/integrations/claude-code/tests/test_coldstart_retry.py
+++ b/integrations/claude-code/tests/test_coldstart_retry.py
@@ -1,4 +1,4 @@
-"""Unit tests for cold-start recall retry (issue #3542).
+"""Unit tests for cold-start recall retry.
 
 The first recall of a session often lands while the server is still warming, so
 it times out even though a retry a moment later succeeds. These tests cover the
@@ -94,9 +94,6 @@ def test_core_backoff_never_exceeds_budget():
     assert ok is False
     assert sum(slept) <= 1.0 + 1e-9  # never sleeps past the budget
     assert clock["t"] <= 1.0 + 1e-9
-
-
-# ── recall() integration ───────────────────────────────────────────────────
 
 
 def test_first_recall_retries_then_returns_context():

--- a/integrations/codex/plugins/cognee/scripts/_cognee_client.py
+++ b/integrations/codex/plugins/cognee/scripts/_cognee_client.py
@@ -18,6 +18,7 @@ uses) would not survive between calls. State lives in the plugin state dir.
 import json
 import os
 import pathlib
+import random
 import sys
 import time
 
@@ -27,6 +28,106 @@ from _recall_http import UNREACHABLE, _error, do_recall
 _THRESHOLD = int(os.environ.get("COGNEE_BREAKER_THRESHOLD", "5"))
 _COOLDOWN = float(os.environ.get("COGNEE_BREAKER_COOLDOWN", "120"))
 _RECALL_TIMEOUT = float(os.environ.get("COGNEE_RECALL_TIMEOUT", "20"))
+
+# Cold-start retry: the very first recall of a session often lands while the
+# server is still warming (booting, migrating, cold DB/embedding pools), so the
+# connection times out even though a retry a moment later succeeds. We retry ONLY
+# that first recall; steady-state recalls stay single-shot so the per-prompt
+# latency budget is untouched. Defaults are conservative and env-tunable.
+_COLDSTART_SEEN_MAX = 256  # bound the marker file's session list
+
+
+def coldstart_config() -> tuple[int, float]:
+    """(extra_retries, base_backoff_seconds) for the first-recall cold-start path.
+
+    Read live so runtime/test env changes take effect. Named ``COLDSTART`` to
+    signal these apply only to the first recall of a session, not every recall.
+    """
+    try:
+        retries = int(os.environ.get("COGNEE_RECALL_COLDSTART_RETRIES", "2"))
+    except (TypeError, ValueError):
+        retries = 2
+    try:
+        backoff = float(os.environ.get("COGNEE_RECALL_COLDSTART_BACKOFF", "0.5"))
+    except (TypeError, ValueError):
+        backoff = 0.5
+    return max(0, retries), max(0.0, backoff)
+
+
+def _coldstart_state_path() -> pathlib.Path:
+    base = os.environ.get("COGNEE_PLUGIN_STATE_DIR") or os.path.expanduser("~/.cognee-plugin")
+    return pathlib.Path(base) / "recall-coldstart.json"
+
+
+def _coldstart_seen() -> list:
+    try:
+        data = json.loads(_coldstart_state_path().read_text(encoding="utf-8"))
+        seen = data.get("seen") if isinstance(data, dict) else None
+        return seen if isinstance(seen, list) else []
+    except Exception:
+        return []
+
+
+def is_first_recall(session_id: str) -> bool:
+    """True until ``mark_recall_seen`` records this session (unknown -> treat as first)."""
+    if not session_id:
+        return False
+    return session_id not in _coldstart_seen()
+
+
+def mark_recall_seen(session_id: str) -> None:
+    """Record that this session's first recall has resolved (success or exhausted)."""
+    if not session_id:
+        return
+    seen = _coldstart_seen()
+    if session_id in seen:
+        return
+    seen.append(session_id)
+    if len(seen) > _COLDSTART_SEEN_MAX:
+        seen = seen[-_COLDSTART_SEEN_MAX:]
+    try:
+        path = _coldstart_state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"seen": seen}), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def retry_cold_start(
+    attempt,
+    *,
+    retries: int,
+    backoff: float,
+    deadline=None,
+    sleep=None,
+    rng=None,
+    monotonic=None,
+):
+    """Retry ``attempt`` on a cold-start miss, with jittered exponential backoff.
+
+    ``attempt`` returns ``(ok, value)``: ``ok=False`` marks a retryable cold-start
+    failure (unreachable / timeout). Retries up to ``retries`` extra times. Sleeps
+    a jittered exponential backoff between tries and NEVER sleeps past ``deadline``
+    (a ``monotonic()`` value); once the budget is spent it stops. Returns the final
+    ``(ok, value)``. Injectable ``sleep``/``rng``/``monotonic`` keep it deterministic
+    in tests.
+    """
+    _sleep = sleep or time.sleep
+    _rand = rng or random.random
+    _now = monotonic or time.monotonic
+    ok, value = attempt()
+    tries = 0
+    while not ok and tries < retries:
+        if deadline is not None and (deadline - _now()) <= 0:
+            break
+        delay = backoff * (2**tries) * (0.5 + _rand())  # jitter in [0.5, 1.5)
+        if deadline is not None:
+            delay = min(delay, max(0.0, deadline - _now()))
+        if delay > 0:
+            _sleep(delay)
+        ok, value = attempt()
+        tries += 1
+    return ok, value
 
 
 def _state_path():
@@ -89,16 +190,30 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
         # which would just hammer the same down server).
         return _error(503, "cognee temporarily unavailable (circuit open, retry in ~%ds)" % retry)
 
-    result = do_recall(
-        service_url,
-        api_key,
-        query,
-        session_id,
-        scope,
-        top_k,
-        dataset,
-        timeout=timeout or _RECALL_TIMEOUT,
-    )
+    _timeout = timeout or _RECALL_TIMEOUT
+
+    def _once():
+        return do_recall(
+            service_url, api_key, query, session_id, scope, top_k, dataset, timeout=_timeout
+        )
+
+    # Only the FIRST recall of a session retries a warming/unreachable backend;
+    # every later recall is single-shot. The whole retry burst is ONE breaker
+    # event: the accounting below runs once on the final result, so a slow cold
+    # start can't prematurely trip the circuit. Only UNREACHABLE is retryable —
+    # an error envelope (4xx/5xx/auth) is terminal and must fail fast.
+    if session_id and is_first_recall(session_id):
+
+        def _attempt():
+            r = _once()
+            return (r != UNREACHABLE, r)  # ok unless the server was unreachable
+
+        retries, backoff = coldstart_config()
+        _ok, result = retry_cold_start(_attempt, retries=retries, backoff=backoff)
+        mark_recall_seen(session_id)
+    else:
+        result = _once()
+
     if result == UNREACHABLE:
         record_failure("unreachable")
     elif isinstance(result, dict) and int(result.get("status") or 0) >= 500:

--- a/integrations/codex/plugins/cognee/scripts/_cognee_client.py
+++ b/integrations/codex/plugins/cognee/scripts/_cognee_client.py
@@ -29,20 +29,11 @@ _THRESHOLD = int(os.environ.get("COGNEE_BREAKER_THRESHOLD", "5"))
 _COOLDOWN = float(os.environ.get("COGNEE_BREAKER_COOLDOWN", "120"))
 _RECALL_TIMEOUT = float(os.environ.get("COGNEE_RECALL_TIMEOUT", "20"))
 
-# Cold-start retry: the very first recall of a session often lands while the
-# server is still warming (booting, migrating, cold DB/embedding pools), so the
-# connection times out even though a retry a moment later succeeds. We retry ONLY
-# that first recall; steady-state recalls stay single-shot so the per-prompt
-# latency budget is untouched. Defaults are conservative and env-tunable.
 _COLDSTART_SEEN_MAX = 256  # bound the marker file's session list
 
 
 def coldstart_config() -> tuple[int, float]:
-    """(extra_retries, base_backoff_seconds) for the first-recall cold-start path.
-
-    Read live so runtime/test env changes take effect. Named ``COLDSTART`` to
-    signal these apply only to the first recall of a session, not every recall.
-    """
+    """(extra_retries, base_backoff_seconds) for the first-recall cold-start path."""
     try:
         retries = int(os.environ.get("COGNEE_RECALL_COLDSTART_RETRIES", "2"))
     except (TypeError, ValueError):
@@ -103,15 +94,7 @@ def retry_cold_start(
     rng=None,
     monotonic=None,
 ):
-    """Retry ``attempt`` on a cold-start miss, with jittered exponential backoff.
-
-    ``attempt`` returns ``(ok, value)``: ``ok=False`` marks a retryable cold-start
-    failure (unreachable / timeout). Retries up to ``retries`` extra times. Sleeps
-    a jittered exponential backoff between tries and NEVER sleeps past ``deadline``
-    (a ``monotonic()`` value); once the budget is spent it stops. Returns the final
-    ``(ok, value)``. Injectable ``sleep``/``rng``/``monotonic`` keep it deterministic
-    in tests.
-    """
+    """Retry ``attempt`` on a cold-start miss, with jittered exponential backoff."""
     _sleep = sleep or time.sleep
     _rand = rng or random.random
     _now = monotonic or time.monotonic
@@ -197,11 +180,6 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
             service_url, api_key, query, session_id, scope, top_k, dataset, timeout=_timeout
         )
 
-    # Only the FIRST recall of a session retries a warming/unreachable backend;
-    # every later recall is single-shot. The whole retry burst is ONE breaker
-    # event: the accounting below runs once on the final result, so a slow cold
-    # start can't prematurely trip the circuit. Only UNREACHABLE is retryable —
-    # an error envelope (4xx/5xx/auth) is terminal and must fail fast.
     if session_id and is_first_recall(session_id):
 
         def _attempt():

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -254,9 +254,6 @@ async def _run(prompt: str) -> dict | None:
                         timeout=recall_timeout,
                     )
 
-                # Retry only the first scope of the first recall, and only on a
-                # cold-start error (timeout / connection). An HTTPError is reachable
-                # but rejected, so it fails fast. Backoff is bounded by the budget.
                 if coldstart_first and idx == 0 and cs_retries > 0:
 
                     def _attempt():
@@ -296,8 +293,6 @@ async def _run(prompt: str) -> dict | None:
         except Exception as exc:
             hook_log("recall_error", {"scope": scope_list, "error": str(exc)[:200]})
 
-    # First recall resolved (success or exhausted): mark the session warm so later
-    # recalls take the fast, no-retry path and steady-state latency is unchanged.
     if coldstart_first and session_id:
         mark_recall_seen(session_id)
 

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -16,6 +16,7 @@ import json
 import os
 import sys
 import time
+import urllib.error
 
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
@@ -209,32 +210,72 @@ async def _run(prompt: str) -> dict | None:
     # Respect the shared circuit breaker: when the server has been failing (tripped
     # by the explicit recall path), skip this per-prompt recall rather than hammering
     # a down backend on every keystroke. HTTP/cloud mode only.
+    # Cold-start: only the first recall of a session retries a warming backend.
+    coldstart_first = False
+    cs_retries, cs_backoff = 0, 0.0
     if cloud_mode:
         try:
-            from _cognee_client import breaker_open
-
-            _bopen, _bretry = breaker_open()
+            from _cognee_client import (
+                breaker_open,
+                coldstart_config,
+                is_first_recall,
+                mark_recall_seen,
+                retry_cold_start,
+            )
         except Exception:
-            _bopen, _bretry = False, 0
-        if _bopen:
-            hook_log("recall_breaker_open", {"retry_in": _bretry})
-            scope_specs = []
-    for scope_list, qtype, context_profile in scope_specs:
+            breaker_open = None
+        if breaker_open is not None:
+            try:
+                _bopen, _bretry = breaker_open()
+            except Exception:
+                _bopen, _bretry = False, 0
+            if _bopen:
+                hook_log("recall_breaker_open", {"retry_in": _bretry})
+                scope_specs = []
+            elif session_id and is_first_recall(session_id):
+                coldstart_first = True
+                cs_retries, cs_backoff = coldstart_config()
+    for idx, (scope_list, qtype, context_profile) in enumerate(scope_specs):
         if time.monotonic() >= budget_deadline:
             hook_log("recall_budget_exceeded", {"collected": len(results)})
             break
         try:
             if cloud_mode:
-                part = recall_via_http(
-                    prompt,
-                    session_id=session_id,
-                    top_k=TOP_K,
-                    scope=scope_list,
-                    only_context=True,
-                    search_type=qtype,
-                    context_profile=context_profile,
-                    timeout=recall_timeout,
-                )
+
+                def _do_recall_call(_scope=scope_list, _qtype=qtype, _profile=context_profile):
+                    return recall_via_http(
+                        prompt,
+                        session_id=session_id,
+                        top_k=TOP_K,
+                        scope=_scope,
+                        only_context=True,
+                        search_type=_qtype,
+                        context_profile=_profile,
+                        timeout=recall_timeout,
+                    )
+
+                # Retry only the first scope of the first recall, and only on a
+                # cold-start error (timeout / connection). An HTTPError is reachable
+                # but rejected, so it fails fast. Backoff is bounded by the budget.
+                if coldstart_first and idx == 0 and cs_retries > 0:
+
+                    def _attempt():
+                        try:
+                            return True, _do_recall_call()
+                        except urllib.error.HTTPError:
+                            raise
+                        except (TimeoutError, urllib.error.URLError, OSError) as exc:
+                            hook_log("recall_coldstart_retry", {"error": str(exc)[:160]})
+                            return False, []
+
+                    _ok, part = retry_cold_start(
+                        _attempt,
+                        retries=cs_retries,
+                        backoff=cs_backoff,
+                        deadline=budget_deadline,
+                    )
+                else:
+                    part = _do_recall_call()
             else:
                 query_type = getattr(SearchType, qtype, None) if qtype else None
                 part = await asyncio.wait_for(
@@ -254,6 +295,11 @@ async def _run(prompt: str) -> dict | None:
                 results.extend(part)
         except Exception as exc:
             hook_log("recall_error", {"scope": scope_list, "error": str(exc)[:200]})
+
+    # First recall resolved (success or exhausted): mark the session warm so later
+    # recalls take the fast, no-retry path and steady-state latency is unchanged.
+    if coldstart_first and session_id:
+        mark_recall_seen(session_id)
 
     # Bucket results by _source for human-readable output.
     # Local SDK mode returns Pydantic models (ResponseQAEntry, etc.); cloud


### PR DESCRIPTION
## Retry first recall on cold-start timeout

Fixes [#3542](https://github.com/topoteretes/cognee/issues/3542)

### Problem

The first recall of a session often lands while the Cognee server is still warming (booting, migrating, cold DB/embedding pools), so it times out or the connection is refused even though a retry a moment later succeeds. Today that first recall gives up and the turn runs with no memory context.

### Fix

Retry only the **first** recall of a session on a cold-start error, then mark the session warm so later recalls stay single-shot and steady-state latency is unchanged.

- `_cognee_client.py`: shared, injectable `retry_cold_start` core + first-recall gating + live config, wired into `recall()`. Only `UNREACHABLE` is retryable; 4xx/5xx/auth fail fast. The retry burst is one breaker event, so a slow cold start can't trip the circuit.
- `session-context-lookup.py`: routes the auto-recall hook's first recall through the same core, retrying only on timeout/connection errors (never `HTTPError`), with backoff bounded by the recall budget.
- Mirrored to the codex copies.

### Config

| Env var | Default | Meaning |
|---|---|---|
| `COGNEE_RECALL_COLDSTART_RETRIES` | `2` | Extra retries for the first recall (`0` disables); later recalls never retry |
| `COGNEE_RECALL_COLDSTART_BACKOFF` | `0.5` | Base backoff seconds (jittered, exponential, budget-capped) |

### Acceptance

- [x] Retry count configurable via env var with a sane default
- [x] Test simulates timeout-then-success and asserts context is returned
- [x] After exhausting retries, degrades gracefully to no-context (no hard error)

### Testing

9 unit tests in `tests/test_coldstart_retry.py` (timeout-then-success, exhaustion degrade, 4xx not retried, first-recall-only, budget cap, single breaker failure); existing suites pass; ruff clean. Also verified against a live local server over real sockets: retries recover context on a warming/refused server, and a down server degrades to `UNREACHABLE` cleanly.
