### PR TITLE
test(integrations): config precedence tests + matrix for all four integrations (#3559)

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -291,3 +291,39 @@ Config precedence:
 | idle watcher poll | `COGNEE_IDLE_POLL` | `10` | Idle watcher poll interval in seconds |
 | idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle sync fires |
 | idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `120` | Minimum seconds between idle sync runs |
+
+## Configuration precedence
+
+Resolution order: **env > config file > default** (env wins). See `load_config()`
+in `scripts/config.py`. Behavior pinned by `tests/test_config_precedence.py`.
+
+| Setting | Env var | Config key | Default | Who wins |
+| --- | --- | --- | --- | --- |
+| Dataset | `COGNEE_PLUGIN_DATASET` | `dataset` | `agent_sessions` | env |
+| Service URL | `COGNEE_BASE_URL` | `base_url` | unset | env |
+| API key | `COGNEE_API_KEY` | `api_key` | unset | env |
+| Backend | `COGNEE_CLAUDE_BACKEND` | `backend` | `auto` | env |
+
+An empty string cannot override on either layer: an empty config-file value is
+dropped (`v != ""`) and an empty env value is skipped (`if val:`).
+
+Backend `native` (or `local`/`sdk`) forces local mode: `base_url` and `api_key`
+are cleared to empty after the merge.
+
+> **Known issue (#3559): config-file values for the poll/timeout knobs are
+> ignored.** `COGNEE_COGNIFY_POLL_INTERVAL`, `COGNEE_BRIDGE_POLL_DEADLINE`,
+> `COGNEE_BRIDGE_SUBMIT_TIMEOUT`, `COGNEE_REMEMBER_WAIT_SECONDS`, and
+> `COGNEE_STATUS_REQUEST_TIMEOUT` are registered in `_ENV_MAP` (so they appear in
+> the config file), but consumers read them from the environment only (via
+> `_float_env`), so a value set only in the config file has no effect. Captured as
+> a strict `xfail` in `tests/test_config_precedence.py`.
+
+### Testing & scope (#3559)
+
+- **Test + docs only** — no runtime config behavior was changed.
+- Precedence is documented per integration as it behaves today; the four Cognee
+  integrations are intentionally **not** converged (that is a product decision,
+  out of scope here).
+- These tests run locally today, not in CI (`ci.yml` runs pytest only for
+  integrations with their own `pyproject.toml`); wiring claude-code into CI is
+  deferred to a follow-up issue.

--- a/integrations/claude-code/tests/test_config_precedence.py
+++ b/integrations/claude-code/tests/test_config_precedence.py
@@ -15,8 +15,11 @@ import shutil
 import sys
 import tempfile
 
+import pytest
+
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
 
+import _plugin_common as pc  # noqa: E402
 import config  # noqa: E402
 
 
@@ -119,6 +122,42 @@ def test_backend_clearing_native():
         # native backend forces local mode: base_url and api_key are cleared.
         assert merged["base_url"] == ""
         assert merged["api_key"] == ""
+    finally:
+        config._CONFIG_FILE = orig_file
+        _restore_env(saved)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "#3559: COGNEE_COGNIFY_POLL_INTERVAL is registered in _ENV_MAP for "
+        "config-file support, but consumers read it via _float_env() straight "
+        "from os.environ, so the config-file value never reaches runtime (dead "
+        "knob)."
+    ),
+)
+def test_footgun3_config_file_poll_interval_reaches_consumer():
+    # The poll interval is set ONLY in the config file, with the env var unset,
+    # to isolate the config-file path. load_config() surfaces it, but the real
+    # consumer reads it through _float_env(name, default) -- which ignores the
+    # merged config -- so the config-file value is silently dropped.
+    orig_file = config._CONFIG_FILE
+    saved = _snapshot_env("COGNEE_COGNIFY_POLL_INTERVAL")
+    tmpdir = tempfile.mkdtemp()
+    try:
+        config._CONFIG_FILE = _write_config_file(tmpdir, {"cognify_poll_interval": 99.0})
+        os.environ.pop("COGNEE_COGNIFY_POLL_INTERVAL", None)
+
+        # Sanity: load_config() DOES carry the config-file value through.
+        assert config.load_config()["cognify_poll_interval"] == 99.0
+
+        # Desired behavior: the value the consumer sees (via _float_env, exactly
+        # as scripts/_plugin_common.py:1401 calls it) should be the config-file
+        # value. Under current code _float_env returns the hardcoded 3.0 default
+        # because it reads os.environ (empty), so this assertion fails today.
+        consumer_value = pc._float_env("COGNEE_COGNIFY_POLL_INTERVAL", 3.0)
+        assert consumer_value == 99.0
     finally:
         config._CONFIG_FILE = orig_file
         _restore_env(saved)

--- a/integrations/claude-code/tests/test_config_precedence.py
+++ b/integrations/claude-code/tests/test_config_precedence.py
@@ -1,0 +1,125 @@
+"""Config precedence tests for the Cognee claude-code plugin (#3559).
+
+Documents the ACTUAL current behavior: load_config() merges defaults, then the
+config file, then environment variables -- so **env wins** over the config file
+here (see scripts/config.py). This file only pins that behavior down; it changes
+no runtime logic.
+
+Run: python integrations/claude-code/tests/test_config_precedence.py
+"""
+
+import json
+import os
+import pathlib
+import shutil
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import config  # noqa: E402
+
+
+def _snapshot_env(*keys):
+    return {k: os.environ.get(k) for k in keys}
+
+
+def _restore_env(saved):
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def _write_config_file(directory, payload):
+    """Point config._CONFIG_FILE at a temp file holding `payload` (JSON)."""
+    path = pathlib.Path(directory) / "config.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_env_overrides_file():
+    orig_file = config._CONFIG_FILE
+    saved = _snapshot_env("COGNEE_PLUGIN_DATASET")
+    tmpdir = tempfile.mkdtemp()
+    try:
+        config._CONFIG_FILE = _write_config_file(tmpdir, {"dataset": "from_file"})
+        os.environ["COGNEE_PLUGIN_DATASET"] = "from_env"
+        # Env is the last layer, so it wins over the config file.
+        assert config.load_config()["dataset"] == "from_env"
+    finally:
+        config._CONFIG_FILE = orig_file
+        _restore_env(saved)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_file_over_default():
+    orig_file = config._CONFIG_FILE
+    saved = _snapshot_env("COGNEE_PLUGIN_DATASET")
+    tmpdir = tempfile.mkdtemp()
+    try:
+        config._CONFIG_FILE = _write_config_file(tmpdir, {"dataset": "from_file"})
+        os.environ.pop("COGNEE_PLUGIN_DATASET", None)
+        assert config.load_config()["dataset"] == "from_file"
+    finally:
+        config._CONFIG_FILE = orig_file
+        _restore_env(saved)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_default_alone():
+    orig_file = config._CONFIG_FILE
+    saved = _snapshot_env("COGNEE_PLUGIN_DATASET")
+    tmpdir = tempfile.mkdtemp()
+    try:
+        # Non-existent path -> the file layer is skipped entirely.
+        config._CONFIG_FILE = pathlib.Path(tmpdir) / "config.json"
+        os.environ.pop("COGNEE_PLUGIN_DATASET", None)
+        assert config.load_config()["dataset"] == "agent_sessions"
+    finally:
+        config._CONFIG_FILE = orig_file
+        _restore_env(saved)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_footgun1_empty_ignored():
+    orig_file = config._CONFIG_FILE
+    saved = _snapshot_env("COGNEE_PLUGIN_DATASET")
+    tmpdir = tempfile.mkdtemp()
+    try:
+        # File layer: "" is filtered out (`v != ""`), so it cannot override.
+        config._CONFIG_FILE = _write_config_file(tmpdir, {"dataset": ""})
+        os.environ.pop("COGNEE_PLUGIN_DATASET", None)
+        assert config.load_config()["dataset"] == "agent_sessions"
+
+        # Env layer: "" is skipped (`if val:`), so it cannot override the file.
+        config._CONFIG_FILE = _write_config_file(tmpdir, {"dataset": "from_file"})
+        os.environ["COGNEE_PLUGIN_DATASET"] = ""
+        assert config.load_config()["dataset"] == "from_file"
+    finally:
+        config._CONFIG_FILE = orig_file
+        _restore_env(saved)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_backend_clearing_native():
+    orig_file = config._CONFIG_FILE
+    saved = _snapshot_env("COGNEE_CLAUDE_BACKEND", "COGNEE_BASE_URL", "COGNEE_API_KEY")
+    tmpdir = tempfile.mkdtemp()
+    try:
+        config._CONFIG_FILE = _write_config_file(
+            tmpdir, {"base_url": "http://example", "api_key": "secret"}
+        )
+        os.environ.pop("COGNEE_BASE_URL", None)
+        os.environ.pop("COGNEE_API_KEY", None)
+        os.environ["COGNEE_CLAUDE_BACKEND"] = "native"
+
+        merged = config.load_config()
+        # native backend forces local mode: base_url and api_key are cleared.
+        assert merged["base_url"] == ""
+        assert merged["api_key"] == ""
+    finally:
+        config._CONFIG_FILE = orig_file
+        _restore_env(saved)
+        shutil.rmtree(tmpdir, ignore_errors=True)

--- a/integrations/claude-code/tests/test_config_precedence.py
+++ b/integrations/claude-code/tests/test_config_precedence.py
@@ -86,7 +86,13 @@ def test_default_alone():
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
-def test_footgun1_empty_ignored():
+def test_empty_string_never_overrides():
+    """An empty string cannot override on either layer.
+
+    Setting a value to "" (in the config file or an env var) does not clear it:
+    the file merge drops "" (`v != ""`) and the env loop skips "" (`if val:`),
+    so the previous layer's value stands.
+    """
     orig_file = config._CONFIG_FILE
     saved = _snapshot_env("COGNEE_PLUGIN_DATASET")
     tmpdir = tempfile.mkdtemp()
@@ -137,7 +143,7 @@ def test_backend_clearing_native():
         "knob)."
     ),
 )
-def test_footgun3_config_file_poll_interval_reaches_consumer():
+def test_config_file_poll_interval_reaches_consumer():
     # The poll interval is set ONLY in the config file, with the env var unset,
     # to isolate the config-file path. load_config() surfaces it, but the real
     # consumer reads it through _float_env(name, default) -- which ignores the

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -213,6 +213,35 @@ Config precedence:
 | idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle sync fires |
 | idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `120` | Minimum seconds between idle sync runs |
 
+## Configuration precedence
+
+Resolution order: **env > config file > default** (env wins). See `load_config()`
+in `plugins/cognee/scripts/config.py`. Behavior pinned by
+`tests/test_config_precedence.py`.
+
+| Setting | Env var | Config key | Default | Who wins |
+| --- | --- | --- | --- | --- |
+| Dataset | `COGNEE_PLUGIN_DATASET` | `dataset` | `agent_sessions` | env |
+| Service URL | `COGNEE_BASE_URL` | `base_url` | unset | env |
+| API key | `COGNEE_API_KEY` | `api_key` | unset | env |
+| Backend | `COGNEE_CODEX_BACKEND` | `backend` | `auto` | env |
+
+An empty string cannot override on either layer: an empty config-file value is
+dropped (`v != ""`) and an empty env value is skipped (`if val:`).
+
+Backend `native` (or `local`/`sdk`) forces local mode: `base_url` and `api_key`
+are cleared to empty after the merge.
+
+### Testing & scope (#3559)
+
+- **Test + docs only** — no runtime config behavior was changed.
+- Precedence is documented per integration as it behaves today; the four Cognee
+  integrations are intentionally **not** converged (that is a product decision,
+  out of scope here).
+- These tests run locally today, not in CI (`ci.yml` runs pytest only for
+  integrations with their own `pyproject.toml`); wiring codex into CI is deferred
+  to a follow-up issue.
+
 ## Troubleshooting
 
 **Recall returns empty but data was ingested**

--- a/integrations/codex/tests/test_config_precedence.py
+++ b/integrations/codex/tests/test_config_precedence.py
@@ -85,7 +85,13 @@ def test_default_alone():
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
-def test_footgun1_empty_ignored():
+def test_empty_string_never_overrides():
+    """An empty string cannot override on either layer.
+
+    Setting a value to "" (in the config file or an env var) does not clear it:
+    the file merge drops "" (`v != ""`) and the env loop skips "" (`if val:`),
+    so the previous layer's value stands.
+    """
     orig_file = config._CONFIG_FILE
     saved = _snapshot_env("COGNEE_PLUGIN_DATASET")
     tmpdir = tempfile.mkdtemp()

--- a/integrations/codex/tests/test_config_precedence.py
+++ b/integrations/codex/tests/test_config_precedence.py
@@ -1,0 +1,127 @@
+"""Config precedence tests for the Cognee codex plugin (#3559).
+
+Documents the ACTUAL current behavior: load_config() merges defaults, then the
+config file, then environment variables -- so **env wins** over the config file
+here (see plugins/cognee/scripts/config.py). This file only pins that behavior
+down; it changes no runtime logic.
+
+Run: python integrations/codex/tests/test_config_precedence.py
+"""
+
+import json
+import os
+import pathlib
+import shutil
+import sys
+import tempfile
+
+sys.path.insert(
+    0, str(pathlib.Path(__file__).resolve().parents[1] / "plugins" / "cognee" / "scripts")
+)
+
+import config  # noqa: E402
+
+
+def _snapshot_env(*keys):
+    return {k: os.environ.get(k) for k in keys}
+
+
+def _restore_env(saved):
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def _write_config_file(directory, payload):
+    """Point config._CONFIG_FILE at a temp file holding `payload` (JSON)."""
+    path = pathlib.Path(directory) / "config.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_env_overrides_file():
+    orig_file = config._CONFIG_FILE
+    saved = _snapshot_env("COGNEE_PLUGIN_DATASET")
+    tmpdir = tempfile.mkdtemp()
+    try:
+        config._CONFIG_FILE = _write_config_file(tmpdir, {"dataset": "from_file"})
+        os.environ["COGNEE_PLUGIN_DATASET"] = "from_env"
+        # Env is the last layer, so it wins over the config file.
+        assert config.load_config()["dataset"] == "from_env"
+    finally:
+        config._CONFIG_FILE = orig_file
+        _restore_env(saved)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_file_over_default():
+    orig_file = config._CONFIG_FILE
+    saved = _snapshot_env("COGNEE_PLUGIN_DATASET")
+    tmpdir = tempfile.mkdtemp()
+    try:
+        config._CONFIG_FILE = _write_config_file(tmpdir, {"dataset": "from_file"})
+        os.environ.pop("COGNEE_PLUGIN_DATASET", None)
+        assert config.load_config()["dataset"] == "from_file"
+    finally:
+        config._CONFIG_FILE = orig_file
+        _restore_env(saved)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_default_alone():
+    orig_file = config._CONFIG_FILE
+    saved = _snapshot_env("COGNEE_PLUGIN_DATASET")
+    tmpdir = tempfile.mkdtemp()
+    try:
+        # Non-existent path -> the file layer is skipped entirely.
+        config._CONFIG_FILE = pathlib.Path(tmpdir) / "config.json"
+        os.environ.pop("COGNEE_PLUGIN_DATASET", None)
+        assert config.load_config()["dataset"] == "agent_sessions"
+    finally:
+        config._CONFIG_FILE = orig_file
+        _restore_env(saved)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_footgun1_empty_ignored():
+    orig_file = config._CONFIG_FILE
+    saved = _snapshot_env("COGNEE_PLUGIN_DATASET")
+    tmpdir = tempfile.mkdtemp()
+    try:
+        # File layer: "" is filtered out (`v != ""`), so it cannot override.
+        config._CONFIG_FILE = _write_config_file(tmpdir, {"dataset": ""})
+        os.environ.pop("COGNEE_PLUGIN_DATASET", None)
+        assert config.load_config()["dataset"] == "agent_sessions"
+
+        # Env layer: "" is skipped (`if val:`), so it cannot override the file.
+        config._CONFIG_FILE = _write_config_file(tmpdir, {"dataset": "from_file"})
+        os.environ["COGNEE_PLUGIN_DATASET"] = ""
+        assert config.load_config()["dataset"] == "from_file"
+    finally:
+        config._CONFIG_FILE = orig_file
+        _restore_env(saved)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_backend_clearing_native():
+    orig_file = config._CONFIG_FILE
+    saved = _snapshot_env("COGNEE_CODEX_BACKEND", "COGNEE_BASE_URL", "COGNEE_API_KEY")
+    tmpdir = tempfile.mkdtemp()
+    try:
+        config._CONFIG_FILE = _write_config_file(
+            tmpdir, {"base_url": "http://example", "api_key": "secret"}
+        )
+        os.environ.pop("COGNEE_BASE_URL", None)
+        os.environ.pop("COGNEE_API_KEY", None)
+        os.environ["COGNEE_CODEX_BACKEND"] = "native"
+
+        merged = config.load_config()
+        # native backend forces local mode: base_url and api_key are cleared.
+        assert merged["base_url"] == ""
+        assert merged["api_key"] == ""
+    finally:
+        config._CONFIG_FILE = orig_file
+        _restore_env(saved)
+        shutil.rmtree(tmpdir, ignore_errors=True)

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -127,6 +127,37 @@ COGNEE_DATASET=hermes
 > force it. Previously `improve()` was always synchronous; this is the one
 > behavior change to be aware of when upgrading.
 
+## Configuration precedence
+
+Resolution order: **config file > env > default** (the config file wins). The
+config dict is built from environment variables first, then
+`HERMES_HOME/cognee.json` is merged on top — see `load_config()` in
+`cognee_integration_hermes/config.py`. Behavior pinned by
+`tests/test_config_precedence.py`.
+
+| Setting | Env var | Config key | Default | Who wins |
+| --- | --- | --- | --- | --- |
+| Dataset | `COGNEE_DATASET` | `dataset` | `hermes` | config file |
+| Service URL | `COGNEE_BASE_URL` | `service_url` | empty | config file |
+| Top-K results | `COGNEE_TOP_K` | `top_k` | `5` | config file |
+| Local port | `COGNEE_LOCAL_PORT` | `local_port` | `8000` (clamped 1–65535) | config file |
+
+`COGNEE_SERVICE_URL` is a deprecated alias for `COGNEE_BASE_URL` (lower precedence).
+
+> **Empty strings in the config file behave differently by field type.** For a
+> plain string field (e.g. `dataset`) an empty string in the file overrides the
+> env/default layer. For a coerced field (`top_k`, `local_port`, run through
+> `str_to_int`/`str_to_bool`) an empty string fails to parse and falls back to the
+> default, so it does not override.
+
+### Testing & scope (#3559)
+
+- **Test + docs only** — no runtime config behavior was changed.
+- Precedence is documented per integration as it behaves today; the four Cognee
+  integrations are intentionally **not** converged (that is a product decision,
+  out of scope here).
+- These tests run in CI (`uv run pytest tests/`).
+
 ## Hermes Commands
 
 When Cognee is the active memory provider:

--- a/integrations/hermes-agent/tests/test_config_precedence.py
+++ b/integrations/hermes-agent/tests/test_config_precedence.py
@@ -1,0 +1,86 @@
+"""Config precedence tests for the Cognee Hermes plugin (#3559).
+
+Documents the ACTUAL current behavior, not an idealized one: hermes builds the
+config dict from environment variables first, then merges HERMES_HOME/cognee.json
+on top via dict.update() -- so the **config file wins over env** here. See
+load_config() in cognee_integration_hermes/config.py. This file only pins that
+behavior down; it changes no runtime logic.
+"""
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def test_file_overrides_env(tmp_path, monkeypatch):
+    from cognee_integration_hermes.config import load_config, save_config
+
+    monkeypatch.setenv("COGNEE_DATASET", "from_env")
+    save_config({"dataset": "from_file"}, tmp_path)
+
+    # File is the last layer merged, so it wins over the env base.
+    assert load_config(tmp_path)["dataset"] == "from_file"
+
+
+def test_env_used_when_no_file(tmp_path, monkeypatch):
+    from cognee_integration_hermes.config import load_config
+
+    monkeypatch.setenv("COGNEE_DATASET", "from_env")
+
+    # tmp_path has no cognee.json, so the file layer is skipped and env stands.
+    assert load_config(tmp_path)["dataset"] == "from_env"
+
+
+def test_default_when_neither(tmp_path, monkeypatch):
+    from cognee_integration_hermes.config import load_config
+
+    monkeypatch.delenv("COGNEE_DATASET", raising=False)
+
+    assert load_config(tmp_path)["dataset"] == "hermes"
+
+
+def test_base_url_prefers_canonical_over_alias(tmp_path):
+    from cognee_integration_hermes.config import load_config
+
+    # COGNEE_BASE_URL is canonical; COGNEE_SERVICE_URL is a deprecated alias.
+    env = {"COGNEE_BASE_URL": "https://canonical", "COGNEE_SERVICE_URL": "https://legacy"}
+    with mock.patch.dict("os.environ", env, clear=False):
+        assert load_config(tmp_path)["service_url"] == "https://canonical"
+
+
+def test_footgun1a_plain_field_accepts_empty(tmp_path, monkeypatch):
+    from cognee_integration_hermes.config import load_config, save_config
+
+    # Plain string field: the file merge drops only None (not ""), so an empty
+    # string in the config file DOES override the env/default layer.
+    monkeypatch.delenv("COGNEE_DATASET", raising=False)
+    save_config({"dataset": ""}, tmp_path)
+
+    assert load_config(tmp_path)["dataset"] == ""
+
+
+def test_footgun1b_coerced_field_rejects_empty(tmp_path, monkeypatch):
+    from cognee_integration_hermes.config import load_config, save_config
+
+    # Coerced fields run through str_to_int(), where "" fails to parse and falls
+    # back to the default -- so an empty string does NOT override here, unlike 1a.
+    monkeypatch.delenv("COGNEE_TOP_K", raising=False)
+    monkeypatch.delenv("COGNEE_LOCAL_PORT", raising=False)
+    save_config({"top_k": "", "local_port": ""}, tmp_path)
+
+    config = load_config(tmp_path)
+    assert config["top_k"] == 5
+    assert config["local_port"] == 8000
+
+
+def test_local_port_clamped(tmp_path, monkeypatch):
+    from cognee_integration_hermes.config import load_config, save_config
+
+    monkeypatch.delenv("COGNEE_LOCAL_PORT", raising=False)
+    save_config({"local_port": 999999}, tmp_path)
+
+    assert load_config(tmp_path)["local_port"] == 65535

--- a/integrations/hermes-agent/tests/test_config_precedence.py
+++ b/integrations/hermes-agent/tests/test_config_precedence.py
@@ -52,7 +52,7 @@ def test_base_url_prefers_canonical_over_alias(tmp_path):
         assert load_config(tmp_path)["service_url"] == "https://canonical"
 
 
-def test_footgun1a_plain_field_accepts_empty(tmp_path, monkeypatch):
+def test_empty_string_overrides_plain_field(tmp_path, monkeypatch):
     from cognee_integration_hermes.config import load_config, save_config
 
     # Plain string field: the file merge drops only None (not ""), so an empty
@@ -63,11 +63,12 @@ def test_footgun1a_plain_field_accepts_empty(tmp_path, monkeypatch):
     assert load_config(tmp_path)["dataset"] == ""
 
 
-def test_footgun1b_coerced_field_rejects_empty(tmp_path, monkeypatch):
+def test_empty_string_rejected_by_coerced_field(tmp_path, monkeypatch):
     from cognee_integration_hermes.config import load_config, save_config
 
     # Coerced fields run through str_to_int(), where "" fails to parse and falls
-    # back to the default -- so an empty string does NOT override here, unlike 1a.
+    # back to the default -- so an empty string does NOT override here, unlike a
+    # plain string field.
     monkeypatch.delenv("COGNEE_TOP_K", raising=False)
     monkeypatch.delenv("COGNEE_LOCAL_PORT", raising=False)
     save_config({"top_k": "", "local_port": ""}, tmp_path)

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -261,6 +261,39 @@ This lets the agent distinguish between personal context, shared knowledge, and 
 
 Note: Files are stored in Cognee using sanitized relative paths as filenames (e.g., `MEMORY.md.txt` for `MEMORY.md`, `memory.tools.md.txt` for `memory/tools.md`) for easy identification and to avoid path separator issues.
 
+## Configuration precedence
+
+Resolution order: **config > env > default** (the plugin config wins), resolved in
+`resolveConfig()` (`src/config.ts`). Behavior pinned by
+`__tests__/test_configPrecedence.ts`. Two settings are asymmetric — see the notes
+below.
+
+| Setting | Env var | Config key | Default | Who wins |
+| --- | --- | --- | --- | --- |
+| Base URL | `COGNEE_BASE_URL` | `baseUrl` | `http://localhost:8000` | config |
+| Dataset name | — (config-only) | `datasetName` | `openclaw` | config |
+| Mode | `COGNEE_MODE` | `mode` | `local` | config, except env can force `cloud` |
+| API key | `COGNEE_API_KEY` | `apiKey` | empty | see note |
+
+- **`mode`** — the env var can only *force* `"cloud"`; it can never force
+  `"local"`. If either the config or `COGNEE_MODE` is `"cloud"`, the mode is
+  `"cloud"`.
+- **`apiKey`** — `COGNEE_API_KEY` is read only when `mode` is `"cloud"`. A config
+  `apiKey` supports `${VAR}` interpolation from the environment, which throws if
+  the referenced variable is unset.
+- A config value that trims to empty (e.g. whitespace) is treated as unset and
+  falls through to env/default.
+
+### Testing & scope (#3559)
+
+- **Test + docs only** — no runtime config behavior was changed.
+- Precedence is documented per integration as it behaves today; the four Cognee
+  integrations are intentionally **not** converged (that is a product decision,
+  out of scope here).
+- These tests run locally today (`npm test`), not in CI (the openclaw CI job only
+  type-checks; jest is not run); wiring the jest suite into CI is deferred to a
+  follow-up issue.
+
 ## CLI Commands
 
 ```bash

--- a/integrations/openclaw/__tests__/test_configPrecedence.ts
+++ b/integrations/openclaw/__tests__/test_configPrecedence.ts
@@ -56,7 +56,7 @@ describe("resolveConfig precedence (file-wins)", () => {
     expect(resolveConfig({}).baseUrl).toBe("http://localhost:8000");
   });
 
-  test("footgun 1: whitespace-only config value trims to falsy and falls through", () => {
+  test("whitespace-only config value trims to falsy and falls through", () => {
     // No env set -> trimmed "" is falsy -> falls through to the default.
     expect(resolveConfig({ baseUrl: "   " }).baseUrl).toBe("http://localhost:8000");
   });

--- a/integrations/openclaw/__tests__/test_configPrecedence.ts
+++ b/integrations/openclaw/__tests__/test_configPrecedence.ts
@@ -1,0 +1,107 @@
+/**
+ * Config precedence tests for the Cognee openclaw plugin (#3559).
+ *
+ * Documents the ACTUAL current behavior of resolveConfig(): the plugin config
+ * object (raw) is checked before process.env, so the **config file wins** over
+ * env for most settings. Two settings are asymmetric and are NOT flat file-wins:
+ * `mode` (env can only force "cloud") and `apiKey` (env consulted only in cloud
+ * mode; config values support ${VAR} interpolation). This file only pins that
+ * behavior down; it changes no runtime logic.
+ */
+
+import { resolveConfig, resolveEnvVars } from "../src/config";
+
+// Every key any test touches -- snapshotted and cleared before each test, then
+// restored after, so tests never leak env into one another (or the runner).
+const TOUCHED_KEYS = [
+  "COGNEE_BASE_URL",
+  "COGNEE_MODE",
+  "COGNEE_API_KEY",
+  "COGNEE_DATASET_NAME",
+  "MY_KEY",
+];
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of TOUCHED_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of TOUCHED_KEYS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedEnv[key];
+    }
+  }
+});
+
+describe("resolveConfig precedence (file-wins)", () => {
+  test("config overrides env", () => {
+    process.env.COGNEE_BASE_URL = "http://from-env";
+    expect(resolveConfig({ baseUrl: "http://from-config" }).baseUrl).toBe("http://from-config");
+  });
+
+  test("env used when config empty", () => {
+    process.env.COGNEE_BASE_URL = "http://from-env";
+    expect(resolveConfig({}).baseUrl).toBe("http://from-env");
+  });
+
+  test("default when neither", () => {
+    expect(resolveConfig({}).baseUrl).toBe("http://localhost:8000");
+  });
+
+  test("footgun 1: whitespace-only config value trims to falsy and falls through", () => {
+    // No env set -> trimmed "" is falsy -> falls through to the default.
+    expect(resolveConfig({ baseUrl: "   " }).baseUrl).toBe("http://localhost:8000");
+  });
+
+  test("config-only field ignores env", () => {
+    // datasetName has no env read, so a bogus env var cannot affect it.
+    process.env.COGNEE_DATASET_NAME = "bogus";
+    expect(resolveConfig({}).datasetName).toBe("openclaw");
+  });
+});
+
+describe("resolveConfig mode asymmetry (env can only force cloud)", () => {
+  test("env forces cloud over config local", () => {
+    process.env.COGNEE_MODE = "cloud";
+    expect(resolveConfig({ mode: "local" }).mode).toBe("cloud");
+  });
+
+  test("config cloud with no env", () => {
+    expect(resolveConfig({ mode: "cloud" }).mode).toBe("cloud");
+  });
+
+  test("env cannot force local", () => {
+    process.env.COGNEE_MODE = "local";
+    expect(resolveConfig({ mode: "cloud" }).mode).toBe("cloud");
+  });
+});
+
+describe("resolveConfig apiKey asymmetry", () => {
+  test("cloud mode reads COGNEE_API_KEY from env", () => {
+    process.env.COGNEE_API_KEY = "k";
+    expect(resolveConfig({ mode: "cloud" }).apiKey).toBe("k");
+  });
+
+  test("local mode ignores COGNEE_API_KEY from env", () => {
+    process.env.COGNEE_API_KEY = "k";
+    expect(resolveConfig({ mode: "local" }).apiKey).toBe("");
+  });
+
+  test("${VAR} interpolation resolves from env", () => {
+    process.env.MY_KEY = "secret";
+    expect(resolveConfig({ apiKey: "${MY_KEY}", mode: "cloud" }).apiKey).toBe("secret");
+  });
+
+  test("${VAR} with a missing env var throws", () => {
+    expect(() => resolveConfig({ apiKey: "${MY_KEY}", mode: "cloud" })).toThrow();
+    expect(() => resolveEnvVars("${MY_KEY}")).toThrow();
+  });
+});


### PR DESCRIPTION
Closes topoteretes/cognee#3559.

## What this does

Adds config-precedence tests + a documented precedence matrix for all four in-scope integrations: **claude-code, codex, hermes-agent, openclaw**.

## The thing I found while tracing the code

The issue asks to test precedence as `env > config file > defaults` uniformly — but the four integrations **don't share one precedence order**, so a single shared assertion would be wrong for half of them:

| Integration | Loader | Order | env vs file |
|---|---|---|---|
| claude-code | `scripts/config.py` `load_config()` | defaults → file → env | **env wins** |
| codex | `plugins/cognee/scripts/config.py` `load_config()` | defaults → file → env | **env wins** |
| hermes-agent | `config.py` `load_config()` | env → file → clamp | **file wins** |
| openclaw | `src/config.ts` `resolveConfig()` | default → env → file | **file wins** |

hermes builds the dict from `os.environ` first then `.update()`s the file over it (file wins); openclaw's `raw || process.env || default` chain checks the config value first (file wins). So instead of forcing one order, I wrote a **per-integration matrix** where each integration's tests assert its *actual* behavior, and each README documents that behavior.

## Scope (test + docs only)

No runtime config logic was changed anywhere. These tests pin down and document current behavior; they don't try to change or unify it. Converging the four onto one order is a product decision I've kept out of scope.

## Footguns the tests pin down

- **Empty-string handling differs.** claude-code/codex drop `""` on both layers (`v != ""` file filter, `if val:` env skip); hermes lets an empty config-file value override a *plain* string field but not a *coerced* (int/bool) one; openclaw trims `""`/whitespace to falsy and falls through. Tested as separate cases.
- **openclaw `mode`/`apiKey` are asymmetric** (not flat file-wins): env `COGNEE_MODE` can only force `cloud`, never `local`; `COGNEE_API_KEY` is read only in cloud mode; config `apiKey` supports `${VAR}` interpolation (throws on a missing var). Each is tested explicitly.
- **claude-code poll/timeout dead-knob (documented as a strict `xfail`, not asserted correct).** Five keys (`COGNEE_COGNIFY_POLL_INTERVAL`, `COGNEE_BRIDGE_POLL_DEADLINE`, `COGNEE_BRIDGE_SUBMIT_TIMEOUT`, `COGNEE_REMEMBER_WAIT_SECONDS`, `COGNEE_STATUS_REQUEST_TIMEOUT`) are in `_ENV_MAP` (so they surface in the config file), but consumers read them via `_float_env` from the environment only — so a config-file value is silently ignored. Captured as a `strict xfail` referencing this issue: if the runtime is later fixed, the xfail flips to XPASS and the suite goes red, prompting cleanup.

## CI note (honest)

Today `ci.yml` runs pytest only for integrations that ship their own `pyproject.toml` (**hermes-agent**), and type-checks TypeScript integrations (openclaw's jest isn't run in CI). So of the four new suites, only hermes-agent runs in CI; **claude-code, codex, and openclaw tests run locally** (commands below). Wiring the other three into CI (per-integration `pyproject.toml`/`.python-version`; `npm test` in the TS job) is a small infra change I've left as a **follow-up issue** to keep this PR test-only. All new Python passes `ruff format`/`ruff check`.

## Testing

Every documented matrix row maps to a real assertion. Local run commands:

```bash
# hermes-agent (also runs in CI)
cd integrations/hermes-agent && uv run pytest tests/test_config_precedence.py -v

# claude-code (5 passed, 1 xfailed = the dead-knob)
python -m pytest integrations/claude-code/tests/test_config_precedence.py -v

# codex
python -m pytest integrations/codex/tests/test_config_precedence.py -v

# openclaw
cd integrations/openclaw && npx jest test_configPrecedence
```

**hermes — 7 passed:**
<img width="1446" height="478" alt="image" src="https://github.com/user-attachments/assets/a57125d7-ce2e-4bc1-9a8b-7bf81267c1d1" />

**claude-code — 5 passed, 1 xfailed:**
<img width="1467" height="673" alt="image" src="https://github.com/user-attachments/assets/b617b4cc-25fe-4f54-85c2-47eecbcef2f9" />

**codex — 5 passed:**
<img width="1467" height="673" alt="image" src="https://github.com/user-attachments/assets/ed1f4b27-be42-4819-9c08-0d7fe61e9ed3" />

**openclaw — 12 passed:**
<img width="1457" height="552" alt="image" src="https://github.com/user-attachments/assets/c862e39f-c628-4173-a48f-42b6a09d668a" />

## Minor, out of scope

While documenting, I noticed the existing claude-code README lists `session_prefix` default as `cc` but the code default is `claude` — pre-existing drift unrelated to precedence, so I left it untouched. Flagging in case you want it fixed separately.