### PR TITLE
feat(integrations): add compact status one-liner for claude-code and codex

### DIFF
--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -28,6 +28,9 @@ _ACTIVITY_LOG = _PLUGIN_DIR / "activity.log"
 _SAVE_COUNTER = _PLUGIN_DIR / "save_counter.json"
 _SERVER_READY_MARKER = _SHARED_PLUGIN_ROOT / "server-ready.json"
 _SERVER_READY_TTL_SECONDS = 30
+# Plugin manifest shipped beside this scripts/ dir. Read by the status one-liner
+# to report the installed plugin version (never fatal if absent).
+_PLUGIN_MANIFEST = Path(__file__).resolve().parent.parent / ".claude-plugin" / "plugin.json"
 _SYNC_LOCK = _PLUGIN_DIR / "sync.lock"
 # Per-agent-session buffer dirs. Each agent session (one Claude/Codex terminal)
 # owns its own file under these dirs, so two concurrent agents never
@@ -1019,6 +1022,54 @@ def resolve_runtime_mode() -> dict:
         "url_source": url_source,
         "key_source": key_source,
     }
+
+
+def _plugin_version() -> str:
+    """Installed plugin version from the sibling ``plugin.json`` manifest.
+
+    Returns ``"unknown"`` when the manifest is missing or unreadable so the
+    status one-liner never fails on a partial install.
+    """
+    try:
+        raw = json.loads(_PLUGIN_MANIFEST.read_text(encoding="utf-8"))
+        return str(raw.get("version") or "").strip() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _server_version() -> str:
+    """Cognee server version from the shared readiness marker, else ``""``.
+
+    ``mark_server_ready`` records this when the local server is up; empty means
+    no server has reported in yet.
+    """
+    try:
+        raw = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
+        return str(raw.get("version") or "").strip()
+    except Exception:
+        return ""
+
+
+def runtime_status_line() -> str:
+    """One-line view of the resolved runtime state, e.g.::
+
+        mode=http url=http://localhost:8011 key=missing version=0.2.0
+
+    Reuses the same resolvers the hooks run with (``resolve_runtime_mode``) so
+    the reported state matches real runtime behaviour. The API key value is
+    never printed — only ``key=set`` or ``key=missing``. When the local server
+    has reported its version, a trailing ``server=<version>`` field is appended.
+    Pure-local: reads env vars and ``~/.cognee-plugin`` files, no network call.
+    """
+    runtime = resolve_runtime_mode()
+    mode = str(runtime.get("mode") or "unknown")
+    url = str(runtime.get("base_url") or _local_api_url())
+    key = "set" if runtime.get("api_key_present") else "missing"
+    line = f"mode={mode} url={url} key={key} version={_plugin_version()}"
+    server_version = _server_version()
+    if server_version:
+        line += f" server={server_version}"
+    return line
 
 
 def set_agent_registration(registered: bool, session_key: str = "") -> None:

--- a/integrations/claude-code/scripts/cognee-status.py
+++ b/integrations/claude-code/scripts/cognee-status.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Print the resolved Cognee plugin runtime state as one line, then exit 0.
+
+    mode=<http|local_sdk> url=<service-url> key=<set|missing> version=<plugin-version>
+
+A quick "what am I actually running with?" check. Reuses the same resolvers the
+hooks run with (see ``_plugin_common.resolve_runtime_mode``) so the reported
+state matches real runtime behaviour. The API key value is never printed — only
+whether one is set. Pure-local: reads env vars and ``~/.cognee-plugin`` files,
+makes no network call.
+
+Run: python3 integrations/claude-code/scripts/cognee-status.py
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import _plugin_common as pc  # noqa: E402
+
+
+def main() -> int:
+    sys.stdout.write(pc.runtime_status_line() + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/claude-code/tests/test_status.py
+++ b/integrations/claude-code/tests/test_status.py
@@ -1,0 +1,85 @@
+"""Tests for the compact `status` one-liner: `mode=… url=… key=set|missing version=…`.
+
+The line reuses the same runtime resolvers the hooks run with and must never
+print the API key value — only whether one is set.
+
+Run: python integrations/claude-code/tests/test_status.py
+"""
+
+import contextlib
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+
+@contextlib.contextmanager
+def _patched(runtime, plugin_version="0.2.0", server_version=""):
+    """Swap the resolvers so the line is deterministic regardless of host env."""
+    saved = (pc.resolve_runtime_mode, pc._plugin_version, pc._server_version)
+    pc.resolve_runtime_mode = lambda: dict(runtime)
+    pc._plugin_version = lambda: plugin_version
+    pc._server_version = lambda: server_version
+    try:
+        yield
+    finally:
+        pc.resolve_runtime_mode, pc._plugin_version, pc._server_version = saved
+
+
+def _fields(line):
+    return dict(part.split("=", 1) for part in line.split(" "))
+
+
+def test_shape_and_masks_key_when_present():
+    runtime = {"mode": "http", "base_url": "http://localhost:8011", "api_key_present": True}
+    with _patched(runtime):
+        line = pc.runtime_status_line()
+    assert "\n" not in line
+    assert _fields(line) == {
+        "mode": "http",
+        "url": "http://localhost:8011",
+        "key": "set",
+        "version": "0.2.0",
+    }
+
+
+def test_reports_missing_key():
+    runtime = {"mode": "local_sdk", "base_url": "", "api_key_present": False}
+    with _patched(runtime):
+        assert _fields(pc.runtime_status_line())["key"] == "missing"
+
+
+def test_appends_server_version_when_known():
+    runtime = {"mode": "http", "base_url": "http://localhost:8011", "api_key_present": False}
+    with _patched(runtime, server_version="1.2.2"):
+        fields = _fields(pc.runtime_status_line())
+    assert fields["version"] == "0.2.0"
+    assert fields["server"] == "1.2.2"
+
+
+def test_never_prints_raw_key():
+    """End-to-end through the real resolver: an env key must stay masked."""
+    secret = "sk-super-secret-value"
+    os.environ["COGNEE_API_KEY"] = secret
+    try:
+        line = pc.runtime_status_line()
+    finally:
+        os.environ.pop("COGNEE_API_KEY", None)
+    assert secret not in line
+    assert "key=set" in line
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -27,6 +27,9 @@ _ACTIVITY_LOG = _PLUGIN_DIR / "activity.log"
 _SAVE_COUNTER = _PLUGIN_DIR / "save_counter.json"
 _SERVER_READY_MARKER = _SHARED_PLUGIN_ROOT / "server-ready.json"
 _SERVER_READY_TTL_SECONDS = 30
+# Plugin manifest shipped beside this scripts/ dir. Read by the status one-liner
+# to report the installed plugin version (never fatal if absent).
+_PLUGIN_MANIFEST = Path(__file__).resolve().parent.parent / ".codex-plugin" / "plugin.json"
 _SYNC_LOCK = _PLUGIN_DIR / "sync.lock"
 # Per-agent-session buffer dirs. Each agent session (one Claude/Codex terminal)
 # owns its own file under these dirs, so two concurrent agents never
@@ -999,6 +1002,54 @@ def resolve_runtime_mode() -> dict:
         "base_url": service_url,
         "api_key_present": bool(api_key),
     }
+
+
+def _plugin_version() -> str:
+    """Installed plugin version from the sibling ``plugin.json`` manifest.
+
+    Returns ``"unknown"`` when the manifest is missing or unreadable so the
+    status one-liner never fails on a partial install.
+    """
+    try:
+        raw = json.loads(_PLUGIN_MANIFEST.read_text(encoding="utf-8"))
+        return str(raw.get("version") or "").strip() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _server_version() -> str:
+    """Cognee server version from the shared readiness marker, else ``""``.
+
+    ``mark_server_ready`` records this when the local server is up; empty means
+    no server has reported in yet.
+    """
+    try:
+        raw = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
+        return str(raw.get("version") or "").strip()
+    except Exception:
+        return ""
+
+
+def runtime_status_line() -> str:
+    """One-line view of the resolved runtime state, e.g.::
+
+        mode=http url=http://localhost:8011 key=missing version=1.0.3-local
+
+    Reuses the same resolvers the hooks run with (``resolve_runtime_mode``) so
+    the reported state matches real runtime behaviour. The API key value is
+    never printed — only ``key=set`` or ``key=missing``. When the local server
+    has reported its version, a trailing ``server=<version>`` field is appended.
+    Pure-local: reads env vars and ``~/.cognee-plugin`` files, no network call.
+    """
+    runtime = resolve_runtime_mode()
+    mode = str(runtime.get("mode") or "unknown")
+    url = str(runtime.get("base_url") or _local_api_url())
+    key = "set" if runtime.get("api_key_present") else "missing"
+    line = f"mode={mode} url={url} key={key} version={_plugin_version()}"
+    server_version = _server_version()
+    if server_version:
+        line += f" server={server_version}"
+    return line
 
 
 def set_agent_registration(registered: bool, session_key: str = "") -> None:

--- a/integrations/codex/plugins/cognee/scripts/cognee-status.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee-status.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Print the resolved Cognee plugin runtime state as one line, then exit 0.
+
+    mode=<http|local_sdk> url=<service-url> key=<set|missing> version=<plugin-version>
+
+A quick "what am I actually running with?" check. Reuses the same resolvers the
+hooks run with (see ``_plugin_common.resolve_runtime_mode``) so the reported
+state matches real runtime behaviour. The API key value is never printed — only
+whether one is set. Pure-local: reads env vars and ``~/.cognee-plugin`` files,
+makes no network call.
+
+Run: python3 integrations/codex/plugins/cognee/scripts/cognee-status.py
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import _plugin_common as pc  # noqa: E402
+
+
+def main() -> int:
+    sys.stdout.write(pc.runtime_status_line() + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/codex/plugins/cognee/tests/test_status.py
+++ b/integrations/codex/plugins/cognee/tests/test_status.py
@@ -1,0 +1,85 @@
+"""Tests for the compact `status` one-liner: `mode=… url=… key=set|missing version=…`.
+
+The line reuses the same runtime resolvers the hooks run with and must never
+print the API key value — only whether one is set.
+
+Run: python integrations/codex/plugins/cognee/tests/test_status.py
+"""
+
+import contextlib
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+
+@contextlib.contextmanager
+def _patched(runtime, plugin_version="1.0.3-local", server_version=""):
+    """Swap the resolvers so the line is deterministic regardless of host env."""
+    saved = (pc.resolve_runtime_mode, pc._plugin_version, pc._server_version)
+    pc.resolve_runtime_mode = lambda: dict(runtime)
+    pc._plugin_version = lambda: plugin_version
+    pc._server_version = lambda: server_version
+    try:
+        yield
+    finally:
+        pc.resolve_runtime_mode, pc._plugin_version, pc._server_version = saved
+
+
+def _fields(line):
+    return dict(part.split("=", 1) for part in line.split(" "))
+
+
+def test_shape_and_masks_key_when_present():
+    runtime = {"mode": "http", "base_url": "http://localhost:8011", "api_key_present": True}
+    with _patched(runtime):
+        line = pc.runtime_status_line()
+    assert "\n" not in line
+    assert _fields(line) == {
+        "mode": "http",
+        "url": "http://localhost:8011",
+        "key": "set",
+        "version": "1.0.3-local",
+    }
+
+
+def test_reports_missing_key():
+    runtime = {"mode": "local_sdk", "base_url": "", "api_key_present": False}
+    with _patched(runtime):
+        assert _fields(pc.runtime_status_line())["key"] == "missing"
+
+
+def test_appends_server_version_when_known():
+    runtime = {"mode": "http", "base_url": "http://localhost:8011", "api_key_present": False}
+    with _patched(runtime, server_version="1.2.2"):
+        fields = _fields(pc.runtime_status_line())
+    assert fields["version"] == "1.0.3-local"
+    assert fields["server"] == "1.2.2"
+
+
+def test_never_prints_raw_key():
+    """End-to-end through the real resolver: an env key must stay masked."""
+    secret = "sk-super-secret-value"
+    os.environ["COGNEE_API_KEY"] = secret
+    try:
+        line = pc.runtime_status_line()
+    finally:
+        os.environ.pop("COGNEE_API_KEY", None)
+    assert secret not in line
+    assert "key=set" in line
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Summary

Adds a compact `status` one-liner to the **claude-code** and **codex** plugins that prints the resolved plugin runtime state on a single line and exits `0`:

```
mode=<http|local_sdk> url=<service-url> key=<set|missing> version=<plugin-version>
```

Resolves topoteretes/cognee#3552 (per the plan discussed on the issue).

## Motivation

There was no quick, machine-friendly way to see what the plugin is actually running with (mode / endpoint / whether a key is present / version) without digging through config files, logs, or the statusline UI. This adds a one-shot command for exactly that.

## Design / root cause of the "which values?" question

The runtime resolvers already exist in `_plugin_common.py` and are what the hooks actually run with, so `status` reuses them instead of re-deriving config:

- `mode`, `url`, key-presence &rarr; `resolve_runtime_mode()` (`_local_api_url` / `_api_key` underneath)
- `version` &rarr; the plugin's own `plugin.json` (`0.2.0` for claude-code, `1.0.3-local` for codex), with a trailing `server=<version>` field appended when the local server has reported its version via the shared `server-ready.json` marker.

This is intentionally **not** built on `cognee_statusline_render.py`: that renderer is standalone by design and reads a different set of env vars (`COGNEE_BASE_URL` / `COGNEE_PLUGIN_DATASET`) than the runtime path (`COGNEE_LOCAL_API_URL`), and it has no source for the API key — so a status built there could report a mode/url that differs from what the hooks really use. Basing `status` on the `_plugin_common` resolvers keeps the reported line faithful to the real runtime.

**The API key value is never printed** — only `key=set` or `key=missing`.

## What changed

- `_plugin_common.py` (both plugins): add `_plugin_version()`, `_server_version()`, and `runtime_status_line()`. All are additive and gracefully degrade (`version=unknown`, no `server=` field) if a manifest/marker is missing.
- `scripts/cognee-status.py` (both plugins): tiny entry point that prints `runtime_status_line()` and exits `0`. Pure-local — no network call.
- `tests/test_status.py` (both plugins): assert the one-line format, that a present key renders `key=set` (and the raw key never appears in the output), that a missing key renders `key=missing`, and that `server=` is appended when the server version is known.

## Example output

```
$ python3 integrations/claude-code/scripts/cognee-status.py
mode=http url=http://localhost:8011 key=missing version=0.2.0

$ python3 integrations/codex/plugins/cognee/scripts/cognee-status.py
mode=http url=http://localhost:8011 key=missing version=1.0.3-local
```

## Testing

- `ruff format --check integrations/` &rarr; passes (114 files already formatted)
- `ruff check integrations/` &rarr; all checks passed
- `pytest integrations/claude-code/tests/` &rarr; 64 passed (4 new + existing, no regressions)
- `pytest integrations/codex/plugins/cognee/tests/test_status.py` &rarr; 4 passed
- Both test files also run standalone (`python3 .../test_status.py`), matching the existing test convention.

## Risks & mitigations

- **Backward compatibility:** additive only — no existing function or output is changed; the full existing claude-code suite still passes.
- **Missing/corrupt files:** manifest and server-ready reads are wrapped so `status` never raises — it falls back to `version=unknown` / omits `server=`.
- **Secret exposure:** the key is masked to `set`/`missing`; a dedicated test asserts the raw value is never emitted.

## Done-when (from the issue)

- [x] Prints the resolved runtime state on one line
- [x] Exits `0`
