### PR TITLE
feat(integrations): add shared session-id sanitization conformance test

### DIFF
--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -97,9 +97,12 @@ apply_cognee_env()
 
 
 def _sanitize_session_key(value: str) -> str:
+    # ASCII-only allowed set [A-Za-z0-9-_.], to stay identical across integrations
+    # (including the TypeScript openclaw one). `isascii()` guards against unicode
+    # letters/digits that `isalnum()` would otherwise keep.
     safe = []
     for ch in str(value or ""):
-        if ch.isalnum() or ch in ("-", "_", "."):
+        if (ch.isascii() and ch.isalnum()) or ch in ("-", "_", "."):
             safe.append(ch)
         else:
             safe.append("_")

--- a/integrations/claude-code/tests/test_session_id_conformance.py
+++ b/integrations/claude-code/tests/test_session_id_conformance.py
@@ -1,0 +1,45 @@
+"""Conformance test: claude-code session-id sanitization matches the shared spec.
+
+Loads the shared case table in integrations/conformance/session_id_cases.json
+(the same table the codex, hermes-agent and openclaw tests use) and checks the
+claude-code sanitizer against it. If any implementation drifts from the shared
+rule, its test fails.
+
+Run: python integrations/claude-code/tests/test_session_id_conformance.py (or via pytest).
+"""
+
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+
+def _load_cases():
+    root = next(p for p in pathlib.Path(__file__).resolve().parents if p.name == "integrations")
+    text = (root / "conformance" / "session_id_cases.json").read_text(encoding="utf-8")
+    return json.loads(text)
+
+
+def test_sanitizer_matches_shared_table():
+    mismatches = []
+    for case in _load_cases():
+        result = pc._sanitize_session_key(case["input"])
+        if result != case["expected"]:
+            mismatches.append(f"{case['input']!r} -> {result!r}, expected {case['expected']!r}")
+    assert not mismatches, "session-id sanitization drift:\n" + "\n".join(mismatches)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -97,9 +97,12 @@ apply_cognee_env()
 
 
 def _sanitize_session_key(value: str) -> str:
+    # ASCII-only allowed set [A-Za-z0-9-_.], to stay identical across integrations
+    # (including the TypeScript openclaw one). `isascii()` guards against unicode
+    # letters/digits that `isalnum()` would otherwise keep.
     safe = []
     for ch in str(value or ""):
-        if ch.isalnum() or ch in ("-", "_", "."):
+        if (ch.isascii() and ch.isalnum()) or ch in ("-", "_", "."):
             safe.append(ch)
         else:
             safe.append("_")

--- a/integrations/codex/plugins/cognee/tests/test_session_id_conformance.py
+++ b/integrations/codex/plugins/cognee/tests/test_session_id_conformance.py
@@ -1,0 +1,45 @@
+"""Conformance test: codex session-id sanitization matches the shared spec.
+
+Loads the shared case table in integrations/conformance/session_id_cases.json
+(the same table the claude-code, hermes-agent and openclaw tests use) and checks
+the codex sanitizer against it. If any implementation drifts from the shared
+rule, its test fails.
+
+Run: python integrations/codex/plugins/cognee/tests/test_session_id_conformance.py (or via pytest).
+"""
+
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+
+def _load_cases():
+    root = next(p for p in pathlib.Path(__file__).resolve().parents if p.name == "integrations")
+    text = (root / "conformance" / "session_id_cases.json").read_text(encoding="utf-8")
+    return json.loads(text)
+
+
+def test_sanitizer_matches_shared_table():
+    mismatches = []
+    for case in _load_cases():
+        result = pc._sanitize_session_key(case["input"])
+        if result != case["expected"]:
+            mismatches.append(f"{case['input']!r} -> {result!r}, expected {case['expected']!r}")
+    assert not mismatches, "session-id sanitization drift:\n" + "\n".join(mismatches)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/conformance/README.md
+++ b/integrations/conformance/README.md
@@ -1,0 +1,29 @@
+# Session id sanitization conformance
+
+Every Cognee integration turns a native session id into a Cognee session id with
+the same shape: `{agent}_{native_id}`. Before the native id is used, each
+integration runs it through a small sanitizer. The rule is:
+
+- Keep only the ASCII set `[A-Za-z0-9-_.]`.
+- Replace every other character with `_`.
+- Trim leading and trailing `.` and `_`.
+- Cap the length at 120 characters.
+
+`session_id_cases.json` is the single source of truth for that rule. It is a
+list of `{ "input", "expected", "note" }` cases. Each integration has a small
+test that loads this file and checks its own sanitizer against it:
+
+- claude-code: `integrations/claude-code/tests/test_session_id_conformance.py`
+- codex: `integrations/codex/plugins/cognee/tests/test_session_id_conformance.py`
+- hermes-agent: `integrations/hermes-agent/tests/test_session_id_conformance.py`
+- openclaw: `integrations/openclaw/__tests__/test_session_id_conformance.ts`
+
+Because every test reads the same file, any implementation that drifts from the
+rule fails its test.
+
+## Note on empty results
+
+The table only holds inputs whose sanitized output is not empty. hermes-agent
+returns `"session"` when the result would be empty, while the others return an
+empty string. That one case is left out on purpose so the shared table stays
+identical for all four integrations.

--- a/integrations/conformance/session_id_cases.json
+++ b/integrations/conformance/session_id_cases.json
@@ -1,0 +1,57 @@
+[
+  {
+    "input": "claude_session-01.log",
+    "expected": "claude_session-01.log",
+    "note": "allowed set passes through unchanged"
+  },
+  {
+    "input": "hello world",
+    "expected": "hello_world",
+    "note": "space becomes underscore"
+  },
+  {
+    "input": "a/b\\c:d",
+    "expected": "a_b_c_d",
+    "note": "path separators and colon become underscores"
+  },
+  {
+    "input": "__lead_and_trail__",
+    "expected": "lead_and_trail",
+    "note": "leading and trailing underscores are trimmed"
+  },
+  {
+    "input": "...dots...",
+    "expected": "dots",
+    "note": "leading and trailing dots are trimmed"
+  },
+  {
+    "input": "@@@leading",
+    "expected": "leading",
+    "note": "leading run of disallowed chars is trimmed after replacement"
+  },
+  {
+    "input": "naïve",
+    "expected": "na_ve",
+    "note": "unicode letter is not in the ASCII set, becomes underscore"
+  },
+  {
+    "input": "tab\tnl\n",
+    "expected": "tab_nl",
+    "note": "control chars become underscores, trailing one is trimmed"
+  },
+  {
+    "input": "3.14_pi",
+    "expected": "3.14_pi",
+    "note": "digits, dot and underscore are kept"
+  },
+  {
+    "input": "550e8400-e29b-41d4-a716-446655440000",
+    "expected": "550e8400-e29b-41d4-a716-446655440000",
+    "note": "a real UUID stays intact"
+  },
+  {
+    "input": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "expected": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "note": "length is capped at 120 characters"
+  }
+]

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -82,9 +82,14 @@ def _has_cognee() -> bool:
 def _safe_session_component(value: str) -> str:
     # Sanitization kept consistent with the other integrations' session-id helpers
     # (claude-code/codex `_sanitize_session_key`, openclaw `sanitizeSessionKey`):
-    # keep alphanumerics plus `-` `_` `.`, replace others with `_`, trim `._` ends,
-    # cap length at 120.
-    safe = "".join(ch if ch.isalnum() or ch in ("-", "_", ".") else "_" for ch in value)
+    # keep the ASCII set [A-Za-z0-9-_.], replace others with `_`, trim `._` ends,
+    # cap length at 120. `isascii()` guards against unicode letters/digits that
+    # `isalnum()` would otherwise keep. The trailing `or "session"` fallback is
+    # intentional and hermes-specific, so empty-output cases are excluded from the
+    # shared conformance table.
+    safe = "".join(
+        ch if (ch.isascii() and ch.isalnum()) or ch in ("-", "_", ".") else "_" for ch in value
+    )
     return safe.strip("._")[:120] or "session"
 
 

--- a/integrations/hermes-agent/tests/test_session_id_conformance.py
+++ b/integrations/hermes-agent/tests/test_session_id_conformance.py
@@ -1,0 +1,31 @@
+"""Conformance test: hermes-agent session-id sanitization matches the shared spec.
+
+Loads the shared case table in integrations/conformance/session_id_cases.json
+(the same table the claude-code, codex and openclaw tests use) and checks the
+hermes-agent sanitizer against it. If any implementation drifts from the shared
+rule, its test fails.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _load_cases():
+    root = next(p for p in Path(__file__).resolve().parents if p.name == "integrations")
+    return json.loads((root / "conformance" / "session_id_cases.json").read_text(encoding="utf-8"))
+
+
+def test_sanitizer_matches_shared_table():
+    from cognee_integration_hermes.provider import _safe_session_component
+
+    mismatches = []
+    for case in _load_cases():
+        result = _safe_session_component(case["input"])
+        if result != case["expected"]:
+            mismatches.append(f"{case['input']!r} -> {result!r}, expected {case['expected']!r}")
+    assert not mismatches, "session-id sanitization drift:\n" + "\n".join(mismatches)

--- a/integrations/openclaw/__tests__/test_session_id_conformance.ts
+++ b/integrations/openclaw/__tests__/test_session_id_conformance.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { sanitizeSessionKey } from "../src/scope";
+
+type SanitizeCase = { input: string; expected: string; note: string };
+
+// The shared case table lives at integrations/conformance/session_id_cases.json.
+// The claude-code, codex and hermes-agent tests read the same file, so any
+// implementation that drifts from the shared rule fails its test.
+const casesPath = resolve(__dirname, "..", "..", "conformance", "session_id_cases.json");
+const cases: SanitizeCase[] = JSON.parse(readFileSync(casesPath, "utf-8"));
+
+describe("session-id sanitization conformance", () => {
+  it.each(cases)("$note", ({ input, expected }) => {
+    expect(sanitizeSessionKey(input)).toBe(expected);
+  });
+});

--- a/integrations/openclaw/src/scope.ts
+++ b/integrations/openclaw/src/scope.ts
@@ -127,7 +127,7 @@ export function normalizeAgentId(agentId: string | undefined, cfg: Required<Cogn
  * (`_sanitize_session_key`): keep alphanumerics plus `-` `_` `.`, replace anything
  * else with `_`, trim leading/trailing `.`/`_`, and cap length at 120.
  */
-function sanitizeSessionKey(value: string): string {
+export function sanitizeSessionKey(value: string): string {
   let safe = "";
   for (const ch of value) safe += /[A-Za-z0-9\-_.]/.test(ch) ? ch : "_";
   return safe.replace(/^[._]+/, "").replace(/[._]+$/, "").slice(0, 120);


### PR DESCRIPTION
## Description

Resolves topoteretes/cognee#3548.

Each Cognee integration builds a Cognee session id with the same shape,
`{agent}_{native_id}`. Before the native id is used, every integration runs it
through a small sanitizer.

While reading the code I found the sanitizers were not the same. The Python
helpers (claude-code, codex, hermes-agent) used `isalnum()`, which keeps unicode
letters and digits (like `é`, `ñ`, `中`, `٣`). The openclaw TypeScript helper
used an ASCII regex `[A-Za-z0-9\-_.]`, which keeps only ASCII. So the same input
could turn into a different session id depending on which integration handled it.

This PR does two things:

1. Makes the rule the same in all four integrations. The rule is now:
   - keep only the ASCII set `[A-Za-z0-9-_.]`,
   - replace every other character with `_`,
   - trim leading and trailing `.` and `_`,
   - cap the length at 120 characters.
2. Adds one shared table of cases that all four integrations test against, so the
   rule stays the same from now on.

The shared table lives at `integrations/conformance/session_id_cases.json`. Each
integration has a small test that reads this same file and checks its own
sanitizer. Because they all read one file, if any integration drifts from the
rule, its test fails.

One case is left out of the shared table on purpose. When the result would be
empty, hermes-agent returns `"session"` while the others return an empty string.
That difference is intentional, so empty-output inputs are not in the table.

## Acceptance Criteria

- The same case table is checked by every integration (claude-code, codex,
  hermes-agent, openclaw).
- Every integration passes the table.
- If any integration changes its sanitizer and drifts from the rule, its test
  fails.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Local test runs (all passing):

```
claude-code:  python integrations/claude-code/tests/test_session_id_conformance.py
              PASS test_sanitizer_matches_shared_table
codex:        python integrations/codex/plugins/cognee/tests/test_session_id_conformance.py
              PASS test_sanitizer_matches_shared_table
hermes-agent: pytest integrations/hermes-agent/tests/test_session_id_conformance.py
              1 passed
openclaw:     npm test  (jest)
              PASS __tests__/test_session_id_conformance.ts (11 cases)

ruff format --check integrations/   ->  ok
ruff check integrations/            ->  All checks passed!
```

## Pre-submission Checklist

- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
