### PR TITLE
fix(release): correct inventory.yml version drift + add CI version-consistency check

### DIFF
--- a/.github/workflows/check-version-consistency.yml
+++ b/.github/workflows/check-version-consistency.yml
@@ -1,0 +1,36 @@
+name: Check Version Consistency
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'integrations/inventory.yml'
+      - 'integrations/*/.claude-plugin/plugin.json'
+      - 'integrations/*/**/.codex-plugin/plugin.json'
+      - 'integrations/*/package.json'
+      - '.claude-plugin/marketplace.json'
+      - 'scripts/check_version_consistency.py'
+  push:
+    branches: [main]
+    paths:
+      - 'integrations/inventory.yml'
+      - 'integrations/*/.claude-plugin/plugin.json'
+      - 'integrations/*/**/.codex-plugin/plugin.json'
+      - 'integrations/*/package.json'
+      - '.claude-plugin/marketplace.json'
+      - 'scripts/check_version_consistency.py'
+
+jobs:
+  check-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Check integration version consistency
+        run: python scripts/check_version_consistency.py

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -34,7 +34,7 @@ integrations:
     registry: none
     package_name: null
     cognee_dependency: sdk
-    current_version: "0.1.0"
+    current_version: "0.2.0"
     migration_status: done
     notes: "Claude Code plugin – session storage via hooks, recall via context lookup, session-to-graph sync"
 
@@ -137,7 +137,7 @@ integrations:
     registry: npm
     package_name: "n8n-nodes-cognee"
     cognee_dependency: http-api
-    current_version: "0.4.1"
+    current_version: "0.5.1"
     migration_status: done
     source_repo: https://github.com/topoteretes/cognee-n8n
     notes: "n8n community node – add data, cognify, search, delete. Published via .github/workflows/n8n-publish.yml on `n8n-v*.*.*` tags."

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Check that every integration's version agrees across all of its manifests.
+
+Policy: For each integration that ships a local manifest in this monorepo, the
+version declared in `integrations/inventory.yml` (`current_version`) must match
+the version in that integration's manifest(s):
+
+  - Claude Code plugin:  .claude-plugin/plugin.json  AND the matching entry in
+                         the top-level .claude-plugin/marketplace.json
+  - Codex plugin:        .codex-plugin/plugin.json
+  - npm packages:        package.json
+
+This catches drift like inventory saying 0.1.0 while plugin.json says 0.2.0.
+
+Integrations without a local manifest (pending migrations, pypi-only packages
+published from another repo) are skipped — there is nothing in-tree to compare.
+
+Usage:
+    python scripts/check_version_consistency.py
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+INTEGRATIONS_DIR = ROOT / "integrations"
+INVENTORY = INTEGRATIONS_DIR / "inventory.yml"
+MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
+
+# slug -> list of manifest files whose `version` field must match inventory.
+# Paths are relative to the repo root. Only integrations with an in-tree,
+# versioned manifest are listed; add new ones here when they migrate in.
+MANIFESTS = {
+    "claude-code": ["integrations/claude-code/.claude-plugin/plugin.json"],
+    "codex": ["integrations/codex/plugins/cognee/.codex-plugin/plugin.json"],
+    "openclaw": ["integrations/openclaw/package.json"],
+    "n8n": ["integrations/n8n/package.json"],
+}
+
+
+def parse_inventory_versions(text: str) -> dict[str, set[str]]:
+    """Return {slug: {current_version, ...}} from inventory.yml.
+
+    Minimal line scanner (no PyYAML dep, matching check_version_pins.py's
+    stdlib-only style). The file is a flat list of `- slug:` blocks each with a
+    `current_version:` line; a slug may appear more than once and every listed
+    version for it must agree.
+    """
+    versions: dict[str, set[str]] = {}
+    slug = None
+    for line in text.splitlines():
+        m = re.match(r"\s*-?\s*slug:\s*(\S+)", line)
+        if m:
+            slug = m.group(1).strip().strip('"')
+            continue
+        m = re.match(r'\s*current_version:\s*"?([^"\n]+?)"?\s*$', line)
+        if m and slug:
+            versions.setdefault(slug, set()).add(m.group(1).strip())
+    return versions
+
+
+def manifest_version(path: Path) -> str:
+    return json.loads(path.read_text())["version"]
+
+
+def marketplace_versions() -> dict[str, set[str]]:
+    """Map slug -> {version} for each plugin in marketplace.json.
+
+    Slug is the last path segment of the plugin's `source` (e.g.
+    "./integrations/claude-code" -> "claude-code").
+    """
+    out: dict[str, set[str]] = {}
+    if not MARKETPLACE.exists():
+        return out
+    data = json.loads(MARKETPLACE.read_text())
+    for plugin in data.get("plugins", []):
+        source = plugin.get("source")
+        version = plugin.get("version")
+        if not isinstance(source, str) or version is None:
+            continue
+        slug = source.rstrip("/").split("/")[-1]
+        out.setdefault(slug, set()).add(str(version))
+    return out
+
+
+def main() -> None:
+    if not INVENTORY.exists():
+        print(f"Inventory not found: {INVENTORY}")
+        sys.exit(1)
+
+    inventory = parse_inventory_versions(INVENTORY.read_text())
+    marketplace = marketplace_versions()
+
+    errors: list[str] = []
+    checked = 0
+
+    for slug, manifest_paths in sorted(MANIFESTS.items()):
+        # Collect every version this integration declares, tagged by source.
+        found: dict[str, str] = {}
+
+        inv = inventory.get(slug)
+        if not inv:
+            errors.append(f"{slug}: no current_version in inventory.yml")
+            continue
+        if len(inv) > 1:
+            errors.append(f"{slug}: inventory.yml lists conflicting versions {sorted(inv)}")
+        found["inventory.yml"] = sorted(inv)[0]
+
+        for rel in manifest_paths:
+            path = ROOT / rel
+            if not path.exists():
+                errors.append(f"{slug}: manifest missing: {rel}")
+                continue
+            found[rel] = manifest_version(path)
+
+        for version in sorted(marketplace.get(slug, set())):
+            found[".claude-plugin/marketplace.json"] = version
+
+        checked += 1
+        unique = set(found.values())
+        if len(unique) > 1:
+            detail = ", ".join(f"{src}={ver}" for src, ver in sorted(found.items()))
+            errors.append(f"{slug}: version mismatch -> {detail}")
+
+    print(f"Checked {checked} integration(s) with in-tree manifests.")
+
+    if errors:
+        print(f"\n{len(errors)} version-consistency violation(s) found:\n")
+        for error in errors:
+            print(f"  - {error}")
+        sys.exit(1)
+
+    print("All integration manifests agree with inventory.yml.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Fixes the version drift called out in #3677 and adds a CI check that prevents it from recurring.

### Drift fixed in `integrations/inventory.yml`
| slug | inventory (before) | actual manifest | fixed to |
|---|---|---|---|
| `claude-code` | `0.1.0` | `plugin.json` + `marketplace.json` = `0.2.0` | `0.2.0` |
| `n8n` | `0.4.1` | `package.json` = `0.5.1` (tag `n8n-v0.5.1`) | `0.5.1` |

`codex` (`1.0.3-local`) and `openclaw` (`2026.6.11`) already agreed — left untouched.

### New consistency check
`scripts/check_version_consistency.py` — asserts, per in-tree integration, that `inventory.yml`'s `current_version` matches its manifest(s): `plugin.json`, `package.json`, and the matching `.claude-plugin/marketplace.json` entry. Stdlib-only (no new deps), mirroring the existing `scripts/check_version_pins.py`. Wired via `.github/workflows/check-version-consistency.yml` on the same paths.

New integrations register in the `MANIFESTS` map — same "update on add" convention `inventory.yml` already documents.

## Test evidence

**Before fix — check catches both drifts (exit 1):**
```
$ python scripts/check_version_consistency.py
Checked 4 integration(s) with in-tree manifests.
2 version-consistency violation(s) found:
  - claude-code: version mismatch -> .claude-plugin/marketplace.json=0.2.0, integrations/claude-code/.claude-plugin/plugin.json=0.2.0, inventory.yml=0.1.0
  - n8n: version mismatch -> integrations/n8n/package.json=0.5.1, inventory.yml=0.4.1
```

**After fix — all manifests agree (exit 0):**
```
$ python scripts/check_version_consistency.py
Checked 4 integration(s) with in-tree manifests.
All integration manifests agree with inventory.yml.
```

**Deliberate mismatch still fails CI (exit 1):**
```
$ sed -i '' 's/current_version: "0.5.1"/current_version: "9.9.9"/' integrations/inventory.yml
$ python scripts/check_version_consistency.py
1 version-consistency violation(s) found:
  - n8n: version mismatch -> integrations/n8n/package.json=0.5.1, inventory.yml=9.9.9
```

Satisfies both acceptance criteria: all manifests agree today, and CI fails on a deliberate mismatch.

Closes #3677
