### PR TITLE
docs(release): add CHANGELOG + RELEASING for claude-code and codex

### DIFF
--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to the **Cognee Plugin for Claude Code** (`cognee-memory`) are
+documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Versions are tagged `claude-code-v<version>` (see [RELEASING.md](./RELEASING.md)).
+
+## [Unreleased]
+
+## [0.2.0]
+
+### Added
+- Background `remember` + `cognify` status polling so session capture never blocks the turn.
+- Standardized Cognee session names to `{agent}_{native_session_id}`.
+- Local Cognee API server support for Claude Code / Codex (proxy mode via `API_URL`).
+- Automatic Cognee installation on plugin setup, plus marketplace registration.
+- Prefer Cognee as the default memory over native `MEMORY.md`.
+
+### Changed
+- HTTP-first bridge with a non-blocking background path.
+- Tightened the over-budget poll and gave `parse_error` a uniform shape.
+
+### Fixed
+- Bridge `POST` now catches network and HTTP errors instead of failing the hook.
+- Overall poll deadline + parse-error retry; spin-loop floor to avoid busy-waiting.
+- Recall reaches the graph scope; per-turn audit log.
+- SSL certificate handling for fresh environments.
+
+## [0.1.0]
+
+### Added
+- Initial Claude Code plugin: V2 API, session hooks, and identity (2026-04-10).
+- Typed entries, idle watcher, and auto-improve loop.
+
+[Unreleased]: https://github.com/topoteretes/cognee-integrations/compare/claude-code-v0.2.0...HEAD
+[0.2.0]: https://github.com/topoteretes/cognee-integrations/releases/tag/claude-code-v0.2.0
+[0.1.0]: https://github.com/topoteretes/cognee-integrations/releases/tag/claude-code-v0.1.0

--- a/integrations/claude-code/RELEASING.md
+++ b/integrations/claude-code/RELEASING.md
@@ -1,0 +1,28 @@
+# Releasing the Claude Code plugin
+
+Checklist for cutting a new `cognee-memory` (Claude Code) release.
+
+1. **Bump the version.** Update `version` in
+   [`.claude-plugin/plugin.json`](./.claude-plugin/plugin.json). Use
+   [SemVer](https://semver.org/).
+
+2. **Update the changelog.** Move the relevant notes from `## [Unreleased]` in
+   [`CHANGELOG.md`](./CHANGELOG.md) into a new `## [x.y.z]` section, and add the
+   matching compare/release links at the bottom.
+
+3. **Sync the marketplace + inventory.** Set the same version in:
+   - the `cognee-memory` entry of the top-level
+     [`.claude-plugin/marketplace.json`](../../.claude-plugin/marketplace.json)
+   - the `claude-code` `current_version` in
+     [`integrations/inventory.yml`](../inventory.yml)
+
+   `scripts/check_version_consistency.py` (CI) fails if these drift.
+
+4. **Commit + tag.** Commit the bump, then tag:
+   ```sh
+   git tag claude-code-v<version>
+   git push origin claude-code-v<version>
+   ```
+
+5. **Verify.** Confirm CI is green (import smoke tests + version consistency) and
+   that the plugin installs from the marketplace at the new version.

--- a/integrations/codex/CHANGELOG.md
+++ b/integrations/codex/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to the **Cognee Plugin for Codex** are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Versions are tagged `codex-v<version>` (see [RELEASING.md](./RELEASING.md)).
+
+## [Unreleased]
+
+## [1.0.3-local]
+
+### Added
+- Capture Cognee session memory from Codex session events (start, prompt, tool
+  result, stop).
+- Standardized Cognee session names to `{agent}_{native_session_id}`.
+- Status line surfacing Cognee state.
+- `auto_feedback` env variable (default on).
+
+### Changed
+- Resilient recall client: circuit breaker + bounded timeout; HTTP/auth errors
+  are not treated as authoritative and never silently fall back to the local CLI.
+- Split `remember`/`sync` skills to mirror the `search` skill layout.
+
+### Fixed
+- Recall dataset targeting.
+- SSL certificate handling for fresh environments.
+
+## [1.0.0-local]
+
+### Added
+- Initial Codex Cognee plugin: CLI-first skills for setup, memory, codebase
+  ingestion, and local UI launch (2026-04-24).
+
+[Unreleased]: https://github.com/topoteretes/cognee-integrations/compare/codex-v1.0.3-local...HEAD
+[1.0.3-local]: https://github.com/topoteretes/cognee-integrations/releases/tag/codex-v1.0.3-local
+[1.0.0-local]: https://github.com/topoteretes/cognee-integrations/releases/tag/codex-v1.0.0-local

--- a/integrations/codex/RELEASING.md
+++ b/integrations/codex/RELEASING.md
@@ -1,0 +1,28 @@
+# Releasing the Codex plugin
+
+Checklist for cutting a new Codex Cognee plugin release. This is a **local**
+Codex marketplace plugin (`registry: codex-marketplace`), so versions carry the
+`-local` suffix.
+
+1. **Bump the version.** Update `version` in
+   [`plugins/cognee/.codex-plugin/plugin.json`](./plugins/cognee/.codex-plugin/plugin.json).
+   Use [SemVer](https://semver.org/) with the `-local` pre-release suffix.
+
+2. **Update the changelog.** Move the relevant notes from `## [Unreleased]` in
+   [`CHANGELOG.md`](./CHANGELOG.md) into a new `## [x.y.z-local]` section, and add
+   the matching compare/release links at the bottom.
+
+3. **Sync the inventory.** Set the same version in the `codex` `current_version`
+   in [`integrations/inventory.yml`](../inventory.yml).
+   `scripts/check_version_consistency.py` (CI) fails if these drift. (The Codex
+   `.agents/plugins/marketplace.json` does not carry a version field — nothing to
+   sync there.)
+
+4. **Commit + tag.** Commit the bump, then tag:
+   ```sh
+   git tag codex-v<version>
+   git push origin codex-v<version>
+   ```
+
+5. **Verify.** Confirm CI is green and that the plugin loads from the local Codex
+   marketplace at the new version.


### PR DESCRIPTION
## What

Adds per-integration release docs for the two integrations named in #3678.

### New files
| Integration | Files |
|---|---|
| `claude-code` (0.2.0) | `CHANGELOG.md`, `RELEASING.md` |
| `codex` (1.0.3-local) | `CHANGELOG.md`, `RELEASING.md` |

- **CHANGELOG.md** — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, seeded from git history (grouped Added / Changed / Fixed), with an `Unreleased` section and release-link footers. Earliest entries dated from each plugin's first commit (claude-code 2026-04-10, codex 2026-04-24).
- **RELEASING.md** — short checklist per integration: bump manifest version → move Unreleased notes into a version section → sync `marketplace.json` / `inventory.yml` → tag `claude-code-v*` / `codex-v*` → verify CI.

The RELEASING checklists reference the version-consistency CI check (see #3677 / PR #175) as the guard that keeps `inventory.yml` in sync with the manifests.

Left n8n's existing `auto-changelog`-generated `CHANGELOG.md` untouched.

## Acceptance

> changelog + release doc present for claude-code and codex

Both present for both integrations. Docs-only change — no code paths touched.

Closes #3678
