### PR TITLE
Fix - Embedding-dimension mismatch: clear error instead of silent empty recall

### DIFF
--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -547,43 +547,72 @@ def service_url_is_local(url: str = "") -> bool:
     return host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
 
 
-async def _sample_stored_vector_dim(engine) -> Optional[int]:
-    """Length of one stored vector from any known collection, or None. Never raises.
+# One hedged, low-noise line for the "data present but dim unverifiable" case
+# (store unreadable / read errored). Deliberately softer than the confirmed
+# mismatch diagnostic so it never reads like a hard error.
+_UNVERIFIED_EMBEDDER_HINT = (
+    "Cognee recall found nothing and could not verify the active embedder against the "
+    "stored vectors (store unreadable or timed out). If memory seems missing after an "
+    "embedding-model change, check EMBEDDING_MODEL / EMBEDDING_DIMENSIONS."
+)
+
+
+async def _probe_stored_dim(engine):
+    """Probe the stored vector dimension across known collections. Never raises.
+
+    Returns ``(status, dim)``:
+      - ``("dim", n)``          — read a stored vector's dimension
+      - ``("unverified", None)``— a collection exists but its dim could not be read
+        (open/query raised): a real store is present, we just can't compare
+      - ``("no_data", None)``   — no known collection exists, or collections exist but
+        hold no vectors (a normal fresh/empty state)
 
     Reads are cheap and safe for concurrent access on both supported backends
     (LanceDB row sample; pgvector column type). Each probe is independently
     guarded so a single unreadable collection can't abort the scan.
     """
     is_pgvector = type(engine).__name__ == "PGVectorAdapter"
+    saw_collection = False
+    saw_error = False
     for name in _DIM_PROBE_COLLECTIONS:
         try:
             if not await engine.has_collection(name):
                 continue
+            saw_collection = True
             if is_pgvector:
                 table = await engine.get_table(name)
                 dim = getattr(getattr(table.c.vector, "type", None), "dim", None)
                 if dim:
-                    return int(dim)
+                    return ("dim", int(dim))
             else:
                 collection = await engine.get_collection(name)
                 rows = await collection.query().limit(1).to_list()
                 if rows:
                     vector = rows[0].get("vector")
                     if vector is not None:
-                        return len(vector)
+                        return ("dim", len(vector))
         except Exception:
+            saw_error = True
             continue
-    return None
+    if saw_collection and saw_error:
+        return ("unverified", None)
+    return ("no_data", None)
 
 
-async def embedding_dimension_mismatch_hint(engine=None) -> Optional[str]:
-    """Return a one-line actionable error if the active embedder's vector size
-    differs from the stored vector dimension; else None.
+async def embedding_dimension_report(engine=None):
+    """Classify a zero-result recall against the embedder/store dimensions.
 
-    Best-effort and fail-safe: on any error (cognee not importable, store
-    unreadable, dims indeterminate, or matching) returns None so callers fall
-    back to the normal empty-result path. ``engine`` is injectable for testing;
-    when omitted the in-process cognee vector engine is used.
+    Returns ``(status, message)`` where status is one of:
+      - ``"mismatch"``  — dims differ; ``message`` is a one-line actionable diagnostic
+      - ``"unverified"``— data present but dim unreadable; ``message`` is a hedged hint
+      - ``"match"``     — dims agree (a genuine miss); ``message`` is None
+      - ``"no_data"``   — nothing to compare / cannot introspect; ``message`` is None
+
+    Best-effort and fail-safe: any error resolving the engine/embedder stays quiet
+    (``"no_data"``) so callers fall back to the normal empty-result path. Crucially,
+    the hedged ``"unverified"`` hint fires ONLY when a populated store was seen but
+    its dim couldn't be read — never on fresh/empty sessions (``"no_data"``), so it
+    doesn't nag on every early miss. ``engine`` is injectable for testing.
     """
     try:
         if engine is None:
@@ -592,21 +621,36 @@ async def embedding_dimension_mismatch_hint(engine=None) -> Optional[str]:
             engine = get_vector_engine()
         embed = getattr(engine, "embedding_engine", None)
         if embed is None:
-            return None
+            return ("no_data", None)
         query_dim = int(embed.get_vector_size())
-        stored_dim = await _sample_stored_vector_dim(engine)
-        if not stored_dim or not query_dim or stored_dim == query_dim:
-            return None
+        status, stored_dim = await _probe_stored_dim(engine)
+        if status == "unverified":
+            return ("unverified", _UNVERIFIED_EMBEDDER_HINT)
+        if status != "dim" or not stored_dim or not query_dim:
+            return ("no_data", None)
+        if stored_dim == query_dim:
+            return ("match", None)
         model = getattr(embed, "model", None) or "unknown-model"
         provider = getattr(embed, "provider", None) or "unknown-provider"
-        return (
+        message = (
             "Cognee recall found nothing because the embedder changed: stored vectors are "
             f"{stored_dim}-d but the active embedder '{model}' (provider '{provider}') produces "
             f"{query_dim}-d queries. Re-index this data with the current embedder, or set "
             f"EMBEDDING_MODEL/EMBEDDING_DIMENSIONS back to the {stored_dim}-d model that wrote it."
         )
+        return ("mismatch", message)
     except Exception:
-        return None
+        return ("no_data", None)
+
+
+async def embedding_dimension_mismatch_hint(engine=None) -> Optional[str]:
+    """Back-compat wrapper: the confirmed-mismatch diagnostic string, or None.
+
+    Prefer ``embedding_dimension_report``, which also distinguishes the
+    ``"unverified"`` (data present, dim unreadable) case.
+    """
+    status, message = await embedding_dimension_report(engine)
+    return message if status == "mismatch" else None
 
 
 def hook_log(event: str, detail: Optional[dict] = None) -> None:

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -524,6 +524,91 @@ async def resolve_user(user_id: str):
     return await get_default_user()
 
 
+# --- Embedding-dimension mismatch detection ---------------------------------
+# When the embedding model changes between writing and reading, stored vectors
+# and fresh query vectors have different dimensions, so recall silently matches
+# nothing. These helpers turn that silent miss into a one-line actionable error
+# naming both dimensions and the active embedder. Strictly best-effort and
+# fail-safe: any uncertainty returns None, preserving the normal "no matches"
+# behavior. Only valid against a *local* store this process can introspect
+# (gate callers with ``service_url_is_local``); a remote/cloud store is owned
+# by the server and isn't reflected by the in-process engine here.
+_DIM_PROBE_COLLECTIONS = (
+    "Entity_name",
+    "TextSummary_text",
+    "EntityType_name",
+    "DocumentChunk_text",
+)
+
+
+def service_url_is_local(url: str = "") -> bool:
+    """True when the resolved service URL points at this machine (loopback)."""
+    host = (urllib.parse.urlparse(url or _local_api_url()).hostname or "").lower()
+    return host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
+
+
+async def _sample_stored_vector_dim(engine) -> Optional[int]:
+    """Length of one stored vector from any known collection, or None. Never raises.
+
+    Reads are cheap and safe for concurrent access on both supported backends
+    (LanceDB row sample; pgvector column type). Each probe is independently
+    guarded so a single unreadable collection can't abort the scan.
+    """
+    is_pgvector = type(engine).__name__ == "PGVectorAdapter"
+    for name in _DIM_PROBE_COLLECTIONS:
+        try:
+            if not await engine.has_collection(name):
+                continue
+            if is_pgvector:
+                table = await engine.get_table(name)
+                dim = getattr(getattr(table.c.vector, "type", None), "dim", None)
+                if dim:
+                    return int(dim)
+            else:
+                collection = await engine.get_collection(name)
+                rows = await collection.query().limit(1).to_list()
+                if rows:
+                    vector = rows[0].get("vector")
+                    if vector is not None:
+                        return len(vector)
+        except Exception:
+            continue
+    return None
+
+
+async def embedding_dimension_mismatch_hint(engine=None) -> Optional[str]:
+    """Return a one-line actionable error if the active embedder's vector size
+    differs from the stored vector dimension; else None.
+
+    Best-effort and fail-safe: on any error (cognee not importable, store
+    unreadable, dims indeterminate, or matching) returns None so callers fall
+    back to the normal empty-result path. ``engine`` is injectable for testing;
+    when omitted the in-process cognee vector engine is used.
+    """
+    try:
+        if engine is None:
+            from cognee.infrastructure.databases.vector import get_vector_engine
+
+            engine = get_vector_engine()
+        embed = getattr(engine, "embedding_engine", None)
+        if embed is None:
+            return None
+        query_dim = int(embed.get_vector_size())
+        stored_dim = await _sample_stored_vector_dim(engine)
+        if not stored_dim or not query_dim or stored_dim == query_dim:
+            return None
+        model = getattr(embed, "model", None) or "unknown-model"
+        provider = getattr(embed, "provider", None) or "unknown-provider"
+        return (
+            "Cognee recall found nothing because the embedder changed: stored vectors are "
+            f"{stored_dim}-d but the active embedder '{model}' (provider '{provider}') produces "
+            f"{query_dim}-d queries. Re-index this data with the current embedder, or set "
+            f"EMBEDDING_MODEL/EMBEDDING_DIMENSIONS back to the {stored_dim}-d model that wrote it."
+        )
+    except Exception:
+        return None
+
+
 def hook_log(event: str, detail: Optional[dict] = None) -> None:
     """Append one structured line to ~/.cognee-plugin/hook.log.
 

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -20,6 +20,7 @@ import time
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
+    embedding_dimension_mismatch_hint,
     get_session_key,
     hook_log,
     load_resolved,
@@ -33,6 +34,7 @@ from _plugin_common import (
     resolve_user,
     server_health_ok,
     server_ready_hint,
+    service_url_is_local,
     set_session_key,
 )
 from config import ensure_cognee_ready, get_session_id, load_config
@@ -366,9 +368,27 @@ async def _run(prompt: str) -> dict | None:
         hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
         notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
     else:
-        full_context = f"{header}\n\n(no memory matches for this prompt)"
-        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
-        notify(f"no recall matches; saves last turn {saves_last_turn}")
+        # Zero results can mean a genuine miss OR that the embedding model changed
+        # since indexing (stored vs query vectors differ in size, so nothing can
+        # match). Only the local store is introspectable here; surface a one-line
+        # actionable error when a mismatch is positively confirmed, else fall back
+        # to the normal "no matches" line.
+        mismatch = None
+        if service_url_is_local(service_url):
+            try:
+                mismatch = await asyncio.wait_for(
+                    embedding_dimension_mismatch_hint(), timeout=2.0
+                )
+            except Exception as exc:
+                hook_log("dim_check_error", {"error": str(exc)[:200]})
+        if mismatch:
+            full_context = f"{header}\n\n{mismatch}"
+            hook_log("context_lookup_dim_mismatch", {"message": mismatch})
+            notify(mismatch)
+        else:
+            full_context = f"{header}\n\n(no memory matches for this prompt)"
+            hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
+            notify(f"no recall matches; saves last turn {saves_last_turn}")
 
     # Audit log: persist full recall details per turn. The hook output stays a
     # short summary because Codex renders additionalContext in the terminal.

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -20,7 +20,7 @@ import time
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
-    embedding_dimension_mismatch_hint,
+    embedding_dimension_report,
     get_session_key,
     hook_log,
     load_resolved,
@@ -373,18 +373,20 @@ async def _run(prompt: str) -> dict | None:
         # match). Only the local store is introspectable here; surface a one-line
         # actionable error when a mismatch is positively confirmed, else fall back
         # to the normal "no matches" line.
-        mismatch = None
+        dim_status, dim_message = "no_data", None
         if service_url_is_local(service_url):
             try:
-                mismatch = await asyncio.wait_for(
-                    embedding_dimension_mismatch_hint(), timeout=2.0
+                dim_status, dim_message = await asyncio.wait_for(
+                    embedding_dimension_report(), timeout=2.0
                 )
             except Exception as exc:
                 hook_log("dim_check_error", {"error": str(exc)[:200]})
-        if mismatch:
-            full_context = f"{header}\n\n{mismatch}"
-            hook_log("context_lookup_dim_mismatch", {"message": mismatch})
-            notify(mismatch)
+        if dim_message and dim_status in ("mismatch", "unverified"):
+            full_context = f"{header}\n\n{dim_message}"
+            hook_log(
+                "context_lookup_dim_mismatch", {"status": dim_status, "message": dim_message}
+            )
+            notify(dim_message)
         else:
             full_context = f"{header}\n\n(no memory matches for this prompt)"
             hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})

--- a/integrations/claude-code/tests/test_dim_mismatch.py
+++ b/integrations/claude-code/tests/test_dim_mismatch.py
@@ -1,10 +1,13 @@
-"""Unit tests for the embedding-dimension mismatch hint (_plugin_common.py).
+"""Unit tests for the embedding-dimension probe (_plugin_common.py).
 
 When the embedding model changes between writing and reading, stored vectors and
-fresh query vectors differ in size, so recall silently matches nothing. The hint
-turns that silent miss into a one-line actionable error naming both dimensions
-and the active embedder. These tests inject a fake vector engine so cognee is
-not required.
+fresh query vectors differ in size, so recall silently matches nothing.
+``embedding_dimension_report`` classifies a zero-result recall as:
+  - "mismatch"   -> a one-line actionable diagnostic naming both dims + model
+  - "unverified" -> data present but dim unreadable -> a hedged, low-noise hint
+  - "match"      -> dims agree (a genuine miss) -> no message
+  - "no_data"    -> nothing to compare / fresh-empty session -> no message
+Tests inject a fake vector engine so cognee is not required.
 
 Run: `pytest integrations/claude-code/tests/test_dim_mismatch.py`
 (or `python integrations/claude-code/tests/test_dim_mismatch.py` standalone).
@@ -68,6 +71,19 @@ class _FakeLanceEngine:
         return _FakeCollection(rows)
 
 
+class _FakeErrorEngine:
+    """A collection exists, but reading it raises -> 'unverified'."""
+
+    def __init__(self, query_size):
+        self.embedding_engine = _FakeEmbed(query_size)
+
+    async def has_collection(self, name):
+        return name == "Entity_name"
+
+    async def get_collection(self, _name):
+        raise RuntimeError("store locked")
+
+
 class _FakeVecType:
     def __init__(self, dim):
         self.dim = dim
@@ -102,46 +118,63 @@ class PGVectorAdapter:
         return _FakeTable(self._stored_dim)
 
 
+def _report(engine):
+    return asyncio.run(pc.embedding_dimension_report(engine))
+
+
 def _hint(engine):
     return asyncio.run(pc.embedding_dimension_mismatch_hint(engine))
 
 
 def test_lancedb_mismatch_names_both_dims_and_model():
-    msg = _hint(_FakeLanceEngine(query_size=3072, stored_vector=[0.0] * 1536))
-    assert msg is not None
-    assert "1536" in msg  # stored dim
-    assert "3072" in msg  # query dim
-    assert "text-embedding-3-large" in msg  # active model
-    assert "openai" in msg  # provider
+    status, msg = _report(_FakeLanceEngine(query_size=3072, stored_vector=[0.0] * 1536))
+    assert status == "mismatch"
+    assert "1536" in msg and "3072" in msg
+    assert "text-embedding-3-large" in msg and "openai" in msg
 
 
 def test_pgvector_mismatch_names_both_dims():
-    msg = _hint(PGVectorAdapter(query_size=768, stored_dim=1536))
-    assert msg is not None
-    assert "1536" in msg
-    assert "768" in msg
+    status, msg = _report(PGVectorAdapter(query_size=768, stored_dim=1536))
+    assert status == "mismatch"
+    assert "1536" in msg and "768" in msg
 
 
-def test_matching_dims_returns_none():
-    assert _hint(_FakeLanceEngine(query_size=1536, stored_vector=[0.0] * 1536)) is None
+def test_matching_dims_is_match_no_message():
+    assert _report(_FakeLanceEngine(query_size=1536, stored_vector=[0.0] * 1536)) == ("match", None)
 
 
-def test_no_collections_returns_none():
-    assert _hint(_FakeLanceEngine(query_size=3072, stored_vector=[0.0] * 1536, present=())) is None
+def test_no_collections_is_no_data():
+    engine = _FakeLanceEngine(query_size=3072, stored_vector=[0.0] * 1536, present=())
+    assert _report(engine) == ("no_data", None)
 
 
-def test_empty_collection_returns_none():
-    # Collection present but holds no rows -> stored dim indeterminate -> no false error.
-    assert _hint(_FakeLanceEngine(query_size=3072, stored_vector=None)) is None
+def test_empty_collection_is_no_data():
+    # Collection present but holds no rows -> normal fresh/empty state, no hint.
+    assert _report(_FakeLanceEngine(query_size=3072, stored_vector=None)) == ("no_data", None)
 
 
-def test_never_raises_on_broken_engine():
+def test_unreadable_store_is_unverified_with_hedged_hint():
+    status, msg = _report(_FakeErrorEngine(query_size=3072))
+    assert status == "unverified"
+    assert msg and "could not verify" in msg
+    # The hedged hint must NOT read like the hard mismatch diagnostic.
+    assert "changed" not in msg
+
+
+def test_broken_engine_is_no_data():
     class _Broken:
         @property
         def embedding_engine(self):
             raise RuntimeError("boom")
 
-    assert _hint(_Broken()) is None
+    assert _report(_Broken()) == ("no_data", None)
+
+
+def test_backcompat_hint_returns_message_only_on_mismatch():
+    assert _hint(_FakeLanceEngine(query_size=3072, stored_vector=[0.0] * 1536)) is not None
+    # unverified / match / no_data all yield None through the back-compat wrapper.
+    assert _hint(_FakeErrorEngine(query_size=3072)) is None
+    assert _hint(_FakeLanceEngine(query_size=1536, stored_vector=[0.0] * 1536)) is None
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/tests/test_dim_mismatch.py
+++ b/integrations/claude-code/tests/test_dim_mismatch.py
@@ -1,0 +1,157 @@
+"""Unit tests for the embedding-dimension mismatch hint (_plugin_common.py).
+
+When the embedding model changes between writing and reading, stored vectors and
+fresh query vectors differ in size, so recall silently matches nothing. The hint
+turns that silent miss into a one-line actionable error naming both dimensions
+and the active embedder. These tests inject a fake vector engine so cognee is
+not required.
+
+Run: `pytest integrations/claude-code/tests/test_dim_mismatch.py`
+(or `python integrations/claude-code/tests/test_dim_mismatch.py` standalone).
+"""
+
+import asyncio
+import os
+import pathlib
+import sys
+
+# Pin the loop-guard so importing _plugin_common never re-execs the test process
+# into the plugin venv (its module-level _reexec_into_venv()).
+os.environ.setdefault("COGNEE_PLUGIN_IN_VENV", "1")
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+import _plugin_common as pc  # noqa: E402
+
+
+class _FakeEmbed:
+    def __init__(self, size, model="openai/text-embedding-3-large", provider="openai"):
+        self._size = size
+        self.model = model
+        self.provider = provider
+
+    def get_vector_size(self):
+        return self._size
+
+
+class _FakeQuery:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def limit(self, _n):
+        return self
+
+    async def to_list(self):
+        return self._rows
+
+
+class _FakeCollection:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def query(self):
+        return _FakeQuery(self._rows)
+
+
+class _FakeLanceEngine:
+    """Class name is not 'PGVectorAdapter', so the LanceDB row-sample path runs."""
+
+    def __init__(self, query_size, stored_vector, present=("Entity_name",)):
+        self.embedding_engine = _FakeEmbed(query_size)
+        self._stored_vector = stored_vector
+        self._present = set(present)
+
+    async def has_collection(self, name):
+        return name in self._present
+
+    async def get_collection(self, _name):
+        rows = [{"vector": self._stored_vector}] if self._stored_vector is not None else []
+        return _FakeCollection(rows)
+
+
+class _FakeVecType:
+    def __init__(self, dim):
+        self.dim = dim
+
+
+class _FakeVectorCol:
+    def __init__(self, dim):
+        self.type = _FakeVecType(dim)
+
+
+class _FakeColumns:
+    def __init__(self, dim):
+        self.vector = _FakeVectorCol(dim)
+
+
+class _FakeTable:
+    def __init__(self, dim):
+        self.c = _FakeColumns(dim)
+
+
+class PGVectorAdapter:
+    """Name matches the real adapter so the pgvector column-dim path runs."""
+
+    def __init__(self, query_size, stored_dim):
+        self.embedding_engine = _FakeEmbed(query_size)
+        self._stored_dim = stored_dim
+
+    async def has_collection(self, name):
+        return name == "Entity_name"
+
+    async def get_table(self, _name):
+        return _FakeTable(self._stored_dim)
+
+
+def _hint(engine):
+    return asyncio.run(pc.embedding_dimension_mismatch_hint(engine))
+
+
+def test_lancedb_mismatch_names_both_dims_and_model():
+    msg = _hint(_FakeLanceEngine(query_size=3072, stored_vector=[0.0] * 1536))
+    assert msg is not None
+    assert "1536" in msg  # stored dim
+    assert "3072" in msg  # query dim
+    assert "text-embedding-3-large" in msg  # active model
+    assert "openai" in msg  # provider
+
+
+def test_pgvector_mismatch_names_both_dims():
+    msg = _hint(PGVectorAdapter(query_size=768, stored_dim=1536))
+    assert msg is not None
+    assert "1536" in msg
+    assert "768" in msg
+
+
+def test_matching_dims_returns_none():
+    assert _hint(_FakeLanceEngine(query_size=1536, stored_vector=[0.0] * 1536)) is None
+
+
+def test_no_collections_returns_none():
+    assert _hint(_FakeLanceEngine(query_size=3072, stored_vector=[0.0] * 1536, present=())) is None
+
+
+def test_empty_collection_returns_none():
+    # Collection present but holds no rows -> stored dim indeterminate -> no false error.
+    assert _hint(_FakeLanceEngine(query_size=3072, stored_vector=None)) is None
+
+
+def test_never_raises_on_broken_engine():
+    class _Broken:
+        @property
+        def embedding_engine(self):
+            raise RuntimeError("boom")
+
+    assert _hint(_Broken()) is None
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"ok   {name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -544,43 +544,72 @@ def service_url_is_local(url: str = "") -> bool:
     return host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
 
 
-async def _sample_stored_vector_dim(engine) -> Optional[int]:
-    """Length of one stored vector from any known collection, or None. Never raises.
+# One hedged, low-noise line for the "data present but dim unverifiable" case
+# (store unreadable / read errored). Deliberately softer than the confirmed
+# mismatch diagnostic so it never reads like a hard error.
+_UNVERIFIED_EMBEDDER_HINT = (
+    "Cognee recall found nothing and could not verify the active embedder against the "
+    "stored vectors (store unreadable or timed out). If memory seems missing after an "
+    "embedding-model change, check EMBEDDING_MODEL / EMBEDDING_DIMENSIONS."
+)
+
+
+async def _probe_stored_dim(engine):
+    """Probe the stored vector dimension across known collections. Never raises.
+
+    Returns ``(status, dim)``:
+      - ``("dim", n)``          — read a stored vector's dimension
+      - ``("unverified", None)``— a collection exists but its dim could not be read
+        (open/query raised): a real store is present, we just can't compare
+      - ``("no_data", None)``   — no known collection exists, or collections exist but
+        hold no vectors (a normal fresh/empty state)
 
     Reads are cheap and safe for concurrent access on both supported backends
     (LanceDB row sample; pgvector column type). Each probe is independently
     guarded so a single unreadable collection can't abort the scan.
     """
     is_pgvector = type(engine).__name__ == "PGVectorAdapter"
+    saw_collection = False
+    saw_error = False
     for name in _DIM_PROBE_COLLECTIONS:
         try:
             if not await engine.has_collection(name):
                 continue
+            saw_collection = True
             if is_pgvector:
                 table = await engine.get_table(name)
                 dim = getattr(getattr(table.c.vector, "type", None), "dim", None)
                 if dim:
-                    return int(dim)
+                    return ("dim", int(dim))
             else:
                 collection = await engine.get_collection(name)
                 rows = await collection.query().limit(1).to_list()
                 if rows:
                     vector = rows[0].get("vector")
                     if vector is not None:
-                        return len(vector)
+                        return ("dim", len(vector))
         except Exception:
+            saw_error = True
             continue
-    return None
+    if saw_collection and saw_error:
+        return ("unverified", None)
+    return ("no_data", None)
 
 
-async def embedding_dimension_mismatch_hint(engine=None) -> Optional[str]:
-    """Return a one-line actionable error if the active embedder's vector size
-    differs from the stored vector dimension; else None.
+async def embedding_dimension_report(engine=None):
+    """Classify a zero-result recall against the embedder/store dimensions.
 
-    Best-effort and fail-safe: on any error (cognee not importable, store
-    unreadable, dims indeterminate, or matching) returns None so callers fall
-    back to the normal empty-result path. ``engine`` is injectable for testing;
-    when omitted the in-process cognee vector engine is used.
+    Returns ``(status, message)`` where status is one of:
+      - ``"mismatch"``  — dims differ; ``message`` is a one-line actionable diagnostic
+      - ``"unverified"``— data present but dim unreadable; ``message`` is a hedged hint
+      - ``"match"``     — dims agree (a genuine miss); ``message`` is None
+      - ``"no_data"``   — nothing to compare / cannot introspect; ``message`` is None
+
+    Best-effort and fail-safe: any error resolving the engine/embedder stays quiet
+    (``"no_data"``) so callers fall back to the normal empty-result path. Crucially,
+    the hedged ``"unverified"`` hint fires ONLY when a populated store was seen but
+    its dim couldn't be read — never on fresh/empty sessions (``"no_data"``), so it
+    doesn't nag on every early miss. ``engine`` is injectable for testing.
     """
     try:
         if engine is None:
@@ -589,21 +618,36 @@ async def embedding_dimension_mismatch_hint(engine=None) -> Optional[str]:
             engine = get_vector_engine()
         embed = getattr(engine, "embedding_engine", None)
         if embed is None:
-            return None
+            return ("no_data", None)
         query_dim = int(embed.get_vector_size())
-        stored_dim = await _sample_stored_vector_dim(engine)
-        if not stored_dim or not query_dim or stored_dim == query_dim:
-            return None
+        status, stored_dim = await _probe_stored_dim(engine)
+        if status == "unverified":
+            return ("unverified", _UNVERIFIED_EMBEDDER_HINT)
+        if status != "dim" or not stored_dim or not query_dim:
+            return ("no_data", None)
+        if stored_dim == query_dim:
+            return ("match", None)
         model = getattr(embed, "model", None) or "unknown-model"
         provider = getattr(embed, "provider", None) or "unknown-provider"
-        return (
+        message = (
             "Cognee recall found nothing because the embedder changed: stored vectors are "
             f"{stored_dim}-d but the active embedder '{model}' (provider '{provider}') produces "
             f"{query_dim}-d queries. Re-index this data with the current embedder, or set "
             f"EMBEDDING_MODEL/EMBEDDING_DIMENSIONS back to the {stored_dim}-d model that wrote it."
         )
+        return ("mismatch", message)
     except Exception:
-        return None
+        return ("no_data", None)
+
+
+async def embedding_dimension_mismatch_hint(engine=None) -> Optional[str]:
+    """Back-compat wrapper: the confirmed-mismatch diagnostic string, or None.
+
+    Prefer ``embedding_dimension_report``, which also distinguishes the
+    ``"unverified"`` (data present, dim unreadable) case.
+    """
+    status, message = await embedding_dimension_report(engine)
+    return message if status == "mismatch" else None
 
 
 def hook_log(event: str, detail: Optional[dict] = None) -> None:

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -521,6 +521,91 @@ async def resolve_user(user_id: str):
     return await get_default_user()
 
 
+# --- Embedding-dimension mismatch detection ---------------------------------
+# When the embedding model changes between writing and reading, stored vectors
+# and fresh query vectors have different dimensions, so recall silently matches
+# nothing. These helpers turn that silent miss into a one-line actionable error
+# naming both dimensions and the active embedder. Strictly best-effort and
+# fail-safe: any uncertainty returns None, preserving the normal "no matches"
+# behavior. Only valid against a *local* store this process can introspect
+# (gate callers with ``service_url_is_local``); a remote/cloud store is owned
+# by the server and isn't reflected by the in-process engine here.
+_DIM_PROBE_COLLECTIONS = (
+    "Entity_name",
+    "TextSummary_text",
+    "EntityType_name",
+    "DocumentChunk_text",
+)
+
+
+def service_url_is_local(url: str = "") -> bool:
+    """True when the resolved service URL points at this machine (loopback)."""
+    host = (urllib.parse.urlparse(url or _local_api_url()).hostname or "").lower()
+    return host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
+
+
+async def _sample_stored_vector_dim(engine) -> Optional[int]:
+    """Length of one stored vector from any known collection, or None. Never raises.
+
+    Reads are cheap and safe for concurrent access on both supported backends
+    (LanceDB row sample; pgvector column type). Each probe is independently
+    guarded so a single unreadable collection can't abort the scan.
+    """
+    is_pgvector = type(engine).__name__ == "PGVectorAdapter"
+    for name in _DIM_PROBE_COLLECTIONS:
+        try:
+            if not await engine.has_collection(name):
+                continue
+            if is_pgvector:
+                table = await engine.get_table(name)
+                dim = getattr(getattr(table.c.vector, "type", None), "dim", None)
+                if dim:
+                    return int(dim)
+            else:
+                collection = await engine.get_collection(name)
+                rows = await collection.query().limit(1).to_list()
+                if rows:
+                    vector = rows[0].get("vector")
+                    if vector is not None:
+                        return len(vector)
+        except Exception:
+            continue
+    return None
+
+
+async def embedding_dimension_mismatch_hint(engine=None) -> Optional[str]:
+    """Return a one-line actionable error if the active embedder's vector size
+    differs from the stored vector dimension; else None.
+
+    Best-effort and fail-safe: on any error (cognee not importable, store
+    unreadable, dims indeterminate, or matching) returns None so callers fall
+    back to the normal empty-result path. ``engine`` is injectable for testing;
+    when omitted the in-process cognee vector engine is used.
+    """
+    try:
+        if engine is None:
+            from cognee.infrastructure.databases.vector import get_vector_engine
+
+            engine = get_vector_engine()
+        embed = getattr(engine, "embedding_engine", None)
+        if embed is None:
+            return None
+        query_dim = int(embed.get_vector_size())
+        stored_dim = await _sample_stored_vector_dim(engine)
+        if not stored_dim or not query_dim or stored_dim == query_dim:
+            return None
+        model = getattr(embed, "model", None) or "unknown-model"
+        provider = getattr(embed, "provider", None) or "unknown-provider"
+        return (
+            "Cognee recall found nothing because the embedder changed: stored vectors are "
+            f"{stored_dim}-d but the active embedder '{model}' (provider '{provider}') produces "
+            f"{query_dim}-d queries. Re-index this data with the current embedder, or set "
+            f"EMBEDDING_MODEL/EMBEDDING_DIMENSIONS back to the {stored_dim}-d model that wrote it."
+        )
+    except Exception:
+        return None
+
+
 def hook_log(event: str, detail: Optional[dict] = None) -> None:
     """Append one structured line to ~/.cognee-plugin/codex/hook.log.
 

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -20,7 +20,7 @@ import time
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
-    embedding_dimension_mismatch_hint,
+    embedding_dimension_report,
     get_session_key,
     hook_log,
     load_resolved,
@@ -365,18 +365,20 @@ async def _run(prompt: str) -> dict | None:
         # match). Only the local store is introspectable here; surface a one-line
         # actionable error when a mismatch is positively confirmed, else fall back
         # to the normal "no matches" line.
-        mismatch = None
+        dim_status, dim_message = "no_data", None
         if service_url_is_local(service_url):
             try:
-                mismatch = await asyncio.wait_for(
-                    embedding_dimension_mismatch_hint(), timeout=2.0
+                dim_status, dim_message = await asyncio.wait_for(
+                    embedding_dimension_report(), timeout=2.0
                 )
             except Exception as exc:
                 hook_log("dim_check_error", {"error": str(exc)[:200]})
-        if mismatch:
-            full_context = f"{header}\n\n{mismatch}"
-            hook_log("context_lookup_dim_mismatch", {"message": mismatch})
-            notify(mismatch)
+        if dim_message and dim_status in ("mismatch", "unverified"):
+            full_context = f"{header}\n\n{dim_message}"
+            hook_log(
+                "context_lookup_dim_mismatch", {"status": dim_status, "message": dim_message}
+            )
+            notify(dim_message)
         else:
             full_context = f"{header}\n\n(no memory matches for this prompt)"
             hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -20,6 +20,7 @@ import time
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
+    embedding_dimension_mismatch_hint,
     get_session_key,
     hook_log,
     load_resolved,
@@ -33,6 +34,7 @@ from _plugin_common import (
     resolve_user,
     server_health_ok,
     server_ready_hint,
+    service_url_is_local,
     set_session_key,
 )
 from cognee_statusline_render import render_status_for_host
@@ -358,9 +360,27 @@ async def _run(prompt: str) -> dict | None:
         hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
         notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
     else:
-        full_context = f"{header}\n\n(no memory matches for this prompt)"
-        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
-        notify(f"no recall matches; saves last turn {saves_last_turn}")
+        # Zero results can mean a genuine miss OR that the embedding model changed
+        # since indexing (stored vs query vectors differ in size, so nothing can
+        # match). Only the local store is introspectable here; surface a one-line
+        # actionable error when a mismatch is positively confirmed, else fall back
+        # to the normal "no matches" line.
+        mismatch = None
+        if service_url_is_local(service_url):
+            try:
+                mismatch = await asyncio.wait_for(
+                    embedding_dimension_mismatch_hint(), timeout=2.0
+                )
+            except Exception as exc:
+                hook_log("dim_check_error", {"error": str(exc)[:200]})
+        if mismatch:
+            full_context = f"{header}\n\n{mismatch}"
+            hook_log("context_lookup_dim_mismatch", {"message": mismatch})
+            notify(mismatch)
+        else:
+            full_context = f"{header}\n\n(no memory matches for this prompt)"
+            hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
+            notify(f"no recall matches; saves last turn {saves_last_turn}")
 
     # Audit log: persist full recall details per turn. The hook output stays a
     # short summary because Codex renders additionalContext in the terminal.

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -733,10 +733,14 @@ class CogneeMemoryProvider(MemoryProvider):
             if not items:
                 # Distinguish a genuine miss from an embedding-model change that
                 # makes recall structurally unable to match (stored vs query
-                # vectors differ in size). Embedded mode only.
-                hint = self._embedding_dimension_mismatch_hint()
-                if hint:
-                    return json.dumps({"error": hint, "count": 0})
+                # vectors differ in size). Embedded mode only. A confirmed mismatch
+                # is a hard error; a data-present-but-unverifiable store gets a
+                # softer informational note.
+                dim_status, dim_message = self._embedding_dimension_report()
+                if dim_status == "mismatch":
+                    return json.dumps({"error": dim_message, "count": 0})
+                if dim_status == "unverified":
+                    return json.dumps({"result": dim_message, "count": 0})
                 return json.dumps({"result": "No relevant Cognee memory found.", "count": 0})
             return json.dumps({"results": items, "count": len(items)})
         except Exception as exc:
@@ -801,19 +805,19 @@ class CogneeMemoryProvider(MemoryProvider):
             lines.append(f"- [{source}] {text[:500]}")
         return lines
 
-    def _embedding_dimension_mismatch_hint(self) -> Optional[str]:
-        """Actionable one-line error when the embedder changed (embedded mode only).
+    def _embedding_dimension_report(self) -> tuple[str, Optional[str]]:
+        """Classify a zero-result recall (embedded mode only). Returns (status, message).
 
         In server/remote mode the server owns the vector store, so introspecting
-        the local in-process engine would be meaningless — skip. Best-effort;
-        never raises.
+        the local in-process engine would be meaningless — skip (``"no_data"``).
+        Best-effort; never raises.
         """
         if self._remote_mode:
-            return None
+            return ("no_data", None)
         try:
-            return self._bridge.run(_dimension_mismatch_hint(), timeout=5.0)
+            return self._bridge.run(_dimension_report(), timeout=5.0)
         except Exception:
-            return None
+            return ("no_data", None)
 
     def _is_breaker_open(self) -> bool:
         if self._consecutive_failures < _BREAKER_THRESHOLD:
@@ -853,36 +857,61 @@ _DIM_PROBE_COLLECTIONS = (
 )
 
 
-async def _sample_stored_vector_dim(engine) -> Optional[int]:
-    """Length of one stored vector from any known collection, or None. Never raises."""
+# One hedged, low-noise line for the "data present but dim unverifiable" case
+# (store unreadable / read errored). Softer than the confirmed-mismatch diagnostic.
+_UNVERIFIED_EMBEDDER_HINT = (
+    "Cognee recall found nothing and could not verify the active embedder against the "
+    "stored vectors (store unreadable or timed out). If memory seems missing after an "
+    "embedding-model change, check EMBEDDING_MODEL / EMBEDDING_DIMENSIONS."
+)
+
+
+async def _probe_stored_dim(engine):
+    """Probe the stored vector dimension across known collections. Never raises.
+
+    Returns ``(status, dim)``: ``("dim", n)`` when a stored vector's dimension was
+    read; ``("unverified", None)`` when a collection exists but its dim could not be
+    read (open/query raised); ``("no_data", None)`` when no collection exists or the
+    collections hold no vectors (a normal fresh/empty state).
+    """
     is_pgvector = type(engine).__name__ == "PGVectorAdapter"
+    saw_collection = False
+    saw_error = False
     for name in _DIM_PROBE_COLLECTIONS:
         try:
             if not await engine.has_collection(name):
                 continue
+            saw_collection = True
             if is_pgvector:
                 table = await engine.get_table(name)
                 dim = getattr(getattr(table.c.vector, "type", None), "dim", None)
                 if dim:
-                    return int(dim)
+                    return ("dim", int(dim))
             else:
                 collection = await engine.get_collection(name)
                 rows = await collection.query().limit(1).to_list()
                 if rows:
                     vector = rows[0].get("vector")
                     if vector is not None:
-                        return len(vector)
+                        return ("dim", len(vector))
         except Exception:
+            saw_error = True
             continue
-    return None
+    if saw_collection and saw_error:
+        return ("unverified", None)
+    return ("no_data", None)
 
 
-async def _dimension_mismatch_hint(engine=None) -> Optional[str]:
-    """One-line actionable error if the active embedder's vector size differs from
-    the stored vector dimension; else None. ``engine`` is injectable for testing.
+async def _dimension_report(engine=None):
+    """Classify a zero-result recall against the embedder/store dimensions.
 
-    Best-effort and fail-safe: on any error (cognee not importable, store
-    unreadable, dims indeterminate, or matching) returns None.
+    Returns ``(status, message)``: ``"mismatch"`` (dims differ; message is the
+    actionable diagnostic), ``"unverified"`` (data present but dim unreadable;
+    message is a hedged hint), ``"match"`` (dims agree; message None), or
+    ``"no_data"`` (nothing to compare / cannot introspect; message None).
+    ``engine`` is injectable for testing. Best-effort and fail-safe: any error
+    stays quiet (``"no_data"``); the hedged hint fires only when a populated store
+    was seen but its dim couldn't be read — never on fresh/empty sessions.
     """
     try:
         if engine is None:
@@ -891,21 +920,26 @@ async def _dimension_mismatch_hint(engine=None) -> Optional[str]:
             engine = get_vector_engine()
         embed = getattr(engine, "embedding_engine", None)
         if embed is None:
-            return None
+            return ("no_data", None)
         query_dim = int(embed.get_vector_size())
-        stored_dim = await _sample_stored_vector_dim(engine)
-        if not stored_dim or not query_dim or stored_dim == query_dim:
-            return None
+        status, stored_dim = await _probe_stored_dim(engine)
+        if status == "unverified":
+            return ("unverified", _UNVERIFIED_EMBEDDER_HINT)
+        if status != "dim" or not stored_dim or not query_dim:
+            return ("no_data", None)
+        if stored_dim == query_dim:
+            return ("match", None)
         model = getattr(embed, "model", None) or "unknown-model"
         provider = getattr(embed, "provider", None) or "unknown-provider"
-        return (
+        message = (
             "Cognee recall found nothing because the embedder changed: stored vectors are "
             f"{stored_dim}-d but the active embedder '{model}' (provider '{provider}') produces "
             f"{query_dim}-d queries. Re-index this data with the current embedder, or set "
             f"EMBEDDING_MODEL/EMBEDDING_DIMENSIONS back to the {stored_dim}-d model that wrote it."
         )
+        return ("mismatch", message)
     except Exception:
-        return None
+        return ("no_data", None)
 
 
 def _resolve_search_type(search_type: str):

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -731,6 +731,12 @@ class CogneeMemoryProvider(MemoryProvider):
             self._record_success()
             items = [self._normalize_recall_item(item) for item in results]
             if not items:
+                # Distinguish a genuine miss from an embedding-model change that
+                # makes recall structurally unable to match (stored vs query
+                # vectors differ in size). Embedded mode only.
+                hint = self._embedding_dimension_mismatch_hint()
+                if hint:
+                    return json.dumps({"error": hint, "count": 0})
                 return json.dumps({"result": "No relevant Cognee memory found.", "count": 0})
             return json.dumps({"results": items, "count": len(items)})
         except Exception as exc:
@@ -795,6 +801,20 @@ class CogneeMemoryProvider(MemoryProvider):
             lines.append(f"- [{source}] {text[:500]}")
         return lines
 
+    def _embedding_dimension_mismatch_hint(self) -> Optional[str]:
+        """Actionable one-line error when the embedder changed (embedded mode only).
+
+        In server/remote mode the server owns the vector store, so introspecting
+        the local in-process engine would be meaningless — skip. Best-effort;
+        never raises.
+        """
+        if self._remote_mode:
+            return None
+        try:
+            return self._bridge.run(_dimension_mismatch_hint(), timeout=5.0)
+        except Exception:
+            return None
+
     def _is_breaker_open(self) -> bool:
         if self._consecutive_failures < _BREAKER_THRESHOLD:
             return False
@@ -815,6 +835,77 @@ class CogneeMemoryProvider(MemoryProvider):
                 self._consecutive_failures,
                 _BREAKER_COOLDOWN_SECS,
             )
+
+
+# --- Embedding-dimension mismatch detection ---------------------------------
+# When the embedding model changes between writing and reading, stored vectors
+# and query vectors differ in size, so recall silently matches nothing. These
+# helpers turn that silent miss into a one-line actionable error naming both
+# dimensions and the active embedder. Best-effort and fail-safe (any uncertainty
+# returns None). Only valid in embedded mode, where this process owns the vector
+# store; in server/remote mode the server owns it and the in-process engine here
+# would not reflect it.
+_DIM_PROBE_COLLECTIONS = (
+    "Entity_name",
+    "TextSummary_text",
+    "EntityType_name",
+    "DocumentChunk_text",
+)
+
+
+async def _sample_stored_vector_dim(engine) -> Optional[int]:
+    """Length of one stored vector from any known collection, or None. Never raises."""
+    is_pgvector = type(engine).__name__ == "PGVectorAdapter"
+    for name in _DIM_PROBE_COLLECTIONS:
+        try:
+            if not await engine.has_collection(name):
+                continue
+            if is_pgvector:
+                table = await engine.get_table(name)
+                dim = getattr(getattr(table.c.vector, "type", None), "dim", None)
+                if dim:
+                    return int(dim)
+            else:
+                collection = await engine.get_collection(name)
+                rows = await collection.query().limit(1).to_list()
+                if rows:
+                    vector = rows[0].get("vector")
+                    if vector is not None:
+                        return len(vector)
+        except Exception:
+            continue
+    return None
+
+
+async def _dimension_mismatch_hint(engine=None) -> Optional[str]:
+    """One-line actionable error if the active embedder's vector size differs from
+    the stored vector dimension; else None. ``engine`` is injectable for testing.
+
+    Best-effort and fail-safe: on any error (cognee not importable, store
+    unreadable, dims indeterminate, or matching) returns None.
+    """
+    try:
+        if engine is None:
+            from cognee.infrastructure.databases.vector import get_vector_engine
+
+            engine = get_vector_engine()
+        embed = getattr(engine, "embedding_engine", None)
+        if embed is None:
+            return None
+        query_dim = int(embed.get_vector_size())
+        stored_dim = await _sample_stored_vector_dim(engine)
+        if not stored_dim or not query_dim or stored_dim == query_dim:
+            return None
+        model = getattr(embed, "model", None) or "unknown-model"
+        provider = getattr(embed, "provider", None) or "unknown-provider"
+        return (
+            "Cognee recall found nothing because the embedder changed: stored vectors are "
+            f"{stored_dim}-d but the active embedder '{model}' (provider '{provider}') produces "
+            f"{query_dim}-d queries. Re-index this data with the current embedder, or set "
+            f"EMBEDDING_MODEL/EMBEDDING_DIMENSIONS back to the {stored_dim}-d model that wrote it."
+        )
+    except Exception:
+        return None
 
 
 def _resolve_search_type(search_type: str):

--- a/integrations/hermes-agent/tests/test_dim_mismatch.py
+++ b/integrations/hermes-agent/tests/test_dim_mismatch.py
@@ -1,0 +1,120 @@
+"""Tests for the embedding-dimension mismatch hint in the Hermes provider.
+
+When the embedding model changes between writing and reading, stored vectors and
+fresh query vectors differ in size, so recall silently matches nothing. The hint
+turns that silent miss into a one-line actionable error naming both dimensions
+and the active embedder. A fake vector engine is injected so cognee is not
+required; the provider imports it lazily.
+
+Runs under pytest or standalone (``python3 tests/test_dim_mismatch.py``).
+"""
+
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from cognee_integration_hermes import provider as provider_mod  # noqa: E402
+
+
+class _FakeEmbed:
+    def __init__(self, size, model="openai/text-embedding-3-large", provider="openai"):
+        self._size = size
+        self.model = model
+        self.provider = provider
+
+    def get_vector_size(self):
+        return self._size
+
+
+class _FakeQuery:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def limit(self, _n):
+        return self
+
+    async def to_list(self):
+        return self._rows
+
+
+class _FakeCollection:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def query(self):
+        return _FakeQuery(self._rows)
+
+
+class _FakeLanceEngine:
+    def __init__(self, query_size, stored_vector, present=("Entity_name",)):
+        self.embedding_engine = _FakeEmbed(query_size)
+        self._stored_vector = stored_vector
+        self._present = set(present)
+
+    async def has_collection(self, name):
+        return name in self._present
+
+    async def get_collection(self, _name):
+        rows = [{"vector": self._stored_vector}] if self._stored_vector is not None else []
+        return _FakeCollection(rows)
+
+
+def _hint(engine):
+    return asyncio.run(provider_mod._dimension_mismatch_hint(engine))
+
+
+class TestDimensionMismatchHint(unittest.TestCase):
+    def test_mismatch_names_both_dims_and_model(self):
+        msg = _hint(_FakeLanceEngine(query_size=3072, stored_vector=[0.0] * 1536))
+        self.assertIsNotNone(msg)
+        self.assertIn("1536", msg)
+        self.assertIn("3072", msg)
+        self.assertIn("text-embedding-3-large", msg)
+
+    def test_matching_dims_returns_none(self):
+        self.assertIsNone(_hint(_FakeLanceEngine(query_size=1536, stored_vector=[0.0] * 1536)))
+
+    def test_no_collections_returns_none(self):
+        self.assertIsNone(
+            _hint(_FakeLanceEngine(query_size=3072, stored_vector=[0.0] * 1536, present=()))
+        )
+
+    def test_broken_engine_never_raises(self):
+        class _Broken:
+            @property
+            def embedding_engine(self):
+                raise RuntimeError("boom")
+
+        self.assertIsNone(_hint(_Broken()))
+
+
+class TestProviderGate(unittest.TestCase):
+    def test_remote_mode_skips_check(self):
+        provider = provider_mod.CogneeMemoryProvider()
+        provider._remote_mode = True
+        # No bridge work and no cognee import in remote mode.
+        self.assertIsNone(provider._embedding_dimension_mismatch_hint())
+
+    def test_embedded_mode_runs_check_via_bridge(self):
+        provider = provider_mod.CogneeMemoryProvider()
+        provider._remote_mode = False
+
+        async def _fake_hint():
+            return "DIM MISMATCH"
+
+        original = provider_mod._dimension_mismatch_hint
+        provider_mod._dimension_mismatch_hint = _fake_hint
+        try:
+            self.assertEqual(provider._embedding_dimension_mismatch_hint(), "DIM MISMATCH")
+        finally:
+            provider_mod._dimension_mismatch_hint = original
+            provider._bridge.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/hermes-agent/tests/test_dim_mismatch.py
+++ b/integrations/hermes-agent/tests/test_dim_mismatch.py
@@ -1,10 +1,9 @@
-"""Tests for the embedding-dimension mismatch hint in the Hermes provider.
+"""Tests for the embedding-dimension probe in the Hermes provider.
 
-When the embedding model changes between writing and reading, stored vectors and
-fresh query vectors differ in size, so recall silently matches nothing. The hint
-turns that silent miss into a one-line actionable error naming both dimensions
-and the active embedder. A fake vector engine is injected so cognee is not
-required; the provider imports it lazily.
+``_dimension_report`` classifies a zero-result recall as "mismatch" (actionable
+diagnostic), "unverified" (data present but dim unreadable -> hedged hint),
+"match" (genuine miss), or "no_data" (nothing to compare / cannot introspect).
+A fake vector engine is injected so cognee is not required.
 
 Runs under pytest or standalone (``python3 tests/test_dim_mismatch.py``).
 """
@@ -64,55 +63,73 @@ class _FakeLanceEngine:
         return _FakeCollection(rows)
 
 
-def _hint(engine):
-    return asyncio.run(provider_mod._dimension_mismatch_hint(engine))
+class _FakeErrorEngine:
+    def __init__(self, query_size):
+        self.embedding_engine = _FakeEmbed(query_size)
+
+    async def has_collection(self, name):
+        return name == "Entity_name"
+
+    async def get_collection(self, _name):
+        raise RuntimeError("store locked")
 
 
-class TestDimensionMismatchHint(unittest.TestCase):
+def _report(engine):
+    return asyncio.run(provider_mod._dimension_report(engine))
+
+
+class TestDimensionReport(unittest.TestCase):
     def test_mismatch_names_both_dims_and_model(self):
-        msg = _hint(_FakeLanceEngine(query_size=3072, stored_vector=[0.0] * 1536))
-        self.assertIsNotNone(msg)
+        status, msg = _report(_FakeLanceEngine(query_size=3072, stored_vector=[0.0] * 1536))
+        self.assertEqual(status, "mismatch")
         self.assertIn("1536", msg)
         self.assertIn("3072", msg)
         self.assertIn("text-embedding-3-large", msg)
 
-    def test_matching_dims_returns_none(self):
-        self.assertIsNone(_hint(_FakeLanceEngine(query_size=1536, stored_vector=[0.0] * 1536)))
-
-    def test_no_collections_returns_none(self):
-        self.assertIsNone(
-            _hint(_FakeLanceEngine(query_size=3072, stored_vector=[0.0] * 1536, present=()))
+    def test_matching_dims_is_match(self):
+        self.assertEqual(
+            _report(_FakeLanceEngine(query_size=1536, stored_vector=[0.0] * 1536)), ("match", None)
         )
 
-    def test_broken_engine_never_raises(self):
+    def test_no_collections_is_no_data(self):
+        engine = _FakeLanceEngine(query_size=3072, stored_vector=[0.0] * 1536, present=())
+        self.assertEqual(_report(engine), ("no_data", None))
+
+    def test_unreadable_store_is_unverified(self):
+        status, msg = _report(_FakeErrorEngine(query_size=3072))
+        self.assertEqual(status, "unverified")
+        self.assertIn("could not verify", msg)
+
+    def test_broken_engine_is_no_data(self):
         class _Broken:
             @property
             def embedding_engine(self):
                 raise RuntimeError("boom")
 
-        self.assertIsNone(_hint(_Broken()))
+        self.assertEqual(_report(_Broken()), ("no_data", None))
 
 
 class TestProviderGate(unittest.TestCase):
     def test_remote_mode_skips_check(self):
         provider = provider_mod.CogneeMemoryProvider()
         provider._remote_mode = True
-        # No bridge work and no cognee import in remote mode.
-        self.assertIsNone(provider._embedding_dimension_mismatch_hint())
+        self.assertEqual(provider._embedding_dimension_report(), ("no_data", None))
 
     def test_embedded_mode_runs_check_via_bridge(self):
         provider = provider_mod.CogneeMemoryProvider()
         provider._remote_mode = False
 
-        async def _fake_hint():
-            return "DIM MISMATCH"
+        async def _fake_report():
+            return ("mismatch", "DIM MISMATCH")
 
-        original = provider_mod._dimension_mismatch_hint
-        provider_mod._dimension_mismatch_hint = _fake_hint
+        original = provider_mod._dimension_report
+        provider_mod._dimension_report = _fake_report
         try:
-            self.assertEqual(provider._embedding_dimension_mismatch_hint(), "DIM MISMATCH")
+            self.assertEqual(
+                provider._embedding_dimension_report(), ("mismatch", "DIM MISMATCH")
+            )
         finally:
-            provider_mod._dimension_mismatch_hint = original
+            provider_mod._dimension_report = original
             provider._bridge.shutdown()
 
 


### PR DESCRIPTION
Hey maintainers this PR closes topoteretes/cognee#3547
# Embedding Dimension Mismatch Detection 
 
## Problem Statement
 
When a dataset's vectors were written with one embedding model (dim A) and recall later runs with a different embedder (dim B), the fresh query vector can't match the stored index. Recall returned an empty list silently — indistinguishable from a genuine "nothing stored." The user/agent saw `(no memory matches for this prompt)` / `No relevant Cognee memory found.` with no hint that the real cause was an embedding-model/config change.
 
**Goal**: a dimension mismatch produces a clear, actionable one-line diagnostic naming both dims and the embedder, instead of a silent empty — without breaking recall or producing false alarms.
 
## Proposed Solutions
 
### Phase 1 — Actionable mismatch diagnostic
 
A best-effort, fail-safe probe that runs only on a zero-result recall:
 
- Read the active embedder's vector size + model/provider (`embedding_engine.get_vector_size()`).
- Sample the stored vector dimension from the local store (LanceDB row length / pgvector column dim).
- If both known and they differ → emit a one-line diagnostic; otherwise → `None` (today's behavior).
**Safety**: the probe can only ever add an error on a positively-confirmed mismatch. Any exception / 2s timeout / unreadable store / indeterminate or matching dims → `None`. Gated to a local, in-process store (loopback URL for plugins; embedded mode for hermes) so a remote/cloud store — owned by the server — is never introspected.
 
### Phase 2 — 4-way classifier + hedged hint
 
Phase 1 collapsed five outcomes into a single `None`, so the caller couldn't tell "genuine miss" from "couldn't check." Phase 2 refactors the probe into `embedding_dimension_report()` → `(status, message)`:
 
| `status` | When | Surfaced as |
|---|---|---|
| `mismatch` | stored dim ≠ query dim | hard diagnostic (both dims + active model/provider + remediation) |
| `unverified` | a populated collection exists but its dim couldn't be read (locked/timeout/error) | hedged, low-noise hint ("…could not verify the active embedder…") |
| `match` | dims agree (genuine miss) | plain empty (unchanged) |
| `no_data` | no collections, empty collections, or can't introspect | plain empty (unchanged) |
 
**Key safeguard**: `_probe_stored_dim` tracks `saw_collection` vs `saw_error` — a fresh/empty session → `no_data` → no hint, while data-present-but-unreadable → `unverified` → hint. This closes the "still shows empty bracket on uncertain cases" gap without nagging on every early miss.
 
**Emitted messages:**
 
`mismatch`:
```
Cognee recall found nothing because the embedder changed: stored vectors are 1536-d but the
active embedder 'openai/text-embedding-3-large' (provider 'openai') produces 3072-d queries.
Re-index this data with the current embedder, or set EMBEDDING_MODEL/EMBEDDING_DIMENSIONS
back to the 1536-d model that wrote it.
```
 
`unverified`:
```
Cognee recall found nothing and could not verify the active embedder against the stored vectors
(store unreadable or timed out). If memory seems missing after an embedding-model change,
check EMBEDDING_MODEL / EMBEDDING_DIMENSIONS.
```
 
Note: the stored model name is not emitted — cognee persists only the stored dimension, not the model. Naming it would require a cognee-core change, out of the integration scope.
 
## Files Changed & Why
 
Combined diffstat vs HEAD: 5 files changed, 205 insertions(+), 79 deletions(-) + 2 new test files (327 lines).
 
| File | Why | Phase 1 | Phase 2 |
|---|---|---|---|
| `integrations/claude-code/scripts/_plugin_common.py` | Shared, injectable, fail-safe detection imported by the hooks; loopback gate blocks remote introspection | Added `_DIM_PROBE_COLLECTIONS`, `service_url_is_local()`, `_sample_stored_vector_dim()`, `embedding_dimension_mismatch_hint()` | Replaced with `_probe_stored_dim()` (tracks collection-present vs error), `embedding_dimension_report()` → `(status, message)`, `_UNVERIFIED_EMBEDDER_HINT`; kept `embedding_dimension_mismatch_hint()` as a back-compat wrapper |
| `integrations/codex/plugins/cognee/scripts/_plugin_common.py` | Codex is a twin of the claude-code plugin — keep parity | Same block | Same block |
| `integrations/claude-code/scripts/session-context-lookup.py` | Primary auto-recall path where the silent empty was produced | Wire the hint into the empty-recall branch + `notify()` + `context_lookup_dim_mismatch` hook_log (local-store-gated) | Use `embedding_dimension_report`; surface message for `mismatch` or `unverified`; log `status` + `message` |
| `integrations/codex/plugins/cognee/scripts/session-context-lookup.py` | Twin parity | Same wiring | Same wiring |
| `integrations/hermes-agent/cognee_integration_hermes/provider.py` | Hermes' recall tool returned `"No relevant Cognee memory found."` on empty; embedded mode is the only mode this process owns the store | Module `_sample_stored_vector_dim`/`_dimension_mismatch_hint`; `_embedding_dimension_mismatch_hint()` method; `_handle_recall` returns `{"error": …}` on mismatch | Refactor to `_probe_stored_dim`/`_dimension_report`; `_embedding_dimension_report()`; `_handle_recall` → `{"error": …}` on mismatch, softer `{"result": …}` on unverified |
| `integrations/claude-code/tests/test_dim_mismatch.py` (new) | Verify detection + fail-safe without cognee installed (injectable fake engine) | Created | Rewritten to the status contract |
| `integrations/hermes-agent/tests/test_dim_mismatch.py` (new) | Same, plus the embedded-vs-remote gate | Created | Rewritten to the status contract |
 
## Tests (15 total, all passing)
 
**claude-code — `test_dim_mismatch.py` (8)**
 
- `test_lancedb_mismatch_names_both_dims_and_model` — LanceDB path → `mismatch`; asserts `1536`, `3072`, model, provider.
- `test_pgvector_mismatch_names_both_dims` — pgvector column-dim path → `mismatch`, both dims.
- `test_matching_dims_is_match_no_message` — equal dims → `("match", None)`.
- `test_no_collections_is_no_data` — no collections → `("no_data", None)`.
- `test_empty_collection_is_no_data` — collection present but empty → `("no_data", None)` (no false hint).
- `test_unreadable_store_is_unverified_with_hedged_hint` — collection present but read raises → `("unverified", <hedged>)`; asserts it doesn't read like the hard diagnostic.
- `test_broken_engine_is_no_data` — engine raises → `("no_data", None)` (fail-safe).
- `test_backcompat_hint_returns_message_only_on_mismatch` — wrapper returns the message only for `mismatch`, `None` for `unverified`/`match`.
**hermes — `test_dim_mismatch.py` (7)**
 
- `test_mismatch_names_both_dims_and_model` / `test_matching_dims_is_match` / `test_no_collections_is_no_data` / `test_unreadable_store_is_unverified` / `test_broken_engine_is_no_data` — core classifier + fail-safe.
- `test_remote_mode_skips_check` — remote/server mode → `("no_data", None)` (no introspection).
- `test_embedded_mode_runs_check_via_bridge` — embedded mode runs the check through the async bridge.
Also verified: no regressions — hermes `test_server_mode` 21/21, claude-code `test_recall_http` pass; `py_compile` clean on all 7 files; no leftover old-symbol references; line-length ≤100 / import order per repo ruff config (E, F, I, W).

<img width="1108" height="393" alt="Screenshot 2026-07-01 232353" src="https://github.com/user-attachments/assets/25ef9a1d-ac80-48bf-a0c5-e60b94a9260a" />

<img width="1168" height="308" alt="Screenshot 2026-07-01 232431" src="https://github.com/user-attachments/assets/3be8c00f-be5f-4aac-b92c-79527aadc0cf" />
