### PR TITLE
feat(claude-code): add doctor.py plugin health-check command

### DIFF
--- a/integrations/claude-code/scripts/doctor.py
+++ b/integrations/claude-code/scripts/doctor.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Cognee plugin health check — run to diagnose plugin issues.
+
+Usage: python doctor.py [--json]
+Exit 0 = all checks passed; 1 = issues found.
+"""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+_ROOT = Path.home() / ".cognee-plugin"
+_PLUGIN = _ROOT / "claude-code"
+_BREAKER = _ROOT / "recall-breaker.json"
+_RECALL = _PLUGIN / "last_recall.json"
+_COUNTER = _PLUGIN / "counter.json"
+
+
+def _slurp(p: Path) -> dict:
+    try:
+        return json.loads(p.read_text(encoding="utf-8")) if p.exists() else {}
+    except Exception:
+        return {}
+
+
+def _check_server(base_url: str) -> dict:
+    if not base_url:
+        return {"status": "local_sdk"}
+    import urllib.error
+    import urllib.request
+
+    url = base_url.rstrip("/") + "/health"
+    t0 = time.monotonic()
+    try:
+        with urllib.request.urlopen(url, timeout=3) as r:
+            return {"status": "ok", "latency_ms": int((time.monotonic() - t0) * 1000)}
+    except Exception as exc:
+        return {"status": "error", "error": str(exc)[:120]}
+
+
+def _pkg_version(name: str) -> str:
+    try:
+        import importlib.metadata
+
+        return importlib.metadata.version(name)
+    except Exception:
+        return "?"
+
+
+def build_report() -> dict:
+    sys.path.insert(0, str(Path(__file__).parent))
+    try:
+        from _plugin_common import resolve_runtime_mode
+
+        rt = resolve_runtime_mode()
+    except Exception:
+        rt = {
+            "mode": "unknown",
+            "base_url": "",
+            "api_key_present": False,
+            "url_source": "?",
+            "key_source": "?",
+        }
+
+    breaker = _slurp(_BREAKER)
+    recall = _slurp(_RECALL)
+    counter = _slurp(_COUNTER)
+    base_url = rt.get("base_url", "")
+
+    cooldown = float(breaker.get("cooldown_until") or 0)
+    breaker_open = cooldown > time.time()
+
+    server = _check_server(base_url)
+
+    issues = []
+    if server.get("status") == "error":
+        issues.append(f"server unreachable at {base_url}")
+    if breaker_open:
+        issues.append(f"recall breaker open (cooldown until {cooldown:.0f})")
+
+    return {
+        "mode": rt.get("mode", "unknown"),
+        "base_url": base_url or "(local)",
+        "api_key_present": rt.get("api_key_present", False),
+        "server": server,
+        "recall_breaker": {"open": breaker_open, "failures": breaker.get("failure_count", 0)},
+        "last_recall": {"ts": recall.get("ts", "never"), "hits": recall.get("hits", {})},
+        "turn_counter": counter.get("total", 0),
+        "versions": {
+            "cognee": _pkg_version("cognee"),
+            "plugin": _pkg_version("cognee-plugin"),
+        },
+        "issues": issues,
+    }
+
+
+def _print_human(r: dict) -> None:
+    ok, warn, fail, info = "✓", "⚠", "✗", "·"
+
+    def row(sym: str, label: str, val: str) -> None:
+        print(f"  {sym}  {label:<24}{val}")
+
+    print("\ncognee-plugin doctor\n" + "─" * 42)
+    row(info, "Mode", r["mode"])
+    row(info, "Backend URL", r["base_url"])
+    row(info if r["api_key_present"] else warn, "API key", "present" if r["api_key_present"] else "not set")
+
+    s = r["server"]
+    if s.get("status") == "local_sdk":
+        row(info, "Server", "local SDK (no HTTP check)")
+    elif s.get("status") == "ok":
+        row(ok, "Server", f"reachable ({s.get('latency_ms', '?')} ms)")
+    else:
+        row(fail, "Server", f"unreachable — {s.get('error', '')}")
+
+    br = r["recall_breaker"]
+    row(
+        warn if br["open"] else ok,
+        "Recall breaker",
+        f"OPEN ({br['failures']} failures)" if br["open"] else "closed",
+    )
+
+    lr = r["last_recall"]
+    row(info, "Last recall", lr["ts"])
+    row(info, "Turn counter", str(r["turn_counter"]))
+
+    ver = r["versions"]
+    row(info, "cognee", ver["cognee"])
+    row(info, "plugin", ver["plugin"])
+
+    print()
+    if r["issues"]:
+        for issue in r["issues"]:
+            print(f"  {fail}  {issue}")
+        print()
+    else:
+        print(f"  {ok}  All checks passed\n")
+
+
+def main() -> int:
+    report = build_report()
+    if "--json" in sys.argv:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_human(report)
+    return 1 if report["issues"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/claude-code/tests/test_doctor.py
+++ b/integrations/claude-code/tests/test_doctor.py
@@ -1,0 +1,94 @@
+"""Tests for doctor.py — plugin health check command.
+
+Run: pytest integrations/claude-code/tests/test_doctor.py
+"""
+
+import importlib
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+
+def _reload_doctor(tmp_home: Path, monkeypatch):
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_home))
+    import doctor
+
+    return importlib.reload(doctor)
+
+
+def test_build_report_has_required_keys(tmp_path, monkeypatch):
+    doc = _reload_doctor(tmp_path, monkeypatch)
+    r = doc.build_report()
+    for key in ("mode", "server", "recall_breaker", "last_recall", "issues", "versions"):
+        assert key in r
+
+
+def test_breaker_closed_when_no_file(tmp_path, monkeypatch):
+    doc = _reload_doctor(tmp_path, monkeypatch)
+    # avoid real network calls — no server configured in this clean env
+    monkeypatch.setattr(doc, "_check_server", lambda url: {"status": "local_sdk"})
+    r = doc.build_report()
+    assert not r["recall_breaker"]["open"]
+    assert r["issues"] == []
+
+
+def test_breaker_open_when_in_cooldown(tmp_path, monkeypatch):
+    doc = _reload_doctor(tmp_path, monkeypatch)
+    p = tmp_path / ".cognee-plugin" / "recall-breaker.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({"cooldown_until": time.time() + 3600, "failure_count": 3}))
+    importlib.reload(doc)
+    r = doc.build_report()
+    assert r["recall_breaker"]["open"]
+    assert r["recall_breaker"]["failures"] == 3
+    assert any("recall breaker" in i for i in r["issues"])
+
+
+def test_last_recall_loaded_from_file(tmp_path, monkeypatch):
+    doc = _reload_doctor(tmp_path, monkeypatch)
+    recall_path = tmp_path / ".cognee-plugin" / "claude-code" / "last_recall.json"
+    recall_path.parent.mkdir(parents=True, exist_ok=True)
+    recall_path.write_text(json.dumps({"ts": "2025-01-01T00:00:00+00:00", "hits": {"session": 3}}))
+    importlib.reload(doc)
+    r = doc.build_report()
+    assert r["last_recall"]["ts"] == "2025-01-01T00:00:00+00:00"
+    assert r["last_recall"]["hits"] == {"session": 3}
+
+
+def test_json_flag_emits_valid_json(tmp_path, monkeypatch, capsys):
+    doc = _reload_doctor(tmp_path, monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["doctor.py", "--json"])
+    doc.main()
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert "issues" in parsed
+
+
+def test_exit_code_1_on_server_error(tmp_path, monkeypatch):
+    doc = _reload_doctor(tmp_path, monkeypatch)
+    monkeypatch.setattr(doc, "_check_server", lambda url: {"status": "error", "error": "refused"})
+    monkeypatch.setattr(sys, "argv", ["doctor.py"])
+    # Inject a non-empty base_url so the issue is recorded
+    original_build = doc.build_report
+
+    def patched_build():
+        r = original_build()
+        r["issues"].append("server unreachable at http://fake:8011")
+        return r
+
+    monkeypatch.setattr(doc, "build_report", patched_build)
+    code = doc.main()
+    assert code == 1
+
+
+def test_exit_code_0_when_healthy(tmp_path, monkeypatch, capsys):
+    doc = _reload_doctor(tmp_path, monkeypatch)
+    monkeypatch.setattr(doc, "_check_server", lambda url: {"status": "local_sdk"})
+    monkeypatch.setattr(sys, "argv", ["doctor.py"])
+    code = doc.main()
+    assert code == 0


### PR DESCRIPTION
Closes #3681

## Summary

- Adds `integrations/claude-code/scripts/doctor.py` — a self-contained health-check command that aggregates scattered plugin state into one readable report
- Reads `server-ready.json`, `recall-breaker.json`, `last_recall.json`, and `counter.json` without spawning any background processes
- Supports `--json` flag for machine-readable output (useful in CI or scripted setup checks)
- Exits **0** if all checks pass, **1** if issues are found (unreachable server or open recall breaker)
- Uses existing `_plugin_common.resolve_runtime_mode()` to detect mode and backend URL; falls back gracefully when the plugin venv is not set up yet

## Test plan

- [ ] Run `python integrations/claude-code/scripts/doctor.py` — should print human-readable status
- [ ] Run `python integrations/claude-code/scripts/doctor.py --json` — should emit valid JSON
- [ ] Run `pytest integrations/claude-code/tests/test_doctor.py` — 7 unit tests, all passing
- [ ] With `recall-breaker.json` present and `cooldown_until` in the future, confirm "OPEN" appears and exit code is 1
- [ ] With server unreachable (HTTP mode, server down), confirm exit code is 1