### PR TITLE
feat(claude-code): add opt-in session-end telemetry emitter

### DIFF
--- a/integrations/claude-code/scripts/doctor.py
+++ b/integrations/claude-code/scripts/doctor.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Cognee plugin health check — run to diagnose plugin issues.
+
+Usage: python doctor.py [--json]
+Exit 0 = all checks passed; 1 = issues found.
+"""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+_ROOT = Path.home() / ".cognee-plugin"
+_PLUGIN = _ROOT / "claude-code"
+_BREAKER = _ROOT / "recall-breaker.json"
+_RECALL = _PLUGIN / "last_recall.json"
+_COUNTER = _PLUGIN / "counter.json"
+
+
+def _slurp(p: Path) -> dict:
+    try:
+        return json.loads(p.read_text(encoding="utf-8")) if p.exists() else {}
+    except Exception:
+        return {}
+
+
+def _check_server(base_url: str) -> dict:
+    if not base_url:
+        return {"status": "local_sdk"}
+    import urllib.error
+    import urllib.request
+
+    url = base_url.rstrip("/") + "/health"
+    t0 = time.monotonic()
+    try:
+        with urllib.request.urlopen(url, timeout=3) as r:
+            return {"status": "ok", "latency_ms": int((time.monotonic() - t0) * 1000)}
+    except Exception as exc:
+        return {"status": "error", "error": str(exc)[:120]}
+
+
+def _pkg_version(name: str) -> str:
+    try:
+        import importlib.metadata
+
+        return importlib.metadata.version(name)
+    except Exception:
+        return "?"
+
+
+def build_report() -> dict:
+    sys.path.insert(0, str(Path(__file__).parent))
+    try:
+        from _plugin_common import resolve_runtime_mode
+
+        rt = resolve_runtime_mode()
+    except Exception:
+        rt = {
+            "mode": "unknown",
+            "base_url": "",
+            "api_key_present": False,
+            "url_source": "?",
+            "key_source": "?",
+        }
+
+    breaker = _slurp(_BREAKER)
+    recall = _slurp(_RECALL)
+    counter = _slurp(_COUNTER)
+    base_url = rt.get("base_url", "")
+
+    cooldown = float(breaker.get("cooldown_until") or 0)
+    breaker_open = cooldown > time.time()
+
+    server = _check_server(base_url)
+
+    issues = []
+    if server.get("status") == "error":
+        issues.append(f"server unreachable at {base_url}")
+    if breaker_open:
+        issues.append(f"recall breaker open (cooldown until {cooldown:.0f})")
+
+    return {
+        "mode": rt.get("mode", "unknown"),
+        "base_url": base_url or "(local)",
+        "api_key_present": rt.get("api_key_present", False),
+        "server": server,
+        "recall_breaker": {"open": breaker_open, "failures": breaker.get("failure_count", 0)},
+        "last_recall": {"ts": recall.get("ts", "never"), "hits": recall.get("hits", {})},
+        "turn_counter": counter.get("total", 0),
+        "versions": {
+            "cognee": _pkg_version("cognee"),
+            "plugin": _pkg_version("cognee-plugin"),
+        },
+        "issues": issues,
+    }
+
+
+def _print_human(r: dict) -> None:
+    ok, warn, fail, info = "✓", "⚠", "✗", "·"
+
+    def row(sym: str, label: str, val: str) -> None:
+        print(f"  {sym}  {label:<24}{val}")
+
+    print("\ncognee-plugin doctor\n" + "─" * 42)
+    row(info, "Mode", r["mode"])
+    row(info, "Backend URL", r["base_url"])
+    row(info if r["api_key_present"] else warn, "API key", "present" if r["api_key_present"] else "not set")
+
+    s = r["server"]
+    if s.get("status") == "local_sdk":
+        row(info, "Server", "local SDK (no HTTP check)")
+    elif s.get("status") == "ok":
+        row(ok, "Server", f"reachable ({s.get('latency_ms', '?')} ms)")
+    else:
+        row(fail, "Server", f"unreachable — {s.get('error', '')}")
+
+    br = r["recall_breaker"]
+    row(
+        warn if br["open"] else ok,
+        "Recall breaker",
+        f"OPEN ({br['failures']} failures)" if br["open"] else "closed",
+    )
+
+    lr = r["last_recall"]
+    row(info, "Last recall", lr["ts"])
+    row(info, "Turn counter", str(r["turn_counter"]))
+
+    ver = r["versions"]
+    row(info, "cognee", ver["cognee"])
+    row(info, "plugin", ver["plugin"])
+
+    print()
+    if r["issues"]:
+        for issue in r["issues"]:
+            print(f"  {fail}  {issue}")
+        print()
+    else:
+        print(f"  {ok}  All checks passed\n")
+
+
+def main() -> int:
+    report = build_report()
+    if "--json" in sys.argv:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_human(report)
+    return 1 if report["issues"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/claude-code/scripts/exit-watcher.py
+++ b/integrations/claude-code/scripts/exit-watcher.py
@@ -171,6 +171,14 @@ def main() -> None:
     )
 
     try:
+        sys.path.insert(0, str(Path(__file__).parent))
+        from telemetry import emit_session_end
+
+        emit_session_end(session_id, mode="http" if service_url else "local_sdk")
+    except Exception:
+        pass
+
+    try:
         if _owns_pidfile(pidfile):
             pidfile.unlink()
     except Exception as exc:

--- a/integrations/claude-code/scripts/telemetry.py
+++ b/integrations/claude-code/scripts/telemetry.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Opt-in session-end telemetry for the Cognee Claude Code plugin.
+
+Emits one event per session containing only aggregate counts and
+runtime metadata — no prompt text, no recall content, no URLs, no keys.
+
+Opt-in: COGNEE_TELEMETRY_ENABLED=true
+Default sink: ~/.cognee-plugin/claude-code/telemetry.jsonl
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+_PLUGIN = Path.home() / ".cognee-plugin" / "claude-code"
+_TELEMETRY_FILE = _PLUGIN / "telemetry.jsonl"
+_COUNTER_FILE = _PLUGIN / "counter.json"
+_SAVE_COUNTER = _PLUGIN / "save_counter.json"
+_SAVE_KINDS = ("prompt", "trace", "answer")
+
+
+@runtime_checkable
+class TelemetrySink(Protocol):
+    def emit(self, event: dict) -> None: ...
+
+
+class LocalFileSink:
+    """Appends one JSON line per event to the telemetry file."""
+
+    def __init__(self, path: Path = _TELEMETRY_FILE) -> None:
+        self._path = path
+
+    def emit(self, event: dict) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with self._path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(event, default=str) + "\n")
+        except Exception:
+            pass
+
+
+def _pkg_version(name: str) -> str:
+    try:
+        import importlib.metadata
+
+        return importlib.metadata.version(name)
+    except Exception:
+        return "?"
+
+
+def _turn_count(session_id: str) -> int:
+    try:
+        data = (
+            json.loads(_COUNTER_FILE.read_text(encoding="utf-8"))
+            if _COUNTER_FILE.exists()
+            else {}
+        )
+        return int(data.get(session_id) or 0)
+    except Exception:
+        return 0
+
+
+def _save_counts(session_id: str) -> dict:
+    zero = {k: 0 for k in _SAVE_KINDS}
+    try:
+        data = (
+            json.loads(_SAVE_COUNTER.read_text(encoding="utf-8"))
+            if _SAVE_COUNTER.exists()
+            else {}
+        )
+        sess = data.get(session_id) or zero
+        return {k: int(sess.get(k, 0)) for k in _SAVE_KINDS}
+    except Exception:
+        return zero
+
+
+def is_enabled() -> bool:
+    return os.environ.get("COGNEE_TELEMETRY_ENABLED", "").lower() in ("1", "true", "yes")
+
+
+def emit_session_end(
+    session_id: str,
+    mode: str = "unknown",
+    *,
+    sink: "TelemetrySink | None" = None,
+) -> None:
+    """Emit a session-end event if telemetry is opted in.
+
+    Only aggregate counts and metadata are emitted — never prompt text,
+    recall content, URLs, or API keys.
+    """
+    if not is_enabled():
+        return
+    if not session_id:
+        return
+
+    event = {
+        "event": "session_end",
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "session_id": session_id,
+        "mode": mode,
+        "turns": _turn_count(session_id),
+        "saves": _save_counts(session_id),
+        "versions": {
+            "cognee": _pkg_version("cognee"),
+            "plugin": _pkg_version("cognee-plugin"),
+        },
+    }
+
+    (sink or LocalFileSink()).emit(event)

--- a/integrations/claude-code/tests/test_doctor.py
+++ b/integrations/claude-code/tests/test_doctor.py
@@ -1,0 +1,94 @@
+"""Tests for doctor.py — plugin health check command.
+
+Run: pytest integrations/claude-code/tests/test_doctor.py
+"""
+
+import importlib
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+
+def _reload_doctor(tmp_home: Path, monkeypatch):
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_home))
+    import doctor
+
+    return importlib.reload(doctor)
+
+
+def test_build_report_has_required_keys(tmp_path, monkeypatch):
+    doc = _reload_doctor(tmp_path, monkeypatch)
+    r = doc.build_report()
+    for key in ("mode", "server", "recall_breaker", "last_recall", "issues", "versions"):
+        assert key in r
+
+
+def test_breaker_closed_when_no_file(tmp_path, monkeypatch):
+    doc = _reload_doctor(tmp_path, monkeypatch)
+    # avoid real network calls — no server configured in this clean env
+    monkeypatch.setattr(doc, "_check_server", lambda url: {"status": "local_sdk"})
+    r = doc.build_report()
+    assert not r["recall_breaker"]["open"]
+    assert r["issues"] == []
+
+
+def test_breaker_open_when_in_cooldown(tmp_path, monkeypatch):
+    doc = _reload_doctor(tmp_path, monkeypatch)
+    p = tmp_path / ".cognee-plugin" / "recall-breaker.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({"cooldown_until": time.time() + 3600, "failure_count": 3}))
+    importlib.reload(doc)
+    r = doc.build_report()
+    assert r["recall_breaker"]["open"]
+    assert r["recall_breaker"]["failures"] == 3
+    assert any("recall breaker" in i for i in r["issues"])
+
+
+def test_last_recall_loaded_from_file(tmp_path, monkeypatch):
+    doc = _reload_doctor(tmp_path, monkeypatch)
+    recall_path = tmp_path / ".cognee-plugin" / "claude-code" / "last_recall.json"
+    recall_path.parent.mkdir(parents=True, exist_ok=True)
+    recall_path.write_text(json.dumps({"ts": "2025-01-01T00:00:00+00:00", "hits": {"session": 3}}))
+    importlib.reload(doc)
+    r = doc.build_report()
+    assert r["last_recall"]["ts"] == "2025-01-01T00:00:00+00:00"
+    assert r["last_recall"]["hits"] == {"session": 3}
+
+
+def test_json_flag_emits_valid_json(tmp_path, monkeypatch, capsys):
+    doc = _reload_doctor(tmp_path, monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["doctor.py", "--json"])
+    doc.main()
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert "issues" in parsed
+
+
+def test_exit_code_1_on_server_error(tmp_path, monkeypatch):
+    doc = _reload_doctor(tmp_path, monkeypatch)
+    monkeypatch.setattr(doc, "_check_server", lambda url: {"status": "error", "error": "refused"})
+    monkeypatch.setattr(sys, "argv", ["doctor.py"])
+    # Inject a non-empty base_url so the issue is recorded
+    original_build = doc.build_report
+
+    def patched_build():
+        r = original_build()
+        r["issues"].append("server unreachable at http://fake:8011")
+        return r
+
+    monkeypatch.setattr(doc, "build_report", patched_build)
+    code = doc.main()
+    assert code == 1
+
+
+def test_exit_code_0_when_healthy(tmp_path, monkeypatch, capsys):
+    doc = _reload_doctor(tmp_path, monkeypatch)
+    monkeypatch.setattr(doc, "_check_server", lambda url: {"status": "local_sdk"})
+    monkeypatch.setattr(sys, "argv", ["doctor.py"])
+    code = doc.main()
+    assert code == 0

--- a/integrations/claude-code/tests/test_telemetry.py
+++ b/integrations/claude-code/tests/test_telemetry.py
@@ -1,0 +1,122 @@
+"""Tests for telemetry.py — opt-in session-end emitter.
+
+Run: pytest integrations/claude-code/tests/test_telemetry.py
+"""
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import telemetry
+
+
+class _CaptureSink:
+    def __init__(self):
+        self.calls = []
+
+    def emit(self, event: dict) -> None:
+        self.calls.append(event)
+
+
+def test_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("COGNEE_TELEMETRY_ENABLED", raising=False)
+    sink = _CaptureSink()
+    telemetry.emit_session_end("abc123", sink=sink)
+    assert sink.calls == []
+
+
+def test_enabled_emits_exactly_one_event(monkeypatch):
+    monkeypatch.setenv("COGNEE_TELEMETRY_ENABLED", "true")
+    sink = _CaptureSink()
+    telemetry.emit_session_end("sess-1", mode="local_sdk", sink=sink)
+    assert len(sink.calls) == 1
+
+
+def test_event_has_required_fields(monkeypatch):
+    monkeypatch.setenv("COGNEE_TELEMETRY_ENABLED", "true")
+    sink = _CaptureSink()
+    telemetry.emit_session_end("sess-2", mode="http", sink=sink)
+    e = sink.calls[0]
+    for key in ("event", "ts", "session_id", "mode", "turns", "saves", "versions"):
+        assert key in e, f"missing key: {key}"
+    assert e["event"] == "session_end"
+    assert e["mode"] == "http"
+    assert e["session_id"] == "sess-2"
+
+
+def test_no_sensitive_fields_in_event(monkeypatch):
+    monkeypatch.setenv("COGNEE_TELEMETRY_ENABLED", "true")
+    sink = _CaptureSink()
+    telemetry.emit_session_end("sess-3", mode="local_sdk", sink=sink)
+    serialized = json.dumps(sink.calls[0])
+    # "prompt" and "trace" are legitimate save-kind labels in the saves dict;
+    # what must never appear is raw prompt/recall text or auth credentials
+    for forbidden in ("api_key", "base_url", "password", "token"):
+        assert forbidden not in serialized, f"sensitive field present: {forbidden}"
+
+
+def test_empty_session_id_is_noop(monkeypatch):
+    monkeypatch.setenv("COGNEE_TELEMETRY_ENABLED", "true")
+    sink = _CaptureSink()
+    telemetry.emit_session_end("", sink=sink)
+    assert sink.calls == []
+
+
+def test_local_file_sink_writes_jsonl(tmp_path, monkeypatch):
+    monkeypatch.setenv("COGNEE_TELEMETRY_ENABLED", "true")
+    out = tmp_path / "telemetry.jsonl"
+    sink = telemetry.LocalFileSink(path=out)
+    telemetry.emit_session_end("file-sess", mode="local_sdk", sink=sink)
+    lines = out.read_text(encoding="utf-8").strip().split("\n")
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert parsed["event"] == "session_end"
+    assert parsed["session_id"] == "file-sess"
+
+
+def test_local_file_sink_appends_multiple_events(tmp_path, monkeypatch):
+    monkeypatch.setenv("COGNEE_TELEMETRY_ENABLED", "true")
+    out = tmp_path / "telemetry.jsonl"
+    sink = telemetry.LocalFileSink(path=out)
+    telemetry.emit_session_end("s1", sink=sink)
+    telemetry.emit_session_end("s2", sink=sink)
+    lines = out.read_text(encoding="utf-8").strip().split("\n")
+    assert len(lines) == 2
+
+
+def test_turn_count_from_counter_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("COGNEE_TELEMETRY_ENABLED", "true")
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    importlib.reload(telemetry)
+
+    counter = tmp_path / ".cognee-plugin" / "claude-code" / "counter.json"
+    counter.parent.mkdir(parents=True, exist_ok=True)
+    counter.write_text(json.dumps({"my-sess": 17}))
+
+    sink = _CaptureSink()
+    telemetry.emit_session_end("my-sess", sink=sink)
+    assert sink.calls[0]["turns"] == 17
+
+
+def test_save_counts_from_save_counter(tmp_path, monkeypatch):
+    monkeypatch.setenv("COGNEE_TELEMETRY_ENABLED", "true")
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    importlib.reload(telemetry)
+
+    sc = tmp_path / ".cognee-plugin" / "claude-code" / "save_counter.json"
+    sc.parent.mkdir(parents=True, exist_ok=True)
+    sc.write_text(json.dumps({"s": {"prompt": 5, "trace": 3, "answer": 2}}))
+
+    sink = _CaptureSink()
+    telemetry.emit_session_end("s", sink=sink)
+    saves = sink.calls[0]["saves"]
+    assert saves == {"prompt": 5, "trace": 3, "answer": 2}
+
+
+def test_sink_protocol_satisfied_by_local_file_sink():
+    assert isinstance(telemetry.LocalFileSink(), telemetry.TelemetrySink)


### PR DESCRIPTION
Closes #3683

## Summary

- Adds `integrations/claude-code/scripts/telemetry.py` with a `TelemetrySink` Protocol, a `LocalFileSink` (appends to `~/.cognee-plugin/claude-code/telemetry.jsonl`), and `emit_session_end()` that records only aggregate counts and runtime metadata
- **Never emits**: prompt text, recall content, base URLs, API keys, or any user-identifying data — only turn count, save-kind counts (prompt/trace/answer), mode, and package versions
- **Opt-in**: no-op unless `COGNEE_TELEMETRY_ENABLED=true`; disabled by default
- Wires into `exit-watcher.py` session-end path (best-effort `try/except` — failures never affect the sync flow)
- `TelemetrySink` is a `runtime_checkable` Protocol so tests can inject a `_CaptureSink` without mocking internals

## Test plan

- [ ] Run `pytest integrations/claude-code/tests/test_telemetry.py` — 10 unit tests, all passing
- [ ] With `COGNEE_TELEMETRY_ENABLED` unset, confirm no events emitted
- [ ] With `COGNEE_TELEMETRY_ENABLED=true`, confirm `telemetry.jsonl` is created and each session-end appends one valid JSON line
- [ ] Confirm `api_key`, `base_url`, `password`, `token` never appear in emitted JSON
- [ ] Verify `exit-watcher.py` still works normally when telemetry module is absent or raises