### PR TITLE
fix(release): fix inventory.yml version drift + CI version-consistency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,18 @@ on:
     branches: [main]
     paths:
       - 'integrations/**'
+      - 'scripts/**'
+      - '.claude-plugin/**'
+      - '.agents/**'
       - '.github/workflows/ci.yml'
       - '.github/core-team.txt'
   push:
     branches: [main]
     paths:
       - 'integrations/**'
+      - 'scripts/**'
+      - '.claude-plugin/**'
+      - '.agents/**'
       - '.github/workflows/ci.yml'
       - '.github/core-team.txt'
 
@@ -21,7 +27,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Verify plugin versions match marketplace manifests
-        run: python3 scripts/check_version_consistency.py
+        run: python3 scripts/check_version_consistency.py --check-inventory
 
   detect-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,14 @@ on:
       - '.github/core-team.txt'
 
 jobs:
+  check-version-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Verify plugin versions match marketplace manifests
+        run: python3 scripts/check_version_consistency.py
+
   detect-changes:
     runs-on: ubuntu-latest
     outputs:

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -34,7 +34,7 @@ integrations:
     registry: none
     package_name: null
     cognee_dependency: sdk
-    current_version: "0.1.0"
+    current_version: "0.2.0"
     migration_status: done
     notes: "Claude Code plugin – session storage via hooks, recall via context lookup, session-to-graph sync"
 

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+import json
+import os
+import glob
+import sys
+
+def main():
+    failed = False
+    
+    # Find all marketplace.json files in the repository
+    search_patterns = [
+        "**/*/marketplace.json",
+        "marketplace.json",
+        "*/marketplace.json",
+        ".*/**/marketplace.json",
+        "**/.*/**/marketplace.json",
+        ".*/marketplace.json"
+    ]
+    
+    m_paths = set()
+    for pattern in search_patterns:
+        m_paths.update(glob.glob(pattern, recursive=True))
+        
+    for m_path in sorted(list(m_paths)):
+        try:
+            with open(m_path, 'r') as f:
+                data = json.load(f)
+        except Exception as e:
+            continue
+
+        plugins = data.get("plugins", [])
+        for plugin in plugins:
+            source = plugin.get("source")
+            m_version = plugin.get("version")
+            
+            # We only care about plugins that declare a version and a source
+            if not isinstance(source, str) or not isinstance(m_version, str):
+                continue
+            
+            # The source is usually relative to the repo root, e.g. "./integrations/claude-code"
+            # However, glob can find it relative to the current working directory.
+            source_dir = os.path.normpath(source)
+            
+            # Find any plugin.json inside the source directory (it could be nested inside .claude-plugin etc)
+            p_paths = set()
+            p_patterns = [
+                os.path.join(source_dir, "**", "plugin.json"),
+                os.path.join(source_dir, ".*", "**", "plugin.json"),
+                os.path.join(source_dir, ".*", "plugin.json")
+            ]
+            for pattern in p_patterns:
+                p_paths.update(glob.glob(pattern, recursive=True))
+                
+            if not p_paths:
+                print(f"Warning: Could not find plugin.json for {plugin.get('name')} in {source_dir}")
+                continue
+                
+            for p_path in p_paths:
+                try:
+                    with open(p_path, 'r') as f:
+                        p_data = json.load(f)
+                        p_version = p_data.get("version")
+                        if not p_version:
+                            continue
+                            
+                        if p_version != m_version:
+                            print(f"::error file={p_path}::Version mismatch! {m_path} says {m_version} but {p_path} says {p_version}")
+                            failed = True
+                        else:
+                            print(f"Match: {p_path} ({p_version}) == {m_path} ({m_version})")
+                except Exception as e:
+                    pass
+
+    if failed:
+        print("Version consistency check failed.")
+        sys.exit(1)
+    else:
+        print("All plugin versions match their marketplace.json entries.")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -1,81 +1,237 @@
 #!/usr/bin/env python3
+"""Check that plugin.json versions match their marketplace.json declarations.
+
+For each marketplace.json that declares versioned plugins with a string `source`
+path, this script locates the corresponding plugin.json and asserts that their
+version fields agree.
+
+Marketplace entries that lack a `version` field or use an object `source` (e.g.
+Codex-style manifests) are silently skipped — they follow a different schema and
+are not subject to this check.
+
+Optionally (--check-inventory), cross-references integrations/inventory.yml
+against the resolved manifest versions.
+
+Usage:
+    python scripts/check_version_consistency.py [--check-inventory]
+
+Exit codes:
+    0  All checked versions are consistent.
+    1  At least one mismatch or error was found.
+"""
+
 import json
 import os
+import re
 import glob
 import sys
+from pathlib import Path
 
-def main():
-    failed = False
-    
-    # Find all marketplace.json files in the repository
-    search_patterns = [
-        "**/*/marketplace.json",
-        "marketplace.json",
-        "*/marketplace.json",
-        ".*/**/marketplace.json",
-        "**/.*/**/marketplace.json",
-        ".*/marketplace.json"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def find_marketplace_files():
+    """Find all marketplace.json files in the repository."""
+    patterns = [
+        str(REPO_ROOT / "**" / "marketplace.json"),
+        str(REPO_ROOT / ".*" / "**" / "marketplace.json"),
     ]
-    
-    m_paths = set()
-    for pattern in search_patterns:
-        m_paths.update(glob.glob(pattern, recursive=True))
-        
-    for m_path in sorted(list(m_paths)):
+    paths = set()
+    for pattern in patterns:
+        paths.update(glob.glob(pattern, recursive=True))
+    return sorted(paths)
+
+
+def find_plugin_json(source_dir):
+    """Find plugin.json files inside a source directory (including hidden dirs)."""
+    patterns = [
+        os.path.join(source_dir, "**", "plugin.json"),
+        os.path.join(source_dir, ".*", "plugin.json"),
+        os.path.join(source_dir, ".*", "**", "plugin.json"),
+    ]
+    paths = set()
+    for pattern in patterns:
+        paths.update(glob.glob(pattern, recursive=True))
+    return sorted(paths)
+
+
+def check_marketplace_vs_plugin():
+    """Check plugin.json.version == marketplace.json plugins[].version."""
+    failed = False
+    matched = 0
+
+    marketplace_files = find_marketplace_files()
+    if not marketplace_files:
+        print("::error::No marketplace.json files found in repository.")
+        return True  # treat as failure
+
+    for m_path in marketplace_files:
         try:
-            with open(m_path, 'r') as f:
+            with open(m_path, "r") as f:
                 data = json.load(f)
-        except Exception as e:
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"::error file={m_path}::Failed to read/parse marketplace.json: {e}")
+            failed = True
             continue
 
         plugins = data.get("plugins", [])
         for plugin in plugins:
             source = plugin.get("source")
             m_version = plugin.get("version")
-            
-            # We only care about plugins that declare a version and a source
+
+            # Skip plugins that don't declare a version or use an object source
+            # (e.g. Codex-style manifests with {"source": "local", "path": "..."})
             if not isinstance(source, str) or not isinstance(m_version, str):
                 continue
-            
-            # The source is usually relative to the repo root, e.g. "./integrations/claude-code"
-            # However, glob can find it relative to the current working directory.
-            source_dir = os.path.normpath(source)
-            
-            # Find any plugin.json inside the source directory (it could be nested inside .claude-plugin etc)
-            p_paths = set()
-            p_patterns = [
-                os.path.join(source_dir, "**", "plugin.json"),
-                os.path.join(source_dir, ".*", "**", "plugin.json"),
-                os.path.join(source_dir, ".*", "plugin.json")
-            ]
-            for pattern in p_patterns:
-                p_paths.update(glob.glob(pattern, recursive=True))
-                
+
+            # The source path in marketplace.json is relative to the repo root
+            source_dir = os.path.normpath(str(REPO_ROOT / source))
+
+            p_paths = find_plugin_json(source_dir)
             if not p_paths:
-                print(f"Warning: Could not find plugin.json for {plugin.get('name')} in {source_dir}")
+                print(
+                    f"::error file={m_path}::No plugin.json found for plugin "
+                    f"'{plugin.get('name', '?')}' in {source_dir}"
+                )
+                failed = True
                 continue
-                
+
             for p_path in p_paths:
                 try:
-                    with open(p_path, 'r') as f:
+                    with open(p_path, "r") as f:
                         p_data = json.load(f)
-                        p_version = p_data.get("version")
-                        if not p_version:
-                            continue
-                            
-                        if p_version != m_version:
-                            print(f"::error file={p_path}::Version mismatch! {m_path} says {m_version} but {p_path} says {p_version}")
-                            failed = True
-                        else:
-                            print(f"Match: {p_path} ({p_version}) == {m_path} ({m_version})")
-                except Exception as e:
-                    pass
+                except (json.JSONDecodeError, OSError) as e:
+                    print(f"::error file={p_path}::Failed to read/parse plugin.json: {e}")
+                    failed = True
+                    continue
+
+                p_version = p_data.get("version")
+                if not p_version:
+                    print(
+                        f"::error file={p_path}::plugin.json is missing a 'version' field"
+                    )
+                    failed = True
+                    continue
+
+                if p_version != m_version:
+                    print(
+                        f"::error file={p_path}::Version mismatch! "
+                        f"{os.path.basename(m_path)} says {m_version} "
+                        f"but {os.path.basename(p_path)} says {p_version}"
+                    )
+                    failed = True
+                else:
+                    rel_m = os.path.relpath(m_path, REPO_ROOT)
+                    rel_p = os.path.relpath(p_path, REPO_ROOT)
+                    print(f"  ✓ {rel_p} ({p_version}) == {rel_m} ({m_version})")
+                    matched += 1
+
+    print(f"\nChecked {matched} plugin version(s) against marketplace manifests.")
+    return failed
+
+
+def parse_inventory_versions(inventory_path):
+    """Parse inventory.yml using simple line-by-line parsing (no PyYAML needed).
+
+    Returns a dict of {slug: current_version} for all entries that have both.
+    """
+    versions = {}
+    current_slug = None
+
+    with open(inventory_path, "r") as f:
+        for line in f:
+            slug_match = re.match(r"\s+-\s+slug:\s+(\S+)", line)
+            if slug_match:
+                current_slug = slug_match.group(1)
+                continue
+
+            version_match = re.match(r'\s+current_version:\s+"?([^"\s]+)"?', line)
+            if version_match and current_slug:
+                versions[current_slug] = version_match.group(1)
+                current_slug = None
+
+    return versions
+
+
+def check_inventory(plugin_versions):
+    """Cross-reference inventory.yml against resolved plugin.json versions.
+
+    Args:
+        plugin_versions: dict of {source_dir_basename: version} from the
+                         marketplace/plugin check.
+    """
+    inventory_path = REPO_ROOT / "integrations" / "inventory.yml"
+    if not inventory_path.exists():
+        print("::warning::integrations/inventory.yml not found, skipping inventory check.")
+        return False
+
+    try:
+        inv_versions = parse_inventory_versions(inventory_path)
+    except OSError as e:
+        print(f"::error file=integrations/inventory.yml::Failed to read inventory.yml: {e}")
+        return True
+
+    failed = False
+    checked = 0
+    for slug, inv_ver in inv_versions.items():
+        if slug in plugin_versions:
+            p_ver = plugin_versions[slug]
+            if inv_ver != p_ver:
+                print(
+                    f"::error file=integrations/inventory.yml::"
+                    f"inventory.yml says {slug} is {inv_ver} "
+                    f"but plugin manifest says {p_ver}"
+                )
+                failed = True
+            else:
+                print(f"  ✓ inventory.yml {slug} ({inv_ver}) matches manifest")
+                checked += 1
+
+    print(f"\nCross-checked {checked} inventory entry/entries against manifests.")
+    return failed
+
+
+def collect_plugin_versions():
+    """Build a map of {integration_slug: version} from marketplace/plugin checks."""
+    versions = {}
+    marketplace_files = find_marketplace_files()
+    for m_path in marketplace_files:
+        try:
+            with open(m_path, "r") as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        for plugin in data.get("plugins", []):
+            source = plugin.get("source")
+            m_version = plugin.get("version")
+            if not isinstance(source, str) or not isinstance(m_version, str):
+                continue
+            # The source path is relative to the repo root
+            source_dir = os.path.normpath(str(REPO_ROOT / source))
+            slug = os.path.basename(source_dir)
+            versions[slug] = m_version
+
+    return versions
+
+
+def main():
+    print("=== Plugin version consistency check ===\n")
+    failed = check_marketplace_vs_plugin()
+
+    if "--check-inventory" in sys.argv:
+        print("\n=== Inventory cross-reference check ===\n")
+        plugin_versions = collect_plugin_versions()
+        inv_failed = check_inventory(plugin_versions)
+        failed = failed or inv_failed
 
     if failed:
-        print("Version consistency check failed.")
+        print("\n✗ Version consistency check FAILED.")
         sys.exit(1)
     else:
-        print("All plugin versions match their marketplace.json entries.")
+        print("\n✓ All versions are consistent.")
+        sys.exit(0)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## What this PR does

Closes topoteretes/cognee#3677.
Closes #136.

cc @Vasilije1990 @dexters1 @siillee @NMZivkovic — I was assigned this issue by @siillee, and this PR delivers the full implementation.

---

### The Problem

`integrations/inventory.yml` listed `claude-code` at version `0.1.0`, while both `.claude-plugin/marketplace.json` and `integrations/claude-code/.claude-plugin/plugin.json` had it at `0.2.0`. There was no automated guard to catch this kind of drift.

### What I Did

**1. Fixed the drift**
Updated `inventory.yml` to set `claude-code` `current_version` to `0.2.0`.

**2. Added `scripts/check_version_consistency.py`**
A standalone Python script (stdlib only, no external deps like PyYAML) that:
- Finds all `marketplace.json` files across the repo (including hidden dirs like `.claude-plugin/`)
- For each plugin entry that declares a `version` and a string `source` path, locates the corresponding `plugin.json`
- Asserts `plugin.json.version == marketplace.json plugins[].version`
- With `--check-inventory`, also cross-references `inventory.yml` `current_version` against the resolved manifest versions
- Uses GitHub Actions `::error` annotations for clear inline feedback on failures
- Codex-style marketplace entries (object `source`, no `version`) are correctly skipped since they follow a different schema

**3. Added CI job**
Added a `check-version-consistency` job to `.github/workflows/ci.yml` that runs `python3 scripts/check_version_consistency.py --check-inventory` on every PR and push.

**4. Expanded CI path triggers**
The workflow previously only triggered on changes to `integrations/**`. Added `scripts/**`, `.claude-plugin/**`, and `.agents/**` so changes to any manifest or to the script itself will also trigger the check.

### Issues I Found Along the Way

- **Source path resolution bug:** The `source` field in `marketplace.json` (e.g. `./integrations/claude-code`) is relative to the repo root, not relative to the marketplace.json file. My first version of the script resolved it incorrectly and could not find `plugin.json`. Fixed by resolving against the repo root.
- **Copilot auto-review caught 5 issues** in my initial draft (silent error handling, missing CI triggers, no inventory.yml check). I rewrote the script from scratch to address all of them before re-submitting.

### Tested Locally

- Happy path: all versions match, exit 0
- plugin.json mismatch: deliberately changed version to 0.9.9, script catches it, emits error annotation, exit 1
- inventory.yml drift: reverted current_version back to 0.1.0, script catches it, emits error annotation, exit 1

### What I Expect

The CI runner should pick up the new job on this PR. Since all versions currently agree, the check should pass cleanly. If there are any ubuntu-latest environment quirks (glob patterns for hidden dirs, Python version differences), this PR run will surface them.