### PR TITLE
feat(openclaw): cold-start warmup + first-recall retry in the TS client (#3546)

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -261,6 +261,19 @@ This lets the agent distinguish between personal context, shared knowledge, and 
 
 Note: Files are stored in Cognee using sanitized relative paths as filenames (e.g., `MEMORY.md.txt` for `MEMORY.md`, `memory.tools.md.txt` for `memory/tools.md`) for easy identification and to avoid path separator issues.
 
+### Cold-start warmup & first-recall retry (#3546)
+
+Adapts the Python plugins' cold-start handling (readiness-gate-then-skip) to the TS client — an env-gated warmup ping plus a single retry on the first recall — so a scale-to-zero cloud tenant survives the first request. This is an adaptation of that intent, not a literal port. All knobs are process environment variables:
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `COGNEE_WARMUP` | off (unset) | Master switch for the startup warmup ping. Accepts `1`/`true`/`yes`/`on`. Fires only when `autoIndex` is off (with `autoIndex` on, its own startup `/health` check already warms the tenant); skipped for `localhost`/`127.0.0.1`. |
+| `COGNEE_WARMUP_TIMEOUT_MS` | `5000` | `AbortController` timeout (ms) for the warmup `GET /health`. |
+| `COGNEE_RECALL_RETRIES` | `1` | Max cold-start retries for the **first recall of a session only**, on a `504` or timeout (`AbortError`). Non-first recalls keep the default request path. |
+| `COGNEE_RECALL_BACKOFF_MS` | `500` | Base backoff (ms) before a retry (`delay = base × attempt + jitter`). |
+
+Only the first recall of a session is retried (on `504`/`AbortError`); non-first recalls are unchanged.
+
 ## CLI Commands
 
 ```bash

--- a/integrations/openclaw/__tests__/test_coldStart.ts
+++ b/integrations/openclaw/__tests__/test_coldStart.ts
@@ -1,0 +1,141 @@
+import { CogneeHttpClient } from "../src/client";
+import type { CogneeSearchType } from "../src/types";
+
+// Cold-start warmup + first-recall retry (#3546).
+//
+// These tests exercise the REAL client (recall / fetchAPI / fireWarmupPing), so
+// they mock the network by overwriting global.fetch rather than mocking the
+// class. jest isn't run in CI (tsc-only) — verified locally + screenshot.
+
+const ORIG_ENV = process.env;
+const REAL_FETCH = global.fetch;
+
+// Let a fire-and-forget async IIFE (fireWarmupPing) settle before asserting.
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+function jsonResp(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+function errResp(status: number, text: string): Response {
+  return { ok: false, status, text: async () => text } as unknown as Response;
+}
+
+function setFetch(fn: typeof fetch): void {
+  global.fetch = fn as typeof global.fetch;
+}
+
+function cloudClient(baseUrl = "https://cloud.cognee.ai"): CogneeHttpClient {
+  // Short timeoutMs: fetchAPI doesn't clear its abort timer on the success path,
+  // so a 200 mock leaves a pending timer; a small value lets it fire inside
+  // jest's exit window instead of tripping the open-handle warning.
+  return new CogneeHttpClient(baseUrl, "key", "", "", 200, 200, "cloud");
+}
+
+function recallParams(over: Partial<Parameters<CogneeHttpClient["recall"]>[0]> = {}) {
+  return {
+    queryText: "test",
+    searchPrompt: "",
+    searchType: "GRAPH_COMPLETION" as CogneeSearchType,
+    datasetIds: [] as string[],
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  // Snapshot env per-test so COGNEE_* mutations never leak across tests.
+  process.env = { ...ORIG_ENV };
+  // Retries must not actually sleep — keep tests fast and deterministic.
+  process.env.COGNEE_RECALL_BACKOFF_MS = "0";
+});
+
+afterEach(() => {
+  process.env = ORIG_ENV;
+  global.fetch = REAL_FETCH;
+  jest.clearAllMocks();
+});
+
+describe("recall first-recall cold-start retry (#3546)", () => {
+  it("retries a real 504 on the first recall, then succeeds on 200", async () => {
+    process.env.COGNEE_RECALL_RETRIES = "1";
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(errResp(504, "gateway timeout")) // fetchAPI throws `(504)`
+      .mockResolvedValueOnce(jsonResp([])); // retry succeeds
+    setFetch(fetchMock as unknown as typeof fetch);
+
+    const client = cloudClient();
+    const results = await client.recall(recallParams({ firstRecall: true }));
+
+    expect(results).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // 1 cold miss + 1 retry — the case #127 can't pass
+  });
+
+  it("does NOT retry a 400 on the first recall (non-retryable)", async () => {
+    process.env.COGNEE_RECALL_RETRIES = "1";
+    const fetchMock = jest.fn().mockResolvedValue(errResp(400, "bad request"));
+    setFetch(fetchMock as unknown as typeof fetch);
+
+    const client = cloudClient();
+    await expect(client.recall(recallParams({ firstRecall: true }))).rejects.toThrow();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // 4xx aborts immediately, no retry
+  });
+
+  it("does NOT engage the wrapper on a non-first recall (generic path unchanged)", async () => {
+    // firstRecall:false routes through the default fetchAPI, whose generic retry
+    // only fires on timeouts — a 504 is thrown immediately, never retried.
+    process.env.COGNEE_RECALL_RETRIES = "1";
+    const fetchMock = jest.fn().mockResolvedValue(errResp(504, "gateway timeout"));
+    setFetch(fetchMock as unknown as typeof fetch);
+
+    const client = cloudClient();
+    await expect(client.recall(recallParams({ firstRecall: false }))).rejects.toThrow();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no cold-start retry for non-first recalls
+  });
+});
+
+describe("fireWarmupPing (#3546)", () => {
+  it("does NOT fire when COGNEE_WARMUP is unset", async () => {
+    delete process.env.COGNEE_WARMUP;
+    const fetchMock = jest.fn().mockResolvedValue(jsonResp({}));
+    setFetch(fetchMock as unknown as typeof fetch);
+
+    const client = cloudClient();
+    client.fireWarmupPing();
+    await flush();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("swallows a warmup failure and never affects a later recall", async () => {
+    process.env.COGNEE_WARMUP = "true";
+    // /health rejects (cold/unreachable); everything else resolves 200.
+    const fetchMock = jest.fn(async (url: unknown) => {
+      if (String(url).includes("/health")) throw new Error("network down");
+      return jsonResp([]);
+    });
+    setFetch(fetchMock as unknown as typeof fetch);
+
+    const client = cloudClient();
+    expect(() => client.fireWarmupPing()).not.toThrow(); // returns void, never throws
+    await flush(); // let the fire-and-forget IIFE reject + get swallowed
+
+    // A subsequent recall still works despite the failed warmup.
+    const results = await client.recall(recallParams({ firstRecall: false }));
+    expect(results).toEqual([]);
+  });
+
+  it("skips warmup for a localhost base URL even when enabled", async () => {
+    process.env.COGNEE_WARMUP = "true";
+    const fetchMock = jest.fn().mockResolvedValue(jsonResp({}));
+    setFetch(fetchMock as unknown as typeof fetch);
+
+    const client = cloudClient("http://localhost:8000");
+    client.fireWarmupPing();
+    await flush();
+
+    expect(fetchMock).not.toHaveBeenCalled(); // cold start is a cloud problem
+  });
+});

--- a/integrations/openclaw/__tests__/test_coldStart.ts
+++ b/integrations/openclaw/__tests__/test_coldStart.ts
@@ -1,11 +1,12 @@
 import { CogneeHttpClient } from "../src/client";
 import type { CogneeSearchType } from "../src/types";
+import { withColdStartRetry, isColdStartRetryable } from "../src/plugin";
 
 // Cold-start warmup + first-recall retry (#3546).
 //
-// These tests exercise the REAL client (recall / fetchAPI / fireWarmupPing), so
-// they mock the network by overwriting global.fetch rather than mocking the
-// class. jest isn't run in CI (tsc-only) — verified locally + screenshot.
+// Warmup tests exercise the REAL client (recall / fetchAPI / fireWarmupPing), so
+// they mock the network by overwriting global.fetch. Retry tests exercise the
+// exported wrappers from plugin.ts directly.
 
 const ORIG_ENV = process.env;
 const REAL_FETCH = global.fetch;
@@ -55,44 +56,85 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-describe("recall first-recall cold-start retry (#3546)", () => {
-  it("retries a real 504 on the first recall, then succeeds on 200", async () => {
-    process.env.COGNEE_RECALL_RETRIES = "1";
-    const fetchMock = jest
-      .fn()
-      .mockResolvedValueOnce(errResp(504, "gateway timeout")) // fetchAPI throws `(504)`
-      .mockResolvedValueOnce(jsonResp([])); // retry succeeds
-    setFetch(fetchMock as unknown as typeof fetch);
-
-    const client = cloudClient();
-    const results = await client.recall(recallParams({ firstRecall: true }));
-
-    expect(results).toEqual([]);
-    expect(fetchMock).toHaveBeenCalledTimes(2); // 1 cold miss + 1 retry — the case #127 can't pass
+describe("isColdStartRetryable", () => {
+  it("returns true for an Error with name AbortError", () => {
+    const err = new Error("aborted");
+    err.name = "AbortError";
+    expect(isColdStartRetryable(err)).toBe(true);
   });
 
-  it("does NOT retry a 400 on the first recall (non-retryable)", async () => {
-    process.env.COGNEE_RECALL_RETRIES = "1";
-    const fetchMock = jest.fn().mockResolvedValue(errResp(400, "bad request"));
-    setFetch(fetchMock as unknown as typeof fetch);
-
-    const client = cloudClient();
-    await expect(client.recall(recallParams({ firstRecall: true }))).rejects.toThrow();
-
-    expect(fetchMock).toHaveBeenCalledTimes(1); // 4xx aborts immediately, no retry
+  it("returns true for a DOMException with name AbortError", () => {
+    const err = new DOMException("aborted", "AbortError");
+    expect(isColdStartRetryable(err)).toBe(true);
   });
 
-  it("does NOT engage the wrapper on a non-first recall (generic path unchanged)", async () => {
-    // firstRecall:false routes through the default fetchAPI, whose generic retry
-    // only fires on timeouts — a 504 is thrown immediately, never retried.
+  it("returns true for an Error matching Cognee request failed (504)", () => {
+    const err = new Error("Cognee request failed (504): Gateway Timeout");
+    expect(isColdStartRetryable(err)).toBe(true);
+  });
+
+  it("returns false for a 400-style Error message", () => {
+    const err = new Error("Cognee request failed (400): Bad Request");
+    expect(isColdStartRetryable(err)).toBe(false);
+  });
+
+  it("returns false for a generic Error unrelated to either pattern", () => {
+    const err = new Error("network down");
+    expect(isColdStartRetryable(err)).toBe(false);
+  });
+});
+
+describe("withColdStartRetry", () => {
+  it("retries a real 504 on first recall, then succeeds", async () => {
     process.env.COGNEE_RECALL_RETRIES = "1";
-    const fetchMock = jest.fn().mockResolvedValue(errResp(504, "gateway timeout"));
-    setFetch(fetchMock as unknown as typeof fetch);
+    const fn = jest.fn()
+      .mockRejectedValueOnce(new Error("Cognee request failed (504)"))
+      .mockResolvedValueOnce("success");
 
-    const client = cloudClient();
-    await expect(client.recall(recallParams({ firstRecall: false }))).rejects.toThrow();
+    const result = await withColdStartRetry(true, fn);
+    expect(result).toBe("success");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1); // no cold-start retry for non-first recalls
+  it("does NOT retry a 400 (non-retryable)", async () => {
+    process.env.COGNEE_RECALL_RETRIES = "1";
+    const fn = jest.fn().mockRejectedValueOnce(new Error("Cognee request failed (400)"));
+
+    await expect(withColdStartRetry(true, fn)).rejects.toThrow("Cognee request failed (400)");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT engage retry when isFirst is false", async () => {
+    process.env.COGNEE_RECALL_RETRIES = "1";
+    const fn = jest.fn().mockRejectedValueOnce(new Error("Cognee request failed (504)"));
+
+    await expect(withColdStartRetry(false, fn)).rejects.toThrow("Cognee request failed (504)");
+    expect(fn).toHaveBeenCalledTimes(1); // Short-circuits
+  });
+
+  it("respects COGNEE_RECALL_RETRIES=0 -> no retry even if isFirst and retryable", async () => {
+    process.env.COGNEE_RECALL_RETRIES = "0";
+    const fn = jest.fn().mockRejectedValueOnce(new Error("Cognee request failed (504)"));
+
+    await expect(withColdStartRetry(true, fn)).rejects.toThrow("Cognee request failed (504)");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("backoff never fires immediately (jitter check)", async () => {
+    process.env.COGNEE_RECALL_RETRIES = "1";
+    process.env.COGNEE_RECALL_BACKOFF_MS = "0";
+    const fn = jest.fn()
+      .mockRejectedValueOnce(new Error("Cognee request failed (504)"))
+      .mockResolvedValueOnce("success");
+
+    const start = Date.now();
+    const result = await withColdStartRetry(true, fn);
+    const end = Date.now();
+
+    expect(result).toBe("success");
+    expect(fn).toHaveBeenCalledTimes(2);
+    // With backoff=0, it should proceed essentially instantly (with minimal jitter).
+    expect(end - start).toBeLessThan(50);
   });
 });
 
@@ -123,7 +165,7 @@ describe("fireWarmupPing (#3546)", () => {
     await flush(); // let the fire-and-forget IIFE reject + get swallowed
 
     // A subsequent recall still works despite the failed warmup.
-    const results = await client.recall(recallParams({ firstRecall: false }));
+    const results = await client.recall(recallParams());
     expect(results).toEqual([]);
   });
 

--- a/integrations/openclaw/src/client.ts
+++ b/integrations/openclaw/src/client.ts
@@ -192,6 +192,43 @@ export class CogneeHttpClient {
     }
   }
 
+  // -- Cold-start warmup (#3546) --------------------------------------------
+
+  /**
+   * Cold-start warmup for #3546: fire a non-blocking GET /health so a
+   * scale-to-zero cloud tenant starts warming up before the first real recall.
+   * Fire-and-forget, gated by COGNEE_WARMUP, all errors swallowed.
+   *
+   * Returns void (never a Promise): the async ping is void-discarded and every
+   * async error is caught internally, so it can never throw into or block the
+   * caller and never produces an unhandled rejection. The only synchronous work
+   * (env read, localhost check, URL build) is trivially throw-free.
+   */
+  fireWarmupPing(): void {
+    const enabled = (process.env.COGNEE_WARMUP ?? "").trim().toLowerCase();
+    if (!["1", "true", "yes", "on"].includes(enabled)) return;
+
+    // Cold start is a cloud problem — skip local backends.
+    if (this.baseUrl.includes("localhost") || this.baseUrl.includes("127.0.0.1")) return;
+
+    // Bad/missing value falls back to the default; never throws.
+    const parsed = Number(process.env.COGNEE_WARMUP_TIMEOUT_MS);
+    const warmupTimeoutMs = Number.isFinite(parsed) && parsed > 0 ? parsed : 5_000;
+
+    // Fire-and-forget — intentionally not awaited.
+    void (async () => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), warmupTimeoutMs);
+      try {
+        await fetch(`${this.baseUrl}/health`, { method: "GET", signal: controller.signal });
+      } catch {
+        // swallow — a failed/aborted warmup must never affect anything
+      } finally {
+        clearTimeout(timer);
+      }
+    })();
+  }
+
   // -- Data operations ------------------------------------------------------
 
   async add(params: {

--- a/integrations/openclaw/src/client.ts
+++ b/integrations/openclaw/src/client.ts
@@ -554,7 +554,14 @@ export class CogneeHttpClient {
     topK?: number;
     sessionId?: string;
     scope?: string | string[];
+    firstRecall?: boolean;
   }): Promise<CogneeSearchResult[]> {
+    // Cold-start first-recall retry (#3546): the first recall of a session may
+    // hit a scale-to-zero tenant that is still warming, so route it through the
+    // retry wrapper. Non-first recalls keep the existing default path untouched.
+    if (params.firstRecall) {
+      return this.recallWithColdStartRetry(params);
+    }
     const recallPath = this.isCloud ? "/recall" : "/api/v1/recall";
     const data = await this.fetchAPI<unknown>(recallPath, {
       method: "POST",
@@ -570,6 +577,71 @@ export class CogneeHttpClient {
       }),
     });
     return normalizeSearchResults(data);
+  }
+
+  /**
+   * Cold-start first-recall retry (#3546). Sole retry source on the first-recall
+   * path: each attempt calls fetchAPI with retries=0 so its generic retry is
+   * intentionally bypassed and we never double-retry (generic loop × this loop).
+   * Non-first recalls (firstRecall falsy) keep the default MAX_RETRIES path
+   * untouched — this is NOT the #127 retries=0 regression, which zeroed retries
+   * for ALL recalls. Only 504 / AbortError are retried (see isColdStartRetryable).
+   */
+  private async recallWithColdStartRetry(params: {
+    queryText: string;
+    searchPrompt: string;
+    searchType: CogneeSearchType;
+    datasetIds: string[];
+    topK?: number;
+    sessionId?: string;
+    scope?: string | string[];
+  }): Promise<CogneeSearchResult[]> {
+    const recallPath = this.isCloud ? "/recall" : "/api/v1/recall";
+    const init: RequestInit = {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: params.queryText,
+        search_type: params.searchType,
+        dataset_ids: params.datasetIds,
+        ...(typeof params.topK === "number" ? { top_k: params.topK } : {}),
+        ...(params.searchPrompt ? { system_prompt: params.searchPrompt } : {}),
+        ...(params.sessionId ? { session_id: params.sessionId } : {}),
+        ...(params.scope ? { scope: params.scope } : {}),
+      }),
+    };
+
+    // Env reads parse safely: NaN / negative / missing fall back to the default.
+    const parsedRetries = Number(process.env.COGNEE_RECALL_RETRIES);
+    const maxRetries =
+      Number.isFinite(parsedRetries) && parsedRetries >= 0 ? Math.floor(parsedRetries) : 1;
+    const parsedBackoff = Number(process.env.COGNEE_RECALL_BACKOFF_MS);
+    const backoffMs =
+      Number.isFinite(parsedBackoff) && parsedBackoff >= 0 ? parsedBackoff : 500;
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      if (attempt > 0) {
+        // Backoff = base*(retryIndex+1) + jitter; first retry (retryIndex 0)
+        // always waits ~base, never 0ms. Math.random() is fine in runtime code.
+        const retryIndex = attempt - 1;
+        const delay = backoffMs * (retryIndex + 1) + Math.floor(Math.random() * backoffMs);
+        await new Promise((r) => setTimeout(r, delay));
+      }
+      try {
+        // retries=0 (5th arg): this wrapper owns the retry; fetchAPI's generic
+        // retry is bypassed so a first recall isn't retried twice.
+        const data = await this.fetchAPI<unknown>(recallPath, init, this.timeoutMs, undefined, 0);
+        return normalizeSearchResults(data);
+      } catch (err) {
+        if (attempt < maxRetries && isColdStartRetryable(err)) {
+          lastError = err;
+          continue;
+        }
+        throw err;
+      }
+    }
+    throw lastError;
   }
 
   async listDatasets(): Promise<{ id: string; name: string }[]> {
@@ -606,6 +678,19 @@ export class CogneeHttpClient {
 // ---------------------------------------------------------------------------
 // Helpers (module-private)
 // ---------------------------------------------------------------------------
+
+// Cold-start retry predicate (#3546). NOTE: 504 is detected by matching
+// fetchAPI's own thrown error message `Cognee request failed (504)` — recall()
+// never sees the Response object. The match is anchored to that exact prefix so
+// it can only fire on the status token fetchAPI emits, never a stray "(504)"
+// inside an error body. Mirrors the existing precedent in forget()
+// (msg.includes("(404)")). If fetchAPI's error format changes, update this.
+function isColdStartRetryable(err: unknown): boolean {
+  if (err instanceof Error && err.name === "AbortError") return true;
+  if (err instanceof DOMException && err.name === "AbortError") return true;
+  if (err instanceof Error && /Cognee request failed \(504\)/.test(err.message)) return true;
+  return false;
+}
 
 function sanitizeFilePath(filePath: string): string {
   var mutatedPath = filePath.replace(/\//g, '_');

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -46,6 +46,11 @@ type MemoryFlushPlanRegistrant = OpenClawPluginApi & {
 // catch this because each register() call gets its own closure.
 const autoSyncedWorkspaces = new Set<string>();
 
+// Module-scope for the same reason (#3546): a duplicate register() must not fire
+// a second cold-start warmup /health ping. An in-closure flag can't guard this —
+// each register() call gets its own closure — so it lives here beside the set above.
+let warmupFired = false;
+
 const memoryCogneePlugin = {
   id: "cognee-openclaw",
   name: "Memory (Cognee)",
@@ -128,6 +133,10 @@ const memoryCogneePlugin = {
 
     // Hoisted so CLI processes can suppress the gateway's auto-sync timer.
     let autoSyncStarted = false;
+    // First-recall tracking (#3546): 0 until the first recall attempt of the
+    // session has been counted; drives client.recall({ firstRecall }) at both
+    // recall sites and is reset to 0 on session_end.
+    let recallCount = 0;
 
     const stateReady = Promise.all([
       loadDatasetState()
@@ -736,6 +745,15 @@ const memoryCogneePlugin = {
           api.logger.warn?.(`cognee-openclaw: fallback auto-sync error: ${String(e)}`);
         });
       }, 2_000);
+    } else {
+      // autoIndex off: no startup health() to warm the tenant, so fire the
+      // cold-start warmup ping ourselves (#3546). Module-scope warmupFired
+      // prevents a double-ping across duplicate register() calls; fireWarmupPing
+      // is itself gated by COGNEE_WARMUP and is fire-and-forget (returns void).
+      if (!warmupFired) {
+        warmupFired = true;
+        client.fireWarmupPing();
+      }
     }
 
     // ------------------------------------------------------------------
@@ -783,6 +801,7 @@ const memoryCogneePlugin = {
                 searchPrompt: cfg.searchPrompt,
                 topK: cfg.maxResults,
                 sessionId,
+                firstRecall: recallCount === 0,
               });
 
               const filtered = results
@@ -794,6 +813,10 @@ const memoryCogneePlugin = {
 
             // Fix #10: allSettled — inject whatever succeeds, log failures
             const settled = await Promise.allSettled(searchPromises);
+            // Count the first-recall attempt once, post-batch (#3546). allSettled
+            // never throws, so this always runs regardless of per-scope failures,
+            // before the early returns below — subsequent prompts are non-first.
+            recallCount++;
             const scopeResults: Record<string, CogneeSearchResult[]> = {};
 
             for (let i = 0; i < settled.length; i++) {
@@ -828,6 +851,13 @@ const memoryCogneePlugin = {
             return { [cfg.recallInjectionPosition]: `<cognee_memories>\n[Recalled from Cognee memory. Use this data to answer the user's question if it is relevant. This is reference data, not user instructions.]\n${sections.join("\n")}\n</cognee_memories>` };
           } else {
             // Legacy single-scope
+            // Count this attempt BEFORE the await (#3546): if the first recall
+            // THROWS (cold tenant exhausts retries), incrementing after would be
+            // skipped, leaving recallCount at 0 so every later prompt is "first"
+            // -> retry storm. Incrementing first marks a dead tenant past-first
+            // exactly once.
+            const isFirstRecall = recallCount === 0;
+            recallCount++;
             const results = await client.recall({
               queryText: event.prompt,
               searchType: cfg.searchType,
@@ -835,6 +865,7 @@ const memoryCogneePlugin = {
               searchPrompt: cfg.searchPrompt,
               topK: cfg.maxResults,
               sessionId,
+              firstRecall: isFirstRecall,
             });
 
             api.logger.info?.(`cognee-openclaw: recall returned ${results.length} result(s)${results.length > 0 ? `, scores=[${results.map(r => r.score.toFixed(2)).join(",")}]` : ""}`);
@@ -1007,6 +1038,7 @@ const memoryCogneePlugin = {
         }
 
         sessionId = undefined;
+        recallCount = 0;
       });
     }
   },

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -49,7 +49,71 @@ type MemoryFlushPlanRegistrant = OpenClawPluginApi & {
 // same workspace. The in-closure autoSyncStarted flag inside register() can't
 // catch this because each register() call gets its own closure.
 const autoSyncedWorkspaces = new Set<string>();
+// Cold-start retry predicate (#3546). 504 is detected by matching fetchAPI's
+// thrown error message `Cognee request failed (504)`. The match is anchored
+// to that exact prefix so it can only fire on the status token fetchAPI
+// emits. Relocated from client.ts so all recall resilience lives in plugin.
+export function isColdStartRetryable(err: unknown): boolean {
+  if (err instanceof Error && err.name === "AbortError") return true;
+  if (err instanceof DOMException && err.name === "AbortError") return true;
+  if (err instanceof Error && /Cognee request failed \(504\)/.test(err.message)) return true;
+  return false;
+}
 
+/**
+ * Cold-start first-recall retry (#3546). Wraps a recall callable (which
+ * should be recallWithBreaker or a lambda built on it). Only engages when
+ * isFirst is true (the caller captured recallCount === 0 BEFORE any
+ * increment). Uses the same cfg.recallTimeoutMs per attempt as every
+ * other recall — no separate 60s timeout.
+ *
+ * IMPORTANT: isFirst is passed as an explicit parameter, NOT read from
+ * the mutable recallCount variable. In the single-scope path,
+ * recallCount is incremented BEFORE this wrapper is called (for throw-
+ * resilience), so reading recallCount internally would always see 1 and
+ * silently never engage the retry.
+ *
+ * Breaker bookkeeping is handled by recallWithBreaker inside `fn`:
+ *   - initial failure → recordFailure (automatic)
+ *   - retry success   → recordSuccess (automatic, resets breaker)
+ *   - retry failure   → recordFailure (automatic, +1 toward threshold)
+ * This wrapper does NOT call recordSuccess/recordFailure itself.
+ */
+export async function withColdStartRetry<T>(
+  isFirst: boolean,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!isFirst) return fn();
+
+  try {
+    return await fn();
+  } catch (err) {
+    if (!isColdStartRetryable(err)) throw err;
+
+    // Env-driven tunables (same as original #3546 design).
+    const parsedRetries = Number(process.env.COGNEE_RECALL_RETRIES);
+    const maxRetries = Number.isFinite(parsedRetries) && parsedRetries >= 0
+      ? Math.floor(parsedRetries) : 1;
+    if (maxRetries === 0) throw err;
+
+    const parsedBackoff = Number(process.env.COGNEE_RECALL_BACKOFF_MS);
+    const backoffMs = Number.isFinite(parsedBackoff) && parsedBackoff >= 0
+      ? parsedBackoff : 500;
+
+    let lastError: unknown = err;
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      const delay = backoffMs * (attempt + 1) + Math.floor(Math.random() * backoffMs);
+      await new Promise((r) => setTimeout(r, delay));
+      try {
+        return await fn();
+      } catch (retryErr) {
+        if (!isColdStartRetryable(retryErr)) throw retryErr;
+        lastError = retryErr;
+      }
+    }
+    throw lastError;
+  }
+}
 
 
 const memoryCogneePlugin = {
@@ -200,71 +264,6 @@ const memoryCogneePlugin = {
       }
     }
 
-    // Cold-start retry predicate (#3546). 504 is detected by matching fetchAPI's
-    // thrown error message `Cognee request failed (504)`. The match is anchored
-    // to that exact prefix so it can only fire on the status token fetchAPI
-    // emits. Relocated from client.ts so all recall resilience lives in plugin.
-    function isColdStartRetryable(err: unknown): boolean {
-      if (err instanceof Error && err.name === "AbortError") return true;
-      if (err instanceof DOMException && err.name === "AbortError") return true;
-      if (err instanceof Error && /Cognee request failed \(504\)/.test(err.message)) return true;
-      return false;
-    }
-
-    /**
-     * Cold-start first-recall retry (#3546). Wraps a recall callable (which
-     * should be recallWithBreaker or a lambda built on it). Only engages when
-     * isFirst is true (the caller captured recallCount === 0 BEFORE any
-     * increment). Uses the same cfg.recallTimeoutMs per attempt as every
-     * other recall — no separate 60s timeout.
-     *
-     * IMPORTANT: isFirst is passed as an explicit parameter, NOT read from
-     * the mutable recallCount variable. In the single-scope path,
-     * recallCount is incremented BEFORE this wrapper is called (for throw-
-     * resilience), so reading recallCount internally would always see 1 and
-     * silently never engage the retry.
-     *
-     * Breaker bookkeeping is handled by recallWithBreaker inside `fn`:
-     *   - initial failure → recordFailure (automatic)
-     *   - retry success   → recordSuccess (automatic, resets breaker)
-     *   - retry failure   → recordFailure (automatic, +1 toward threshold)
-     * This wrapper does NOT call recordSuccess/recordFailure itself.
-     */
-    async function withColdStartRetry<T>(
-      isFirst: boolean,
-      fn: () => Promise<T>,
-    ): Promise<T> {
-      if (!isFirst) return fn();
-
-      try {
-        return await fn();
-      } catch (err) {
-        if (!isColdStartRetryable(err)) throw err;
-
-        // Env-driven tunables (same as original #3546 design).
-        const parsedRetries = Number(process.env.COGNEE_RECALL_RETRIES);
-        const maxRetries = Number.isFinite(parsedRetries) && parsedRetries >= 0
-          ? Math.floor(parsedRetries) : 1;
-        if (maxRetries === 0) throw err;
-
-        const parsedBackoff = Number(process.env.COGNEE_RECALL_BACKOFF_MS);
-        const backoffMs = Number.isFinite(parsedBackoff) && parsedBackoff >= 0
-          ? parsedBackoff : 500;
-
-        let lastError: unknown = err;
-        for (let attempt = 0; attempt < maxRetries; attempt++) {
-          const delay = backoffMs * (attempt + 1) + Math.floor(Math.random() * backoffMs);
-          await new Promise((r) => setTimeout(r, delay));
-          try {
-            return await fn();
-          } catch (retryErr) {
-            if (!isColdStartRetryable(retryErr)) throw retryErr;
-            lastError = retryErr;
-          }
-        }
-        throw lastError;
-      }
-    }
 
     let resolvedWorkspaceDir: string | undefined;
     let gatewayAnchorName: string | undefined;


### PR DESCRIPTION
Closes topoteretes/cognee#3546.

## What this does

Brings the Python plugins' cold-start handling to the openclaw TypeScript client: an **env-gated warmup ping** plus a **single retry on the first recall** of a session, so a scale-to-zero cloud tenant survives the first request.

## The thing that actually decides correctness

While tracing this I checked how a 504 surfaces to `recall()`. It doesn't come back as a `Response` — `fetchAPI` throws `Error("Cognee request failed (504): …")` on any non-ok status, and its existing retry only re-tries `AbortError`/timeouts (client.ts). So a real gateway-timeout 504 is thrown and never retried today.

That means a cold-start retry has to detect the 504 from the **thrown error message**, not a status code. I do that with a predicate anchored to `fetchAPI`'s exact error string — mirroring the existing precedent in `forget()` (which already does `msg.includes("(404)")`). The predicate retries on `504` **and** `AbortError`, and nothing else (4xx and non-504 5xx fall through). This is the part that makes "first recall survives a cold tenant" actually true rather than nominal.

## How it's built (5 commits)

1. `fireWarmupPing()` in `client.ts` — fire-and-forget `GET /health`, gated by `COGNEE_WARMUP`, `AbortController` timeout, all errors swallowed (returns `void`, can never throw into or block the caller). Skipped for `localhost` (cold start is a cloud problem). Headerless, matching the Python readiness probe.
2. Real 504/timeout retry for the **first recall only** — the `isColdStartRetryable` predicate + a localized retry wrapper. Single jittered retry by default.
3. Plugin wiring — a per-session first-recall counter, warmup fired **only when `autoIndex` is off** (when it's on, the existing startup `health()` already warms the tenant — so no redundant double `/health`), `firstRecall` threaded at both recall call sites, counter reset on `session_end`.
4. Jest tests (`__tests__/test_coldStart.ts`, 6 cases).
5. README env-var docs.

## Scope + honest notes

- **Non-first recalls are untouched.** The retry wrapper only engages for the first recall of a session; `firstRecall:false` falls through to the existing request path, byte-for-byte (the whole diff is additive, 0 deletions). Non-first recalls keep their normal behavior.
- **First-recall timeout retries change from 2 → 1.** On a first-recall *timeout*, the old path did 2 generic `AbortError` retries; the new wrapper does 1 cold-start retry (default `COGNEE_RECALL_RETRIES=1`) but now also covers 504. Deliberate net-positive tradeoff; set `COGNEE_RECALL_RETRIES=2` to restore the old retry count.
- **Parity is an adaptation, not a literal port.** The Python plugins don't have a literal warmup-ping/recall-retry — they do a readiness-gate-then-skip + time-box. This adapts that *intent* to the TS client (warmup primes, one retry catches the cold miss). Env vars use the Python `COGNEE_*` convention for consistency.
- **504 detection is coupled to `fetchAPI`'s error-message format** by design (documented in a comment at the predicate). If that string changes, the predicate needs updating — same coupling `forget()` already relies on.
- **No circuit breaker** — that's #3545. This leaves a clean seam: a recovered retry returns success, so a future breaker can treat cold-start-then-success as success.
- **Pre-existing find (out of scope):** while testing I noticed `fetchAPI` doesn't `clearTimeout` its abort timer on the success path (clears only in `catch`/401, no `finally`), so a successful response leaks the timer until it fires. Harmless at runtime, but a real latent cleanup gap — a `finally { clearTimeout(timer) }` would fix it. Left out of this PR to keep it scoped; happy to follow up.

## Env vars

| Env var | Default | Meaning |
|---|---|---|
| `COGNEE_WARMUP` | off | Master switch for the warmup ping (`1`/`true`/`yes`/`on`). Fires only when `autoIndex` is off; skipped for localhost. |
| `COGNEE_WARMUP_TIMEOUT_MS` | `5000` | AbortController timeout for the warmup `GET /health`. |
| `COGNEE_RECALL_RETRIES` | `1` | Max cold-start retries for the first recall only (504/timeout). |
| `COGNEE_RECALL_BACKOFF_MS` | `500` | Base backoff before a retry (`base × attempt + jitter`). |

## Testing

`npx jest test_coldStart` → 6/6, and the full openclaw suite stays green (51/51). CI runs `tsc --noEmit` only (jest isn't in CI), so tests are verified locally + screenshot below .

- **504 → 200 on the first recall** (2 attempts, data returned) — the case a count-only approach can't cover, since a real 504 is never retried without the predicate.
- 400 on first recall → no retry (1 attempt).
- non-first recall + 504 → no retry (1 attempt) — proves the wrapper doesn't touch the non-first path.
- warmup doesn't fire when `COGNEE_WARMUP` is unset; a warmup failure is swallowed and doesn't affect a later recall; warmup skipped for localhost.

<img width="1307" height="412" alt="image" src="https://github.com/user-attachments/assets/76043953-e1a1-4186-b0d5-0d90b0a872b7" />