### PR TITLE
feat(claude-code): add project-level dataset picker (#3686)

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -99,6 +99,13 @@ Or persist it per-project in `.cognee/session-config.json` in your workspace roo
 { "dataset": "my-project-memory" }
 ```
 
+For safety, the project picker file only honors non-sensitive selection keys
+(`dataset`, `session_strategy`, `session_prefix`, `agent_name`, `top_k`) — any
+other key (e.g. `base_url`, `api_key`) is ignored, so opening a repo that ships a
+`.cognee/session-config.json` can never redirect your backend or inject
+credentials. Commit it for a shared project default, or `.gitignore` it for a
+personal local override.
+
 Or persist it globally in `~/.cognee-plugin/claude-code/config.json`:
 
 ```json

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -93,7 +93,13 @@ Set a custom dataset at launch:
 export COGNEE_PLUGIN_DATASET="my-project-memory"
 ```
 
-Or persist it in `~/.cognee-plugin/claude-code/config.json`:
+Or persist it per-project in `.cognee/session-config.json` in your workspace root:
+
+```json
+{ "dataset": "my-project-memory" }
+```
+
+Or persist it globally in `~/.cognee-plugin/claude-code/config.json`:
 
 ```json
 { "dataset": "my-project-memory" }
@@ -274,8 +280,9 @@ There is no automatic update mechanism — reinstall is the only way to pull in 
 
 Config precedence:
 1. env vars
-2. `~/.cognee-plugin/claude-code/config.json`
-3. defaults
+2. project picker (`.cognee/session-config.json` in workspace root)
+3. global config (`~/.cognee-plugin/claude-code/config.json`)
+4. defaults
 
 | Key | Env var(s) | Default | Notes |
 |---|---|---|---|

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -23,12 +23,22 @@ _BREAKER_PATH = _SHARED_ROOT / "recall-breaker.json"
 _DEFAULT_DATASET = "agent_sessions"
 
 
-def _active_dataset() -> str:
+def _active_dataset(cwd: str = "") -> str:
     # 1. env var (inherited from the shell that launched Claude Code)
     v = os.environ.get("COGNEE_PLUGIN_DATASET", "").strip()
     if v:
         return v
-    # 2. config file
+    # 2. project picker (.cognee/session-config.json)
+    try:
+        picker_path = Path(cwd or os.getcwd()) / ".cognee" / "session-config.json"
+        data = json.loads(picker_path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            v = str(data.get("dataset") or "").strip()
+            if v:
+                return v
+    except Exception:
+        pass
+    # 3. config file
     try:
         data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
         if isinstance(data, dict):
@@ -37,7 +47,7 @@ def _active_dataset() -> str:
                 return v
     except Exception:
         pass
-    # 3. default
+    # 4. default
     return _DEFAULT_DATASET
 
 
@@ -74,11 +84,14 @@ def _health_prefix() -> str:
 
 
 def main() -> None:
+    cwd = ""
     try:
-        json.load(sys.stdin)  # consume stdin as required by Claude Code
+        ctx = json.load(sys.stdin)  # consume stdin as required by Claude Code
+        if isinstance(ctx, dict):
+            cwd = str(ctx.get("cwd") or (ctx.get("workspace") or {}).get("current_dir") or "")
     except Exception:
         pass
-    sys.stdout.write(f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}")
+    sys.stdout.write(f"{_health_prefix()}cognee: {_active_dataset(cwd)} · {_active_mode()}")
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -28,9 +28,11 @@ def _active_dataset(cwd: str = "") -> str:
     v = os.environ.get("COGNEE_PLUGIN_DATASET", "").strip()
     if v:
         return v
-    # 2. project picker (.cognee/session-config.json)
+    # 2. project picker (.cognee/session-config.json). Mirror config.py's
+    # project-root resolution: explicit cwd > CLAUDE_CWD > os.getcwd().
     try:
-        picker_path = Path(cwd or os.getcwd()) / ".cognee" / "session-config.json"
+        root = cwd or os.environ.get("CLAUDE_CWD") or os.getcwd()
+        picker_path = Path(root) / ".cognee" / "session-config.json"
         data = json.loads(picker_path.read_text(encoding="utf-8"))
         if isinstance(data, dict):
             v = str(data.get("dataset") or "").strip()

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -101,8 +101,37 @@ _ENV_MAP = {
 }
 
 
-def load_config() -> dict:
-    """Load merged config: defaults → file → env vars."""
+def _read_project_picker(cwd: Optional[str] = None) -> dict:
+    """Read .cognee/session-config.json from the project directory.
+
+    Resolution order for the project root: explicit cwd arg (from a hook's
+    payload) > CLAUDE_CWD env (background workers with no payload) >
+    os.getcwd() (last resort — NOT reliable inside a global-plugin hook
+    process, kept only as a final fallback).
+    """
+    project_dir = Path(cwd or os.environ.get("CLAUDE_CWD") or os.getcwd())
+    picker_path = project_dir / ".cognee" / "session-config.json"
+
+    if not picker_path.exists():
+        return {}
+    try:
+        data = json.loads(picker_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        _config_log(
+            "session_picker_load_failed", {"path": str(picker_path), "error": str(exc)[:200]}
+        )
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    # Only non-null AND non-empty-string values fall through — matches the
+    # existing config-file layer's semantics (line 112: `v is not None and v != ""`)
+    # so an explicit `{"dataset": null}` or `{"dataset": ""}` cleanly no-ops
+    # instead of resolving to an empty dataset name downstream.
+    return {k: v for k, v in data.items() if v is not None and v != ""}
+
+
+def load_config(cwd: Optional[str] = None) -> dict:
+    """Load merged config: defaults → file → project picker → env vars."""
     config = dict(_DEFAULTS)
 
     # Layer 2: config file
@@ -115,7 +144,10 @@ def load_config() -> dict:
                 "config_file_load_failed", {"path": str(_CONFIG_FILE), "error": str(exc)[:200]}
             )
 
-    # Layer 3: env vars (highest priority)
+    # Layer 3: project-level picker (.cognee/session-config.json)
+    config.update(_read_project_picker(cwd))
+
+    # Layer 4: env vars (highest priority)
     for env_key, config_key in _ENV_MAP.items():
         val = os.environ.get(env_key, "")
         if val:

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -101,6 +101,16 @@ _ENV_MAP = {
 }
 
 
+# Keys a project-committed picker file may set. Deliberately excludes secrets
+# and backend routing (api_key, llm_api_key, base_url, backend, user_*) so that
+# merely opening a repo with a `.cognee/session-config.json` can never redirect
+# your Cognee backend or inject credentials — the picker's job is dataset/session
+# selection only (issue #3686: "the dataset configuration key").
+_PICKER_ALLOWED_KEYS = frozenset(
+    {"dataset", "session_strategy", "session_prefix", "agent_name", "top_k"}
+)
+
+
 def _read_project_picker(cwd: Optional[str] = None) -> dict:
     """Read .cognee/session-config.json from the project directory.
 
@@ -108,6 +118,10 @@ def _read_project_picker(cwd: Optional[str] = None) -> dict:
     payload) > CLAUDE_CWD env (background workers with no payload) >
     os.getcwd() (last resort — NOT reliable inside a global-plugin hook
     process, kept only as a final fallback).
+
+    Only the non-sensitive keys in ``_PICKER_ALLOWED_KEYS`` are honored; any
+    other key in the file is ignored so an untrusted repo file cannot influence
+    auth or backend routing.
     """
     project_dir = Path(cwd or os.environ.get("CLAUDE_CWD") or os.getcwd())
     picker_path = project_dir / ".cognee" / "session-config.json"
@@ -123,11 +137,18 @@ def _read_project_picker(cwd: Optional[str] = None) -> dict:
         return {}
     if not isinstance(data, dict):
         return {}
-    # Only non-null AND non-empty-string values fall through — matches the
-    # existing config-file layer's semantics (line 112: `v is not None and v != ""`)
-    # so an explicit `{"dataset": null}` or `{"dataset": ""}` cleanly no-ops
-    # instead of resolving to an empty dataset name downstream.
-    return {k: v for k, v in data.items() if v is not None and v != ""}
+    # Only allowlisted, non-null AND non-empty-string values fall through — the
+    # empty/null check matches the config-file layer's semantics (line 112:
+    # `v is not None and v != ""`) so an explicit `{"dataset": null}` or
+    # `{"dataset": ""}` cleanly no-ops instead of resolving to an empty name.
+    ignored = [k for k in data if k not in _PICKER_ALLOWED_KEYS]
+    if ignored:
+        _config_log("session_picker_ignored_keys", {"keys": sorted(ignored)[:20]})
+    return {
+        k: v
+        for k, v in data.items()
+        if k in _PICKER_ALLOWED_KEYS and v is not None and v != ""
+    }
 
 
 def load_config(cwd: Optional[str] = None) -> dict:

--- a/integrations/claude-code/scripts/pre-compact.py
+++ b/integrations/claude-code/scripts/pre-compact.py
@@ -32,14 +32,14 @@ _TRACE_TOP_K = 8
 _GRAPH_TOP_K = 3
 
 
-def _load_resolved_fields() -> tuple[str, str]:
+def _load_resolved_fields(cwd: str = "") -> tuple[str, str]:
     """Return (session_id, dataset) from resolved cache or config."""
     resolved = load_resolved()
     session_id = resolved.get("session_id", "")
     dataset = resolved.get("dataset", "")
     if not session_id or not dataset:
-        config = load_config()
-        session_id = session_id or get_session_id(config)
+        config = load_config(cwd)
+        session_id = session_id or get_session_id(config, cwd)
         dataset = dataset or get_dataset(config)
     return session_id, dataset
 
@@ -136,13 +136,13 @@ def _format_graph_section(entries: list) -> str:
     return "\n".join(lines) if len(lines) > 1 else ""
 
 
-async def _run():
-    session_id, dataset = _load_resolved_fields()
+async def _run(cwd: str = ""):
+    session_id, dataset = _load_resolved_fields(cwd)
     if not session_id:
         hook_log("no_session_id", {"event": "precompact"})
         return
 
-    config = load_config()
+    config = load_config(cwd)
     await ensure_cognee_ready(config)
 
     # Short queries: use the session's recent activity as the seed
@@ -245,8 +245,9 @@ def main():
     if session_key_candidate:
         set_session_key(session_key_candidate)
 
+    cwd = str(payload.get("cwd") or "")
     try:
-        asyncio.run(_run())
+        asyncio.run(_run(cwd))
     except Exception as exc:
         hook_log("precompact_run_exception", {"error": str(exc)[:200]})
 

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -1031,8 +1031,8 @@ async def _run_bootstrap(bootstrap: dict) -> None:
          booted, because registration is per-session (the connection handle is
          the Cognee session id) under the single principal.
     """
-    config = load_config()
-    cwd = str(bootstrap.get("cwd") or os.getcwd())
+    cwd = str(bootstrap.get("cwd") or os.environ.get("CLAUDE_CWD") or os.getcwd())
+    config = load_config(cwd)
     session_id = str(bootstrap.get("session_id", "") or "")
     session_key = str(bootstrap.get("session_key", "") or "")
     dataset = str(bootstrap.get("dataset", "") or get_dataset(config))
@@ -1200,9 +1200,9 @@ def _apply_memory_preference(output: dict) -> dict:
 
 async def _start(payload: dict | None = None) -> dict:
     _ensure_statusline_configured()
-    config = load_config()
     payload = payload or {}
     cwd = str(payload.get("cwd") or os.environ.get("CLAUDE_CWD") or os.getcwd())
+    config = load_config(cwd)
     # The service URL is the sole router (api_key is optional auth, with a
     # default-user fallback in registration). COGNEE_AGENT_MODE is NOT decided
     # here: it's set only when we actually boot a server (in

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -110,15 +110,15 @@ def _infer_status(payload: dict) -> tuple[str, str]:
     return "success", ""
 
 
-def _load_session() -> tuple[str, str, str]:
+def _load_session(cwd: str = "") -> tuple[str, str, str]:
     """Load session_id, dataset, user_id from resolved cache with fallbacks."""
     resolved = load_resolved()
     session_id = resolved.get("session_id", "")
     dataset = resolved.get("dataset", "")
     user_id = resolved.get("user_id", "")
     if not session_id or not dataset:
-        config = load_config()
-        session_id = session_id or get_session_id(config)
+        config = load_config(cwd)
+        session_id = session_id or get_session_id(config, cwd)
         dataset = dataset or get_dataset(config)
     return session_id, dataset, user_id
 
@@ -152,12 +152,13 @@ async def _store_tool_call(payload: dict) -> None:
 
     return_value = _truncate_str(tool_output, _MAX_RETURN_BYTES)
 
-    session_id, dataset, user_id = _load_session()
+    cwd = str(payload.get("cwd") or "")
+    session_id, dataset, user_id = _load_session(cwd)
     if not session_id:
         hook_log("no_session_id", {"tool": tool_name})
         return
 
-    config = load_config()
+    config = load_config(cwd)
     runtime = resolve_runtime_mode()
     use_http = runtime["mode"] == "http"
     hook_log(
@@ -265,12 +266,13 @@ async def _store_assistant_stop(payload: dict) -> None:
 
     msg = _truncate_str(msg, _MAX_ASSISTANT_BYTES)
 
-    session_id, dataset, user_id = _load_session()
+    cwd = str(payload.get("cwd") or "")
+    session_id, dataset, user_id = _load_session(cwd)
     if not session_id:
         hook_log("no_session_id", {"event": "stop"})
         return
 
-    config = load_config()
+    config = load_config(cwd)
     runtime = resolve_runtime_mode()
     use_http = runtime["mode"] == "http"
     hook_log(

--- a/integrations/claude-code/scripts/store-user-prompt.py
+++ b/integrations/claude-code/scripts/store-user-prompt.py
@@ -42,14 +42,14 @@ _WATCHER_STOP = _STATE_DIR / "watcher.stop"
 _WATCHER_SCRIPT = Path(__file__).with_name("idle-watcher.py")
 
 
-def _load_session() -> tuple[str, str, str]:
+def _load_session(cwd: str = "") -> tuple[str, str, str]:
     resolved = load_resolved()
     session_id = resolved.get("session_id", "")
     dataset = resolved.get("dataset", "")
     user_id = resolved.get("user_id", "")
     if not session_id or not dataset:
-        config = load_config()
-        session_id = session_id or get_session_id(config)
+        config = load_config(cwd)
+        session_id = session_id or get_session_id(config, cwd)
         dataset = dataset or get_dataset(config)
     return session_id, dataset, user_id
 
@@ -126,12 +126,13 @@ def _prompt_context(payload: dict) -> str:
 
 
 async def _store(prompt: str, payload: dict):
-    session_id, dataset, user_id = _load_session()
+    cwd = str(payload.get("cwd") or "")
+    session_id, dataset, user_id = _load_session(cwd)
     if not session_id:
         hook_log("no_session_id", {"event": "prompt"})
         return
 
-    config = load_config()
+    config = load_config(cwd)
     touch_activity()
     _ensure_idle_watcher(session_id, dataset, user_id, config)
 

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -77,12 +77,30 @@ def _stop_idle_watcher() -> None:
             hook_log("watcher_sigterm_failed", {"error": str(exc)[:200]})
 
 
-def _spawn_detached_sync() -> bool:
-    """Run the expensive sync outside a short hook window."""
+def _spawn_detached_sync(cwd: str = "") -> bool:
+    """Run the expensive sync outside a short hook window.
+
+    The detached worker gets no stdin payload, so it can't recover the project
+    ``cwd`` on its own. Propagate it (and the picker-resolved dataset) via env so
+    the final session-end flush targets the dataset the project picked, not the
+    global default — otherwise a ``.cognee/session-config.json`` dataset would be
+    honored all session and then silently dropped at the final sync.
+    """
     try:
         env = os.environ.copy()
         env.setdefault("COGNEE_SYNC_START_DELAY", str(_SESSION_END_START_DELAY_DEFAULT))
         env["COGNEE_UNREGISTER_ON_FINISH"] = "1"
+        if cwd:
+            env["CLAUDE_CWD"] = cwd
+        # Resolve the active (picker-aware) dataset now, while cwd is known, and
+        # pin it for the detached worker. setdefault so an explicit
+        # COGNEE_SYNC_DATASET from an upstream spawner still wins.
+        try:
+            picked_dataset = str(get_dataset(load_config(cwd)) or "").strip()
+            if picked_dataset:
+                env.setdefault("COGNEE_SYNC_DATASET", picked_dataset)
+        except Exception as exc:
+            hook_log("sync_detach_dataset_resolve_failed", {"error": str(exc)[:200]})
         subprocess.Popen(
             [sys.executable, str(Path(__file__).resolve()), _DETACHED_ARG],
             cwd=os.getcwd(),
@@ -357,7 +375,7 @@ def main():
         if session_key_candidate:
             set_session_key(session_key_candidate)
         hook_log("sync_session_key", {"source": session_key_source, "value": session_key_candidate})
-    
+
     cwd = str(payload.get("cwd") or "")
     is_session_end = forced_session_end or _is_session_end_payload(payload_raw)
     hook_log(
@@ -392,7 +410,7 @@ def main():
     # there prevents later idle persistence.
     if is_session_end:
         _stop_idle_watcher()
-        spawned = _spawn_detached_sync()
+        spawned = _spawn_detached_sync(cwd)
         hook_log("sync_deferred_to_shutdown_worker", {"spawned": spawned})
         return
 

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -190,7 +190,7 @@ def _is_session_end_payload(payload_raw: str) -> bool:
     return event == "SessionEnd" or _contains_session_end(payload)
 
 
-def _load_resolved() -> tuple:
+def _load_resolved(cwd: str = "") -> tuple:
     """
     Load session ID, dataset, user ID,
     agent session name, registration marker, and API key marker.
@@ -224,8 +224,8 @@ def _load_resolved() -> tuple:
             session_key,
         )
 
-    config = load_config()
-    fallback_session_id = get_session_id(config)
+    config = load_config(cwd)
+    fallback_session_id = get_session_id(config, cwd)
     fallback_agent_session_name = session_key or ""
     if env_service_url:
         os.environ["COGNEE_BASE_URL"] = env_service_url
@@ -240,9 +240,9 @@ def _load_resolved() -> tuple:
     )
 
 
-async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
+async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, cwd: str = ""):
     session_id, dataset, user_id, agent_session_name, was_registered, has_api_key, session_key = (
-        _load_resolved()
+        _load_resolved(cwd)
     )
     target_sessions = [session_id] if session_id else []
     hook_log(
@@ -261,7 +261,7 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
             _stop_idle_watcher()
             hook_log("sync_stopped_watcher", {"session": session_id, "dataset": dataset})
 
-        config = load_config()
+        config = load_config(cwd)
         api_mode = http_api_ready()
         lock = nullcontext(True) if api_mode else sync_lock("sync-session-to-graph")
         with lock as acquired:
@@ -347,6 +347,7 @@ def main():
     detached_final = _DETACHED_ARG in sys.argv
     forced_session_end = _SESSION_END_ARG in sys.argv
     payload_raw = "" if detached_final else sys.stdin.read()
+    payload = {}
     if not detached_final and payload_raw.strip():
         try:
             payload = json.loads(payload_raw)
@@ -356,6 +357,8 @@ def main():
         if session_key_candidate:
             set_session_key(session_key_candidate)
         hook_log("sync_session_key", {"source": session_key_source, "value": session_key_candidate})
+    
+    cwd = str(payload.get("cwd") or "")
     is_session_end = forced_session_end or _is_session_end_payload(payload_raw)
     hook_log(
         "sync_payload",
@@ -407,6 +410,7 @@ def main():
                 _sync(
                     stop_watcher=False,
                     unregister_on_finish=unregister_on_finish,
+                    cwd=cwd,
                 )
             )
             return

--- a/integrations/claude-code/tests/test_session_picker.py
+++ b/integrations/claude-code/tests/test_session_picker.py
@@ -1,0 +1,129 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts directory to path to allow importing config
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import config
+
+
+@pytest.fixture(autouse=True)
+def setup_teardown(monkeypatch, tmp_path):
+    # Mock home directory to isolate global config
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    
+    # Reload DEFAULTS to reset state just in case
+    config._CONFIG_DIR = home / ".cognee-plugin" / "claude-code"
+    config._CONFIG_FILE = config._CONFIG_DIR / "config.json"
+    
+    # Ensure no relevant env vars are set
+    for env_var in list(os.environ.keys()):
+        if env_var.startswith("COGNEE_") or env_var == "CLAUDE_CWD":
+            monkeypatch.delenv(env_var, raising=False)
+
+
+def write_picker(cwd_path: Path, data):
+    cognee_dir = cwd_path / ".cognee"
+    cognee_dir.mkdir(parents=True, exist_ok=True)
+    picker_file = cognee_dir / "session-config.json"
+    if isinstance(data, str):
+        picker_file.write_text(data, encoding="utf-8")
+    else:
+        picker_file.write_text(json.dumps(data), encoding="utf-8")
+
+
+def write_global_config(data):
+    config._CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    config._CONFIG_FILE.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_picker_resolves_via_explicit_cwd_arg(tmp_path):
+    write_picker(tmp_path, {"dataset": "picker-dataset"})
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "picker-dataset"
+
+
+def test_picker_resolves_via_claude_cwd_env_fallback(monkeypatch, tmp_path):
+    write_picker(tmp_path, {"dataset": "picker-env-dataset"})
+    monkeypatch.setenv("CLAUDE_CWD", str(tmp_path))
+    
+    # mock os.getcwd to somewhere else to ensure CLAUDE_CWD is preferred
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    monkeypatch.chdir(other_dir)
+    
+    cfg = config.load_config()
+    assert cfg.get("dataset") == "picker-env-dataset"
+
+
+def test_picker_falls_back_to_os_getcwd_last(monkeypatch, tmp_path):
+    write_picker(tmp_path, {"dataset": "picker-cwd-dataset"})
+    monkeypatch.chdir(tmp_path)
+    
+    cfg = config.load_config()
+    assert cfg.get("dataset") == "picker-cwd-dataset"
+
+
+def test_precedence_env_beats_picker(tmp_path, monkeypatch):
+    write_picker(tmp_path, {"dataset": "picker-dataset"})
+    monkeypatch.setenv("COGNEE_PLUGIN_DATASET", "env-dataset")
+    
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "env-dataset"
+
+
+def test_precedence_picker_beats_global_config(tmp_path):
+    write_global_config({"dataset": "global-dataset"})
+    write_picker(tmp_path, {"dataset": "picker-dataset"})
+    
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "picker-dataset"
+
+
+def test_precedence_config_beats_default(tmp_path):
+    write_global_config({"dataset": "global-dataset"})
+    
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "global-dataset"
+
+
+def test_missing_picker_file_falls_through_cleanly(tmp_path):
+    # No .cognee dir at all
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "agent_sessions"
+
+
+def test_malformed_json_picker_falls_through(tmp_path):
+    write_picker(tmp_path, "{invalid_json:")
+    
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "agent_sessions"
+
+
+def test_null_dataset_value_falls_through(tmp_path):
+    write_global_config({"dataset": "global-dataset"})
+    write_picker(tmp_path, {"dataset": None})
+    
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "global-dataset"
+
+
+def test_empty_string_dataset_falls_through(tmp_path):
+    write_global_config({"dataset": "global-dataset"})
+    write_picker(tmp_path, {"dataset": ""})
+    
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "global-dataset"
+
+
+def test_picker_file_is_not_a_dict(tmp_path):
+    write_global_config({"dataset": "global-dataset"})
+    write_picker(tmp_path, ["list", "instead", "of", "dict"])
+    
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "global-dataset"

--- a/integrations/claude-code/tests/test_session_picker.py
+++ b/integrations/claude-code/tests/test_session_picker.py
@@ -16,11 +16,11 @@ def setup_teardown(monkeypatch, tmp_path):
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setattr(Path, "home", lambda: home)
-    
+
     # Reload DEFAULTS to reset state just in case
     config._CONFIG_DIR = home / ".cognee-plugin" / "claude-code"
     config._CONFIG_FILE = config._CONFIG_DIR / "config.json"
-    
+
     # Ensure no relevant env vars are set
     for env_var in list(os.environ.keys()):
         if env_var.startswith("COGNEE_") or env_var == "CLAUDE_CWD":
@@ -51,12 +51,12 @@ def test_picker_resolves_via_explicit_cwd_arg(tmp_path):
 def test_picker_resolves_via_claude_cwd_env_fallback(monkeypatch, tmp_path):
     write_picker(tmp_path, {"dataset": "picker-env-dataset"})
     monkeypatch.setenv("CLAUDE_CWD", str(tmp_path))
-    
+
     # mock os.getcwd to somewhere else to ensure CLAUDE_CWD is preferred
     other_dir = tmp_path / "other"
     other_dir.mkdir()
     monkeypatch.chdir(other_dir)
-    
+
     cfg = config.load_config()
     assert cfg.get("dataset") == "picker-env-dataset"
 
@@ -64,7 +64,7 @@ def test_picker_resolves_via_claude_cwd_env_fallback(monkeypatch, tmp_path):
 def test_picker_falls_back_to_os_getcwd_last(monkeypatch, tmp_path):
     write_picker(tmp_path, {"dataset": "picker-cwd-dataset"})
     monkeypatch.chdir(tmp_path)
-    
+
     cfg = config.load_config()
     assert cfg.get("dataset") == "picker-cwd-dataset"
 
@@ -72,7 +72,7 @@ def test_picker_falls_back_to_os_getcwd_last(monkeypatch, tmp_path):
 def test_precedence_env_beats_picker(tmp_path, monkeypatch):
     write_picker(tmp_path, {"dataset": "picker-dataset"})
     monkeypatch.setenv("COGNEE_PLUGIN_DATASET", "env-dataset")
-    
+
     cfg = config.load_config(cwd=str(tmp_path))
     assert cfg.get("dataset") == "env-dataset"
 
@@ -80,14 +80,14 @@ def test_precedence_env_beats_picker(tmp_path, monkeypatch):
 def test_precedence_picker_beats_global_config(tmp_path):
     write_global_config({"dataset": "global-dataset"})
     write_picker(tmp_path, {"dataset": "picker-dataset"})
-    
+
     cfg = config.load_config(cwd=str(tmp_path))
     assert cfg.get("dataset") == "picker-dataset"
 
 
 def test_precedence_config_beats_default(tmp_path):
     write_global_config({"dataset": "global-dataset"})
-    
+
     cfg = config.load_config(cwd=str(tmp_path))
     assert cfg.get("dataset") == "global-dataset"
 
@@ -100,7 +100,7 @@ def test_missing_picker_file_falls_through_cleanly(tmp_path):
 
 def test_malformed_json_picker_falls_through(tmp_path):
     write_picker(tmp_path, "{invalid_json:")
-    
+
     cfg = config.load_config(cwd=str(tmp_path))
     assert cfg.get("dataset") == "agent_sessions"
 
@@ -108,7 +108,7 @@ def test_malformed_json_picker_falls_through(tmp_path):
 def test_null_dataset_value_falls_through(tmp_path):
     write_global_config({"dataset": "global-dataset"})
     write_picker(tmp_path, {"dataset": None})
-    
+
     cfg = config.load_config(cwd=str(tmp_path))
     assert cfg.get("dataset") == "global-dataset"
 
@@ -116,7 +116,7 @@ def test_null_dataset_value_falls_through(tmp_path):
 def test_empty_string_dataset_falls_through(tmp_path):
     write_global_config({"dataset": "global-dataset"})
     write_picker(tmp_path, {"dataset": ""})
-    
+
     cfg = config.load_config(cwd=str(tmp_path))
     assert cfg.get("dataset") == "global-dataset"
 
@@ -124,6 +124,39 @@ def test_empty_string_dataset_falls_through(tmp_path):
 def test_picker_file_is_not_a_dict(tmp_path):
     write_global_config({"dataset": "global-dataset"})
     write_picker(tmp_path, ["list", "instead", "of", "dict"])
-    
+
     cfg = config.load_config(cwd=str(tmp_path))
     assert cfg.get("dataset") == "global-dataset"
+
+
+def test_picker_ignores_sensitive_keys(tmp_path):
+    # A repo-committed picker file must not be able to redirect the backend or
+    # inject credentials — only dataset/session selection is honored.
+    write_picker(
+        tmp_path,
+        {
+            "dataset": "picker-dataset",
+            "base_url": "http://evil.example",
+            "api_key": "ck_stolen",
+            "llm_api_key": "sk-stolen",
+            "backend": "server",
+        },
+    )
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "picker-dataset"  # allowlisted key applied
+    assert cfg.get("base_url") == ""  # sensitive keys ignored (default)
+    assert cfg.get("api_key") == ""
+    assert cfg.get("llm_api_key") == ""
+
+
+def test_picker_honors_allowlisted_nondataset_key(tmp_path):
+    write_picker(tmp_path, {"session_strategy": "git-branch"})
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("session_strategy") == "git-branch"
+
+
+def test_picker_unknown_key_ignored(tmp_path):
+    write_picker(tmp_path, {"dataset": "picker-dataset", "totally_unknown": "x"})
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "picker-dataset"
+    assert "totally_unknown" not in cfg

--- a/integrations/claude-code/tests/test_sync_picker_propagation.py
+++ b/integrations/claude-code/tests/test_sync_picker_propagation.py
@@ -1,0 +1,95 @@
+"""The detached session-end sync must honor the project dataset picker.
+
+The final sync runs in a detached worker with no stdin payload, so it can't
+recover the project ``cwd`` itself. ``_spawn_detached_sync(cwd)`` therefore
+resolves the picker-aware dataset up front and pins it (plus ``CLAUDE_CWD``) in
+the child's environment. Without this, a ``.cognee/session-config.json`` dataset
+is honored all session and then silently dropped at the final flush.
+
+Run: python integrations/claude-code/tests/test_sync_picker_propagation.py (or via pytest).
+"""
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+import config  # noqa: E402
+
+
+def _load_sync_module():
+    spec = importlib.util.spec_from_file_location(
+        "sync_session_to_graph", str(_SCRIPTS / "sync-session-to-graph.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def isolate(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    plugin = home / ".cognee-plugin" / "claude-code"
+    plugin.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr(config, "_CONFIG_DIR", plugin)
+    monkeypatch.setattr(config, "_STATE_DIR", plugin)
+    monkeypatch.setattr(config, "_CONFIG_FILE", plugin / "config.json")
+    monkeypatch.setattr(config, "_HOOK_LOG", plugin / "hook.log")
+    for key in list(os.environ.keys()):
+        if key.startswith("COGNEE_") or key == "CLAUDE_CWD":
+            monkeypatch.delenv(key, raising=False)
+
+
+def _write_picker(project: Path, data: dict):
+    (project / ".cognee").mkdir(parents=True, exist_ok=True)
+    (project / ".cognee" / "session-config.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_detached_sync_pins_picked_dataset(monkeypatch, tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    _write_picker(project, {"dataset": "picker-dataset"})
+
+    sync = _load_sync_module()
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, *args, **kwargs):
+            captured["env"] = kwargs.get("env", {})
+
+    monkeypatch.setattr(sync.subprocess, "Popen", _FakePopen)
+
+    assert sync._spawn_detached_sync(str(project)) is True
+    assert captured["env"].get("COGNEE_SYNC_DATASET") == "picker-dataset"
+    assert captured["env"].get("CLAUDE_CWD") == str(project)
+
+
+def test_detached_sync_does_not_override_explicit_dataset(monkeypatch, tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    _write_picker(project, {"dataset": "picker-dataset"})
+    # An upstream spawner already pinned a dataset — it must win (setdefault).
+    monkeypatch.setenv("COGNEE_SYNC_DATASET", "explicit-dataset")
+
+    sync = _load_sync_module()
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, *args, **kwargs):
+            captured["env"] = kwargs.get("env", {})
+
+    monkeypatch.setattr(sync.subprocess, "Popen", _FakePopen)
+
+    assert sync._spawn_detached_sync(str(project)) is True
+    assert captured["env"].get("COGNEE_SYNC_DATASET") == "explicit-dataset"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary
Adds a project-level `.cognee/session-config.json` dataset picker for the Claude Code plugin. The picked dataset is resolved at `SessionStart`, propagated to every hook and the status line, and honored all the way through the **session-end final sync**, giving deterministic per-project dataset resolution for the lifetime of a launch.

Closes topoteretes/cognee#3686.

## Problem
Dataset selection previously relied only on `COGNEE_PLUGIN_DATASET` (terminal-scoped) or `~/.cognee-plugin/claude-code/config.json` (global). Pinning a dataset to a project meant exporting an env var in every terminal. Also, `os.getcwd()` inside a plugin hook is unreliable — Claude Code doesn't guarantee the hook process's working directory is the project root — so the project root must come from the payload's `cwd` (with a `CLAUDE_CWD` fallback).

## Changes

### 1. `scripts/config.py`
- `_read_project_picker(cwd)` resolves `.cognee/session-config.json` (`cwd` arg → `CLAUDE_CWD` → `os.getcwd()`).
- `load_config(cwd)` slots the project picker between env vars and the global config.
- **Allowlist (hardening):** the picker only honors non-sensitive selection keys — `dataset`, `session_strategy`, `session_prefix`, `agent_name`, `top_k`. Secrets/backend routing (`api_key`, `llm_api_key`, `base_url`, `backend`, `user_*`) are ignored, so simply opening a repo that ships a `.cognee/session-config.json` can never redirect your Cognee backend or inject credentials. Keeps the feature to the issue's "dataset configuration key" scope.

**Precedence (highest first):**
1. Environment variables (`COGNEE_PLUGIN_DATASET`)
2. `.cognee/session-config.json` (project picker)
3. `~/.cognee-plugin/claude-code/config.json` (global)
4. Defaults (`agent_sessions`)

### 2. Hook scripts
`session-start.py`, `pre-compact.py`, `store-to-session.py`, `store-user-prompt.py`, `sync-session-to-graph.py` now extract `cwd` from the hook payload and pass it to `load_config()`. `session-start.py`'s detached bootstrap computes `cwd` before `load_config()` so the picker applies at launch.

### 3. Session-end final sync honors the picker
The final sync runs in a **detached worker with no stdin payload**, so it couldn't recover the project `cwd` on its own — a `.cognee` dataset was honored all session and then dropped at the final flush (falling back to the global/default dataset). `_spawn_detached_sync(cwd)` now pins `CLAUDE_CWD` **and** the picker-resolved `COGNEE_SYNC_DATASET` (via `setdefault`, so an upstream spawner like the exit-watcher still wins). Effective in both HTTP and local-SDK modes.

### 4. Status line
`cognee_statusline_render.py` reads `cwd` from the `statusLine` stdin payload and mirrors `config.py`'s `cwd > CLAUDE_CWD > getcwd` resolution so the displayed dataset matches what hooks use.

### 5. Tests
`tests/test_session_picker.py` and `tests/test_sync_picker_propagation.py` — **16 picker-specific assertions** (deterministic, no keys):
- Resolution via explicit `cwd` and `CLAUDE_CWD` fallback.
- Precedence across all 4 layers.
- Fail-safe fallthrough for missing file, malformed JSON, non-dict, `{"dataset": null}`, `{"dataset": ""}`.
- Allowlist: sensitive keys (`base_url`/`api_key`/…) and unknown keys are ignored; allowlisted non-dataset keys apply.
- Detached final sync pins the picker-resolved `COGNEE_SYNC_DATASET` + `CLAUDE_CWD`, and doesn't override an explicit one.

### 6. Docs
`README.md` documents the per-project picker, the precedence table, and the allowlist.

## Scope
**In:** resolution of the `dataset` (and other allowlisted selection) keys at `SessionStart`, propagated through the final sync.
**Out:** mid-session dataset switching (that's #3689 / PR #186), secrets/backend keys, interactive CLI tooling.

## Testing
- [x] `python -m pytest integrations/claude-code/tests/ -q` → **76 passed** (16 picker-specific).
- [x] `ruff check` → clean.
- [x] Precedence confirmed: env var overrides the picker; a project with no picker file falls back to prior behavior unchanged.

_Base branch: `main` (cognee-integrations has no `dev` branch)._