### PR TITLE
feat(claude-code): mid-session dataset switch (seal bridge + re-register)

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -99,9 +99,23 @@ Or persist it in `~/.cognee-plugin/claude-code/config.json`:
 { "dataset": "my-project-memory" }
 ```
 
-The dataset is fixed for the lifetime of a launch. Recall searches only the active dataset. If you want to
-change the active dataset, you have to exit Claude, change the dataset via env, and then start Claude again.
-Data added outside of Claude to the dataset (via SDK or the server for example) is visible in Claude via the Cognee plugin.
+Recall searches only the active dataset. Data added outside of Claude to the dataset (via SDK or the server
+for example) is visible in Claude via the Cognee plugin.
+
+### Switching datasets mid-session
+
+You can change the active dataset **without restarting Claude** and without losing the current conversation:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/dataset-switch.py my-other-dataset
+# or the skill: /cognee-memory:cognee-dataset-switch
+```
+
+The switch seals the old dataset's bridge (flushing its pending writes to the old graph, never orphaning
+them), re-registers the agent on the new dataset, and keeps the same `session_id`. Because the session cache
+is keyed by `session_id` — not the dataset — prior-conversation `recall` still works after the switch, while
+new memory is written only to the new dataset (no duplicate graph writes). Switching to the already-active
+dataset is a no-op.
 
 ## Hooks
 
@@ -155,6 +169,7 @@ Final sync on session end is triggered by the `SessionEnd` detached worker, with
 - `/cognee-memory:cognee-remember`
 - `/cognee-memory:cognee-search`
 - `/cognee-memory:cognee-sync`
+- `/cognee-memory:cognee-dataset-switch`
 
 ## Remember (write) behavior
 

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -44,6 +44,13 @@ _API_KEY_CACHE = _SHARED_PLUGIN_ROOT / "api_key.json"
 # as an identity. A genuinely new launch gets a new host id -> new Cognee session;
 # a `resume` reuses the host id -> continues the same Cognee session.
 _SESSIONS_MAP_DIR = _PLUGIN_DIR / "sessions"
+# Per-session dataset-switch lifecycle: which dataset is active for a session,
+# plus, for each dataset that session has used, the high-water baseline
+# (how many QA/trace entries already belong to an earlier dataset) and a sealed
+# marker. Consumed by dataset-switch.py and the local-SDK bridge to keep the
+# post-switch dataset receiving only post-switch content (no duplicate graph
+# writes) while old state is flushed rather than orphaned.
+_SWITCH_STATE_FILE = _PLUGIN_DIR / "switch_state.json"
 
 # Save-kinds tracked per turn. Keep this tuple in sync with bump_save_counter callers.
 SAVE_KINDS = ("prompt", "trace", "answer")
@@ -504,6 +511,162 @@ def append_http_bridge_entry(
     if trace:
         session_cache.setdefault("trace", []).append(trace)
     _write_json_file(_bridge_file(session_id), cache)
+
+
+# --- Mid-session dataset switch: state, sealing, baselines --------------------
+# A dataset switch keeps the SAME session_id/conn_uuid (so conversation context
+# survives — the session cache is keyed by session_id, not dataset) and only
+# repoints where new graph writes land. The state below records the active
+# dataset per session and, for each dataset, the entry high-water baseline used
+# by the local-SDK bridge to avoid re-emitting pre-switch turns into the new
+# dataset's graph. In HTTP mode the per-dataset bridge buckets already partition
+# writes, so the baseline is a no-op there and only the seal-flush matters.
+
+
+def read_switch_state() -> dict:
+    """Return the whole per-session dataset-switch ledger ({} if absent)."""
+    data = _load_json_file(_SWITCH_STATE_FILE)
+    return data if isinstance(data, dict) else {}
+
+
+def get_switch_record(session_id: str) -> dict:
+    """Return the switch record for one session: {active, datasets:{...}}."""
+    if not session_id:
+        return {}
+    rec = read_switch_state().get(session_id)
+    return rec if isinstance(rec, dict) else {}
+
+
+def _mutate_switch_record(session_id: str, mutate) -> dict:
+    """Read-modify-write one session's switch record; returns the new record."""
+    if not session_id:
+        return {}
+    state = read_switch_state()
+    rec = state.get(session_id)
+    if not isinstance(rec, dict):
+        rec = {}
+    rec.setdefault("datasets", {})
+    mutate(rec)
+    state[session_id] = rec
+    _write_json_file(_SWITCH_STATE_FILE, state)
+    return rec
+
+
+def active_dataset_for_session(session_id: str) -> str:
+    """Return the dataset last recorded active for this session, or ''."""
+    return str(get_switch_record(session_id).get("active") or "")
+
+
+def set_active_dataset_for_session(session_id: str, dataset: str) -> None:
+    """Record which dataset is now active for this session (informational)."""
+    if not session_id or not dataset:
+        return
+    _mutate_switch_record(session_id, lambda rec: rec.__setitem__("active", dataset))
+
+
+def dataset_baseline(session_id: str, dataset: str) -> tuple[int, int]:
+    """Return (qa_start, trace_start) — entries before these belong to an earlier
+    dataset and must NOT be re-persisted into ``dataset``. Defaults to (0, 0) so
+    a session that never switched behaves exactly as before."""
+    ds = get_switch_record(session_id).get("datasets", {})
+    entry = ds.get(dataset) if isinstance(ds, dict) else None
+    if not isinstance(entry, dict):
+        return 0, 0
+    try:
+        return int(entry.get("qa_start", 0) or 0), int(entry.get("trace_start", 0) or 0)
+    except (TypeError, ValueError):
+        return 0, 0
+
+
+def set_dataset_baseline(session_id: str, dataset: str, qa_start: int, trace_start: int) -> None:
+    """Seed the high-water baseline for ``dataset`` (called on switch-in)."""
+    if not session_id or not dataset:
+        return
+
+    def _apply(rec: dict) -> None:
+        entry = rec["datasets"].get(dataset)
+        if not isinstance(entry, dict):
+            entry = {}
+        entry["qa_start"] = int(max(0, qa_start))
+        entry["trace_start"] = int(max(0, trace_start))
+        rec["datasets"][dataset] = entry
+
+    _mutate_switch_record(session_id, _apply)
+
+
+def mark_dataset_sealed(session_id: str, dataset: str) -> None:
+    """Flag a dataset's bridge as sealed for this session (switch-out)."""
+    if not session_id or not dataset:
+        return
+
+    def _apply(rec: dict) -> None:
+        entry = rec["datasets"].get(dataset)
+        if not isinstance(entry, dict):
+            entry = {}
+        entry["sealed"] = True
+        entry["sealed_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        rec["datasets"][dataset] = entry
+
+    _mutate_switch_record(session_id, _apply)
+
+
+def is_dataset_sealed(session_id: str, dataset: str) -> bool:
+    ds = get_switch_record(session_id).get("datasets", {})
+    entry = ds.get(dataset) if isinstance(ds, dict) else None
+    return bool(entry.get("sealed")) if isinstance(entry, dict) else False
+
+
+def count_http_bridge_entries(dataset: str, session_id: str) -> tuple[int, int]:
+    """Return (qa_count, trace_count) buffered in the HTTP bridge bucket for
+    ``(dataset, session_id)`` — the switch high-water for the NEXT dataset."""
+    if not dataset or not session_id:
+        return 0, 0
+    cache = _load_json_file(_bridge_file(session_id))
+    if not isinstance(cache, dict):
+        return 0, 0
+    bucket = cache.get(_bridge_cache_key(dataset, session_id), {})
+    if not isinstance(bucket, dict):
+        return 0, 0
+    return len(bucket.get("qa", []) or []), len(bucket.get("trace", []) or [])
+
+
+def seal_bridge_state(old_dataset: str, session_id: str) -> dict:
+    """Seal the HTTP-mode ``(old_dataset, session_id)`` bridge.
+
+    Flushes the old dataset's buffered QA/trace to its graph BEFORE the switch
+    repoints new writes — otherwise the session-end sync (which resolves only
+    the *current* dataset) would never flush the old bucket, orphaning it. The
+    flush is digest-deduped (``_state``) so re-sealing is a safe no-op. Marks
+    the old dataset sealed and logs ``old bridge sealed`` for the acceptance
+    check. Returns the high-water counts so the caller can seed the new
+    dataset's baseline.
+    """
+    qa_count, trace_count = count_http_bridge_entries(old_dataset, session_id)
+    flushed = False
+    if old_dataset and session_id:
+        try:
+            flushed = persist_session_cache_to_graph_via_http(old_dataset, session_id)
+        except Exception as exc:
+            hook_log("dataset_switch_seal_flush_failed", {"error": str(exc)[:200]})
+        mark_dataset_sealed(session_id, old_dataset)
+    hook_log(
+        "dataset_switch_bridge_sealed",
+        {
+            "message": "old bridge sealed",
+            "old_dataset": old_dataset,
+            "session": session_id,
+            "qa": qa_count,
+            "trace": trace_count,
+            "flushed": flushed,
+        },
+    )
+    return {
+        "sealed": True,
+        "old_dataset": old_dataset,
+        "qa_count": qa_count,
+        "trace_count": trace_count,
+        "flushed": flushed,
+    }
 
 
 async def resolve_user(user_id: str):

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -431,13 +431,22 @@ async def persist_session_cache_to_graph(dataset: str, session_id: str, user) ->
     bridge_state = _load_bridge_state()
     state_changed = False
 
+    # After a mid-session dataset switch the whole session cache (keyed by
+    # session_id) still contains the pre-switch turns. Skip everything before
+    # this dataset's high-water baseline so the new dataset's graph receives
+    # only post-switch content — the "no duplicate graph writes" guarantee.
+    # A session that never switched has baseline (0, 0): unchanged behavior.
+    from _plugin_common import dataset_baseline
+
+    qa_start, trace_start = dataset_baseline(session_id, dataset)
+
     qa_entries = await session_manager.get_session(
         user_id=user_id,
         session_id=session_id,
         formatted=False,
     )
     qa_lines: list[str] = []
-    for entry in qa_entries or []:
+    for entry in (qa_entries or [])[qa_start:]:
         question = _read_field(entry, "question").strip()
         answer = _read_field(entry, "answer").strip()
         if question:
@@ -472,7 +481,8 @@ async def persist_session_cache_to_graph(dataset: str, session_id: str, user) ->
         user_id=user_id,
         session_id=session_id,
     )
-    trace_text = "\n".join(str(value).strip() for value in trace_values or [] if str(value).strip())
+    trace_values = (trace_values or [])[trace_start:]
+    trace_text = "\n".join(str(value).strip() for value in trace_values if str(value).strip())
     if trace_text:
         trace_document = f"Session ID: {session_id}\n\n{trace_text}"
         trace_key = _bridge_state_key(dataset, session_id, user_id, "trace")
@@ -498,6 +508,120 @@ async def persist_session_cache_to_graph(dataset: str, session_id: str, user) ->
         _save_bridge_state(bridge_state)
 
     return wrote
+
+
+def set_active_dataset(new_dataset: str, cwd: Optional[str] = None) -> dict:
+    """Persist ``new_dataset`` as the active dataset for subsequent hooks.
+
+    Each hook runs as a fresh process, so an in-process env change wouldn't
+    survive. The dataset is written to the global plugin config (effective in
+    every mode) and, when a project-level picker file already exists, to that
+    file too — it is the higher-precedence layer the picker owns, so leaving it
+    stale would shadow the switch. Also sets the env for the current process so
+    an in-process caller sees the change immediately.
+
+    Returns ``{"config": bool, "picker": bool}`` recording which stores changed.
+    """
+    result = {"config": False, "picker": False}
+    dataset = str(new_dataset or "").strip()
+    if not dataset:
+        return result
+
+    os.environ["COGNEE_PLUGIN_DATASET"] = dataset
+
+    # Global plugin config: merge-preserving so unrelated keys survive.
+    try:
+        _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        current = {}
+        if _CONFIG_FILE.exists():
+            try:
+                current = json.loads(_CONFIG_FILE.read_text(encoding="utf-8"))
+            except Exception:
+                current = {}
+        if not isinstance(current, dict):
+            current = {}
+        current["dataset"] = dataset
+        _CONFIG_FILE.write_text(json.dumps(current, indent=2), encoding="utf-8")
+        result["config"] = True
+    except Exception as exc:
+        _config_log("set_active_dataset_config_failed", {"error": str(exc)[:200]})
+
+    # Project picker file (.cognee/session-config.json): only update if present,
+    # so we don't litter a repo on installs without the picker, but stay in sync
+    # when the picker is in use (it takes precedence over global config).
+    try:
+        project_dir = Path(cwd or os.environ.get("CLAUDE_CWD") or os.getcwd())
+        picker_path = project_dir / ".cognee" / "session-config.json"
+        if picker_path.exists():
+            try:
+                picker = json.loads(picker_path.read_text(encoding="utf-8"))
+            except Exception:
+                picker = {}
+            if not isinstance(picker, dict):
+                picker = {}
+            picker["dataset"] = dataset
+            picker_path.write_text(json.dumps(picker, indent=2), encoding="utf-8")
+            result["picker"] = True
+    except Exception as exc:
+        _config_log("set_active_dataset_picker_failed", {"error": str(exc)[:200]})
+
+    return result
+
+
+async def seal_session_bridge_local(old_dataset: str, session_id: str, user) -> dict:
+    """Local-SDK seal: flush the old dataset (delta only) and mark it sealed.
+
+    Returns the high-water entry counts ``{"qa_count", "trace_count", ...}`` so
+    the caller can seed the new dataset's baseline, keeping post-switch turns out
+    of the old dataset's re-persist and pre-switch turns out of the new one.
+    """
+    from _plugin_common import hook_log, mark_dataset_sealed
+
+    qa_count = 0
+    trace_count = 0
+    flushed = False
+    if session_id and user:
+        try:
+            from cognee.infrastructure.session.get_session_manager import get_session_manager
+
+            session_manager = get_session_manager()
+            if session_manager.is_available:
+                user_id = str(user.id)
+                qa_entries = await session_manager.get_session(
+                    user_id=user_id, session_id=session_id, formatted=False
+                )
+                trace_values = await session_manager.get_agent_trace_feedback(
+                    user_id=user_id, session_id=session_id
+                )
+                qa_count = len(qa_entries or [])
+                trace_count = len(trace_values or [])
+        except Exception as exc:
+            _config_log("seal_local_count_failed", {"error": str(exc)[:200]})
+        try:
+            flushed = await persist_session_cache_to_graph(old_dataset, session_id, user)
+        except Exception as exc:
+            _config_log("seal_local_flush_failed", {"error": str(exc)[:200]})
+        mark_dataset_sealed(session_id, old_dataset)
+
+    hook_log(
+        "dataset_switch_bridge_sealed",
+        {
+            "message": "old bridge sealed",
+            "old_dataset": old_dataset,
+            "session": session_id,
+            "qa": qa_count,
+            "trace": trace_count,
+            "flushed": flushed,
+            "mode": "local",
+        },
+    )
+    return {
+        "sealed": True,
+        "old_dataset": old_dataset,
+        "qa_count": qa_count,
+        "trace_count": trace_count,
+        "flushed": flushed,
+    }
 
 
 def _get_git_branch(cwd: str) -> str:

--- a/integrations/claude-code/scripts/dataset-switch.py
+++ b/integrations/claude-code/scripts/dataset-switch.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Switch the active dataset mid-session without dropping conversation context.
+
+A dataset switch keeps the SAME Cognee ``session_id`` (and the ``conn_uuid``
+registration handle), so the session cache — which is keyed by ``session_id``,
+not the dataset — is untouched and ``recall`` still returns prior-conversation
+context after the switch. Only *where new graph writes land* changes.
+
+Three phases, ordered so a crash mid-switch never orphans or duplicates state:
+
+  1. Seal the old ``(dataset, session_id)`` bridge: flush its buffered QA/trace
+     to the old dataset's graph (else the session-end sync, which resolves only
+     the *current* dataset, would never flush it), then mark it sealed.
+  2. Switch the active dataset (persist it so every later hook keys under the new
+     dataset) and seed the new dataset's high-water baseline from the sealed
+     counts, so the local-SDK bridge re-emits only post-switch turns.
+  3. Re-register the agent against the new dataset with the SAME
+     ``agent_session_name`` (conn_uuid) + ``session_id`` — an in-place
+     re-register, not a fresh connection.
+
+Idempotent: switching to the dataset already active is a no-op. Best-effort:
+failures log and degrade; they never crash the calling hook.
+
+Invocation (any of):
+  * ``python dataset-switch.py <new_dataset>``
+  * ``COGNEE_SWITCH_DATASET=<new_dataset> python dataset-switch.py``
+  * a hook payload on stdin carrying ``new_dataset`` / ``dataset``
+"""
+
+import asyncio
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from _plugin_common import (
+    get_session_key,
+    hook_log,
+    http_api_ready,
+    register_agent_via_http,
+    resolve_cognee_session_id,
+    resolve_conn_uuid,
+    resolve_session_key_from_payload,
+    resolve_user,
+    resolved_http_endpoint_auth,
+    seal_bridge_state,
+    set_active_dataset_for_session,
+    set_dataset_baseline,
+    set_session_key,
+)
+from config import (
+    ensure_cognee_ready,
+    ensure_dataset_ready,
+    get_dataset,
+    load_config,
+    seal_session_bridge_local,
+    set_active_dataset,
+)
+
+
+def _resolve_new_dataset(payload: dict, argv: list[str]) -> str:
+    """Resolve the requested new dataset from CLI arg, env, or hook payload."""
+    for arg in argv[1:]:
+        text = str(arg or "").strip()
+        if text and not text.startswith("-"):
+            return text
+    env = str(os.environ.get("COGNEE_SWITCH_DATASET", "") or "").strip()
+    if env:
+        return env
+    if isinstance(payload, dict):
+        for key in ("new_dataset", "dataset", "datasetName", "dataset_name"):
+            val = str(payload.get(key) or "").strip()
+            if val:
+                return val
+    return ""
+
+
+async def switch_dataset(new_dataset: str, cwd: str = "") -> dict:
+    """Orchestrate the three-phase switch. Returns a structured result dict."""
+    new_dataset = str(new_dataset or "").strip()
+    session_key = set_session_key(get_session_key())
+    session_id = resolve_cognee_session_id(session_key, cwd)
+    conn_uuid = resolve_conn_uuid(session_key)
+    config = load_config()
+    old_dataset = str(get_dataset(config) or "").strip()
+
+    if not new_dataset:
+        hook_log("dataset_switch_noop", {"reason": "no_new_dataset", "session": session_id})
+        return {"status": "noop", "reason": "no_new_dataset"}
+    if not session_id:
+        hook_log("dataset_switch_noop", {"reason": "no_session_id"})
+        return {"status": "noop", "reason": "no_session_id"}
+    if new_dataset == old_dataset:
+        hook_log(
+            "dataset_switch_noop",
+            {"reason": "already_active", "dataset": new_dataset, "session": session_id},
+        )
+        return {"status": "noop", "reason": "already_active", "dataset": new_dataset}
+
+    hook_log(
+        "dataset_switch_requested",
+        {"old_dataset": old_dataset, "new_dataset": new_dataset, "session": session_id},
+    )
+
+    api_mode = http_api_ready()
+
+    # Phase 1: seal the old bridge (flush old dataset, mark sealed, high-water).
+    if api_mode:
+        seal = seal_bridge_state(old_dataset, session_id)
+    else:
+        config_local = load_config()
+        try:
+            await ensure_cognee_ready(config_local)
+        except Exception as exc:
+            hook_log("dataset_switch_local_ready_failed", {"error": str(exc)[:200]})
+        user = await resolve_user("")
+        try:
+            await ensure_dataset_ready(old_dataset, user)
+        except Exception as exc:
+            hook_log("dataset_switch_local_dataset_ready_failed", {"error": str(exc)[:200]})
+        seal = await seal_session_bridge_local(old_dataset, session_id, user)
+
+    # Phase 2: switch the active dataset + seed the new dataset's baseline so it
+    # only ever receives post-switch content (no duplicate graph writes).
+    stores = set_active_dataset(new_dataset, cwd)
+    set_dataset_baseline(
+        session_id,
+        new_dataset,
+        int(seal.get("qa_count", 0) or 0),
+        int(seal.get("trace_count", 0) or 0),
+    )
+    set_active_dataset_for_session(session_id, new_dataset)
+
+    # Phase 3: re-register the agent in place (same conn_uuid + session_id).
+    reregistered = False
+    if api_mode:
+        resolved_http_endpoint_auth()
+        reregistered, registration = register_agent_via_http(
+            agent_session_name=conn_uuid,
+            session_id=session_id,
+            dataset_names=[new_dataset],
+        )
+        hook_log(
+            "dataset_switch_agent_reregistered",
+            {
+                "message": "agent re-registered",
+                "agent_session_name": conn_uuid,
+                "session": session_id,
+                "new_dataset": new_dataset,
+                "ok": reregistered,
+                "connection_id": str(registration.get("id", "")) if registration else "",
+            },
+        )
+    else:
+        # Local SDK mode has no server-side agent registry to re-register against.
+        hook_log(
+            "dataset_switch_agent_reregister_skipped",
+            {"reason": "local_sdk_mode", "session": session_id, "new_dataset": new_dataset},
+        )
+
+    hook_log(
+        "dataset_switch_complete",
+        {
+            "old_dataset": old_dataset,
+            "new_dataset": new_dataset,
+            "session": session_id,
+            "mode": "http" if api_mode else "local_sdk",
+            "sealed": seal.get("sealed", False),
+            "flushed": seal.get("flushed", False),
+            "reregistered": reregistered,
+            "stores": stores,
+        },
+    )
+    return {
+        "status": "switched",
+        "old_dataset": old_dataset,
+        "new_dataset": new_dataset,
+        "session_id": session_id,
+        "mode": "http" if api_mode else "local_sdk",
+        "seal": seal,
+        "reregistered": reregistered,
+    }
+
+
+def main() -> None:
+    payload: dict = {}
+    if not sys.stdin.isatty():
+        try:
+            raw = sys.stdin.read()
+        except Exception:
+            raw = ""
+        if raw.strip():
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                payload = {}
+    if isinstance(payload, dict) and payload:
+        session_key_candidate, _ = resolve_session_key_from_payload(payload)
+        if session_key_candidate:
+            set_session_key(session_key_candidate)
+
+    new_dataset = _resolve_new_dataset(payload, sys.argv)
+    cwd = str(
+        (payload.get("cwd") if isinstance(payload, dict) else "")
+        or os.environ.get("CLAUDE_CWD")
+        or os.getcwd()
+    )
+
+    try:
+        result = asyncio.run(switch_dataset(new_dataset, cwd))
+    except Exception as exc:
+        hook_log("dataset_switch_failed", {"error": str(exc)[:300]})
+        print(f"cognee-dataset-switch: failed ({exc})", file=sys.stderr)
+        return
+
+    status = result.get("status")
+    if status == "switched":
+        print(
+            f"cognee-dataset-switch: {result.get('old_dataset')} -> "
+            f"{result.get('new_dataset')} (session={result.get('session_id')})",
+            file=sys.stderr,
+        )
+    else:
+        print(f"cognee-dataset-switch: no-op ({result.get('reason')})", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/claude-code/skills/cognee-dataset-switch/SKILL.md
+++ b/integrations/claude-code/skills/cognee-dataset-switch/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: cognee-dataset-switch
+description: Switch the active Cognee dataset mid-session without losing conversation context. Seals the old dataset's bridge, re-registers the agent on the new dataset, and keeps recall of prior turns intact.
+---
+
+# Switch Dataset Mid-Session
+
+Repoint where new memory is written — to a different Cognee dataset — while
+keeping the current conversation's context.
+
+## Instructions
+
+Run the switch script with the new dataset name:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/dataset-switch.py <new_dataset>
+```
+
+## What this does
+
+1. **Seals the old bridge** — flushes the current dataset's buffered Q&A/trace
+   into its permanent graph *before* switching, so nothing is orphaned. The old
+   `(dataset, session_id)` bridge is marked sealed. `hook.log` records
+   `old bridge sealed`.
+2. **Switches the active dataset** — persists the new dataset so every
+   subsequent hook writes there (updates the global plugin config, and the
+   project `.cognee/session-config.json` picker if present).
+3. **Re-registers the agent** — calls `/api/v1/agents/register` with the *same*
+   `agent_session_name` (connection handle) and `session_id`, bound to the new
+   dataset. `hook.log` records `agent re-registered`.
+
+## What stays the same
+
+The Cognee `session_id` (and connection handle) never change, and the session
+cache is keyed by `session_id` — **not** the dataset. So the conversation
+context carries over: `recall` still returns prior-conversation turns after the
+switch. Only *new* graph writes go to the new dataset; pre-switch turns stay in
+the old dataset (no duplicate graph writes).
+
+## When to use
+
+- You want to store the rest of this session's memory under a different dataset
+  (e.g. switching projects/topics) but keep the ongoing conversation.
+- Switching to the dataset that is already active is a safe no-op.

--- a/integrations/claude-code/tests/test_dataset_switch.py
+++ b/integrations/claude-code/tests/test_dataset_switch.py
@@ -1,0 +1,283 @@
+"""Tests for mid-session dataset switching (dataset-switch.py + helpers).
+
+Covers the acceptance criteria for a mid-session dataset switch:
+  * the old ``(dataset, session_id)`` bridge is sealed (flushed + marked) and
+    ``hook.log`` records ``old bridge sealed``;
+  * the agent is re-registered against the new dataset with the SAME
+    ``agent_session_name`` (conn_uuid) + ``session_id`` and ``hook.log`` records
+    ``agent re-registered``;
+  * the new dataset's high-water baseline is seeded so it receives only
+    post-switch content (no duplicate graph writes);
+  * switching to the already-active dataset is a no-op.
+
+All I/O is redirected under a temp home and every network call is mocked, so
+the suite is deterministic and needs no live Cognee server.
+
+Run: python integrations/claude-code/tests/test_dataset_switch.py (or via pytest).
+"""
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+import _plugin_common as pc  # noqa: E402
+import config  # noqa: E402
+
+
+def _load_dataset_switch():
+    """Import the hyphenated dataset-switch.py module by path."""
+    spec = importlib.util.spec_from_file_location(
+        "dataset_switch", str(_SCRIPTS / "dataset-switch.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def isolate(monkeypatch, tmp_path):
+    """Redirect every plugin path under a temp home and clear COGNEE_* env."""
+    home = tmp_path / "home"
+    plugin = home / ".cognee-plugin" / "claude-code"
+    shared = home / ".cognee-plugin"
+    plugin.mkdir(parents=True)
+
+    # _plugin_common module-level paths (computed from Path.home at import).
+    monkeypatch.setattr(pc, "_PLUGIN_DIR", plugin)
+    monkeypatch.setattr(pc, "_SHARED_PLUGIN_ROOT", shared)
+    monkeypatch.setattr(pc, "_HOOK_LOG", plugin / "hook.log")
+    monkeypatch.setattr(pc, "_SWITCH_STATE_FILE", plugin / "switch_state.json")
+    monkeypatch.setattr(pc, "_BRIDGE_DIR", plugin / "bridge")
+    monkeypatch.setattr(pc, "_PENDING_DIR", plugin / "pending")
+    monkeypatch.setattr(pc, "_SESSIONS_MAP_DIR", plugin / "sessions")
+    monkeypatch.setattr(pc, "_API_KEY_CACHE", shared / "api_key.json")
+
+    # config module-level paths.
+    monkeypatch.setattr(config, "_CONFIG_DIR", plugin)
+    monkeypatch.setattr(config, "_STATE_DIR", plugin)
+    monkeypatch.setattr(config, "_CONFIG_FILE", plugin / "config.json")
+    monkeypatch.setattr(config, "_BRIDGE_STATE_FILE", plugin / "bridge_state.json")
+    monkeypatch.setattr(config, "_HOOK_LOG", plugin / "hook.log")
+
+    for key in list(os.environ.keys()):
+        if key.startswith("COGNEE_") or key == "CLAUDE_CWD":
+            monkeypatch.delenv(key, raising=False)
+
+    monkeypatch.setenv("COGNEE_SESSION_KEY", "hostkey1")
+    return home
+
+
+def _read_hook_events():
+    lines = pc._HOOK_LOG.read_text(encoding="utf-8").splitlines()
+    return [json.loads(line) for line in lines if line.strip()]
+
+
+# --- state helpers -----------------------------------------------------------
+
+
+def test_baseline_defaults_to_zero():
+    assert pc.dataset_baseline("s1", "A") == (0, 0)
+
+
+def test_baseline_roundtrip():
+    pc.set_dataset_baseline("s1", "B", 5, 12)
+    assert pc.dataset_baseline("s1", "B") == (5, 12)
+    # An unrelated dataset in the same session is unaffected.
+    assert pc.dataset_baseline("s1", "A") == (0, 0)
+
+
+def test_sealed_marker_roundtrip():
+    assert pc.is_dataset_sealed("s1", "A") is False
+    pc.mark_dataset_sealed("s1", "A")
+    assert pc.is_dataset_sealed("s1", "A") is True
+
+
+def test_active_dataset_for_session():
+    assert pc.active_dataset_for_session("s1") == ""
+    pc.set_active_dataset_for_session("s1", "B")
+    assert pc.active_dataset_for_session("s1") == "B"
+
+
+def test_count_http_bridge_entries():
+    pc.append_http_bridge_entry("A", "s1", question="q1", answer="a1")
+    pc.append_http_bridge_entry("A", "s1", trace="t1")
+    pc.append_http_bridge_entry("A", "s1", trace="t2")
+    assert pc.count_http_bridge_entries("A", "s1") == (1, 2)
+    # A different dataset bucket is counted independently.
+    assert pc.count_http_bridge_entries("B", "s1") == (0, 0)
+
+
+# --- seal --------------------------------------------------------------------
+
+
+def test_seal_flushes_marks_and_logs(monkeypatch):
+    pc.append_http_bridge_entry("A", "s1", question="q1", answer="a1")
+    calls = {}
+
+    def _fake_persist(dataset, session_id, timeout=600.0):
+        calls["persist"] = (dataset, session_id)
+        return True
+
+    monkeypatch.setattr(pc, "persist_session_cache_to_graph_via_http", _fake_persist)
+
+    result = pc.seal_bridge_state("A", "s1")
+
+    assert calls["persist"] == ("A", "s1")
+    assert result["sealed"] is True
+    assert result["qa_count"] == 1
+    assert result["flushed"] is True
+    assert pc.is_dataset_sealed("s1", "A") is True
+
+    events = _read_hook_events()
+    sealed = [e for e in events if e["event"] == "dataset_switch_bridge_sealed"]
+    assert sealed and sealed[0]["detail"]["message"] == "old bridge sealed"
+
+
+# --- set_active_dataset ------------------------------------------------------
+
+
+def test_set_active_dataset_writes_global_config():
+    stores = config.set_active_dataset("B", cwd="")
+    assert stores["config"] is True
+    assert stores["picker"] is False
+    saved = json.loads(config._CONFIG_FILE.read_text(encoding="utf-8"))
+    assert saved["dataset"] == "B"
+    assert os.environ["COGNEE_PLUGIN_DATASET"] == "B"
+
+
+def test_set_active_dataset_preserves_other_config_keys():
+    config._CONFIG_FILE.write_text(json.dumps({"agent_name": "keep-me"}), encoding="utf-8")
+    config.set_active_dataset("B")
+    saved = json.loads(config._CONFIG_FILE.read_text(encoding="utf-8"))
+    assert saved["agent_name"] == "keep-me"
+    assert saved["dataset"] == "B"
+
+
+def test_set_active_dataset_updates_picker_when_present(tmp_path):
+    project = tmp_path / "proj"
+    cognee_dir = project / ".cognee"
+    cognee_dir.mkdir(parents=True)
+    picker = cognee_dir / "session-config.json"
+    picker.write_text(json.dumps({"dataset": "A", "session_id": "keep"}), encoding="utf-8")
+
+    stores = config.set_active_dataset("B", cwd=str(project))
+    assert stores["picker"] is True
+    updated = json.loads(picker.read_text(encoding="utf-8"))
+    assert updated["dataset"] == "B"
+    assert updated["session_id"] == "keep"  # unrelated keys preserved
+
+
+def test_set_active_dataset_does_not_create_picker(tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    stores = config.set_active_dataset("B", cwd=str(project))
+    assert stores["picker"] is False
+    assert not (project / ".cognee" / "session-config.json").exists()
+
+
+# --- orchestration (http mode) ----------------------------------------------
+
+
+def _wire_http_mode(monkeypatch, ds, register_result=(True, {"id": "conn-123"})):
+    monkeypatch.setattr(ds, "http_api_ready", lambda: True)
+    monkeypatch.setattr(pc, "persist_session_cache_to_graph_via_http", lambda *a, **k: True)
+    captured = {}
+
+    def _fake_register(*, agent_session_name, session_id="", dataset_names=None, timeout=15.0):
+        captured["agent_session_name"] = agent_session_name
+        captured["session_id"] = session_id
+        captured["dataset_names"] = dataset_names
+        return register_result
+
+    monkeypatch.setattr(ds, "register_agent_via_http", _fake_register)
+    return captured
+
+
+def test_switch_http_seals_reregisters_and_seeds_baseline(monkeypatch):
+    monkeypatch.setenv("COGNEE_SESSION_ID", "sess-1")
+    config._CONFIG_FILE.write_text(json.dumps({"dataset": "A"}), encoding="utf-8")
+    # Two pre-switch QA turns buffered under dataset A -> high-water = (2, 0).
+    pc.append_http_bridge_entry("A", "sess-1", question="q1", answer="a1")
+    pc.append_http_bridge_entry("A", "sess-1", question="q2", answer="a2")
+
+    ds = _load_dataset_switch()
+    captured = _wire_http_mode(monkeypatch, ds)
+
+    import asyncio
+
+    result = asyncio.run(ds.switch_dataset("B", cwd=""))
+
+    assert result["status"] == "switched"
+    assert result["old_dataset"] == "A"
+    assert result["new_dataset"] == "B"
+
+    # Old bridge sealed.
+    assert pc.is_dataset_sealed("sess-1", "A") is True
+    # Agent re-registered in place: same conn_uuid handle + session, new dataset.
+    assert captured["session_id"] == "sess-1"
+    assert captured["dataset_names"] == ["B"]
+    assert captured["agent_session_name"].startswith("conn_")
+    # New dataset seeded with the high-water baseline (2 pre-switch QA turns).
+    assert pc.dataset_baseline("sess-1", "B") == (2, 0)
+    # Active dataset persisted.
+    assert config.get_dataset(config.load_config()) == "B"
+
+    events = {e["event"] for e in _read_hook_events()}
+    assert "dataset_switch_bridge_sealed" in events
+    assert "dataset_switch_agent_reregistered" in events
+    assert "dataset_switch_complete" in events
+
+
+def test_switch_noop_when_same_dataset(monkeypatch):
+    monkeypatch.setenv("COGNEE_SESSION_ID", "sess-1")
+    config._CONFIG_FILE.write_text(json.dumps({"dataset": "A"}), encoding="utf-8")
+
+    ds = _load_dataset_switch()
+    captured = _wire_http_mode(monkeypatch, ds)
+
+    import asyncio
+
+    result = asyncio.run(ds.switch_dataset("A", cwd=""))
+
+    assert result["status"] == "noop"
+    assert result["reason"] == "already_active"
+    assert "agent_session_name" not in captured  # never re-registered
+    assert pc.is_dataset_sealed("sess-1", "A") is False
+
+
+def test_switch_noop_when_no_new_dataset(monkeypatch):
+    monkeypatch.setenv("COGNEE_SESSION_ID", "sess-1")
+    config._CONFIG_FILE.write_text(json.dumps({"dataset": "A"}), encoding="utf-8")
+
+    ds = _load_dataset_switch()
+    _wire_http_mode(monkeypatch, ds)
+
+    import asyncio
+
+    result = asyncio.run(ds.switch_dataset("", cwd=""))
+    assert result["status"] == "noop"
+    assert result["reason"] == "no_new_dataset"
+
+
+def test_resolve_new_dataset_precedence(monkeypatch):
+    ds = _load_dataset_switch()
+    # CLI arg wins over env and payload.
+    monkeypatch.setenv("COGNEE_SWITCH_DATASET", "env-ds")
+    assert ds._resolve_new_dataset({"new_dataset": "payload-ds"}, ["prog", "cli-ds"]) == "cli-ds"
+    # env wins over payload.
+    assert ds._resolve_new_dataset({"new_dataset": "payload-ds"}, ["prog"]) == "env-ds"
+    monkeypatch.delenv("COGNEE_SWITCH_DATASET", raising=False)
+    # payload fallback.
+    assert ds._resolve_new_dataset({"dataset": "payload-ds"}, ["prog"]) == "payload-ds"
+    assert ds._resolve_new_dataset({}, ["prog"]) == ""
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Implements mid-session dataset switching for the Claude Code plugin.

Closes topoteretes/cognee#3689 (roadmap WS4, `area:datasets`).

## What & why

Switching datasets mid-session must **seal** the old `(dataset, session_id)` bridge and **re-register** the agent on the new dataset — without orphaning state or duplicating graph writes, and while preserving conversation context (*same session, different dataset*).

The key realization from tracing the code: the design **already** separates `session_id` (the switchable data-scoping key) from `conn_uuid` (the fixed registration handle), and the session cache is keyed by `session_id` — **not** the dataset. So a switch just repoints *where new graph writes land*; conversation `recall` carries over for free as long as `session_id`/`conn_uuid` are left unchanged.

## Design — three-phase switch (`scripts/dataset-switch.py`)

Ordered so a crash mid-switch never orphans or duplicates state:

1. **Seal the old bridge** — flush the old dataset's buffered QA/trace to its graph *before* repointing (the session-end sync only resolves the *current* dataset, so the old bucket would otherwise be orphaned), then mark it sealed.
2. **Switch the active dataset** — persist it so every later hook keys under the new dataset, and seed the new dataset's high-water baseline.
3. **Re-register the agent in place** — `register_agent_via_http(agent_session_name=conn_uuid, session_id=…, dataset_names=[new])` — same handle + session, new dataset binding (not a fresh connection).

Idempotent (no-op when the dataset is unchanged) and best-effort (failures log + degrade, never crash a hook). Works in both HTTP/server and local-SDK modes.

### No duplicate graph writes

- **HTTP mode** (primary): the local bridge shadow already partitions by `{dataset}:{session_id}` buckets and dedups via `_state` digests, so post-switch writes naturally land only in the new bucket. The seal-flush is what prevents the old bucket from being *orphaned*.
- **Local-SDK mode**: `persist_session_cache_to_graph()` reads the *whole* session cache (keyed by `session_id`), so a naive switch would re-emit pre-switch turns into the new dataset. Fixed with a per-`(session, dataset)` **high-water baseline** — the new dataset receives only entries after the switch. Default baseline `(0, 0)` ⇒ unchanged behavior for sessions that never switch. This composes correctly across multiple switches (each dataset gets exactly its era).

## Files

| File | Change |
|---|---|
| `scripts/dataset-switch.py` | **new** — three-phase orchestrator (CLI arg / `COGNEE_SWITCH_DATASET` / hook payload) |
| `scripts/_plugin_common.py` | switch-state ledger, `seal_bridge_state()` (HTTP), baseline + sealed-marker helpers |
| `scripts/config.py` | `set_active_dataset()`, baseline-aware `persist_session_cache_to_graph()`, `seal_session_bridge_local()` |
| `skills/cognee-dataset-switch/SKILL.md` | **new** — `/cognee-memory:cognee-dataset-switch` |
| `README.md` | documents the mid-session switch |
| `tests/test_dataset_switch.py` | **new** — 14 tests, fully mocked (no live server) |

## Acceptance

- [x] Switch mid-session → recall still returns prior-conversation context (`session_id`/`conn_uuid` unchanged, cache keyed by `session_id`).
- [x] `hook.log` shows **old bridge sealed** (`dataset_switch_bridge_sealed`) + **agent re-registered** (`dataset_switch_agent_reregistered`).
- [x] No duplicate graph writes (HTTP per-dataset buckets + digests; local high-water baseline).
- [x] No orphaned state (old bucket flushed before switch).

## Testing

```
python -m pytest integrations/claude-code/tests/ -q
# 74 passed  (14 new)
ruff check … → All checks passed!
```

## Scope notes

- **Integrations-only** — no core `cognee` changes (the issue pointers all live here).
- **Claude-code only** this PR; mirroring to the `codex` twin is a straightforward follow-up.
- **Forward-compatible with the `.cognee` picker** (#3686): `set_active_dataset()` updates the project `.cognee/session-config.json` when present (the picker's higher-precedence layer) and always the global config, so it's effective on `main` today and stays in sync once the picker lands.

_Base branch: `main` (cognee-integrations has no `dev` branch)._