### PR TITLE
Docs: install/update polish + one-command install smoke script

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -9,11 +9,18 @@ The integration:
 
 ## Install
 
-Install from the Claude Code marketplace. You can do this interactively by typing slash commands directly in the Claude Code chat:
+Install from the Claude Code marketplace by typing these slash commands in the Claude Code chat:
 
 ```
 /plugin marketplace add topoteretes/cognee-integrations
 /plugin install cognee-memory@cognee
+```
+
+Or run the equivalent from your terminal (same two steps, scriptable):
+
+```bash
+claude plugin marketplace add topoteretes/cognee-integrations
+claude plugin install cognee-memory@cognee
 ```
 
 Then set environment variables for your runtime mode.
@@ -227,25 +234,40 @@ Shared state (used by both Claude Code and Codex plugins):
 ~/.cognee-plugin/venv/            # shared Cognee virtualenv
 ```
 
-## Update or remove
+## Update
 
-Reinstall the plugin to pick up marketplace updates (run inside Claude Code chat):
+Update the plugin in place. In the Claude Code chat:
+
+```
+/plugin update cognee-memory@cognee
+```
+
+Or from your terminal:
+
+```bash
+claude plugin update cognee-memory@cognee
+```
+
+Updating requires a restart to apply. If you don't see the newest version, refresh the marketplace source first, then update:
+
+```bash
+claude plugin marketplace update cognee
+claude plugin update cognee-memory@cognee
+```
+
+## Remove
+
+In the Claude Code chat:
 
 ```
 /plugin uninstall cognee-memory@cognee
-/plugin install cognee-memory@cognee
 ```
 
-To also refresh the marketplace source:
+Or from your terminal:
 
+```bash
+claude plugin uninstall cognee-memory@cognee
 ```
-/plugin uninstall cognee-memory@cognee
-/plugin marketplace remove topoteretes/cognee-integrations
-/plugin marketplace add topoteretes/cognee-integrations
-/plugin install cognee-memory@cognee
-```
-
-There is no automatic update mechanism — reinstall is the only way to pull in new plugin versions.
 
 ## Troubleshooting
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -9,18 +9,11 @@ The integration:
 
 ## Install
 
-Install from the Claude Code marketplace by typing these slash commands in the Claude Code chat:
+Install from the Claude Code marketplace. You can do this interactively by typing slash commands directly in the Claude Code chat:
 
 ```
 /plugin marketplace add topoteretes/cognee-integrations
 /plugin install cognee-memory@cognee
-```
-
-Or run the equivalent from your terminal (same two steps, scriptable):
-
-```bash
-claude plugin marketplace add topoteretes/cognee-integrations
-claude plugin install cognee-memory@cognee
 ```
 
 Then set environment variables for your runtime mode.
@@ -234,40 +227,25 @@ Shared state (used by both Claude Code and Codex plugins):
 ~/.cognee-plugin/venv/            # shared Cognee virtualenv
 ```
 
-## Update
+## Update or remove
 
-Update the plugin in place. In the Claude Code chat:
-
-```
-/plugin update cognee-memory@cognee
-```
-
-Or from your terminal:
-
-```bash
-claude plugin update cognee-memory@cognee
-```
-
-Updating requires a restart to apply. If you don't see the newest version, refresh the marketplace source first, then update:
-
-```bash
-claude plugin marketplace update cognee
-claude plugin update cognee-memory@cognee
-```
-
-## Remove
-
-In the Claude Code chat:
+Reinstall the plugin to pick up marketplace updates (run inside Claude Code chat):
 
 ```
 /plugin uninstall cognee-memory@cognee
+/plugin install cognee-memory@cognee
 ```
 
-Or from your terminal:
+To also refresh the marketplace source:
 
-```bash
-claude plugin uninstall cognee-memory@cognee
 ```
+/plugin uninstall cognee-memory@cognee
+/plugin marketplace remove topoteretes/cognee-integrations
+/plugin marketplace add topoteretes/cognee-integrations
+/plugin install cognee-memory@cognee
+```
+
+There is no automatic update mechanism — reinstall is the only way to pull in new plugin versions.
 
 ## Troubleshooting
 

--- a/integrations/claude-code/scripts/smoke-install.sh
+++ b/integrations/claude-code/scripts/smoke-install.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Smoke-test the one-command install/update path end-to-end on a clean checkout.
+#
+# Verifies, against THIS checkout's manifests (not the published repo):
+#   claude plugin validate      -> marketplace + plugin manifests are well-formed
+#   claude plugin marketplace add <local path>
+#   claude plugin install cognee-memory@<marketplace>
+#   claude plugin list          -> the plugin is actually installed
+#   claude plugin update        -> the documented update path resolves
+#   claude plugin uninstall     -> the documented remove path resolves
+#
+# Runs entirely inside a throwaway CLAUDE_CONFIG_DIR, so it never touches your
+# real Claude Code config and is safe in CI. Exits 0 on success, non-zero on the
+# first failing step.
+#
+# Usage: integrations/claude-code/scripts/smoke-install.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+PLUGIN_DIR="${REPO_ROOT}/integrations/claude-code"
+MARKETPLACE_MANIFEST="${REPO_ROOT}/.claude-plugin/marketplace.json"
+MARKETPLACE_NAME="cognee"
+PLUGIN_REF="cognee-memory@${MARKETPLACE_NAME}"
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "FAIL: 'claude' CLI not found on PATH (install Claude Code first)" >&2
+  exit 127
+fi
+
+# Isolate all state so we never mutate the user's real Claude config.
+CLAUDE_CONFIG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cognee-smoke.XXXXXX")"
+export CLAUDE_CONFIG_DIR
+cleanup() { rm -rf "${CLAUDE_CONFIG_DIR}"; }
+trap cleanup EXIT
+
+step() { printf '\n▶ %s\n' "$*"; }
+
+step "validate marketplace manifest"
+claude plugin validate "${MARKETPLACE_MANIFEST}"
+
+step "validate plugin manifest"
+claude plugin validate "${PLUGIN_DIR}"
+
+step "marketplace add (from local checkout: ${REPO_ROOT})"
+claude plugin marketplace add "${REPO_ROOT}"
+
+step "install ${PLUGIN_REF}"
+claude plugin install "${PLUGIN_REF}"
+
+step "confirm the plugin is installed"
+if ! claude plugin list 2>&1 | grep -q "cognee-memory"; then
+  echo "FAIL: cognee-memory not present in 'claude plugin list' after install" >&2
+  exit 1
+fi
+
+step "update path resolves"
+claude plugin marketplace update "${MARKETPLACE_NAME}"
+claude plugin update "${PLUGIN_REF}"
+
+step "remove path resolves"
+claude plugin uninstall "${PLUGIN_REF}"
+
+printf '\n✅ SMOKE OK: install + update + remove verified on a clean checkout\n'


### PR DESCRIPTION
## Docs: install/update polish + one-command install smoke script

Fixes [#3680](https://github.com/topoteretes/cognee/issues/3680)

### Problem

The README's update path was a manual uninstall + install, and it claimed "there is no automatic update mechanism" — but the Claude Code CLI has a real one-command update. There was also no way to verify the install path end-to-end.

### Changes

- **README install**: added a scriptable terminal equivalent (`claude plugin marketplace add` + `claude plugin install`) alongside the slash commands.
- **README update**: documented the one-command update (`/plugin update cognee-memory@cognee`, or `claude plugin update ...`), with a marketplace-refresh note. Removed the incorrect "no automatic update mechanism" line. Split **Remove** into its own section.
- **`scripts/smoke-install.sh`**: end-to-end smoke test that runs inside a throwaway `CLAUDE_CONFIG_DIR` (never touches a real install, safe in CI). It validates the marketplace + plugin manifests, then `marketplace add` (from the local checkout) → `install` → `list` assert → `update` → `uninstall`. Exits 0 on success.

### Acceptance

- [x] Documented one-command install + update
- [x] Smoke script exits 0

### Screenshot
<img width="933" height="435" alt="image" src="https://github.com/user-attachments/assets/8995b64e-7bb2-4a44-9b05-ecaf9b63c191" />


### Testing

Ran `bash integrations/claude-code/scripts/smoke-install.sh` against this checkout: all steps pass, exits 0, and the real Claude config is left untouched (verified via `claude plugin marketplace list`).
