### PR TITLE
feat(integrations): re-register agent session on mid-session COGNEE_BASE_URL change

### DIFF
--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -354,6 +354,380 @@ def _resolve_agent_name() -> str:
     return _normalize("claude-code-agent")
 
 
+def _login_default_user_via_http(service_url: str, config: dict) -> str:
+    base = _normalize_service_url(service_url)
+    email = config.get("user_email") or "default_user@example.com"
+    password = config.get("user_password") or "default_password"
+
+    params = urllib.parse.urlencode({"username": email, "password": password}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base}/api/v1/auth/login",
+        data=params,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10.0) as resp:
+            if resp.status != 200:
+                return ""
+            login_data = json.loads(resp.read().decode("utf-8"))
+            jwt = str(login_data.get("access_token", "") or "")
+    except Exception as exc:
+        hook_log("sync_login_failed", {"error": str(exc)[:200]})
+        return ""
+
+    if not jwt:
+        return ""
+
+    req_keys = urllib.request.Request(
+        f"{base}/api/v1/auth/api-keys",
+        headers={"Cookie": f"auth_token={jwt}"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req_keys, timeout=10.0) as resp:
+            if resp.status == 200:
+                keys = json.loads(resp.read().decode("utf-8"))
+                if isinstance(keys, list) and keys:
+                    key = str(keys[0].get("key", "") or "")
+                    if key:
+                        return key
+    except Exception:
+        pass
+
+    req_mint = urllib.request.Request(
+        f"{base}/api/v1/auth/api-keys",
+        data=json.dumps({"name": "claude-owner-bootstrap"}).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "Cookie": f"auth_token={jwt}"
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req_mint, timeout=10.0) as resp:
+            if resp.status == 200:
+                payload = json.loads(resp.read().decode("utf-8"))
+                return str(payload.get("key", "") or "")
+    except Exception as exc:
+        hook_log("sync_mint_failed", {"error": str(exc)[:200]})
+    return ""
+
+
+def _ensure_dataset_ready_via_http(service_url: str, api_key: str, dataset: str) -> None:
+    if not service_url or not api_key or not dataset:
+        return
+    base = service_url.rstrip("/")
+    headers = {
+        "Content-Type": "application/json",
+        "X-Api-Key": api_key,
+    }
+    payload = json.dumps({"name": dataset}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base}/api/v1/datasets",
+        data=payload,
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=15.0) as resp:
+        if resp.status not in (200, 201):
+            raise RuntimeError(f"remote dataset ensure failed ({resp.status})")
+
+
+def _find_parent_pid() -> int:
+    import subprocess
+    import re
+    fallback = os.getppid()
+    try:
+        raw = subprocess.check_output(
+            ["ps", "-axo", "pid=,ppid=,command="],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception as exc:
+        hook_log("find_parent_pid_failed", {"error": str(exc)[:200]})
+        return fallback
+
+    table: dict[int, tuple[int, str]] = {}
+    for line in raw.splitlines():
+        parts = line.strip().split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        table[pid] = (ppid, parts[2])
+
+    host_re = re.compile(r"(?:^|/)(?:claude|codex)(?:-[\w.]+)?(?:\s|$)")
+    pid = fallback
+    seen: set[int] = set()
+    while pid > 1 and pid not in seen:
+        seen.add(pid)
+        if pid not in table:
+            break
+        ppid, command = table[pid]
+        if command and host_re.search(command):
+            return pid
+        pid = ppid
+    return fallback
+
+
+def _spawn_idle_watcher_helper(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str):
+    import subprocess
+    if os.environ.get("COGNEE_IDLE_DISABLED", "").lower() in ("1", "true", "yes"):
+        return
+    _WATCHER_SCRIPT = Path(__file__).parent / "idle-watcher.py"
+    if not _WATCHER_SCRIPT.exists():
+        return
+    bootstrap = {
+        "session_id": session_id,
+        "dataset": dataset,
+        "session_key": session_key,
+        "config": {
+            "base_url": current_url,
+            "dataset": dataset,
+        },
+    }
+    log_path = _PLUGIN_DIR / "watcher.log"
+    try:
+        log_fh = log_path.open("a", encoding="utf-8")
+    except Exception:
+        log_fh = subprocess.DEVNULL
+    try:
+        env = os.environ.copy()
+        if session_key:
+            env["COGNEE_SESSION_KEY"] = session_key
+        env["COGNEE_BASE_URL"] = current_url
+        if api_key:
+            env["COGNEE_API_KEY"] = api_key
+        subprocess.Popen(
+            [sys.executable, str(_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            env=env,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except Exception as e:
+        hook_log("idle_watcher_restart_spawn_failed", {"error": str(e)[:300]})
+
+
+def _spawn_exit_watcher_helper(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str, parent_pid: int):
+    import subprocess
+    _EXIT_WATCHER_SCRIPT = Path(__file__).parent / "exit-watcher.py"
+    if not _EXIT_WATCHER_SCRIPT.exists():
+        return
+    bootstrap = {
+        "parent_pid": parent_pid,
+        "session_id": session_id,
+        "dataset": dataset,
+        "session_key": session_key,
+        "agent_session_name": conn_uuid,
+        "api_key": api_key,
+        "base_url": current_url,
+        "pidfile": str(_PLUGIN_DIR / "exit-watchers" / f"{parent_pid}.pid"),
+    }
+    log_path = _PLUGIN_DIR / "exit-watcher.log"
+    try:
+        log_fh = log_path.open("a", encoding="utf-8")
+    except Exception:
+        log_fh = subprocess.DEVNULL
+    try:
+        env = os.environ.copy()
+        if session_key:
+            env["COGNEE_SESSION_KEY"] = session_key
+        env["COGNEE_BASE_URL"] = current_url
+        if api_key:
+            env["COGNEE_API_KEY"] = api_key
+        subprocess.Popen(
+            [sys.executable, str(_EXIT_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            env=env,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except Exception as e:
+        hook_log("exit_watcher_restart_spawn_failed", {"error": str(e)[:300]})
+
+
+def _restart_watchers(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str):
+    # Kill idle watcher
+    watcher_pid_file = _PLUGIN_DIR / "watcher.pid"
+    if watcher_pid_file.exists():
+        try:
+            pid = int(watcher_pid_file.read_text(encoding="utf-8").strip())
+            os.kill(pid, 15) # SIGTERM
+        except Exception as exc:
+            hook_log("idle_watcher_kill_failed", {"error": str(exc)[:200]})
+
+    # Kill exit watcher
+    parent_pid = _find_parent_pid()
+    exit_pid_file = _PLUGIN_DIR / "exit-watchers" / f"{parent_pid}.pid"
+    if exit_pid_file.exists():
+        try:
+            pid = int(exit_pid_file.read_text(encoding="utf-8").strip())
+            os.kill(pid, 15) # SIGTERM
+        except Exception as exc:
+            hook_log("exit_watcher_kill_failed", {"error": str(exc)[:200]})
+
+    # Spawn idle watcher
+    _spawn_idle_watcher_helper(session_id, dataset, conn_uuid, api_key, current_url, session_key)
+
+    # Spawn exit watcher
+    _spawn_exit_watcher_helper(session_id, dataset, conn_uuid, api_key, current_url, session_key, parent_pid)
+
+
+def _do_re_registration(session_key: str, current_url: str, last_registered_url: str, resolved: dict, conn_uuid: str, cognee_session_id: str):
+    try:
+        from config import load_config, get_dataset
+        config = load_config()
+        dataset = get_dataset(config)
+    except Exception:
+        config = {}
+        dataset = "agent_sessions"
+
+    # Resolve credentials for the new URL
+    cached_old_key = ""
+    try:
+        key_data = _load_json_file(_API_KEY_CACHE)
+        if isinstance(key_data, dict):
+            cached_old_key = str(key_data.get("api_key") or "").strip()
+    except Exception:
+        pass
+
+    # If env key matches the old cached key, temporarily clear it
+    env_key = os.environ.get("COGNEE_API_KEY", "")
+    if env_key and cached_old_key and env_key == cached_old_key:
+        env_key = ""
+
+    new_api_key = load_cached_api_key(current_url)
+    if not new_api_key and env_key:
+        new_api_key = env_key
+
+    if not new_api_key:
+        # Perform sync login
+        new_api_key = _login_default_user_via_http(current_url, config)
+        if new_api_key:
+            save_cached_api_key(current_url, new_api_key)
+
+    # Set new key
+    if new_api_key:
+        os.environ["COGNEE_API_KEY"] = new_api_key
+        resolved["api_key"] = new_api_key
+
+    # 1. ensure dataset is ready via HTTP
+    try:
+        _ensure_dataset_ready_via_http(current_url, new_api_key, dataset)
+    except Exception as exc:
+        hook_log("dataset_ready_via_http_failed", {"error": str(exc)[:200]})
+        raise exc
+
+    # 2. Register agent via HTTP on new URL
+    reg_ok, registration = register_agent_via_http(
+        agent_session_name=conn_uuid,
+        session_id=cognee_session_id,
+        dataset_names=[dataset],
+    )
+
+    if reg_ok:
+        hook_log("re-registered_on_new_target", {
+            "base_url": current_url,
+            "agent_session_name": conn_uuid,
+            "session_id": cognee_session_id
+        })
+
+        # 3. Update server readiness marker
+        mark_server_ready(current_url)
+
+        # 4. Unregister agent on old URL best-effort
+        if cached_old_key:
+            old_env_url = os.environ.get("COGNEE_BASE_URL")
+            old_env_key = os.environ.get("COGNEE_API_KEY")
+            try:
+                os.environ["COGNEE_BASE_URL"] = last_registered_url
+                os.environ["COGNEE_API_KEY"] = cached_old_key
+                unregister_agent_via_http(agent_session_name=conn_uuid)
+            except Exception as exc:
+                hook_log("unregister_old_target_failed", {"error": str(exc)[:200]})
+            finally:
+                if old_env_url is not None:
+                    os.environ["COGNEE_BASE_URL"] = old_env_url
+                if old_env_key is not None:
+                    os.environ["COGNEE_API_KEY"] = old_env_key
+
+        # 5. Restart watchers
+        _restart_watchers(cognee_session_id, dataset, conn_uuid, new_api_key, current_url, session_key)
+    else:
+        raise RuntimeError("Agent registration failed on new target URL")
+
+
+def _resolve_url_mismatch(session_key: str, current_url: str, last_registered_url: str, resolved: dict, conn_uuid: str, cognee_session_id: str):
+    import time
+    lock_file = _PLUGIN_DIR / "reregister.lock"
+    timeout = 10.0
+    poll = 0.2
+    start_time = time.monotonic()
+    
+    while time.monotonic() - start_time < timeout:
+        # Check if mismatch is already resolved by another process
+        try:
+            if _SERVER_READY_MARKER.exists():
+                ready_data = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
+                marked_url = _normalize_service_url(ready_data.get("base_url", ""))
+                if marked_url == current_url:
+                    return
+        except Exception:
+            pass
+            
+        # Try to acquire lock
+        acquired = False
+        now = datetime.now(timezone.utc).timestamp()
+        if lock_file.exists():
+            try:
+                current = json.loads(lock_file.read_text(encoding="utf-8"))
+                pid = int(current.get("pid", 0))
+                created_at = float(current.get("created_at", 0))
+                pid_alive = False
+                if pid > 0:
+                    try:
+                        os.kill(pid, 0)
+                        pid_alive = True
+                    except ProcessLookupError:
+                        pid_alive = False
+                    except Exception:
+                        pid_alive = True
+                if not pid_alive or now - created_at > 60: # 1 min timeout
+                    try:
+                        lock_file.unlink()
+                    except Exception:
+                        pass
+            except Exception:
+                pass
+        try:
+            fd = os.open(str(lock_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump({"pid": os.getpid(), "created_at": now}, fh)
+            acquired = True
+        except FileExistsError:
+            time.sleep(poll)
+            continue
+            
+        if acquired:
+            try:
+                _do_re_registration(session_key, current_url, last_registered_url, resolved, conn_uuid, cognee_session_id)
+                return
+            finally:
+                try:
+                    lock_file.unlink()
+                except Exception:
+                    pass
+
+
 def load_resolved(session_key: str = "") -> dict:
     """Load runtime state from Cognee HTTP endpoints (no file cache)."""
     resolved: dict = {}
@@ -373,6 +747,21 @@ def load_resolved(session_key: str = "") -> dict:
     service_url = _local_api_url().strip()
     if service_url:
         resolved["base_url"] = service_url
+
+    last_registered_url = ""
+    if _SERVER_READY_MARKER.exists():
+        try:
+            ready_data = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
+            last_registered_url = _normalize_service_url(ready_data.get("base_url", ""))
+        except Exception:
+            pass
+
+    current_url = _normalize_service_url(service_url)
+    if last_registered_url and current_url and last_registered_url != current_url:
+        try:
+            _resolve_url_mismatch(active_session_key, current_url, last_registered_url, resolved, conn_uuid, cognee_session_id)
+        except Exception as exc:
+            hook_log("resolve_url_mismatch_failed", {"error": str(exc)[:200]})
 
     api_key = _api_key().strip()
     if api_key:

--- a/integrations/claude-code/tests/test_mid_session_reregister.py
+++ b/integrations/claude-code/tests/test_mid_session_reregister.py
@@ -1,0 +1,181 @@
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import threading
+import time
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import MagicMock, patch
+
+# Adjust sys.path to find the scripts folder
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+# Redirect plugin directory to a temp folder BEFORE importing common plugin module
+_TMP_DIR = tempfile.mkdtemp(prefix="cognee-reregister-test-")
+os.environ["COGNEE_PLUGIN_STATE_DIR"] = _TMP_DIR
+
+import _plugin_common  # noqa: E402
+
+# Force path variables to point to our temp folder so we don't mess up real data
+_TMP_PATH = pathlib.Path(_TMP_DIR)
+_plugin_common._SHARED_PLUGIN_ROOT = _TMP_PATH
+_plugin_common._PLUGIN_DIR = _TMP_PATH / "claude-code"
+_plugin_common._HOOK_LOG = _plugin_common._PLUGIN_DIR / "hook.log"
+_plugin_common._COUNTER_FILE = _plugin_common._PLUGIN_DIR / "counter.json"
+_plugin_common._ACTIVITY_FILE = _plugin_common._PLUGIN_DIR / "activity.ts"
+_plugin_common._ACTIVITY_LOG = _plugin_common._PLUGIN_DIR / "activity.log"
+_plugin_common._SAVE_COUNTER = _plugin_common._PLUGIN_DIR / "save_counter.json"
+_plugin_common._SERVER_READY_MARKER = _TMP_PATH / "server-ready.json"
+_plugin_common._SYNC_LOCK = _plugin_common._PLUGIN_DIR / "sync.lock"
+_plugin_common._BRIDGE_DIR = _plugin_common._PLUGIN_DIR / "bridge"
+_plugin_common._PENDING_DIR = _plugin_common._PLUGIN_DIR / "pending"
+_plugin_common._SUBPROCESS_LOG = _plugin_common._PLUGIN_DIR / "subprocess.log"
+_plugin_common._API_KEY_CACHE = _TMP_PATH / "api_key.json"
+_plugin_common._SESSIONS_MAP_DIR = _plugin_common._PLUGIN_DIR / "sessions"
+
+
+class MockServerRequestHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        pass
+
+    def do_GET(self):
+        self.server.calls.append(("GET", self.path))
+        if self.path == "/health":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"OK")
+        elif self.path.startswith("/api/v1/users/me"):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"id": "user_123"}).encode("utf-8"))
+        elif self.path.startswith("/api/v1/agents/connections/me"):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"agent": {"agent_session_name": "some_conn", "status": "active"}}).encode("utf-8"))
+        elif self.path.startswith("/api/v1/auth/api-keys"):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps([{"key": "test_api_key"}]).encode("utf-8"))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length).decode("utf-8") if content_length > 0 else ""
+        self.server.calls.append(("POST", self.path, body))
+
+        if self.path == "/api/v1/agents/register":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"id": "conn_registered"}).encode("utf-8"))
+        elif self.path == "/api/v1/datasets":
+            self.send_response(201)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"name": "dataset_123"}).encode("utf-8"))
+        elif self.path == "/api/v1/agents/unregister":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"activeAgents": 0}).encode("utf-8"))
+        elif self.path == "/api/v1/auth/login":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"access_token": "token_123"}).encode("utf-8"))
+        elif self.path == "/api/v1/auth/api-keys":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"key": "test_api_key"}).encode("utf-8"))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def test_mid_session_reregister():
+    # Spin up Server A and Server B on dynamic ports
+    server_a = HTTPServer(("localhost", 0), MockServerRequestHandler)
+    server_a.calls = []
+    thread_a = threading.Thread(target=server_a.serve_forever)
+    thread_a.daemon = True
+    thread_a.start()
+
+    server_b = HTTPServer(("localhost", 0), MockServerRequestHandler)
+    server_b.calls = []
+    thread_b = threading.Thread(target=server_b.serve_forever)
+    thread_b.daemon = True
+    thread_b.start()
+
+    url_a = f"http://localhost:{server_a.server_port}"
+    url_b = f"http://localhost:{server_b.server_port}"
+
+    # Setup the initial session on Server A
+    os.environ["COGNEE_SESSION_KEY"] = "test-session-key"
+    os.environ["COGNEE_BASE_URL"] = url_a
+    _plugin_common.mark_server_ready(url_a)
+
+    # Resolve initial status to make sure we're on Server A
+    resolved = _plugin_common.load_resolved()
+    assert resolved.get("base_url") == url_a
+
+    # Now change COGNEE_BASE_URL to Server B
+    os.environ["COGNEE_BASE_URL"] = url_b
+
+    # Mock subprocess.Popen and os.kill so we don't start real processes or kill things
+    with patch("subprocess.Popen") as mock_popen, patch("os.kill") as mock_kill:
+        mock_popen.return_value = MagicMock()
+
+        # Trigger load_resolved, which should detect the mismatch
+        resolved_new = _plugin_common.load_resolved()
+
+        # Assertions:
+        # 1. Base URL has switched to B
+        assert resolved_new.get("base_url") == url_b
+
+        # 2. server-ready.json was updated to url_b
+        assert _plugin_common._SERVER_READY_MARKER.exists()
+        ready_data = json.loads(_plugin_common._SERVER_READY_MARKER.read_text(encoding="utf-8"))
+        assert ready_data.get("base_url") == url_b
+
+        # 3. Server B received the registration and dataset requests
+        register_calls = [c for c in server_b.calls if c[1] == "/api/v1/agents/register"]
+        dataset_calls = [c for c in server_b.calls if c[1] == "/api/v1/datasets"]
+        assert len(register_calls) > 0
+        assert len(dataset_calls) > 0
+
+        # 4. Mock popen was called to restart watchers with B config
+        # (check that popen args contain B's url)
+        assert mock_popen.call_count >= 2
+        called_args = [call[0][0] for call in mock_popen.call_args_list]
+        called_envs = [call[1].get("env", {}) for call in mock_popen.call_args_list]
+
+        # Verify idle-watcher and exit-watcher arguments
+        assert any("idle-watcher.py" in str(arg) for arg in called_args)
+        assert any("exit-watcher.py" in str(arg) for arg in called_args)
+        assert any(url_b in str(env.get("COGNEE_BASE_URL")) for env in called_envs)
+
+    # Clean up mock servers
+    server_a.shutdown()
+    server_b.shutdown()
+    thread_a.join()
+    thread_b.join()
+
+
+if __name__ == "__main__":
+    try:
+        test_mid_session_reregister()
+        print("PASS test_mid_session_reregister")
+        sys.exit(0)
+    except AssertionError as e:
+        import traceback
+        traceback.print_exc()
+        print("FAIL test_mid_session_reregister")
+        sys.exit(1)

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -352,6 +352,380 @@ def _resolve_agent_name() -> str:
     return _normalize("codex-agent")
 
 
+def _login_default_user_via_http(service_url: str, config: dict) -> str:
+    base = _normalize_service_url(service_url)
+    email = config.get("user_email") or "default_user@example.com"
+    password = config.get("user_password") or "default_password"
+
+    params = urllib.parse.urlencode({"username": email, "password": password}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base}/api/v1/auth/login",
+        data=params,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10.0) as resp:
+            if resp.status != 200:
+                return ""
+            login_data = json.loads(resp.read().decode("utf-8"))
+            jwt = str(login_data.get("access_token", "") or "")
+    except Exception as exc:
+        hook_log("sync_login_failed", {"error": str(exc)[:200]})
+        return ""
+
+    if not jwt:
+        return ""
+
+    req_keys = urllib.request.Request(
+        f"{base}/api/v1/auth/api-keys",
+        headers={"Cookie": f"auth_token={jwt}"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req_keys, timeout=10.0) as resp:
+            if resp.status == 200:
+                keys = json.loads(resp.read().decode("utf-8"))
+                if isinstance(keys, list) and keys:
+                    key = str(keys[0].get("key", "") or "")
+                    if key:
+                        return key
+    except Exception:
+        pass
+
+    req_mint = urllib.request.Request(
+        f"{base}/api/v1/auth/api-keys",
+        data=json.dumps({"name": "claude-owner-bootstrap"}).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "Cookie": f"auth_token={jwt}"
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req_mint, timeout=10.0) as resp:
+            if resp.status == 200:
+                payload = json.loads(resp.read().decode("utf-8"))
+                return str(payload.get("key", "") or "")
+    except Exception as exc:
+        hook_log("sync_mint_failed", {"error": str(exc)[:200]})
+    return ""
+
+
+def _ensure_dataset_ready_via_http(service_url: str, api_key: str, dataset: str) -> None:
+    if not service_url or not api_key or not dataset:
+        return
+    base = service_url.rstrip("/")
+    headers = {
+        "Content-Type": "application/json",
+        "X-Api-Key": api_key,
+    }
+    payload = json.dumps({"name": dataset}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base}/api/v1/datasets",
+        data=payload,
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=15.0) as resp:
+        if resp.status not in (200, 201):
+            raise RuntimeError(f"remote dataset ensure failed ({resp.status})")
+
+
+def _find_parent_pid() -> int:
+    import subprocess
+    import re
+    fallback = os.getppid()
+    try:
+        raw = subprocess.check_output(
+            ["ps", "-axo", "pid=,ppid=,command="],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception as exc:
+        hook_log("find_parent_pid_failed", {"error": str(exc)[:200]})
+        return fallback
+
+    table: dict[int, tuple[int, str]] = {}
+    for line in raw.splitlines():
+        parts = line.strip().split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        table[pid] = (ppid, parts[2])
+
+    host_re = re.compile(r"(?:^|/)(?:claude|codex)(?:-[\w.]+)?(?:\s|$)")
+    pid = fallback
+    seen: set[int] = set()
+    while pid > 1 and pid not in seen:
+        seen.add(pid)
+        if pid not in table:
+            break
+        ppid, command = table[pid]
+        if command and host_re.search(command):
+            return pid
+        pid = ppid
+    return fallback
+
+
+def _spawn_idle_watcher_helper(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str):
+    import subprocess
+    if os.environ.get("COGNEE_IDLE_DISABLED", "").lower() in ("1", "true", "yes"):
+        return
+    _WATCHER_SCRIPT = Path(__file__).parent / "idle-watcher.py"
+    if not _WATCHER_SCRIPT.exists():
+        return
+    bootstrap = {
+        "session_id": session_id,
+        "dataset": dataset,
+        "session_key": session_key,
+        "config": {
+            "base_url": current_url,
+            "dataset": dataset,
+        },
+    }
+    log_path = _PLUGIN_DIR / "watcher.log"
+    try:
+        log_fh = log_path.open("a", encoding="utf-8")
+    except Exception:
+        log_fh = subprocess.DEVNULL
+    try:
+        env = os.environ.copy()
+        if session_key:
+            env["COGNEE_SESSION_KEY"] = session_key
+        env["COGNEE_BASE_URL"] = current_url
+        if api_key:
+            env["COGNEE_API_KEY"] = api_key
+        subprocess.Popen(
+            [sys.executable, str(_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            env=env,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except Exception as e:
+        hook_log("idle_watcher_restart_spawn_failed", {"error": str(e)[:300]})
+
+
+def _spawn_exit_watcher_helper(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str, parent_pid: int):
+    import subprocess
+    _EXIT_WATCHER_SCRIPT = Path(__file__).parent / "exit-watcher.py"
+    if not _EXIT_WATCHER_SCRIPT.exists():
+        return
+    bootstrap = {
+        "parent_pid": parent_pid,
+        "session_id": session_id,
+        "dataset": dataset,
+        "session_key": session_key,
+        "agent_session_name": conn_uuid,
+        "api_key": api_key,
+        "base_url": current_url,
+        "pidfile": str(_PLUGIN_DIR / "exit-watchers" / f"{parent_pid}.pid"),
+    }
+    log_path = _PLUGIN_DIR / "exit-watcher.log"
+    try:
+        log_fh = log_path.open("a", encoding="utf-8")
+    except Exception:
+        log_fh = subprocess.DEVNULL
+    try:
+        env = os.environ.copy()
+        if session_key:
+            env["COGNEE_SESSION_KEY"] = session_key
+        env["COGNEE_BASE_URL"] = current_url
+        if api_key:
+            env["COGNEE_API_KEY"] = api_key
+        subprocess.Popen(
+            [sys.executable, str(_EXIT_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            env=env,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except Exception as e:
+        hook_log("exit_watcher_restart_spawn_failed", {"error": str(e)[:300]})
+
+
+def _restart_watchers(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str):
+    # Kill idle watcher
+    watcher_pid_file = _PLUGIN_DIR / "watcher.pid"
+    if watcher_pid_file.exists():
+        try:
+            pid = int(watcher_pid_file.read_text(encoding="utf-8").strip())
+            os.kill(pid, 15) # SIGTERM
+        except Exception as exc:
+            hook_log("idle_watcher_kill_failed", {"error": str(exc)[:200]})
+
+    # Kill exit watcher
+    parent_pid = _find_parent_pid()
+    exit_pid_file = _PLUGIN_DIR / "exit-watchers" / f"{parent_pid}.pid"
+    if exit_pid_file.exists():
+        try:
+            pid = int(exit_pid_file.read_text(encoding="utf-8").strip())
+            os.kill(pid, 15) # SIGTERM
+        except Exception as exc:
+            hook_log("exit_watcher_kill_failed", {"error": str(exc)[:200]})
+
+    # Spawn idle watcher
+    _spawn_idle_watcher_helper(session_id, dataset, conn_uuid, api_key, current_url, session_key)
+
+    # Spawn exit watcher
+    _spawn_exit_watcher_helper(session_id, dataset, conn_uuid, api_key, current_url, session_key, parent_pid)
+
+
+def _do_re_registration(session_key: str, current_url: str, last_registered_url: str, resolved: dict, conn_uuid: str, cognee_session_id: str):
+    try:
+        from config import load_config, get_dataset
+        config = load_config()
+        dataset = get_dataset(config)
+    except Exception:
+        config = {}
+        dataset = "agent_sessions"
+
+    # Resolve credentials for the new URL
+    cached_old_key = ""
+    try:
+        key_data = _load_json_file(_API_KEY_CACHE)
+        if isinstance(key_data, dict):
+            cached_old_key = str(key_data.get("api_key") or "").strip()
+    except Exception:
+        pass
+
+    # If env key matches the old cached key, temporarily clear it
+    env_key = os.environ.get("COGNEE_API_KEY", "")
+    if env_key and cached_old_key and env_key == cached_old_key:
+        env_key = ""
+
+    new_api_key = load_cached_api_key(current_url)
+    if not new_api_key and env_key:
+        new_api_key = env_key
+
+    if not new_api_key:
+        # Perform sync login
+        new_api_key = _login_default_user_via_http(current_url, config)
+        if new_api_key:
+            save_cached_api_key(current_url, new_api_key)
+
+    # Set new key
+    if new_api_key:
+        os.environ["COGNEE_API_KEY"] = new_api_key
+        resolved["api_key"] = new_api_key
+
+    # 1. ensure dataset is ready via HTTP
+    try:
+        _ensure_dataset_ready_via_http(current_url, new_api_key, dataset)
+    except Exception as exc:
+        hook_log("dataset_ready_via_http_failed", {"error": str(exc)[:200]})
+        raise exc
+
+    # 2. Register agent via HTTP on new URL
+    reg_ok, registration = register_agent_via_http(
+        agent_session_name=conn_uuid,
+        session_id=cognee_session_id,
+        dataset_names=[dataset],
+    )
+
+    if reg_ok:
+        hook_log("re-registered_on_new_target", {
+            "base_url": current_url,
+            "agent_session_name": conn_uuid,
+            "session_id": cognee_session_id
+        })
+
+        # 3. Update server readiness marker
+        mark_server_ready(current_url)
+
+        # 4. Unregister agent on old URL best-effort
+        if cached_old_key:
+            old_env_url = os.environ.get("COGNEE_BASE_URL")
+            old_env_key = os.environ.get("COGNEE_API_KEY")
+            try:
+                os.environ["COGNEE_BASE_URL"] = last_registered_url
+                os.environ["COGNEE_API_KEY"] = cached_old_key
+                unregister_agent_via_http(agent_session_name=conn_uuid)
+            except Exception as exc:
+                hook_log("unregister_old_target_failed", {"error": str(exc)[:200]})
+            finally:
+                if old_env_url is not None:
+                    os.environ["COGNEE_BASE_URL"] = old_env_url
+                if old_env_key is not None:
+                    os.environ["COGNEE_API_KEY"] = old_env_key
+
+        # 5. Restart watchers
+        _restart_watchers(cognee_session_id, dataset, conn_uuid, new_api_key, current_url, session_key)
+    else:
+        raise RuntimeError("Agent registration failed on new target URL")
+
+
+def _resolve_url_mismatch(session_key: str, current_url: str, last_registered_url: str, resolved: dict, conn_uuid: str, cognee_session_id: str):
+    import time
+    lock_file = _PLUGIN_DIR / "reregister.lock"
+    timeout = 10.0
+    poll = 0.2
+    start_time = time.monotonic()
+    
+    while time.monotonic() - start_time < timeout:
+        # Check if mismatch is already resolved by another process
+        try:
+            if _SERVER_READY_MARKER.exists():
+                ready_data = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
+                marked_url = _normalize_service_url(ready_data.get("base_url", ""))
+                if marked_url == current_url:
+                    return
+        except Exception:
+            pass
+            
+        # Try to acquire lock
+        acquired = False
+        now = datetime.now(timezone.utc).timestamp()
+        if lock_file.exists():
+            try:
+                current = json.loads(lock_file.read_text(encoding="utf-8"))
+                pid = int(current.get("pid", 0))
+                created_at = float(current.get("created_at", 0))
+                pid_alive = False
+                if pid > 0:
+                    try:
+                        os.kill(pid, 0)
+                        pid_alive = True
+                    except ProcessLookupError:
+                        pid_alive = False
+                    except Exception:
+                        pid_alive = True
+                if not pid_alive or now - created_at > 60: # 1 min timeout
+                    try:
+                        lock_file.unlink()
+                    except Exception:
+                        pass
+            except Exception:
+                pass
+        try:
+            fd = os.open(str(lock_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump({"pid": os.getpid(), "created_at": now}, fh)
+            acquired = True
+        except FileExistsError:
+            time.sleep(poll)
+            continue
+            
+        if acquired:
+            try:
+                _do_re_registration(session_key, current_url, last_registered_url, resolved, conn_uuid, cognee_session_id)
+                return
+            finally:
+                try:
+                    lock_file.unlink()
+                except Exception:
+                    pass
+
+
 def load_resolved(session_key: str = "") -> dict:
     """Load runtime state from Cognee HTTP endpoints (no file cache)."""
     resolved: dict = {}
@@ -371,6 +745,21 @@ def load_resolved(session_key: str = "") -> dict:
     service_url = _local_api_url().strip()
     if service_url:
         resolved["base_url"] = service_url
+
+    last_registered_url = ""
+    if _SERVER_READY_MARKER.exists():
+        try:
+            ready_data = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
+            last_registered_url = _normalize_service_url(ready_data.get("base_url", ""))
+        except Exception:
+            pass
+
+    current_url = _normalize_service_url(service_url)
+    if last_registered_url and current_url and last_registered_url != current_url:
+        try:
+            _resolve_url_mismatch(active_session_key, current_url, last_registered_url, resolved, conn_uuid, cognee_session_id)
+        except Exception as exc:
+            hook_log("resolve_url_mismatch_failed", {"error": str(exc)[:200]})
 
     api_key = _api_key().strip()
     if api_key:


### PR DESCRIPTION
## Description

Closes topoteretes/cognee#3544

When `COGNEE_BASE_URL` changes mid-session, newly spawned hook processes inherit the updated URL but the active session is never registered on the new target. Recall is bypassed entirely, memory writes fall back to local 
cache, and the background idle/exit watchers keep pointing at the old server with no error and no warning.

The root cause is in `load_resolved()` — it reads the current URL but never compares it against the `base_url` stored in `server-ready.json`. There's no detection, so no re-registration ever happens.

**What this PR does:**

On every call to `load_resolved()`, we now compare the resolved URL against `server-ready.json`. On mismatch, a filesystem spin-lock (`reregister.lock`) gates the re-registration so concurrent hooks don't race. We resolve credentials for the new URL (handling both local and cloud), register the session on the new target, ensure the dataset is ready, re-mark readiness via 
`mark_server_ready(new_url)`, unregister the old connection best-effort, and restart both idle-watcher and exit-watcher so they inherit the new URL. If registration fails on the new target, we roll back and leave the old target intact.

Changes are mirrored to the Codex integration, respecting its directory structure and agent naming.

## Changes

- `integrations/claude-code/scripts/_plugin_common.py` — URL mismatch detection, lock-gated re-registration, credential resolution, watcher restart, rollback on failure
- `integrations/codex/plugins/cognee/scripts/_plugin_common.py` — mirrored changes with Codex-specific namespace
- `integrations/claude-code/tests/test_mid_session_reregister.py` — new standalone test with two mock servers on ephemeral ports

## How to Test

Run the new standalone test:
```bash
python integrations/claude-code/tests/test_mid_session_reregister.py
```

Run existing tests to verify no regressions:
```bash
python integrations/claude-code/tests/test_cognee_client.py
python integrations/claude-code/tests/test_memory_preference.py
python integrations/claude-code/tests/test_recall_http.py
python integrations/claude-code/tests/test_remember_http.py
python integrations/claude-code/tests/test_session_id.py
```

## Pre-submission Checklist
- [x] Tested changes thoroughly before submitting
- [x] Minimal changes necessary to address the issue
- [x] Follows project coding standards
- [x] Tests added and passing
- [x] No regressions in existing tests
- [x] Linked relevant issue in description
- [x] Clear and descriptive commit messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to 
the terms of the Topoteretes Developer Certificate of Origin.