### PR TITLE
feat(claude-code): standardize and namespace hook event names (#3679)

### DIFF
--- a/integrations/claude-code/EVENTS.md
+++ b/integrations/claude-code/EVENTS.md
@@ -1,0 +1,329 @@
+# Structured Hook Events
+
+The Claude Code plugin emits structured events through
+[`_plugin_common.hook_log`](scripts/_plugin_common.py) — one JSON line per
+event to `~/.cognee-plugin/hook.log`. Every event name is namespaced
+`<namespace>.<event>` so a telemetry emitter can consume and route them
+uniformly (subscribe to `recall.*`, `bridge.*`, `session.*`, …).
+
+The canonical set lives in [`scripts/event_names.py`](scripts/event_names.py)
+as `KNOWN_EVENTS`; `EVENT_RENAMES` in that module is the migration map from
+the historical flat names. `tests/test_event_names.py` asserts that the events
+emitted in the scripts, the module, and this document all agree.
+
+**146 events across 19 namespaces.**
+
+## Namespaces
+
+| Namespace | Events | Purpose |
+|---|---|---|
+| `activity.*` | 2 | Activity-log bookkeeping. |
+| `agent.*` | 7 | Agent register/unregister lifecycle. |
+| `bootstrap.*` | 10 | First-run bootstrap of the plugin runtime (spawn/wait/health). |
+| `bridge.*` | 12 | Session->graph HTTP bridge: posting a session document and polling cognify. |
+| `context.*` | 5 | Context lookup for injecting relevant memory. |
+| `install.*` | 10 | Runtime provisioning: venv, uv, cognee package, data dir. |
+| `io.*` | 3 | Low-level JSON read/write and payload parsing failures. |
+| `mode.*` | 2 | Endpoint / operating-mode selection decisions. |
+| `precompact.*` | 5 | PreCompact hook: anchoring memory before a context compaction. |
+| `prompt.*` | 5 | UserPromptSubmit handling and the prompt watcher. |
+| `recall.*` | 6 | Recalling prior memory/context for the current turn. |
+| `runtime.*` | 3 | Runtime-state probes (connection, users/me) and user resolution. |
+| `server.*` | 8 | Local cognee server lifecycle and the bootstrap lock/ready flags. |
+| `session.*` | 9 | Session identity, resolution, and the session<->path map. |
+| `statusline.*` | 3 | Status line configuration. |
+| `store.*` | 12 | Capturing tool calls / prompts into session memory (incl. counters). |
+| `sync.*` | 24 | Background sync of a finished session into the knowledge graph. |
+| `trace.*` | 5 | Storing/falling back the reasoning trace for a turn. |
+| `watcher.*` | 15 | Background watcher processes (idle, exit, prompt, generic). |
+
+## Events by namespace
+
+### `activity.*`
+
+Activity-log bookkeeping.
+
+| Event | Legacy name |
+|---|---|
+| `activity.log_write_failed` | `activity_log_write_failed` |
+| `activity.touch_failed` | `activity_touch_failed` |
+
+### `agent.*`
+
+Agent register/unregister lifecycle.
+
+| Event | Legacy name |
+|---|---|
+| `agent.lifecycle_error` | `agent_lifecycle_error` |
+| `agent.register_failed` | `agent_register_failed` |
+| `agent.register_result` | `agent_register_result` |
+| `agent.unregister_failed` | `agent_unregister_failed` |
+| `agent.unregister_result` | `agent_unregister_result` |
+| `agent.unregister_skipped_no_auth` | `agent_unregister_skipped_no_auth` |
+| `agent.unregister_skipped_no_session_name` | `agent_unregister_skipped_no_session_name` |
+
+### `bootstrap.*`
+
+First-run bootstrap of the plugin runtime (spawn/wait/health).
+
+| Event | Legacy name |
+|---|---|
+| `bootstrap.complete` | `bootstrap_complete` |
+| `bootstrap.failed` | `bootstrap_failed` |
+| `bootstrap.lock_release_failed` | `bootstrap_lock_release_failed` |
+| `bootstrap.lock_unlink_failed` | `bootstrap_lock_unlink_failed` |
+| `bootstrap.log_open_failed` | `bootstrap_log_open_failed` |
+| `bootstrap.main_exception` | `bootstrap_main_exception` |
+| `bootstrap.server_unhealthy` | `bootstrap_server_unhealthy` |
+| `bootstrap.spawn_failed` | `bootstrap_spawn_failed` |
+| `bootstrap.spawned` | `bootstrap_spawned` |
+| `bootstrap.waiting_for_peer` | `bootstrap_waiting_for_peer` |
+
+### `bridge.*`
+
+Session->graph HTTP bridge: posting a session document and polling cognify.
+
+| Event | Legacy name |
+|---|---|
+| `bridge.auto_error` | `auto_bridge_error` |
+| `bridge.auto_fired` | `auto_bridge_fired` |
+| `bridge.cognify_poll_transient` | `cognify_poll_transient` |
+| `bridge.deadline_exceeded` | `http_bridge_deadline_exceeded` |
+| `bridge.done` | `http_bridge_done` |
+| `bridge.failed` | `http_bridge_failed` |
+| `bridge.no_dataset_id` | `http_bridge_no_dataset_id` |
+| `bridge.parse_error` | `http_bridge_parse_error` |
+| `bridge.poll` | `http_bridge_poll` |
+| `bridge.post_failed` | `http_bridge_post_failed` |
+| `bridge.skipped_empty_cache` | `http_bridge_skipped_empty_cache` |
+| `bridge.skipped_no_api_key` | `http_bridge_skipped_no_api_key` |
+
+### `context.*`
+
+Context lookup for injecting relevant memory.
+
+| Event | Legacy name |
+|---|---|
+| `context.lookup_empty` | `context_lookup_empty` |
+| `context.lookup_exception` | `context_lookup_exception` |
+| `context.lookup_hit` | `context_lookup_hit` |
+| `context.lookup_missing_session_key` | `context_lookup_missing_session_key` |
+| `context.lookup_session_key` | `context_lookup_session_key` |
+
+### `install.*`
+
+Runtime provisioning: venv, uv, cognee package, data dir.
+
+| Event | Legacy name |
+|---|---|
+| `install.cognee_failed` | `cognee_install_failed` |
+| `install.cognee_ready` | `cognee_install_ready` |
+| `install.data_dir_mkdir_failed` | `cognee_data_dir_mkdir_failed` |
+| `install.uv_failed` | `uv_install_failed` |
+| `install.venv_lock_release_failed` | `venv_install_lock_release_failed` |
+| `install.venv_lock_unlink_failed` | `venv_install_lock_unlink_failed` |
+| `install.venv_ready_write_failed` | `venv_ready_write_failed` |
+| `install.venv_reexec_failed` | `venv_reexec_failed` |
+| `install.venv_unusable` | `cognee_venv_unusable` |
+| `install.version_probe_failed` | `cognee_version_probe_failed` |
+
+### `io.*`
+
+Low-level JSON read/write and payload parsing failures.
+
+| Event | Legacy name |
+|---|---|
+| `io.invalid_payload_json` | `invalid_payload_json` |
+| `io.json_load_failed` | `json_load_failed` |
+| `io.json_write_failed` | `json_write_failed` |
+
+### `mode.*`
+
+Endpoint / operating-mode selection decisions.
+
+| Event | Legacy name |
+|---|---|
+| `mode.decision` | `mode_decision` |
+| `mode.endpoint_selected` | `endpoint_mode_selected` |
+
+### `precompact.*`
+
+PreCompact hook: anchoring memory before a context compaction.
+
+| Event | Legacy name |
+|---|---|
+| `precompact.anchor` | `precompact_anchor` |
+| `precompact.direct_fetch_error` | `precompact_direct_fetch_error` |
+| `precompact.empty` | `precompact_empty` |
+| `precompact.recall_error` | `precompact_recall_error` |
+| `precompact.run_exception` | `precompact_run_exception` |
+
+### `prompt.*`
+
+UserPromptSubmit handling and the prompt watcher.
+
+| Event | Legacy name |
+|---|---|
+| `prompt.missing_session_key` | `prompt_missing_session_key` |
+| `prompt.pending` | `prompt_pending` |
+| `prompt.prepare_warning` | `prompt_prepare_warning` |
+| `prompt.run_exception` | `prompt_run_exception` |
+| `prompt.session_key` | `prompt_session_key` |
+
+### `recall.*`
+
+Recalling prior memory/context for the current turn.
+
+| Event | Legacy name |
+|---|---|
+| `recall.audit_write_failed` | `recall_audit_write_failed` |
+| `recall.breaker_open` | `recall_breaker_open` |
+| `recall.budget_exceeded` | `recall_budget_exceeded` |
+| `recall.error` | `recall_error` |
+| `recall.last_write_failed` | `last_recall_write_failed` |
+| `recall.skipped_warming` | `recall_skipped_warming` |
+
+### `runtime.*`
+
+Runtime-state probes (connection, users/me) and user resolution.
+
+| Event | Legacy name |
+|---|---|
+| `runtime.resolve_user_failed` | `resolve_user_failed` |
+| `runtime.state_connection_lookup_failed` | `runtime_state_connection_lookup_failed` |
+| `runtime.state_users_me_failed` | `runtime_state_users_me_failed` |
+
+### `server.*`
+
+Local cognee server lifecycle and the bootstrap lock/ready flags.
+
+| Event | Legacy name |
+|---|---|
+| `server.bootstrap_lock_acquired` | `server_bootstrap_lock_acquired` |
+| `server.bootstrap_lock_release_failed` | `server_bootstrap_lock_release_failed` |
+| `server.bootstrap_lock_released` | `server_bootstrap_lock_released` |
+| `server.bootstrap_lock_stale_reaped` | `server_bootstrap_lock_stale_reaped` |
+| `server.bootstrap_lock_unlink_failed` | `server_bootstrap_lock_unlink_failed` |
+| `server.bootstrap_warning` | `server_bootstrap_warning` |
+| `server.ready_clear_failed` | `server_ready_clear_failed` |
+| `server.ready_mark_failed` | `server_ready_mark_failed` |
+
+### `session.*`
+
+Session identity, resolution, and the session<->path map.
+
+| Event | Legacy name |
+|---|---|
+| `session.find_claude_parent_failed` | `find_claude_parent_failed` |
+| `session.legacy_resolved_dir_remove_failed` | `legacy_resolved_dir_remove_failed` |
+| `session.legacy_resolved_unlink_failed` | `legacy_resolved_unlink_failed` |
+| `session.map_create_failed` | `map_create_failed` |
+| `session.map_read_failed` | `session_map_read_failed` |
+| `session.missing_payload_session_id` | `missing_payload_session_id` |
+| `session.no_session_id` | `no_session_id` |
+| `session.resolved` | `session_resolved` |
+| `session.start_exception` | `session_start_exception` |
+
+### `statusline.*`
+
+Status line configuration.
+
+| Event | Legacy name |
+|---|---|
+| `statusline.configured` | `statusline_configured` |
+| `statusline.setup_failed` | `statusline_setup_failed` |
+| `statusline.setup_skipped` | `statusline_setup_skipped` |
+
+### `store.*`
+
+Capturing tool calls / prompts into session memory (incl. counters).
+
+| Event | Legacy name |
+|---|---|
+| `store.buffered_warming` | `store_buffered_warming` |
+| `store.missing_session_key` | `store_missing_session_key` |
+| `store.run_exception` | `run_exception` |
+| `store.save_counter_read_failed` | `save_counter_read_failed` |
+| `store.save_counter_reset_read_failed` | `save_counter_reset_read_failed` |
+| `store.save_counter_reset_write_failed` | `save_counter_reset_write_failed` |
+| `store.save_counter_write_failed` | `save_counter_write_failed` |
+| `store.session_key` | `store_session_key` |
+| `store.skip_self_cognee_bash` | `skip_self_cognee_bash` |
+| `store.stop_error` | `stop_store_error` |
+| `store.stop_stored` | `stop_stored` |
+| `store.turn_counter_write_failed` | `turn_counter_write_failed` |
+
+### `sync.*`
+
+Background sync of a finished session into the knowledge graph.
+
+| Event | Legacy name |
+|---|---|
+| `sync.bridge_done` | `sync_bridge_done` |
+| `sync.deferred_to_shutdown_worker` | `sync_deferred_to_shutdown_worker` |
+| `sync.detach_failed` | `sync_detach_failed` |
+| `sync.detached_skipped_duplicate` | `sync_detached_skipped_duplicate` |
+| `sync.failed` | `sync_failed` |
+| `sync.final_already_claimed` | `final_sync_once_already_claimed` |
+| `sync.final_claim_failed` | `final_sync_once_claim_failed` |
+| `sync.final_claimed` | `final_sync_once_claimed` |
+| `sync.final_no_token` | `final_sync_once_no_token` |
+| `sync.final_prune_failed` | `final_sync_once_prune_failed` |
+| `sync.final_pruned` | `final_sync_once_pruned` |
+| `sync.lock_busy` | `sync_lock_busy` |
+| `sync.lock_read_failed` | `sync_lock_read_failed` |
+| `sync.lock_release_failed` | `sync_lock_release_failed` |
+| `sync.lock_unlink_failed` | `sync_lock_unlink_failed` |
+| `sync.missing_session_key` | `sync_missing_session_key` |
+| `sync.no_target_sessions` | `sync_no_target_sessions` |
+| `sync.payload` | `sync_payload` |
+| `sync.retry_scheduled` | `sync_retry_scheduled` |
+| `sync.session_key` | `sync_session_key` |
+| `sync.skipped_lock_busy` | `sync_skipped_lock_busy` |
+| `sync.start` | `sync_start` |
+| `sync.start_delayed` | `sync_start_delayed` |
+| `sync.stopped_watcher` | `sync_stopped_watcher` |
+
+### `trace.*`
+
+Storing/falling back the reasoning trace for a turn.
+
+| Event | Legacy name |
+|---|---|
+| `trace.fallback_error` | `trace_fallback_error` |
+| `trace.fallback_hit` | `trace_fallback_hit` |
+| `trace.store_error` | `trace_store_error` |
+| `trace.store_noresult` | `trace_store_noresult` |
+| `trace.stored` | `trace_stored` |
+
+### `watcher.*`
+
+Background watcher processes (idle, exit, prompt, generic).
+
+| Event | Legacy name |
+|---|---|
+| `watcher.exit_already_running` | `exit_watcher_already_running` |
+| `watcher.exit_launch_failed` | `exit_watcher_launch_failed` |
+| `watcher.exit_log_open_failed` | `exit_watcher_log_open_failed` |
+| `watcher.exit_prune_failed` | `exit_watcher_prune_failed` |
+| `watcher.exit_started` | `exit_watcher_started` |
+| `watcher.idle_kill_failed` | `idle_watcher_kill_failed` |
+| `watcher.idle_restart_failed` | `idle_watcher_restart_failed` |
+| `watcher.idle_restarted` | `idle_watcher_restarted` |
+| `watcher.log_open_failed` | `watcher_log_open_failed` |
+| `watcher.prompt_alive_check_failed` | `prompt_watcher_alive_check_failed` |
+| `watcher.prompt_log_open_failed` | `prompt_watcher_log_open_failed` |
+| `watcher.prompt_stop_unlink_failed` | `prompt_watcher_stop_unlink_failed` |
+| `watcher.sigterm_failed` | `watcher_sigterm_failed` |
+| `watcher.stop_unlink_failed` | `watcher_stop_unlink_failed` |
+| `watcher.stop_write_failed` | `watcher_stop_write_failed` |
+
+## Adding a new event
+
+1. Choose the right namespace (add one to `NAMESPACES` only if nothing fits).
+2. Add the `"legacy_or_same": "namespace.event"` entry to `EVENT_RENAMES`
+   in `scripts/event_names.py` (for a brand-new event, map it to itself).
+3. Emit the namespaced name from your `hook_log(...)` call.
+4. Add a row to the table above.
+5. Run `pytest tests/test_event_names.py` — it fails if the three sets drift.
+

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -169,7 +169,7 @@ def _read_map_record(host_key: str) -> dict:
             if isinstance(data, dict):
                 return data
     except Exception as exc:
-        hook_log("session_map_read_failed", {"error": str(exc)[:200]})
+        hook_log("session.map_read_failed", {"error": str(exc)[:200]})
     return {}
 
 
@@ -199,7 +199,7 @@ def _create_map_record_if_absent(host_key: str, record: dict) -> dict:
     except FileExistsError:
         return _read_map_record(host_key) or record
     except Exception as exc:
-        hook_log("map_create_failed", {"error": str(exc)[:200]})
+        hook_log("session.map_create_failed", {"error": str(exc)[:200]})
         # Best-effort fallback: plain write, then read back whatever landed.
         _write_map_record(host_key, record)
         return _read_map_record(host_key) or record
@@ -387,7 +387,7 @@ def load_resolved(session_key: str = "") -> dict:
             if user_id:
                 resolved["user_id"] = user_id
     except Exception as exc:
-        hook_log("runtime_state_users_me_failed", {"error": str(exc)[:200]})
+        hook_log("runtime.state_users_me_failed", {"error": str(exc)[:200]})
 
     # Resolve active connection details. The connection is registered under the
     # per-launch conn_uuid handle, so query by that — not the session id (which
@@ -415,7 +415,7 @@ def load_resolved(session_key: str = "") -> dict:
                 status = str(agent.get("status") or "").strip().lower()
                 resolved["registered"] = status == "active"
     except Exception as exc:
-        hook_log("runtime_state_connection_lookup_failed", {"error": str(exc)[:200]})
+        hook_log("runtime.state_connection_lookup_failed", {"error": str(exc)[:200]})
 
     return resolved
 
@@ -430,7 +430,7 @@ def _load_json_file(path: Path) -> dict:
         try:
             return json.loads(path.read_text(encoding="utf-8"))
         except Exception as exc:
-            hook_log("json_load_failed", {"path": str(path), "error": str(exc)[:200]})
+            hook_log("io.json_load_failed", {"path": str(path), "error": str(exc)[:200]})
     return {}
 
 
@@ -443,7 +443,7 @@ def _write_json_file(path: Path, data: dict) -> None:
         tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
         os.replace(tmp, path)
     except Exception as exc:
-        hook_log("json_write_failed", {"path": str(path), "error": str(exc)[:200]})
+        hook_log("io.json_write_failed", {"path": str(path), "error": str(exc)[:200]})
 
 
 def _bridge_cache_key(dataset: str, session_id: str) -> str:
@@ -518,7 +518,7 @@ async def resolve_user(user_id: str):
             if user:
                 return user
         except Exception as exc:
-            hook_log("resolve_user_failed", {"user_id": user_id, "error": str(exc)[:200]})
+            hook_log("runtime.resolve_user_failed", {"user_id": user_id, "error": str(exc)[:200]})
     from cognee.modules.users.methods import get_default_user
 
     return await get_default_user()
@@ -575,7 +575,7 @@ def _reexec_into_venv() -> None:
         os.execv(str(vpy), [str(vpy), *sys.argv])
     except OSError as exc:
         # Better to run degraded under the host interpreter than to die.
-        hook_log("venv_reexec_failed", {"error": str(exc)[:200]})
+        hook_log("install.venv_reexec_failed", {"error": str(exc)[:200]})
 
 
 # Fired on import: every cognee-touching hook imports this module before any
@@ -604,7 +604,7 @@ def notify(msg: str) -> None:
             with _ACTIVITY_LOG.open("a", encoding="utf-8") as fh:
                 fh.write(f"{ts} {line}\n")
         except Exception as exc:
-            hook_log("activity_log_write_failed", {"error": str(exc)[:200]})
+            hook_log("activity.log_write_failed", {"error": str(exc)[:200]})
 
 
 @contextmanager
@@ -653,7 +653,10 @@ def bump_save_counter(session_id: str, kind: str) -> None:
             json.loads(_SAVE_COUNTER.read_text(encoding="utf-8")) if _SAVE_COUNTER.exists() else {}
         )
     except Exception as exc:
-        hook_log("save_counter_read_failed", {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]})
+        hook_log(
+            "store.save_counter_read_failed",
+            {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]},
+        )
         data = {}
     sess = data.get(session_id) or {k: 0 for k in SAVE_KINDS}
     sess[kind] = int(sess.get(kind, 0)) + 1
@@ -662,7 +665,10 @@ def bump_save_counter(session_id: str, kind: str) -> None:
         _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
         _SAVE_COUNTER.write_text(json.dumps(data), encoding="utf-8")
     except Exception as exc:
-        hook_log("save_counter_write_failed", {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]})
+        hook_log(
+            "store.save_counter_write_failed",
+            {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]},
+        )
 
 
 def read_and_reset_save_counter(session_id: str) -> dict:
@@ -676,7 +682,8 @@ def read_and_reset_save_counter(session_id: str) -> dict:
         )
     except Exception as exc:
         hook_log(
-            "save_counter_reset_read_failed", {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]}
+            "store.save_counter_reset_read_failed",
+            {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]},
         )
         return zero
     sess = data.get(session_id) or zero
@@ -686,7 +693,8 @@ def read_and_reset_save_counter(session_id: str) -> dict:
         _SAVE_COUNTER.write_text(json.dumps(data), encoding="utf-8")
     except Exception as exc:
         hook_log(
-            "save_counter_reset_write_failed", {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]}
+            "store.save_counter_reset_write_failed",
+            {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]},
         )
     return {k: int(sess.get(k, 0)) for k in SAVE_KINDS}
 
@@ -774,7 +782,10 @@ def bump_turn_counter(session_id: str) -> tuple[int, bool]:
         _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
         _COUNTER_FILE.write_text(json.dumps(data), encoding="utf-8")
     except Exception as exc:
-        hook_log("turn_counter_write_failed", {"path": str(_COUNTER_FILE), "error": str(exc)[:200]})
+        hook_log(
+            "store.turn_counter_write_failed",
+            {"path": str(_COUNTER_FILE), "error": str(exc)[:200]},
+        )
 
     should_improve = threshold > 0 and count % threshold == 0
     return count, should_improve
@@ -786,7 +797,7 @@ def touch_activity() -> None:
         _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
         _ACTIVITY_FILE.write_text(str(datetime.now(timezone.utc).timestamp()), encoding="utf-8")
     except Exception as exc:
-        hook_log("activity_touch_failed", {"path": str(_ACTIVITY_FILE), "error": str(exc)[:200]})
+        hook_log("activity.touch_failed", {"path": str(_ACTIVITY_FILE), "error": str(exc)[:200]})
 
 
 @contextmanager
@@ -802,7 +813,7 @@ def sync_lock(owner: str):
                 created_at = float(current.get("created_at", 0))
                 pid = int(current.get("pid", 0))
             except Exception as exc:
-                hook_log("sync_lock_read_failed", {"owner": owner, "error": str(exc)[:200]})
+                hook_log("sync.lock_read_failed", {"owner": owner, "error": str(exc)[:200]})
                 created_at = 0
                 pid = 0
             pid_alive = False
@@ -818,7 +829,7 @@ def sync_lock(owner: str):
                 try:
                     _SYNC_LOCK.unlink()
                 except Exception as exc:
-                    hook_log("sync_lock_unlink_failed", {"owner": owner, "error": str(exc)[:200]})
+                    hook_log("sync.lock_unlink_failed", {"owner": owner, "error": str(exc)[:200]})
         try:
             fd = os.open(str(_SYNC_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
             with os.fdopen(fd, "w", encoding="utf-8") as fh:
@@ -826,14 +837,14 @@ def sync_lock(owner: str):
             acquired = True
             yield True
         except FileExistsError:
-            hook_log("sync_lock_busy", {"owner": owner})
+            hook_log("sync.lock_busy", {"owner": owner})
             yield False
     finally:
         if acquired:
             try:
                 _SYNC_LOCK.unlink()
             except Exception as exc:
-                hook_log("sync_lock_release_failed", {"owner": owner, "error": str(exc)[:200]})
+                hook_log("sync.lock_release_failed", {"owner": owner, "error": str(exc)[:200]})
 
 
 def _local_api_url_with_source() -> tuple[str, str]:
@@ -964,7 +975,7 @@ def mark_server_ready(service_url: str, version: str = "") -> None:
         tmp.write_text(json.dumps(payload), encoding="utf-8")
         os.replace(tmp, _SERVER_READY_MARKER)
     except Exception as exc:
-        hook_log("server_ready_mark_failed", {"error": str(exc)[:200]})
+        hook_log("server.ready_mark_failed", {"error": str(exc)[:200]})
 
 
 def clear_server_ready() -> None:
@@ -974,7 +985,7 @@ def clear_server_ready() -> None:
     except FileNotFoundError:
         return
     except Exception as exc:
-        hook_log("server_ready_clear_failed", {"error": str(exc)[:200]})
+        hook_log("server.ready_clear_failed", {"error": str(exc)[:200]})
 
 
 def server_ready_hint(service_url: str = "") -> bool:
@@ -1100,12 +1111,15 @@ def wait_for_cognify(
                 # Older server without the status route — can't confirm, don't loop.
                 return "unknown"
             hook_log(
-                "cognify_poll_transient",
+                "bridge.cognify_poll_transient",
                 {"dataset_id": dataset_id, "error": f"HTTP {exc.code}"},
             )
             result = None
         except (urllib.error.URLError, TimeoutError, OSError) as exc:
-            hook_log("cognify_poll_transient", {"dataset_id": dataset_id, "error": str(exc)[:120]})
+            hook_log(
+                "bridge.cognify_poll_transient",
+                {"dataset_id": dataset_id, "error": str(exc)[:120]},
+            )
             result = None
 
         status = ""
@@ -1179,7 +1193,7 @@ def register_agent_via_http(
             return True, result
         return True, {}
     except Exception as exc:
-        hook_log("agent_register_failed", {"error": str(exc)[:200]})
+        hook_log("agent.register_failed", {"error": str(exc)[:200]})
         return False, {}
 
 
@@ -1198,7 +1212,7 @@ def unregister_agent_via_http(
             return True, count
         return True, 0
     except Exception as exc:
-        hook_log("agent_unregister_failed", {"error": str(exc)[:200]})
+        hook_log("agent.unregister_failed", {"error": str(exc)[:200]})
         return False, 0
 
 
@@ -1385,12 +1399,12 @@ def persist_session_cache_to_graph_via_http(
         return False
     api_key = _api_key()
     if not api_key:
-        hook_log("http_bridge_skipped_no_api_key", {"dataset": dataset, "session": session_id})
+        hook_log("bridge.skipped_no_api_key", {"dataset": dataset, "session": session_id})
         return False
 
     qa_doc, trace_doc = _format_cached_bridge_document(dataset, session_id)
     if not qa_doc and not trace_doc:
-        hook_log("http_bridge_skipped_empty_cache", {"dataset": dataset, "session": session_id})
+        hook_log("bridge.skipped_empty_cache", {"dataset": dataset, "session": session_id})
         return False
 
     # `timeout` is reinterpreted as the overall poll deadline (it used to be the
@@ -1420,7 +1434,7 @@ def persist_session_cache_to_graph_via_http(
             # poll_deadline is an OVERALL budget across all documents, not per-document,
             # so two documents can't compound to 2x the configured wait.
             if time.monotonic() - overall_start >= poll_deadline:
-                hook_log("http_bridge_deadline_exceeded", {"dataset": dataset, "kind": kind})
+                hook_log("bridge.deadline_exceeded", {"dataset": dataset, "kind": kind})
                 break
             submitted = _post_remember_document(
                 base_url, api_key, dataset, document, node_set, submit_timeout
@@ -1429,7 +1443,7 @@ def persist_session_cache_to_graph_via_http(
                 # Skip this document (digest stays unmarked → retried later) but keep
                 # syncing the others; one bad/transient document must not abort the sync.
                 hook_log(
-                    "http_bridge_post_failed",
+                    "bridge.post_failed",
                     {"dataset": dataset, "kind": kind, "status": submitted.get("status")},
                 )
                 continue
@@ -1438,18 +1452,18 @@ def persist_session_cache_to_graph_via_http(
                 if submitted.get("parse_error"):
                     # 2xx but an unparseable body (e.g. a proxy/nginx error page): we
                     # can't trust the write landed, so leave the digest unmarked to retry.
-                    hook_log("http_bridge_parse_error", {"dataset": dataset, "kind": kind})
+                    hook_log("bridge.parse_error", {"dataset": dataset, "kind": kind})
                     continue
                 # Valid response with no handle to poll. Mark written so we don't
                 # resubmit and duplicate the cognify on every future sync.
                 state[state_key] = digest
                 wrote = True
-                hook_log("http_bridge_no_dataset_id", {"dataset": dataset, "kind": kind})
+                hook_log("bridge.no_dataset_id", {"dataset": dataset, "kind": kind})
                 continue
             remaining = poll_deadline - (time.monotonic() - overall_start)
             if remaining <= 0:
                 # The POST consumed the remaining budget — don't start a poll.
-                hook_log("http_bridge_deadline_exceeded", {"dataset": dataset, "kind": kind})
+                hook_log("bridge.deadline_exceeded", {"dataset": dataset, "kind": kind})
                 break
             outcome = wait_for_cognify(
                 dataset_id,
@@ -1464,20 +1478,20 @@ def persist_session_cache_to_graph_via_http(
                 state[state_key] = digest
                 wrote = True
             hook_log(
-                "http_bridge_poll",
+                "bridge.poll",
                 {"dataset": dataset, "kind": kind, "outcome": outcome, "dataset_id": dataset_id},
             )
         if isinstance(bridge_cache, dict):
             bridge_cache["_state"] = state
             _write_json_file(bridge_path, bridge_cache)
         hook_log(
-            "http_bridge_done",
+            "bridge.done",
             {"dataset": dataset, "session": session_id, "wrote": wrote},
         )
         return wrote
     except (urllib.error.URLError, TimeoutError, OSError) as exc:
         hook_log(
-            "http_bridge_failed",
+            "bridge.failed",
             {"error": str(exc)[:200], "dataset": dataset, "session": session_id},
         )
         return False

--- a/integrations/claude-code/scripts/event_names.py
+++ b/integrations/claude-code/scripts/event_names.py
@@ -1,0 +1,224 @@
+"""Canonical structured-event taxonomy for the Claude Code plugin.
+
+Single source of truth for every event name passed to
+``_plugin_common.hook_log``. Names are namespaced ``<namespace>.<event>``
+so a downstream telemetry emitter can group and route them uniformly
+(e.g. everything under ``recall.*`` or ``bridge.*``).
+
+``EVENT_RENAMES`` is the one migration map from the historical flat
+snake_case names to the namespaced names. ``KNOWN_EVENTS`` is the frozen
+set of canonical names and is what tests and emitters should import.
+Keep this module, EVENTS.md, and the emitted call sites in lockstep — a
+test enforces that they agree.
+"""
+
+from __future__ import annotations
+
+# Namespaces, in taxonomy order.
+NAMESPACES: frozenset[str] = frozenset(
+    {
+        "activity",
+        "agent",
+        "bootstrap",
+        "bridge",
+        "context",
+        "install",
+        "io",
+        "mode",
+        "precompact",
+        "prompt",
+        "recall",
+        "runtime",
+        "server",
+        "session",
+        "statusline",
+        "store",
+        "sync",
+        "trace",
+        "watcher",
+    }
+)
+
+# Historical flat name -> canonical namespaced name. The one rename map.
+EVENT_RENAMES: dict[str, str] = {
+    # activity.*
+    "activity_log_write_failed": "activity.log_write_failed",
+    "activity_touch_failed": "activity.touch_failed",
+    # agent.*
+    "agent_lifecycle_error": "agent.lifecycle_error",
+    "agent_register_failed": "agent.register_failed",
+    "agent_register_result": "agent.register_result",
+    "agent_unregister_failed": "agent.unregister_failed",
+    "agent_unregister_result": "agent.unregister_result",
+    "agent_unregister_skipped_no_auth": "agent.unregister_skipped_no_auth",
+    "agent_unregister_skipped_no_session_name": "agent.unregister_skipped_no_session_name",
+    # bootstrap.*
+    "bootstrap_complete": "bootstrap.complete",
+    "bootstrap_failed": "bootstrap.failed",
+    "bootstrap_lock_release_failed": "bootstrap.lock_release_failed",
+    "bootstrap_lock_unlink_failed": "bootstrap.lock_unlink_failed",
+    "bootstrap_log_open_failed": "bootstrap.log_open_failed",
+    "bootstrap_main_exception": "bootstrap.main_exception",
+    "bootstrap_server_unhealthy": "bootstrap.server_unhealthy",
+    "bootstrap_spawn_failed": "bootstrap.spawn_failed",
+    "bootstrap_spawned": "bootstrap.spawned",
+    "bootstrap_waiting_for_peer": "bootstrap.waiting_for_peer",
+    # bridge.*
+    "auto_bridge_error": "bridge.auto_error",
+    "auto_bridge_fired": "bridge.auto_fired",
+    "cognify_poll_transient": "bridge.cognify_poll_transient",
+    "http_bridge_deadline_exceeded": "bridge.deadline_exceeded",
+    "http_bridge_done": "bridge.done",
+    "http_bridge_failed": "bridge.failed",
+    "http_bridge_no_dataset_id": "bridge.no_dataset_id",
+    "http_bridge_parse_error": "bridge.parse_error",
+    "http_bridge_poll": "bridge.poll",
+    "http_bridge_post_failed": "bridge.post_failed",
+    "http_bridge_skipped_empty_cache": "bridge.skipped_empty_cache",
+    "http_bridge_skipped_no_api_key": "bridge.skipped_no_api_key",
+    # context.*
+    "context_lookup_empty": "context.lookup_empty",
+    "context_lookup_exception": "context.lookup_exception",
+    "context_lookup_hit": "context.lookup_hit",
+    "context_lookup_missing_session_key": "context.lookup_missing_session_key",
+    "context_lookup_session_key": "context.lookup_session_key",
+    # install.*
+    "cognee_install_failed": "install.cognee_failed",
+    "cognee_install_ready": "install.cognee_ready",
+    "cognee_data_dir_mkdir_failed": "install.data_dir_mkdir_failed",
+    "uv_install_failed": "install.uv_failed",
+    "venv_install_lock_release_failed": "install.venv_lock_release_failed",
+    "venv_install_lock_unlink_failed": "install.venv_lock_unlink_failed",
+    "venv_ready_write_failed": "install.venv_ready_write_failed",
+    "venv_reexec_failed": "install.venv_reexec_failed",
+    "cognee_venv_unusable": "install.venv_unusable",
+    "cognee_version_probe_failed": "install.version_probe_failed",
+    # io.*
+    "invalid_payload_json": "io.invalid_payload_json",
+    "json_load_failed": "io.json_load_failed",
+    "json_write_failed": "io.json_write_failed",
+    # mode.*
+    "mode_decision": "mode.decision",
+    "endpoint_mode_selected": "mode.endpoint_selected",
+    # precompact.*
+    "precompact_anchor": "precompact.anchor",
+    "precompact_direct_fetch_error": "precompact.direct_fetch_error",
+    "precompact_empty": "precompact.empty",
+    "precompact_recall_error": "precompact.recall_error",
+    "precompact_run_exception": "precompact.run_exception",
+    # prompt.*
+    "prompt_missing_session_key": "prompt.missing_session_key",
+    "prompt_pending": "prompt.pending",
+    "prompt_prepare_warning": "prompt.prepare_warning",
+    "prompt_run_exception": "prompt.run_exception",
+    "prompt_session_key": "prompt.session_key",
+    # recall.*
+    "recall_audit_write_failed": "recall.audit_write_failed",
+    "recall_breaker_open": "recall.breaker_open",
+    "recall_budget_exceeded": "recall.budget_exceeded",
+    "recall_error": "recall.error",
+    "last_recall_write_failed": "recall.last_write_failed",
+    "recall_skipped_warming": "recall.skipped_warming",
+    # runtime.*
+    "resolve_user_failed": "runtime.resolve_user_failed",
+    "runtime_state_connection_lookup_failed": "runtime.state_connection_lookup_failed",
+    "runtime_state_users_me_failed": "runtime.state_users_me_failed",
+    # server.*
+    "server_bootstrap_lock_acquired": "server.bootstrap_lock_acquired",
+    "server_bootstrap_lock_release_failed": "server.bootstrap_lock_release_failed",
+    "server_bootstrap_lock_released": "server.bootstrap_lock_released",
+    "server_bootstrap_lock_stale_reaped": "server.bootstrap_lock_stale_reaped",
+    "server_bootstrap_lock_unlink_failed": "server.bootstrap_lock_unlink_failed",
+    "server_bootstrap_warning": "server.bootstrap_warning",
+    "server_ready_clear_failed": "server.ready_clear_failed",
+    "server_ready_mark_failed": "server.ready_mark_failed",
+    # session.*
+    "find_claude_parent_failed": "session.find_claude_parent_failed",
+    "legacy_resolved_dir_remove_failed": "session.legacy_resolved_dir_remove_failed",
+    "legacy_resolved_unlink_failed": "session.legacy_resolved_unlink_failed",
+    "map_create_failed": "session.map_create_failed",
+    "session_map_read_failed": "session.map_read_failed",
+    "missing_payload_session_id": "session.missing_payload_session_id",
+    "no_session_id": "session.no_session_id",
+    "session_resolved": "session.resolved",
+    "session_start_exception": "session.start_exception",
+    # statusline.*
+    "statusline_configured": "statusline.configured",
+    "statusline_setup_failed": "statusline.setup_failed",
+    "statusline_setup_skipped": "statusline.setup_skipped",
+    # store.*
+    "store_buffered_warming": "store.buffered_warming",
+    "store_missing_session_key": "store.missing_session_key",
+    "run_exception": "store.run_exception",
+    "save_counter_read_failed": "store.save_counter_read_failed",
+    "save_counter_reset_read_failed": "store.save_counter_reset_read_failed",
+    "save_counter_reset_write_failed": "store.save_counter_reset_write_failed",
+    "save_counter_write_failed": "store.save_counter_write_failed",
+    "store_session_key": "store.session_key",
+    "skip_self_cognee_bash": "store.skip_self_cognee_bash",
+    "stop_store_error": "store.stop_error",
+    "stop_stored": "store.stop_stored",
+    "turn_counter_write_failed": "store.turn_counter_write_failed",
+    # sync.*
+    "sync_bridge_done": "sync.bridge_done",
+    "sync_deferred_to_shutdown_worker": "sync.deferred_to_shutdown_worker",
+    "sync_detach_failed": "sync.detach_failed",
+    "sync_detached_skipped_duplicate": "sync.detached_skipped_duplicate",
+    "sync_failed": "sync.failed",
+    "final_sync_once_already_claimed": "sync.final_already_claimed",
+    "final_sync_once_claim_failed": "sync.final_claim_failed",
+    "final_sync_once_claimed": "sync.final_claimed",
+    "final_sync_once_no_token": "sync.final_no_token",
+    "final_sync_once_prune_failed": "sync.final_prune_failed",
+    "final_sync_once_pruned": "sync.final_pruned",
+    "sync_lock_busy": "sync.lock_busy",
+    "sync_lock_read_failed": "sync.lock_read_failed",
+    "sync_lock_release_failed": "sync.lock_release_failed",
+    "sync_lock_unlink_failed": "sync.lock_unlink_failed",
+    "sync_missing_session_key": "sync.missing_session_key",
+    "sync_no_target_sessions": "sync.no_target_sessions",
+    "sync_payload": "sync.payload",
+    "sync_retry_scheduled": "sync.retry_scheduled",
+    "sync_session_key": "sync.session_key",
+    "sync_skipped_lock_busy": "sync.skipped_lock_busy",
+    "sync_start": "sync.start",
+    "sync_start_delayed": "sync.start_delayed",
+    "sync_stopped_watcher": "sync.stopped_watcher",
+    # trace.*
+    "trace_fallback_error": "trace.fallback_error",
+    "trace_fallback_hit": "trace.fallback_hit",
+    "trace_store_error": "trace.store_error",
+    "trace_store_noresult": "trace.store_noresult",
+    "trace_stored": "trace.stored",
+    # watcher.*
+    "exit_watcher_already_running": "watcher.exit_already_running",
+    "exit_watcher_launch_failed": "watcher.exit_launch_failed",
+    "exit_watcher_log_open_failed": "watcher.exit_log_open_failed",
+    "exit_watcher_prune_failed": "watcher.exit_prune_failed",
+    "exit_watcher_started": "watcher.exit_started",
+    "idle_watcher_kill_failed": "watcher.idle_kill_failed",
+    "idle_watcher_restart_failed": "watcher.idle_restart_failed",
+    "idle_watcher_restarted": "watcher.idle_restarted",
+    "watcher_log_open_failed": "watcher.log_open_failed",
+    "prompt_watcher_alive_check_failed": "watcher.prompt_alive_check_failed",
+    "prompt_watcher_log_open_failed": "watcher.prompt_log_open_failed",
+    "prompt_watcher_stop_unlink_failed": "watcher.prompt_stop_unlink_failed",
+    "watcher_sigterm_failed": "watcher.sigterm_failed",
+    "watcher_stop_unlink_failed": "watcher.stop_unlink_failed",
+    "watcher_stop_write_failed": "watcher.stop_write_failed",
+}
+
+# The canonical set of namespaced event names emitted by the plugin.
+KNOWN_EVENTS: frozenset[str] = frozenset(EVENT_RENAMES.values())
+
+
+def canonical(event: str) -> str:
+    """Return the canonical namespaced name for *event*.
+
+    Accepts either a legacy flat name (translated via EVENT_RENAMES) or an
+    already-namespaced name (returned unchanged). Unknown names are returned
+    as-is so logging never fails on a not-yet-registered event.
+    """
+    if event in EVENT_RENAMES:
+        return EVENT_RENAMES[event]
+    return event

--- a/integrations/claude-code/scripts/pre-compact.py
+++ b/integrations/claude-code/scripts/pre-compact.py
@@ -76,7 +76,7 @@ async def _recall(session_id: str, dataset: str, query: str, scope: list[str], t
         )
         return list(results) if results else []
     except Exception as exc:
-        hook_log("precompact_recall_error", {"scope": scope, "error": str(exc)[:200]})
+        hook_log("precompact.recall_error", {"scope": scope, "error": str(exc)[:200]})
         return []
 
 
@@ -139,7 +139,7 @@ def _format_graph_section(entries: list) -> str:
 async def _run():
     session_id, dataset = _load_resolved_fields()
     if not session_id:
-        hook_log("no_session_id", {"event": "precompact"})
+        hook_log("session.no_session_id", {"event": "precompact"})
         return
 
     config = load_config()
@@ -177,7 +177,7 @@ async def _run():
                     )
                     trace_entries = list(raw_trace)[-_TRACE_TOP_K:] if raw_trace else []
         except Exception as exc:
-            hook_log("precompact_direct_fetch_error", {"error": str(exc)[:200]})
+            hook_log("precompact.direct_fetch_error", {"error": str(exc)[:200]})
 
     session_entries = session_entries[-_SESSION_TOP_K:]
     trace_entries = trace_entries[-_TRACE_TOP_K:]
@@ -211,7 +211,7 @@ async def _run():
             sections.append(s)
 
     if not sections:
-        hook_log("precompact_empty")
+        hook_log("precompact.empty")
         return
 
     header = (
@@ -221,7 +221,7 @@ async def _run():
     anchor = header + "\n\n".join(sections)
 
     hook_log(
-        "precompact_anchor",
+        "precompact.anchor",
         {
             "session_entries": len(session_entries),
             "trace_entries": len(trace_entries),
@@ -248,7 +248,7 @@ def main():
     try:
         asyncio.run(_run())
     except Exception as exc:
-        hook_log("precompact_run_exception", {"error": str(exc)[:200]})
+        hook_log("precompact.run_exception", {"error": str(exc)[:200]})
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -137,7 +137,7 @@ async def _recent_trace_fallback(session_id: str, user_id: str, top_k: int) -> l
         raw_trace = await sm.get_agent_trace_session(user_id=user_id, session_id=session_id)
         entries = list(raw_trace or [])[-top_k:]
     except Exception as exc:
-        hook_log("trace_fallback_error", {"error": str(exc)[:200]})
+        hook_log("trace.fallback_error", {"error": str(exc)[:200]})
         return []
 
     normalized: list[dict] = []
@@ -161,7 +161,7 @@ async def _run(prompt: str) -> dict | None:
     runtime = resolve_runtime_mode()
     cloud_mode = runtime["mode"] == "http"
     hook_log(
-        "mode_decision",
+        "mode.decision",
         {
             "hook": "session-context-lookup",
             "mode": runtime["mode"],
@@ -180,7 +180,7 @@ async def _run(prompt: str) -> dict | None:
         if server_health_ok(service_url, timeout=_float_env("COGNEE_READY_PROBE_TIMEOUT", 1.0)):
             mark_server_ready(service_url)
         else:
-            hook_log("recall_skipped_warming", {"base_url": service_url})
+            hook_log("recall.skipped_warming", {"base_url": service_url})
             return None
 
     if not cloud_mode:
@@ -188,7 +188,7 @@ async def _run(prompt: str) -> dict | None:
 
     session_id = _load_session_id()
     if not session_id:
-        hook_log("no_session_id", {"event": "context_lookup"})
+        hook_log("session.no_session_id", {"event": "context_lookup"})
         return None
 
     saves_last_turn = read_and_reset_save_counter(session_id)
@@ -227,11 +227,11 @@ async def _run(prompt: str) -> dict | None:
         except Exception:
             _bopen, _bretry = False, 0
         if _bopen:
-            hook_log("recall_breaker_open", {"retry_in": _bretry})
+            hook_log("recall.breaker_open", {"retry_in": _bretry})
             scope_specs = []
     for scope_list, qtype, context_profile in scope_specs:
         if time.monotonic() >= budget_deadline:
-            hook_log("recall_budget_exceeded", {"collected": len(results)})
+            hook_log("recall.budget_exceeded", {"collected": len(results)})
             break
         try:
             if cloud_mode:
@@ -263,7 +263,7 @@ async def _run(prompt: str) -> dict | None:
             if part:
                 results.extend(part)
         except Exception as exc:
-            hook_log("recall_error", {"scope": scope_list, "error": str(exc)[:200]})
+            hook_log("recall.error", {"scope": scope_list, "error": str(exc)[:200]})
 
     # Bucket results by _source for human-readable output.
     # Local SDK mode returns Pydantic models (ResponseQAEntry, etc.); cloud
@@ -297,7 +297,7 @@ async def _run(prompt: str) -> dict | None:
         )
         if fallback_traces:
             by_source["trace"].extend(fallback_traces)
-            hook_log("trace_fallback_hit", {"count": len(fallback_traces)})
+            hook_log("trace.fallback_hit", {"count": len(fallback_traces)})
 
     counts = {k: len(v) for k, v in by_source.items()}
     total = sum(counts.values())
@@ -323,7 +323,7 @@ async def _run(prompt: str) -> dict | None:
             encoding="utf-8",
         )
     except Exception as exc:
-        hook_log("last_recall_write_failed", {"error": str(exc)[:200]})
+        hook_log("recall.last_write_failed", {"error": str(exc)[:200]})
 
     # Build a one-line visibility header so the user (via the assistant's
     # context) can tell that memory fired on this turn — both what it
@@ -363,11 +363,11 @@ async def _run(prompt: str) -> dict | None:
             f"{header}\n\nRelevant context from this session's memory:\n\n"
             + "\n".join(section_lines).strip()
         )
-        hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
+        hook_log("context.lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
         notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
     else:
         full_context = f"{header}\n\n(no memory matches for this prompt)"
-        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
+        hook_log("context.lookup_empty", {"saves_last_turn": saves_last_turn})
         notify(f"no recall matches; saves last turn {saves_last_turn}")
 
     # Audit log: persist full recall details per turn. The hook output stays a
@@ -393,7 +393,7 @@ async def _run(prompt: str) -> dict | None:
                 + "\n"
             )
     except Exception as exc:
-        hook_log("recall_audit_write_failed", {"error": str(exc)[:200]})
+        hook_log("recall.audit_write_failed", {"error": str(exc)[:200]})
 
     output = {
         "hookSpecificOutput": {
@@ -419,10 +419,10 @@ def main():
     if session_key_candidate:
         set_session_key(session_key_candidate)
     hook_log(
-        "context_lookup_session_key", {"source": session_key_source, "value": session_key_candidate}
+        "context.lookup_session_key", {"source": session_key_source, "value": session_key_candidate}
     )
     if not get_session_key():
-        hook_log("context_lookup_missing_session_key")
+        hook_log("context.lookup_missing_session_key")
         return
 
     prompt = payload.get("prompt", "")
@@ -434,7 +434,7 @@ def main():
         with quiet_hook_output("session-context-lookup"):
             output = asyncio.run(_run(prompt))
     except Exception as exc:
-        hook_log("context_lookup_exception", {"error": str(exc)[:200]})
+        hook_log("context.lookup_exception", {"error": str(exc)[:200]})
     if output:
         print(json.dumps(output))
 

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -133,7 +133,7 @@ def _install_uv() -> str:
         if _UV_BIN.exists():
             return str(_UV_BIN)
     except Exception as exc:
-        hook_log("uv_install_failed", {"error": str(exc)[:300]})
+        hook_log("install.uv_failed", {"error": str(exc)[:300]})
     return ""
 
 
@@ -155,7 +155,7 @@ def _venv_cognee_version() -> str:
         if out.returncode == 0:
             return out.stdout.strip()
     except Exception as exc:
-        hook_log("cognee_version_probe_failed", {"error": str(exc)[:200]})
+        hook_log("install.version_probe_failed", {"error": str(exc)[:200]})
     return ""
 
 
@@ -170,7 +170,7 @@ def _write_venv_ready(version: str) -> None:
         tmp.write_text(json.dumps(payload), encoding="utf-8")
         os.replace(tmp, _VENV_READY_MARKER)
     except Exception as exc:
-        hook_log("venv_ready_write_failed", {"error": str(exc)[:200]})
+        hook_log("install.venv_ready_write_failed", {"error": str(exc)[:200]})
 
 
 def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
@@ -191,7 +191,7 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
             directory.mkdir(parents=True, exist_ok=True)
         except Exception as exc:
             hook_log(
-                "cognee_data_dir_mkdir_failed", {"dir": str(directory), "error": str(exc)[:200]}
+                "install.data_dir_mkdir_failed", {"dir": str(directory), "error": str(exc)[:200]}
             )
 
     owner = f"install:{os.getpid()}"
@@ -216,7 +216,7 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
                     try:
                         _VENV_INSTALL_LOCK.unlink()
                     except Exception as exc:
-                        hook_log("venv_install_lock_unlink_failed", {"error": str(exc)[:200]})
+                        hook_log("install.venv_lock_unlink_failed", {"error": str(exc)[:200]})
 
             try:
                 fd = os.open(str(_VENV_INSTALL_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
@@ -266,7 +266,7 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
                     timeout=timeout,
                 )
             except Exception as exc:
-                hook_log("cognee_install_failed", {"via": "uv", "error": str(exc)[:300]})
+                hook_log("install.cognee_failed", {"via": "uv", "error": str(exc)[:300]})
         elif not venv_present:
             # Last-resort fallback: stdlib venv + pip. Slower, and relies on the
             # system python3 being a cognee-compatible version (3.10-3.14).
@@ -293,21 +293,21 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
                     timeout=timeout,
                 )
             except Exception as exc:
-                hook_log("cognee_install_failed", {"via": "venv_pip", "error": str(exc)[:300]})
+                hook_log("install.cognee_failed", {"via": "venv_pip", "error": str(exc)[:300]})
 
         version = _venv_cognee_version()
         if not version:
-            hook_log("cognee_venv_unusable", {"venv_python": str(_VENV_PYTHON)})
+            hook_log("install.venv_unusable", {"venv_python": str(_VENV_PYTHON)})
             return False
         _write_venv_ready(version)
-        hook_log("cognee_install_ready", {"version": version})
+        hook_log("install.cognee_ready", {"version": version})
         return True
     finally:
         if acquired:
             try:
                 _VENV_INSTALL_LOCK.unlink()
             except Exception as exc:
-                hook_log("venv_install_lock_release_failed", {"error": str(exc)[:200]})
+                hook_log("install.venv_lock_release_failed", {"error": str(exc)[:200]})
 
 
 def _parse_host_port(url: str) -> tuple[str, int]:
@@ -402,16 +402,16 @@ def _ensure_local_server_running(
                 if stale:
                     try:
                         _SERVER_BOOT_LOCK.unlink()
-                        hook_log("server_bootstrap_lock_stale_reaped", {"owner": owner})
+                        hook_log("server.bootstrap_lock_stale_reaped", {"owner": owner})
                     except Exception as exc:
-                        hook_log("server_bootstrap_lock_unlink_failed", {"error": str(exc)[:200]})
+                        hook_log("server.bootstrap_lock_unlink_failed", {"error": str(exc)[:200]})
 
             try:
                 fd = os.open(str(_SERVER_BOOT_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
                 with os.fdopen(fd, "w", encoding="utf-8") as fh:
                     json.dump({"owner": owner, "pid": os.getpid(), "created_at": now}, fh)
                 acquired = True
-                hook_log("server_bootstrap_lock_acquired", {"owner": owner})
+                hook_log("server.bootstrap_lock_acquired", {"owner": owner})
                 break
             except FileExistsError:
                 if _health_ok(health_url):
@@ -451,9 +451,9 @@ def _ensure_local_server_running(
         if acquired:
             try:
                 _SERVER_BOOT_LOCK.unlink()
-                hook_log("server_bootstrap_lock_released", {"owner": owner})
+                hook_log("server.bootstrap_lock_released", {"owner": owner})
             except Exception as exc:
-                hook_log("server_bootstrap_lock_release_failed", {"error": str(exc)[:200]})
+                hook_log("server.bootstrap_lock_release_failed", {"error": str(exc)[:200]})
 
 
 def _pid_alive(pid: int) -> bool:
@@ -592,7 +592,7 @@ async def _ensure_agent_credentials_and_register(
         raise RuntimeError(f"Failed to register session '{session_id}' on {service_url}.")
 
     hook_log(
-        "agent_register_result",
+        "agent.register_result",
         {
             "agent_session_name": agent_session_name,
             "registered": registered,
@@ -631,14 +631,14 @@ def _spawn_idle_watcher(
             pid = int(_WATCHER_PID.read_text(encoding="utf-8").strip())
             os.kill(pid, signal.SIGTERM)
         except Exception as exc:
-            hook_log("idle_watcher_kill_failed", {"error": str(exc)[:200]})
+            hook_log("watcher.idle_kill_failed", {"error": str(exc)[:200]})
 
     # Clear any stale stop sentinel from a previous run.
     try:
         if _WATCHER_STOP.exists():
             _WATCHER_STOP.unlink()
     except Exception as exc:
-        hook_log("watcher_stop_unlink_failed", {"error": str(exc)[:200]})
+        hook_log("watcher.stop_unlink_failed", {"error": str(exc)[:200]})
 
     # Only the non-secret surface of config needs to travel — the
     # watcher re-runs ``ensure_cognee_ready`` on its own.
@@ -659,7 +659,7 @@ def _spawn_idle_watcher(
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_fh = log_path.open("a", encoding="utf-8")
     except Exception as exc:
-        hook_log("watcher_log_open_failed", {"error": str(exc)[:200]})
+        hook_log("watcher.log_open_failed", {"error": str(exc)[:200]})
         log_fh = subprocess.DEVNULL
 
     try:
@@ -690,7 +690,7 @@ def _find_claude_parent_pid() -> int:
             stderr=subprocess.DEVNULL,
         )
     except Exception as exc:
-        hook_log("find_claude_parent_failed", {"error": str(exc)[:200]})
+        hook_log("session.find_claude_parent_failed", {"error": str(exc)[:200]})
         return fallback
 
     table: dict[int, tuple[int, str]] = {}
@@ -757,7 +757,7 @@ def _spawn_exit_watcher(
                 except Exception:
                     continue
     except Exception as exc:
-        hook_log("exit_watcher_prune_failed", {"error": str(exc)[:200]})
+        hook_log("watcher.exit_prune_failed", {"error": str(exc)[:200]})
 
     parent_pid = _find_claude_parent_pid()
     watcher_pidfile = _EXIT_WATCHERS_DIR / f"{parent_pid}.pid"
@@ -766,7 +766,7 @@ def _spawn_exit_watcher(
             existing = int(watcher_pidfile.read_text(encoding="utf-8").strip())
             if _pid_alive(existing):
                 hook_log(
-                    "exit_watcher_already_running",
+                    "watcher.exit_already_running",
                     {"parent_pid": parent_pid, "pidfile": str(watcher_pidfile)},
                 )
                 return
@@ -789,7 +789,7 @@ def _spawn_exit_watcher(
         _EXIT_WATCHERS_DIR.mkdir(parents=True, exist_ok=True)
         log_fh = log_path.open("a", encoding="utf-8")
     except Exception as exc:
-        hook_log("exit_watcher_log_open_failed", {"error": str(exc)[:200]})
+        hook_log("watcher.exit_log_open_failed", {"error": str(exc)[:200]})
         log_fh = subprocess.DEVNULL
 
     try:
@@ -806,7 +806,7 @@ def _spawn_exit_watcher(
             close_fds=True,
         )
         hook_log(
-            "exit_watcher_started",
+            "watcher.exit_started",
             {
                 "parent_pid": parent_pid,
                 "session_id": session_id,
@@ -815,7 +815,7 @@ def _spawn_exit_watcher(
             },
         )
     except Exception as e:
-        hook_log("exit_watcher_launch_failed", {"error": str(e)[:300]})
+        hook_log("watcher.exit_launch_failed", {"error": str(e)[:300]})
 
 
 def _purge_legacy_resolved_files() -> None:
@@ -825,12 +825,12 @@ def _purge_legacy_resolved_files() -> None:
         if legacy.exists():
             legacy.unlink()
     except Exception as exc:
-        hook_log("legacy_resolved_unlink_failed", {"error": str(exc)[:200]})
+        hook_log("session.legacy_resolved_unlink_failed", {"error": str(exc)[:200]})
     try:
         if scoped_dir.exists():
             shutil.rmtree(scoped_dir)
     except Exception as exc:
-        hook_log("legacy_resolved_dir_remove_failed", {"error": str(exc)[:200]})
+        hook_log("session.legacy_resolved_dir_remove_failed", {"error": str(exc)[:200]})
 
 
 @contextmanager
@@ -857,7 +857,7 @@ def _bootstrap_singleflight():
                 try:
                     _BOOTSTRAP_LOCK.unlink()
                 except Exception as exc:
-                    hook_log("bootstrap_lock_unlink_failed", {"error": str(exc)[:200]})
+                    hook_log("bootstrap.lock_unlink_failed", {"error": str(exc)[:200]})
         try:
             fd = os.open(str(_BOOTSTRAP_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
             with os.fdopen(fd, "w", encoding="utf-8") as fh:
@@ -871,7 +871,7 @@ def _bootstrap_singleflight():
             try:
                 _BOOTSTRAP_LOCK.unlink()
             except Exception as exc:
-                hook_log("bootstrap_lock_release_failed", {"error": str(exc)[:200]})
+                hook_log("bootstrap.lock_release_failed", {"error": str(exc)[:200]})
 
 
 def _spawn_bootstrap(
@@ -896,7 +896,7 @@ def _spawn_bootstrap(
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_fh = log_path.open("a", encoding="utf-8")
     except Exception as exc:
-        hook_log("bootstrap_log_open_failed", {"error": str(exc)[:200]})
+        hook_log("bootstrap.log_open_failed", {"error": str(exc)[:200]})
         log_fh = subprocess.DEVNULL
     try:
         env = os.environ.copy()
@@ -911,9 +911,9 @@ def _spawn_bootstrap(
             start_new_session=True,
             close_fds=True,
         )
-        hook_log("bootstrap_spawned", {"session_id": session_id})
+        hook_log("bootstrap.spawned", {"session_id": session_id})
     except Exception as exc:
-        hook_log("bootstrap_spawn_failed", {"error": str(exc)[:300]})
+        hook_log("bootstrap.spawn_failed", {"error": str(exc)[:300]})
 
 
 async def _run_heavy(
@@ -938,7 +938,7 @@ async def _run_heavy(
         try:
             _ensure_local_server_running(config, health_timeout=boot_timeout)
         except Exception as exc:
-            hook_log("server_bootstrap_warning", {"error": str(exc)[:200]})
+            hook_log("server.bootstrap_warning", {"error": str(exc)[:200]})
 
     # On a cold start this worker began under the host python3, so the
     # _plugin_common import-time guard could not re-exec us. The boot above
@@ -977,7 +977,7 @@ async def _run_heavy(
                 user_id = agent_id
         except Exception as exc:
             message = str(exc)[:300]
-            hook_log("agent_lifecycle_error", {"error": message})
+            hook_log("agent.lifecycle_error", {"error": message})
             print(f"cognee-plugin: agent lifecycle failed ({message})", file=sys.stderr)
             return "", "", False
     else:
@@ -1056,11 +1056,11 @@ async def _run_bootstrap(bootstrap: dict) -> None:
                         config, health_timeout=_SERVER_BOOT_DEADLINE_SECONDS
                     )
                 except Exception as exc:
-                    hook_log("server_bootstrap_warning", {"error": str(exc)[:200]})
+                    hook_log("server.bootstrap_warning", {"error": str(exc)[:200]})
             else:
-                hook_log("bootstrap_waiting_for_peer", {"session_id": session_id})
+                hook_log("bootstrap.waiting_for_peer", {"session_id": session_id})
         if not _wait_for_health(_SERVER_BOOT_DEADLINE_SECONDS, health_url):
-            hook_log("bootstrap_server_unhealthy", {"session_id": session_id})
+            hook_log("bootstrap.server_unhealthy", {"session_id": session_id})
             return
 
     # 2. Register this agent/session. Runs for every agent — NOT gated by the
@@ -1077,9 +1077,9 @@ async def _run_bootstrap(bootstrap: dict) -> None:
             managed_endpoint=False,
             boot_timeout=_SERVER_BOOT_DEADLINE_SECONDS,
         )
-        hook_log("bootstrap_complete", {"session_id": session_id})
+        hook_log("bootstrap.complete", {"session_id": session_id})
     except Exception as exc:
-        hook_log("bootstrap_failed", {"error": str(exc)[:300]})
+        hook_log("bootstrap.failed", {"error": str(exc)[:300]})
 
 
 def _session_start_guidance(mode: str, dataset: str, session_id: str, ready: bool) -> dict:
@@ -1124,7 +1124,7 @@ def _ensure_statusline_configured() -> None:
 
     if not statusline_sh.exists():
         hook_log(
-            "statusline_setup_skipped", {"reason": "script_not_found", "path": str(statusline_sh)}
+            "statusline.setup_skipped", {"reason": "script_not_found", "path": str(statusline_sh)}
         )
         return
 
@@ -1155,9 +1155,9 @@ def _ensure_statusline_configured() -> None:
             except OSError:
                 pass
             raise
-        hook_log("statusline_configured", {"path": str(statusline_sh)})
+        hook_log("statusline.configured", {"path": str(statusline_sh)})
     except Exception as exc:
-        hook_log("statusline_setup_failed", {"error": str(exc)[:200]})
+        hook_log("statusline.setup_failed", {"error": str(exc)[:200]})
 
 
 _MEMORY_PREFERENCE_STEER = (
@@ -1222,7 +1222,7 @@ async def _start(payload: dict | None = None) -> dict:
     session_candidate, session_source = resolve_session_key_from_payload(payload)
     session_key = set_session_key(session_candidate)
     if not session_key:
-        hook_log("missing_payload_session_id", {"cwd": cwd, "payload": payload})
+        hook_log("session.missing_payload_session_id", {"cwd": cwd, "payload": payload})
         print(
             "cognee-plugin: missing payload session_id; refusing to register",
             file=sys.stderr,
@@ -1242,7 +1242,7 @@ async def _start(payload: dict | None = None) -> dict:
     os.environ["COGNEE_SESSION_ID"] = session_id
     agent_session_name = conn_uuid
     hook_log(
-        "session_resolved",
+        "session.resolved",
         {
             "source": session_source,
             "session_key": session_key,
@@ -1262,7 +1262,7 @@ async def _start(payload: dict | None = None) -> dict:
     server_live = _health_ok(_health_url(target_url))
     will_boot = (not server_live) and _is_local_url(target_url)
     hook_log(
-        "endpoint_mode_selected",
+        "mode.endpoint_selected",
         {"base_url": target_url, "server_live": server_live, "will_boot": will_boot},
     )
     if will_boot and _LAZY_BOOTSTRAP:
@@ -1342,7 +1342,7 @@ def main():
         try:
             asyncio.run(_run_bootstrap(bootstrap))
         except Exception as exc:
-            hook_log("bootstrap_main_exception", {"error": str(exc)[:200]})
+            hook_log("bootstrap.main_exception", {"error": str(exc)[:200]})
         return
 
     payload_raw = sys.stdin.read()
@@ -1356,7 +1356,7 @@ def main():
         with quiet_hook_output("session-start"):
             output = asyncio.run(_start(payload))
     except Exception as exc:
-        hook_log("session_start_exception", {"error": str(exc)[:200]})
+        hook_log("session.start_exception", {"error": str(exc)[:200]})
     output = _apply_memory_preference(output)
     print(json.dumps(output or {}))
 

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -61,7 +61,7 @@ async def _fire_improve_background(dataset: str, session_id: str, user, reason: 
         if http_api_ready():
             wrote = persist_session_cache_to_graph_via_http(dataset, session_id)
             hook_log(
-                "auto_bridge_fired",
+                "bridge.auto_fired",
                 {"reason": reason, "session": session_id, "via": "http_remember", "wrote": wrote},
             )
             if wrote:
@@ -72,7 +72,7 @@ async def _fire_improve_background(dataset: str, session_id: str, user, reason: 
         wrote = await persist_session_cache_to_graph(dataset, session_id, user)
         graph_result = await sync_graph_context_to_session(dataset, session_id, user)
         hook_log(
-            "auto_bridge_fired",
+            "bridge.auto_fired",
             {
                 "reason": reason,
                 "session": session_id,
@@ -82,7 +82,7 @@ async def _fire_improve_background(dataset: str, session_id: str, user, reason: 
         )
         notify(f"session bridge persisted ({reason})")
     except Exception as exc:
-        hook_log("auto_bridge_error", {"reason": reason, "error": str(exc)[:200]})
+        hook_log("bridge.auto_error", {"reason": reason, "error": str(exc)[:200]})
 
 
 def _truncate_str(value, cap: int) -> str:
@@ -136,7 +136,7 @@ async def _store_tool_call(payload: dict) -> None:
         if isinstance(tool_input, dict):
             cmd = str(tool_input.get("command", ""))
         if "cognee" in cmd:
-            hook_log("skip_self_cognee_bash", {"cmd_prefix": cmd[:80]})
+            hook_log("store.skip_self_cognee_bash", {"cmd_prefix": cmd[:80]})
             return
 
     status, error_message = _infer_status(payload)
@@ -154,14 +154,14 @@ async def _store_tool_call(payload: dict) -> None:
 
     session_id, dataset, user_id = _load_session()
     if not session_id:
-        hook_log("no_session_id", {"tool": tool_name})
+        hook_log("session.no_session_id", {"tool": tool_name})
         return
 
     config = load_config()
     runtime = resolve_runtime_mode()
     use_http = runtime["mode"] == "http"
     hook_log(
-        "mode_decision",
+        "mode.decision",
         {
             "hook": "store-to-session:tool",
             "mode": runtime["mode"],
@@ -182,7 +182,7 @@ async def _store_tool_call(payload: dict) -> None:
         )
         append_http_bridge_entry(dataset, session_id, trace=trace_text)
         bump_save_counter(session_id, "trace")
-        hook_log("store_buffered_warming", {"hook": "tool", "tool": tool_name})
+        hook_log("store.buffered_warming", {"hook": "tool", "tool": tool_name})
         return
     if not use_http:
         await ensure_cognee_ready(config)
@@ -217,7 +217,7 @@ async def _store_tool_call(payload: dict) -> None:
                 user=user,
             )
     except Exception as exc:
-        hook_log("trace_store_error", {"tool": tool_name, "error": str(exc)[:200]})
+        hook_log("trace.store_error", {"tool": tool_name, "error": str(exc)[:200]})
         notify(f"trace store failed ({exc})")
         return
 
@@ -228,7 +228,7 @@ async def _store_tool_call(payload: dict) -> None:
             else getattr(result, "entry_id", None)
         )
         hook_log(
-            "trace_stored",
+            "trace.stored",
             {
                 "tool": tool_name,
                 "status": status,
@@ -254,7 +254,7 @@ async def _store_tool_call(payload: dict) -> None:
         if should_improve:
             await _fire_improve_background(dataset, session_id, user, reason=f"turn_{count}")
     else:
-        hook_log("trace_store_noresult", {"tool": tool_name})
+        hook_log("trace.store_noresult", {"tool": tool_name})
 
 
 async def _store_assistant_stop(payload: dict) -> None:
@@ -267,14 +267,14 @@ async def _store_assistant_stop(payload: dict) -> None:
 
     session_id, dataset, user_id = _load_session()
     if not session_id:
-        hook_log("no_session_id", {"event": "stop"})
+        hook_log("session.no_session_id", {"event": "stop"})
         return
 
     config = load_config()
     runtime = resolve_runtime_mode()
     use_http = runtime["mode"] == "http"
     hook_log(
-        "mode_decision",
+        "mode.decision",
         {
             "hook": "store-to-session:stop",
             "mode": runtime["mode"],
@@ -296,7 +296,7 @@ async def _store_assistant_stop(payload: dict) -> None:
             answer=msg,
         )
         bump_save_counter(session_id, "answer")
-        hook_log("store_buffered_warming", {"hook": "stop"})
+        hook_log("store.buffered_warming", {"hook": "stop"})
         return
     if not use_http:
         await ensure_cognee_ready(config)
@@ -330,7 +330,7 @@ async def _store_assistant_stop(payload: dict) -> None:
                 user=user,
             )
     except Exception as exc:
-        hook_log("stop_store_error", {"error": str(exc)[:200]})
+        hook_log("store.stop_error", {"error": str(exc)[:200]})
         notify(f"stop store failed ({exc})")
         return
 
@@ -347,7 +347,7 @@ async def _store_assistant_stop(payload: dict) -> None:
             if isinstance(result, dict)
             else getattr(result, "entry_id", None)
         )
-        hook_log("stop_stored", {"chars": len(msg), "qa_id": qa_id})
+        hook_log("store.stop_stored", {"chars": len(msg), "qa_id": qa_id})
         notify(f"assistant message stored ({len(msg)} chars)")
         bump_save_counter(session_id, "answer")
 
@@ -365,15 +365,15 @@ def main():
     try:
         payload = json.loads(payload_raw)
     except json.JSONDecodeError:
-        hook_log("invalid_payload_json")
+        hook_log("io.invalid_payload_json")
         return
 
     session_key_candidate, session_key_source = resolve_session_key_from_payload(payload)
     if session_key_candidate:
         set_session_key(session_key_candidate)
-    hook_log("store_session_key", {"source": session_key_source, "value": session_key_candidate})
+    hook_log("store.session_key", {"source": session_key_source, "value": session_key_candidate})
     if not get_session_key():
-        hook_log("store_missing_session_key")
+        hook_log("store.missing_session_key")
         return
 
     is_stop = "--stop" in sys.argv
@@ -384,7 +384,7 @@ def main():
             else:
                 asyncio.run(_store_tool_call(payload))
     except Exception as exc:
-        hook_log("run_exception", {"stop": is_stop, "error": str(exc)[:200]})
+        hook_log("store.run_exception", {"stop": is_stop, "error": str(exc)[:200]})
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/scripts/store-user-prompt.py
+++ b/integrations/claude-code/scripts/store-user-prompt.py
@@ -62,7 +62,7 @@ def _watcher_alive() -> bool:
         os.kill(pid, 0)
         return True
     except Exception as exc:
-        hook_log("prompt_watcher_alive_check_failed", {"error": str(exc)[:200]})
+        hook_log("watcher.prompt_alive_check_failed", {"error": str(exc)[:200]})
         return False
 
 
@@ -77,7 +77,7 @@ def _ensure_idle_watcher(session_id: str, dataset: str, user_id: str, config: di
         if _WATCHER_STOP.exists():
             _WATCHER_STOP.unlink()
     except Exception as exc:
-        hook_log("prompt_watcher_stop_unlink_failed", {"error": str(exc)[:200]})
+        hook_log("watcher.prompt_stop_unlink_failed", {"error": str(exc)[:200]})
 
     bootstrap = {
         "session_id": session_id,
@@ -96,7 +96,7 @@ def _ensure_idle_watcher(session_id: str, dataset: str, user_id: str, config: di
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_fh = log_path.open("a", encoding="utf-8")
     except Exception as exc:
-        hook_log("prompt_watcher_log_open_failed", {"error": str(exc)[:200]})
+        hook_log("watcher.prompt_log_open_failed", {"error": str(exc)[:200]})
         log_fh = subprocess.DEVNULL
 
     try:
@@ -110,9 +110,9 @@ def _ensure_idle_watcher(session_id: str, dataset: str, user_id: str, config: di
             start_new_session=True,
             close_fds=True,
         )
-        hook_log("idle_watcher_restarted", {"session": session_id, "dataset": dataset})
+        hook_log("watcher.idle_restarted", {"session": session_id, "dataset": dataset})
     except Exception as exc:
-        hook_log("idle_watcher_restart_failed", {"error": str(exc)[:200]})
+        hook_log("watcher.idle_restart_failed", {"error": str(exc)[:200]})
 
 
 def _prompt_context(payload: dict) -> str:
@@ -128,7 +128,7 @@ def _prompt_context(payload: dict) -> str:
 async def _store(prompt: str, payload: dict):
     session_id, dataset, user_id = _load_session()
     if not session_id:
-        hook_log("no_session_id", {"event": "prompt"})
+        hook_log("session.no_session_id", {"event": "prompt"})
         return
 
     config = load_config()
@@ -137,7 +137,7 @@ async def _store(prompt: str, payload: dict):
 
     runtime = resolve_runtime_mode()
     hook_log(
-        "mode_decision",
+        "mode.decision",
         {
             "hook": "store-user-prompt",
             "mode": runtime["mode"],
@@ -156,7 +156,7 @@ async def _store(prompt: str, payload: dict):
             await ensure_cognee_ready(config)
             await resolve_user(user_id)
         except Exception as exc:
-            hook_log("prompt_prepare_warning", {"error": str(exc)[:200]})
+            hook_log("prompt.prepare_warning", {"error": str(exc)[:200]})
 
     remember_pending_prompt(
         session_id,
@@ -164,7 +164,7 @@ async def _store(prompt: str, payload: dict):
         turn_id=str(payload.get("turn_id") or ""),
         context=_prompt_context(payload),
     )
-    hook_log("prompt_pending", {"chars": len(prompt), "turn_id": payload.get("turn_id")})
+    hook_log("prompt.pending", {"chars": len(prompt), "turn_id": payload.get("turn_id")})
     notify(f"user prompt pending ({len(prompt)} chars)")
     bump_save_counter(session_id, "prompt")
 
@@ -177,15 +177,15 @@ def main():
     try:
         payload = json.loads(payload_raw)
     except json.JSONDecodeError:
-        hook_log("invalid_payload_json", {"event": "prompt"})
+        hook_log("io.invalid_payload_json", {"event": "prompt"})
         return
 
     session_key_candidate, session_key_source = resolve_session_key_from_payload(payload)
     if session_key_candidate:
         set_session_key(session_key_candidate)
-    hook_log("prompt_session_key", {"source": session_key_source, "value": session_key_candidate})
+    hook_log("prompt.session_key", {"source": session_key_source, "value": session_key_candidate})
     if not get_session_key():
-        hook_log("prompt_missing_session_key")
+        hook_log("prompt.missing_session_key")
         return
 
     prompt = payload.get("prompt", "")
@@ -196,7 +196,7 @@ def main():
         with quiet_hook_output("store-user-prompt"):
             asyncio.run(_store(prompt, payload))
     except Exception as exc:
-        hook_log("prompt_run_exception", {"error": str(exc)[:200]})
+        hook_log("prompt.run_exception", {"error": str(exc)[:200]})
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -68,13 +68,13 @@ def _stop_idle_watcher() -> None:
         _WATCHER_STOP.parent.mkdir(parents=True, exist_ok=True)
         _WATCHER_STOP.write_text("stop", encoding="utf-8")
     except Exception as exc:
-        hook_log("watcher_stop_write_failed", {"error": str(exc)[:200]})
+        hook_log("watcher.stop_write_failed", {"error": str(exc)[:200]})
     if _WATCHER_PID.exists():
         try:
             pid = int(_WATCHER_PID.read_text(encoding="utf-8").strip())
             os.kill(pid, signal.SIGTERM)
         except Exception as exc:
-            hook_log("watcher_sigterm_failed", {"error": str(exc)[:200]})
+            hook_log("watcher.sigterm_failed", {"error": str(exc)[:200]})
 
 
 def _spawn_detached_sync() -> bool:
@@ -94,7 +94,7 @@ def _spawn_detached_sync() -> bool:
         )
         return True
     except Exception as exc:
-        hook_log("sync_detach_failed", {"error": str(exc)[:300]})
+        hook_log("sync.detach_failed", {"error": str(exc)[:300]})
         return False
 
 
@@ -116,7 +116,7 @@ def _claim_final_sync_once() -> bool:
     token, source = _final_sync_identity()
     if not token:
         # No stable identity available; do not risk skipping final sync.
-        hook_log("final_sync_once_no_token", {"source": source})
+        hook_log("sync.final_no_token", {"source": source})
         return True
 
     digest = hashlib.sha1(token.encode("utf-8")).hexdigest()
@@ -126,14 +126,14 @@ def _claim_final_sync_once() -> bool:
         fd = os.open(str(marker), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(token)
-        hook_log("final_sync_once_claimed", {"source": source, "marker": str(marker)})
+        hook_log("sync.final_claimed", {"source": source, "marker": str(marker)})
         return True
     except FileExistsError:
-        hook_log("final_sync_once_already_claimed", {"source": source, "marker": str(marker)})
+        hook_log("sync.final_already_claimed", {"source": source, "marker": str(marker)})
         return False
     except Exception as exc:
         # On marker failure, prefer proceeding to avoid data loss.
-        hook_log("final_sync_once_claim_failed", {"source": source, "error": str(exc)[:200]})
+        hook_log("sync.final_claim_failed", {"source": source, "error": str(exc)[:200]})
         return True
 
 
@@ -156,11 +156,11 @@ def _prune_final_sync_markers() -> None:
                 continue
         if removed:
             hook_log(
-                "final_sync_once_pruned",
+                "sync.final_pruned",
                 {"removed": removed, "ttl_seconds": _FINAL_SYNC_ONCE_TTL_SECONDS},
             )
     except Exception as exc:
-        hook_log("final_sync_once_prune_failed", {"error": str(exc)[:200]})
+        hook_log("sync.final_prune_failed", {"error": str(exc)[:200]})
 
 
 def _is_session_end_payload(payload_raw: str) -> bool:
@@ -206,7 +206,7 @@ def _load_resolved() -> tuple:
     env_service_url = env_service_url or resolved_service_url
 
     if not session_key:
-        hook_log("sync_missing_session_key")
+        hook_log("sync.missing_session_key")
     data = load_resolved(session_key=session_key)
     if data:
         service_url = env_service_url or str(data.get("base_url", "") or "").strip()
@@ -246,7 +246,7 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
     )
     target_sessions = [session_id] if session_id else []
     hook_log(
-        "sync_start",
+        "sync.start",
         {
             "session": session_id,
             "targets": target_sessions,
@@ -259,26 +259,26 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
     try:
         if stop_watcher:
             _stop_idle_watcher()
-            hook_log("sync_stopped_watcher", {"session": session_id, "dataset": dataset})
+            hook_log("sync.stopped_watcher", {"session": session_id, "dataset": dataset})
 
         config = load_config()
         api_mode = http_api_ready()
         lock = nullcontext(True) if api_mode else sync_lock("sync-session-to-graph")
         with lock as acquired:
             if not acquired:
-                hook_log("sync_skipped_lock_busy", {"session": session_id, "dataset": dataset})
+                hook_log("sync.skipped_lock_busy", {"session": session_id, "dataset": dataset})
                 print("cognee-sync: skipped, another sync is running", file=sys.stderr)
                 return
 
             if not target_sessions:
-                hook_log("sync_no_target_sessions", {"dataset": dataset})
+                hook_log("sync.no_target_sessions", {"dataset": dataset})
                 return
 
             if api_mode:
                 for sid in target_sessions:
                     wrote = persist_session_cache_to_graph_via_http(dataset, sid)
                     hook_log(
-                        "sync_bridge_done",
+                        "sync.bridge_done",
                         {
                             "session": sid,
                             "dataset": dataset,
@@ -300,7 +300,7 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
                 wrote = await persist_session_cache_to_graph(dataset, sid, user)
                 graph_result = await sync_graph_context_to_session(dataset, sid, user)
                 hook_log(
-                    "sync_bridge_done",
+                    "sync.bridge_done",
                     {
                         "session": sid,
                         "dataset": dataset,
@@ -318,20 +318,20 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
         if unregister_on_finish:
             if not (was_registered or has_api_key):
                 hook_log(
-                    "agent_unregister_skipped_no_auth",
+                    "agent.unregister_skipped_no_auth",
                     {"session": session_id, "dataset": dataset},
                 )
             else:
                 unregister_name = str(agent_session_name or session_key or "").strip()
                 if not unregister_name:
                     hook_log(
-                        "agent_unregister_skipped_no_session_name",
+                        "agent.unregister_skipped_no_session_name",
                         {"session": session_id, "dataset": dataset},
                     )
                     return
                 ok, active = unregister_agent_via_http(agent_session_name=unregister_name)
                 hook_log(
-                    "agent_unregister_result",
+                    "agent.unregister_result",
                     {
                         "session": session_id,
                         "dataset": dataset,
@@ -355,10 +355,10 @@ def main():
         session_key_candidate, session_key_source = resolve_session_key_from_payload(payload)
         if session_key_candidate:
             set_session_key(session_key_candidate)
-        hook_log("sync_session_key", {"source": session_key_source, "value": session_key_candidate})
+        hook_log("sync.session_key", {"source": session_key_source, "value": session_key_candidate})
     is_session_end = forced_session_end or _is_session_end_payload(payload_raw)
     hook_log(
-        "sync_payload",
+        "sync.payload",
         {
             "is_session_end": is_session_end,
             "detached_final": detached_final,
@@ -374,10 +374,10 @@ def main():
         except ValueError:
             delay = 0.0
         if delay > 0:
-            hook_log("sync_start_delayed", {"seconds": delay})
+            hook_log("sync.start_delayed", {"seconds": delay})
             time.sleep(delay)
         if not _claim_final_sync_once():
-            hook_log("sync_detached_skipped_duplicate")
+            hook_log("sync.detached_skipped_duplicate")
             return
 
     unregister_on_finish = detached_final and os.environ.get(
@@ -390,7 +390,7 @@ def main():
     if is_session_end:
         _stop_idle_watcher()
         spawned = _spawn_detached_sync()
-        hook_log("sync_deferred_to_shutdown_worker", {"spawned": spawned})
+        hook_log("sync.deferred_to_shutdown_worker", {"spawned": spawned})
         return
 
     attempts = 1
@@ -413,12 +413,12 @@ def main():
         except Exception as exc:
             # Non-fatal: session sync failure should not crash Codex.
             hook_log(
-                "sync_failed",
+                "sync.failed",
                 {"attempt": attempt, "attempts": attempts, "error": str(exc)[:300]},
             )
             print(f"cognee-sync: failed ({exc})", file=sys.stderr)
             if attempt < attempts:
-                hook_log("sync_retry_scheduled", {"attempt": attempt + 1, "delay": retry_delay})
+                hook_log("sync.retry_scheduled", {"attempt": attempt + 1, "delay": retry_delay})
                 time.sleep(retry_delay)
 
 

--- a/integrations/claude-code/tests/test_event_names.py
+++ b/integrations/claude-code/tests/test_event_names.py
@@ -1,0 +1,97 @@
+"""Guard the structured-event taxonomy.
+
+Asserts that the three sources of truth for hook event names stay in lockstep:
+
+  1. the names actually emitted by ``hook_log(...)`` across ``scripts/``,
+  2. the canonical set declared in ``scripts/event_names.py`` (``KNOWN_EVENTS``),
+  3. the set documented in ``EVENTS.md``.
+
+If any of them drifts (a new event added without updating the map or the doc,
+a typo, an un-namespaced name), one of these tests fails with a precise diff.
+
+Run: python integrations/claude-code/tests/test_event_names.py  (or via pytest).
+"""
+
+import pathlib
+import re
+import sys
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+DOC = pathlib.Path(__file__).resolve().parents[1] / "EVENTS.md"
+sys.path.insert(0, str(SCRIPTS))
+
+import event_names as en  # noqa: E402
+
+# First string literal of every hook_log(...) call (same-line or multiline).
+_HOOK_LOG = re.compile(r"hook_log\(\s*([\"'])([A-Za-z0-9_.]+)\1", re.DOTALL)
+# `namespace.event` in a Markdown inline-code span, e.g. `recall.error`.
+_DOC_EVENT = re.compile(r"`([a-z]+(?:\.[a-z0-9_]+)+)`")
+
+
+def _emitted_events() -> set[str]:
+    """Every event name passed to hook_log() across the plugin scripts."""
+    events: set[str] = set()
+    for path in SCRIPTS.glob("*.py"):
+        if path.name == "event_names.py":
+            continue
+        for match in _HOOK_LOG.finditer(path.read_text()):
+            events.add(match.group(2))
+    return events
+
+
+def _documented_events() -> set[str]:
+    """Namespaced events referenced in the per-namespace tables of EVENTS.md."""
+    return {
+        token
+        for token in _DOC_EVENT.findall(DOC.read_text())
+        if token.split(".")[0] in en.NAMESPACES
+    }
+
+
+def test_every_event_is_namespaced():
+    """No flat legacy names should remain; each is `namespace.event`."""
+    bad = [e for e in en.KNOWN_EVENTS if not re.fullmatch(r"[a-z]+(?:\.[a-z0-9_]+)+", e)]
+    assert not bad, f"malformed / un-namespaced event names: {sorted(bad)}"
+
+
+def test_known_namespaces_are_declared():
+    """Every namespace used by a known event is declared in NAMESPACES."""
+    used = {e.split(".")[0] for e in en.KNOWN_EVENTS}
+    assert used <= set(en.NAMESPACES), f"undeclared namespaces: {sorted(used - set(en.NAMESPACES))}"
+
+
+def test_rename_map_targets_are_known_events():
+    """Every value in the rename map is a canonical known event, and the set matches."""
+    assert set(en.EVENT_RENAMES.values()) == set(en.KNOWN_EVENTS)
+
+
+def test_emitted_events_match_known_events():
+    """The events emitted in the scripts are exactly the documented known set."""
+    emitted = _emitted_events()
+    known = set(en.KNOWN_EVENTS)
+    assert emitted == known, (
+        f"emitted-but-unknown: {sorted(emitted - known)}; "
+        f"known-but-unemitted: {sorted(known - emitted)}"
+    )
+
+
+def test_events_md_matches_known_events():
+    """EVENTS.md documents exactly the canonical known set."""
+    documented = _documented_events()
+    known = set(en.KNOWN_EVENTS)
+    assert documented == known, (
+        f"documented-but-unknown: {sorted(documented - known)}; "
+        f"known-but-undocumented: {sorted(known - documented)}"
+    )
+
+
+if __name__ == "__main__":
+    test_every_event_is_namespaced()
+    test_known_namespaces_are_declared()
+    test_rename_map_targets_are_known_events()
+    test_emitted_events_match_known_events()
+    test_events_md_matches_known_events()
+    print(
+        f"OK: {len(en.KNOWN_EVENTS)} events across {len(en.NAMESPACES)} namespaces "
+        "agree across scripts, event_names.py, and EVENTS.md."
+    )


### PR DESCRIPTION
## Summary

Closes topoteretes/cognee#3679.

The Claude Code plugin emits structured diagnostic events via `_plugin_common.hook_log(event, detail)`. Over time ~146 distinct event names accumulated ad-hoc — flat `snake_case`, no namespaces, no single source of truth — so a telemetry emitter can't group or route them.

This PR documents the taxonomy and namespaces every event consistently (`recall.*`, `bridge.*`, `session.*`, `sync.*`, … 19 namespaces).

## Changes

- **`scripts/event_names.py`** (new) — the single source of truth:
  - `EVENT_RENAMES`: the one map, legacy flat name → `namespace.event`.
  - `KNOWN_EVENTS`: the frozen canonical set (what emitters/tests import).
  - `canonical(event)`: normalizes a legacy or namespaced name.
- **Renamed all 161 `hook_log()` call sites** across 7 scripts to the   namespaced names.
- **`EVENTS.md`** (new) — documents all 146 events across 19 namespaces,  with purpose and legacy-name migration tables.
- **`tests/test_event_names.py`** (new) — asserts the events emitted in   the scripts, the module, and `EVENTS.md` are exactly the same set, so  the three can never drift.

## Acceptance criteria

- [x] `EVENTS.md` reference.
- [x] Events renamed via one map (`EVENT_RENAMES`).
- [x] A test asserts known events match the documented set.

## Testing

- Full suite: 65 passed (60 existing + 5 new), no regressions.
- `ruff format --check integrations/` and `ruff check integrations/` pass.
- Emitted event set == `KNOWN_EVENTS` == `EVENTS.md` == 146 events.
<img width="1919" height="839" alt="1st test case" src="https://github.com/user-attachments/assets/d5d31c48-edb4-4f7e-a56c-ddfebf463a21" />
<img width="1919" height="839" alt="2" src="https://github.com/user-attachments/assets/7a57948f-85d2-4d01-be65-a7ae40b121cd" />
<img width="1919" height="839" alt="3" src="https://github.com/user-attachments/assets/35eace0d-c077-46b6-a8b7-fc7fa486a35d" />


Note: `integrations/claude-code` has no `pyproject.toml`, so the CI matrix doesn't run its tests today — the new test was run locally (`pytest integrations/claude-code/tests/`). Happy to add a `pyproject.toml` in a follow-up if you'd like CI to pick these up.

## Backward compatibility

`hook_log`'s signature is unchanged; only the emitted string values are namespaced. `EVENT_RENAMES` records every old→new pair for anyone parsing historical `hook.log` files.
