### PR TITLE
observability: add elapsed_ms to recall / bridge / improve hook events (#3676)

### DIFF
--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1065,6 +1065,15 @@ def _float_env(name: str, default: float) -> float:
         return default
 
 
+def elapsed_ms(start: float) -> int:
+    """Whole milliseconds elapsed since a ``time.monotonic()`` start marker.
+
+    Monotonic-based so it is immune to wall-clock jumps / NTP drift, and rounded to
+    an int so the ``elapsed_ms`` fields in hook.log stay compact and easy to query.
+    """
+    return int(round((time.monotonic() - start) * 1000))
+
+
 def wait_for_cognify(
     dataset_id: str,
     *,
@@ -1422,15 +1431,25 @@ def persist_session_cache_to_graph_via_http(
             if time.monotonic() - overall_start >= poll_deadline:
                 hook_log("http_bridge_deadline_exceeded", {"dataset": dataset, "kind": kind})
                 break
+            # Time the POST + wait_for_cognify poll together so http_bridge_poll
+            # reports the full latency the caller waited on (submit + confirm).
+            doc_start = time.monotonic()
             submitted = _post_remember_document(
                 base_url, api_key, dataset, document, node_set, submit_timeout
             )
             if not submitted.get("ok"):
                 # Skip this document (digest stays unmarked → retried later) but keep
                 # syncing the others; one bad/transient document must not abort the sync.
+                # Emit elapsed_ms on the failure path too, so slow-failing submits
+                # (e.g. a POST that times out) are still visible in latency logs.
                 hook_log(
                     "http_bridge_post_failed",
-                    {"dataset": dataset, "kind": kind, "status": submitted.get("status")},
+                    {
+                        "dataset": dataset,
+                        "kind": kind,
+                        "status": submitted.get("status"),
+                        "elapsed_ms": elapsed_ms(doc_start),
+                    },
                 )
                 continue
             dataset_id = submitted.get("dataset_id") or ""
@@ -1438,13 +1457,19 @@ def persist_session_cache_to_graph_via_http(
                 if submitted.get("parse_error"):
                     # 2xx but an unparseable body (e.g. a proxy/nginx error page): we
                     # can't trust the write landed, so leave the digest unmarked to retry.
-                    hook_log("http_bridge_parse_error", {"dataset": dataset, "kind": kind})
+                    hook_log(
+                        "http_bridge_parse_error",
+                        {"dataset": dataset, "kind": kind, "elapsed_ms": elapsed_ms(doc_start)},
+                    )
                     continue
                 # Valid response with no handle to poll. Mark written so we don't
                 # resubmit and duplicate the cognify on every future sync.
                 state[state_key] = digest
                 wrote = True
-                hook_log("http_bridge_no_dataset_id", {"dataset": dataset, "kind": kind})
+                hook_log(
+                    "http_bridge_no_dataset_id",
+                    {"dataset": dataset, "kind": kind, "elapsed_ms": elapsed_ms(doc_start)},
+                )
                 continue
             remaining = poll_deadline - (time.monotonic() - overall_start)
             if remaining <= 0:
@@ -1465,7 +1490,13 @@ def persist_session_cache_to_graph_via_http(
                 wrote = True
             hook_log(
                 "http_bridge_poll",
-                {"dataset": dataset, "kind": kind, "outcome": outcome, "dataset_id": dataset_id},
+                {
+                    "dataset": dataset,
+                    "kind": kind,
+                    "outcome": outcome,
+                    "dataset_id": dataset_id,
+                    "elapsed_ms": elapsed_ms(doc_start),
+                },
             )
         if isinstance(bridge_cache, dict):
             bridge_cache["_state"] = state

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -20,6 +20,7 @@ import time
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
+    elapsed_ms,
     get_session_key,
     hook_log,
     load_resolved,
@@ -215,7 +216,8 @@ async def _run(prompt: str) -> dict | None:
     # never be the long pole. Each scope gets a short per-call timeout, and the
     # whole loop stops once the overall budget is spent. Partial results are fine.
     recall_timeout = _float_env("COGNEE_RECALL_TIMEOUT", 2.5)
-    budget_deadline = time.monotonic() + _float_env("COGNEE_RECALL_BUDGET", 4.0)
+    recall_start = time.monotonic()
+    budget_deadline = recall_start + _float_env("COGNEE_RECALL_BUDGET", 4.0)
     # Respect the shared circuit breaker: when the server has been failing (tripped
     # by the explicit recall path), skip this per-prompt recall rather than hammering
     # a down backend on every keystroke. HTTP/cloud mode only.
@@ -363,11 +365,21 @@ async def _run(prompt: str) -> dict | None:
             f"{header}\n\nRelevant context from this session's memory:\n\n"
             + "\n".join(section_lines).strip()
         )
-        hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
+        hook_log(
+            "context_lookup_hit",
+            {
+                "counts": counts,
+                "saves_last_turn": saves_last_turn,
+                "elapsed_ms": elapsed_ms(recall_start),
+            },
+        )
         notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
     else:
         full_context = f"{header}\n\n(no memory matches for this prompt)"
-        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
+        hook_log(
+            "context_lookup_empty",
+            {"saves_last_turn": saves_last_turn, "elapsed_ms": elapsed_ms(recall_start)},
+        )
         notify(f"no recall matches; saves last turn {saves_last_turn}")
 
     # Audit log: persist full recall details per turn. The hook output stays a

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import os
 import sys
+import time
 
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
@@ -23,6 +24,7 @@ from _plugin_common import (
     append_http_bridge_entry,
     bump_save_counter,
     bump_turn_counter,
+    elapsed_ms,
     get_session_key,
     hook_log,
     http_api_ready,
@@ -57,12 +59,19 @@ _MAX_ASSISTANT_BYTES = 8000
 
 async def _fire_improve_background(dataset: str, session_id: str, user, reason: str) -> None:
     """Fire-and-forget session bridge; failures are logged but never raised."""
+    improve_start = time.monotonic()
     try:
         if http_api_ready():
             wrote = persist_session_cache_to_graph_via_http(dataset, session_id)
             hook_log(
                 "auto_bridge_fired",
-                {"reason": reason, "session": session_id, "via": "http_remember", "wrote": wrote},
+                {
+                    "reason": reason,
+                    "session": session_id,
+                    "via": "http_remember",
+                    "wrote": wrote,
+                    "elapsed_ms": elapsed_ms(improve_start),
+                },
             )
             if wrote:
                 notify(f"session bridge persisted ({reason})")
@@ -78,11 +87,16 @@ async def _fire_improve_background(dataset: str, session_id: str, user, reason: 
                 "session": session_id,
                 "wrote": wrote,
                 "graph_synced": graph_result.get("synced", 0),
+                "elapsed_ms": elapsed_ms(improve_start),
             },
         )
         notify(f"session bridge persisted ({reason})")
     except Exception as exc:
-        hook_log("auto_bridge_error", {"reason": reason, "error": str(exc)[:200]})
+        # Emit elapsed_ms on the failure path too, so time-to-failure stays visible.
+        hook_log(
+            "auto_bridge_error",
+            {"reason": reason, "error": str(exc)[:200], "elapsed_ms": elapsed_ms(improve_start)},
+        )
 
 
 def _truncate_str(value, cap: int) -> str:

--- a/integrations/claude-code/tests/test_hook_timing.py
+++ b/integrations/claude-code/tests/test_hook_timing.py
@@ -1,0 +1,116 @@
+"""Unit tests for observability timing (#3676): elapsed_ms on recall / bridge / improve.
+
+Covers:
+  * elapsed_ms(): monotonic-based, integer milliseconds, non-negative.
+  * persist_session_cache_to_graph_via_http: http_bridge_poll carries elapsed_ms.
+  * the failure path (http_bridge_post_failed) also carries elapsed_ms, so a
+    slow-failing submit is still visible in latency logs.
+
+Run: python integrations/claude-code/tests/test_hook_timing.py (or via pytest).
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+
+def test_elapsed_ms_is_non_negative_int():
+    start = pc.time.monotonic()
+    value = pc.elapsed_ms(start)
+    assert isinstance(value, int)
+    assert value >= 0
+
+
+def test_elapsed_ms_measures_delta():
+    # Drive time.monotonic() deterministically: start at 100.0, read at 100.25 -> 250 ms.
+    seq = iter([100.0, 100.25])
+    orig = pc.time.monotonic
+    pc.time.monotonic = lambda: next(seq)
+    try:
+        start = pc.time.monotonic()
+        assert pc.elapsed_ms(start) == 250
+    finally:
+        pc.time.monotonic = orig
+
+
+def _run_bridge(outcome, *, post_result=None):
+    """Drive persist_session_cache_to_graph_via_http with HTTP seams mocked,
+    capturing every hook_log(event, detail) call for assertion."""
+    events = []
+    saved = {
+        k: getattr(pc, k)
+        for k in (
+            "_local_api_url",
+            "_backend_reachable",
+            "_api_key",
+            "_format_cached_bridge_document",
+            "_bridge_file",
+            "_load_json_file",
+            "_write_json_file",
+            "_post_remember_document",
+            "wait_for_cognify",
+            "hook_log",
+        )
+    }
+    pc._local_api_url = lambda: "http://x"
+    pc._backend_reachable = lambda url: True
+    pc._api_key = lambda: "k"
+    pc._format_cached_bridge_document = lambda dataset, sid: ("qa text", "")
+    pc._bridge_file = lambda sid: pathlib.Path("/tmp/_bridge_timing_test.json")
+    pc._load_json_file = lambda p: {}
+    pc._write_json_file = lambda p, data: None
+    pc._post_remember_document = lambda *a, **k: (
+        post_result or {"ok": True, "dataset_id": "d1", "pipeline_run_id": "p1"}
+    )
+    pc.wait_for_cognify = lambda *a, **k: outcome
+    pc.hook_log = lambda event, detail=None: events.append((event, detail or {}))
+    try:
+        pc.persist_session_cache_to_graph_via_http("ds", "sid")
+    finally:
+        for k, v in saved.items():
+            setattr(pc, k, v)
+    return events
+
+
+def _detail_for(events, event_name):
+    for name, detail in events:
+        if name == event_name:
+            return detail
+    return None
+
+
+def test_http_bridge_poll_carries_elapsed_ms():
+    detail = _detail_for(_run_bridge("completed"), "http_bridge_poll")
+    assert detail is not None, "expected an http_bridge_poll event"
+    assert "elapsed_ms" in detail
+    assert isinstance(detail["elapsed_ms"], int)
+    assert detail["elapsed_ms"] >= 0
+    # No behavior change: the existing fields are still present.
+    assert detail["outcome"] == "completed"
+    assert detail["dataset_id"] == "d1"
+
+
+def test_failed_post_still_carries_elapsed_ms():
+    detail = _detail_for(
+        _run_bridge("completed", post_result={"ok": False, "status": 503}),
+        "http_bridge_post_failed",
+    )
+    assert detail is not None, "expected an http_bridge_post_failed event"
+    assert isinstance(detail.get("elapsed_ms"), int)
+    assert detail["elapsed_ms"] >= 0
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
Fixes topoteretes/cognee#3676 . (Assigned to me by @siillee.)

Adds latency visibility to the hook events via a shared `elapsed_ms(start)` helper
(monotonic, integer ms) in `_plugin_common.py`, keeping the timed sites consistent:

- recall (`session-context-lookup.py`) → `context_lookup_hit` / `context_lookup_empty`
- bridge (`persist_session_cache_to_graph_via_http`) → `http_bridge_poll`
  (POST + `wait_for_cognify` timed together)
- improve (`_fire_improve_background`) → `auto_bridge_fired`

`elapsed_ms` is also emitted on the failure paths (`http_bridge_post_failed`,
`http_bridge_parse_error`, `http_bridge_no_dataset_id`, `auto_bridge_error`), so slow
failures stay visible — not just slow successes. Purely additive to the log detail;
no behavior change. New tests in `tests/test_hook_timing.py`; existing suite green (64/64).

Out of scope (separate follow-up if wanted): mirroring the same fields into the
`integrations/codex/...` script copies.
