### PR TITLE
docs: add CHANGELOG.md and RELEASING.md for claude-code and codex

### DIFF
--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to the **claude-code** integration will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-07-02
+
+### Added
+
+- **Cognee as the default memory backend**: The integration now prefers Cognee over Claude's native `MEMORY.md` for storing and retrieving session memory.
+- **Background memory ingestion**: After a session, memory is written to the Cognee graph in a background task so the agent is never blocked waiting for ingestion to complete.
+- **Cognify status polling**: The integration polls for background `cognify` job completion, giving users visibility into when their memory graph is ready.
+- **Session distillation**: Integrated new session distillation logic to summarise and persist session knowledge into Cognee.
+- **Standardised session naming**: Cognee session names now follow the `{agent}_{native_session_id}` convention for consistency across integrations.
+- **Resilient recall client with circuit breaker**: The recall skill uses an HTTP-first strategy with a circuit breaker and bounded timeouts, falling back gracefully when the server is unavailable.
+- **`auto_feedback` environment variable**: Added `AUTO_FEEDBACK` env var (default: `true`) to control automated feedback behaviour without code changes.
+- **SSL certificate handling**: Added automatic resolution of SSL certificate issues for outbound requests from within the bridge.
+
+### Changed
+
+- **Recall strategy**: The recall skill now queries the Cognee HTTP server first instead of the local CLI, and no longer falls back to CLI when the server returns an authoritative HTTP error.
+- **Unified error shape**: `parse_error` responses now use a consistent shape across all code paths, making error handling predictable for callers.
+- **Over-budget poll tightened**: The poll loop for over-budget detection now enforces a strict overall deadline and includes a minimum spin-loop floor to avoid busy-waiting.
+- **Session ID handling**: The native session ID is now sanitised and wrapped consistently before being passed to Cognee, matching the format expected by the session naming convention.
+- **`remember` and `sync` skills refactored**: Directory structure split to mirror the `search` skill layout, improving maintainability.
+- **Cognee version pinned**: Pinned the Cognee dependency to `1.2.2.dev0` for reproducible installs.
+
+### Fixed
+
+- **Network errors in bridge POST**: Unhandled network-level exceptions in the bridge POST handler are now caught and returned as structured error responses.
+- **HTTP errors in bridge POST**: Non-2xx responses from the bridge endpoint are now detected and surfaced rather than silently ignored.
+- **Background graph build write timeouts**: Write timeouts during background graph construction are no longer misclassified as the Cognee server being unreachable.
+- **Recall dataset targeting**: Fixed a bug where the recall skill was hitting the wrong dataset when multiple datasets existed.
+- **HTTP errors treated as non-authoritative in recall**: Corrected recall fallback logic so that transient HTTP errors do not permanently prevent the local CLI from being used.
+- **Overall poll deadline for bridge requests**: Added a hard deadline on the polling loop so it cannot run indefinitely when the upstream service is unresponsive.
+- **Parse-error retry behaviour**: The bridge now retries on parse errors with correct backoff instead of immediately surfacing the error to the caller.

--- a/integrations/claude-code/RELEASING.md
+++ b/integrations/claude-code/RELEASING.md
@@ -1,0 +1,17 @@
+# Releasing claude-code
+
+1. Bump the version in `plugin.json`.
+2. Move all `[Unreleased]` entries into a new `[vX.Y.Z] - YYYY-MM-DD` section in `CHANGELOG.md`.
+3. Commit both files:
+   ```
+   git commit -m "release: vX.Y.Z"
+   ```
+4. Tag the release:
+   ```
+   git tag claude-code-vX.Y.Z
+   ```
+5. Push the tag:
+   ```
+   git push origin claude-code-vX.Y.Z
+   ```
+6. Sync the marketplace version if applicable.

--- a/integrations/codex/CHANGELOG.md
+++ b/integrations/codex/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to the **codex** integration will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-07-02
+
+### Added
+
+- **Dataset-based memory storage**: Replaced session switching with a dataset-per-agent model, using a single shared dataset by default (consistent with the Claude Code integration).
+- **Session distillation**: Integrated new session distillation logic to summarise and persist session knowledge into Cognee.
+- **Standardised session naming**: Cognee session names now follow the `{agent}_{native_session_id}` convention for consistency across integrations.
+- **Resilient recall client with circuit breaker**: The recall skill uses an HTTP-first strategy with a circuit breaker and bounded timeouts, falling back gracefully when the server is unavailable.
+- **`auto_feedback` environment variable**: Added `AUTO_FEEDBACK` env var (default: `true`) to control automated feedback behaviour without code changes.
+- **SSL certificate handling**: Added automatic resolution of SSL certificate issues for outbound requests.
+
+### Changed
+
+- **Session management removed**: Session switching logic has been removed; the integration now uses datasets directly, which simplifies state management and avoids conflicts when multiple agents share Cognee.
+- **Unified default dataset**: Both Codex and Claude Code now default to the same single dataset, ensuring cross-agent memory is shared out of the box.
+- **Recall strategy**: The recall skill now queries the Cognee HTTP server first instead of the local CLI, and no longer falls back to CLI when the server returns an authoritative HTTP error.
+- **`remember` and `sync` skills refactored**: Directory structure split to mirror the `search` skill layout, improving maintainability.
+- **Status line setup**: Automatic status line initialisation is now configured during startup, reducing required manual setup steps.
+- **Cognee version pinned**: Pinned the Cognee dependency to `1.2.2.dev0` (previously `1.2.1`) for reproducible installs.
+- **`base_url` renamed from `service`**: The configuration key for the Cognee server address has been renamed from `service` to `base_url` for clarity.
+
+### Fixed
+
+- **Background graph build write timeouts**: Write timeouts during background graph construction are no longer misclassified as the Cognee server being unreachable.
+- **Recall dataset targeting**: Fixed a bug where the recall skill was hitting the wrong dataset when multiple datasets existed.
+- **HTTP errors treated as non-authoritative in recall**: Corrected recall fallback logic so that transient HTTP errors do not permanently prevent the local CLI from being used.
+- **`base_url` bug**: Fixed a crash caused by incorrect resolution of the server base URL when connecting to an existing dataset.
+- **Connecting to an existing dataset**: Resolved issues that prevented the integration from attaching to an already-initialised Codex dataset on startup.
+- **New session behaviour**: Fixed several edge cases in how new Codex sessions were initialised and handed off to Cognee.

--- a/integrations/codex/RELEASING.md
+++ b/integrations/codex/RELEASING.md
@@ -1,0 +1,17 @@
+# Releasing codex
+
+1. Bump the version in `plugin.json`.
+2. Move all `[Unreleased]` entries into a new `[vX.Y.Z] - YYYY-MM-DD` section in `CHANGELOG.md`.
+3. Commit both files:
+   ```
+   git commit -m "release: vX.Y.Z"
+   ```
+4. Tag the release:
+   ```
+   git tag codex-vX.Y.Z
+   ```
+5. Push the tag:
+   ```
+   git push origin codex-vX.Y.Z
+   ```
+6. Sync the marketplace version if applicable.


### PR DESCRIPTION
## Summary
Adds CHANGELOG.md (Keep a Changelog format) and RELEASING.md (release checklist) for both the `claude-code` and `codex` integrations, seeded from git history.

## Changes
- `integrations/claude-code/CHANGELOG.md`
- `integrations/claude-code/RELEASING.md`
- `integrations/codex/CHANGELOG.md`
- `integrations/codex/RELEASING.md`

Closes #3678