### PR TITLE
Add local offline metrics command to Claude Code & Codex plugins

### DIFF
--- a/integrations/claude-code/scripts/cognee-plugin
+++ b/integrations/claude-code/scripts/cognee-plugin
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+# Add script directory to Python path to import cognee_plugin
+sys.path.insert(0, str(Path(__file__).parent))
+
+import cognee_plugin
+
+if __name__ == "__main__":
+    sys.exit(cognee_plugin.main())

--- a/integrations/claude-code/scripts/cognee_plugin.py
+++ b/integrations/claude-code/scripts/cognee_plugin.py
@@ -1,0 +1,283 @@
+"""cognee-plugin — CLI utility for the cognee Claude-Code / Codex plugin.
+
+Usage:
+    cognee-plugin metrics [--json] [--plugin <claude-code|codex>]
+
+Computes usage rollup purely from local files — no network required:
+    ~/.cognee-plugin/<plugin>/hook.log
+    ~/.cognee-plugin/<plugin>/save_counter.json
+    ~/.cognee-plugin/<plugin>/last_recall.json
+    ~/.cognee-plugin/<plugin>/recall-audit.log
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_jsonl(path: Path) -> list:
+    """Read a JSON-Lines file; skip malformed lines silently."""
+    if not path.exists():
+        return []
+    lines = []
+    try:
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                obj = json.loads(raw)
+                if isinstance(obj, dict):
+                    lines.append(obj)
+            except json.JSONDecodeError:
+                pass
+    except OSError:
+        pass
+    return lines
+
+
+def _read_json_file(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return data
+    except (OSError, json.JSONDecodeError):
+        pass
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Metric computation
+# ---------------------------------------------------------------------------
+
+def _compute_metrics(plugin_dir: Path) -> dict:
+    hook_log_path     = plugin_dir / "hook.log"
+    save_counter_path = plugin_dir / "save_counter.json"
+    last_recall_path  = plugin_dir / "last_recall.json"
+    recall_audit_path = plugin_dir / "recall-audit.log"
+
+    # -----------------------------------------------------------------------
+    # 1. hook.log — sessions, mode split, breaker trips, save events
+    # -----------------------------------------------------------------------
+    hook_lines = _parse_jsonl(hook_log_path)
+
+    unique_sessions: set = set()
+    local_decisions = 0
+    cloud_decisions = 0
+    breaker_trips = 0
+    saves_from_log = {"prompt": 0, "trace": 0, "answer": 0}
+
+    for line in hook_lines:
+        ev = line.get("event", "")
+        detail = line.get("detail") or {}
+
+        # Collect session ids from any log line
+        for key in ("session_id", "session"):
+            sid = detail.get(key) or line.get(key)
+            if sid and isinstance(sid, str):
+                unique_sessions.add(sid)
+
+        # Mode decisions
+        if ev == "mode_decision":
+            mode = detail.get("mode", "")
+            if mode == "http":
+                cloud_decisions += 1
+            elif mode in ("local", "loopback"):
+                local_decisions += 1
+
+        # Breaker trips recorded via hook_log
+        if ev == "recall_breaker_open":
+            breaker_trips += 1
+
+        # Save events that appear in hook.log
+        if ev == "prompt_pending":
+            saves_from_log["prompt"] += 1
+        if ev == "trace_stored":
+            saves_from_log["trace"] += 1
+        if ev == "stop_stored":
+            saves_from_log["answer"] += 1
+
+    # -----------------------------------------------------------------------
+    # 2. save_counter.json — live per-session save counts
+    # -----------------------------------------------------------------------
+    save_data = _read_json_file(save_counter_path)
+    saves_counter = {"prompt": 0, "trace": 0, "answer": 0}
+    for _sid, counts in save_data.items():
+        if isinstance(counts, dict):
+            for kind in ("prompt", "trace", "answer"):
+                saves_counter[kind] += int(counts.get(kind, 0))
+        
+        # In case a session exists in save_counter but wasn't in hook.log
+        if isinstance(_sid, str):
+            unique_sessions.add(_sid)
+
+    # Prefer log-derived totals (historical) and supplement with live counter
+    total_saves = {
+        kind: saves_from_log[kind] + saves_counter[kind]
+        for kind in ("prompt", "trace", "answer")
+    }
+
+    # -----------------------------------------------------------------------
+    # 3. last_recall.json — most-recent recall hit counts
+    # -----------------------------------------------------------------------
+    last_recall = _read_json_file(last_recall_path)
+    last_hits = last_recall.get("hits") or {}
+    last_recall_ts = last_recall.get("ts", "")
+    if last_recall.get("session_id"):
+        unique_sessions.add(last_recall.get("session_id"))
+
+    # -----------------------------------------------------------------------
+    # 4. recall-audit.log — total recalls + hit rate
+    # -----------------------------------------------------------------------
+    audit_lines = _parse_jsonl(recall_audit_path)
+    total_recalls = len(audit_lines)
+    recall_hits = 0
+    for entry in audit_lines:
+        hits = entry.get("hits") or {}
+        total_hit_count = sum(int(v) for v in hits.values() if isinstance(v, (int, float)))
+        if total_hit_count > 0:
+            recall_hits += 1
+        
+        # Extract session ID from audit logs as well
+        sid = entry.get("session_id")
+        if sid and isinstance(sid, str):
+            unique_sessions.add(sid)
+
+    hit_rate_pct = round(100.0 * recall_hits / total_recalls, 1) if total_recalls > 0 else 0.0
+
+    total_sessions = len(unique_sessions)
+    total_decisions = local_decisions + cloud_decisions
+    local_pct = round(100.0 * local_decisions / total_decisions, 1) if total_decisions > 0 else 0.0
+    cloud_pct = round(100.0 * cloud_decisions / total_decisions, 1) if total_decisions > 0 else 0.0
+
+    return {
+        "sessions": total_sessions,
+        "recalls": {
+            "total": total_recalls,
+            "hits": recall_hits,
+            "hit_rate_pct": hit_rate_pct,
+        },
+        "saves": total_saves,
+        "mode_split": {
+            "local_pct": local_pct,
+            "cloud_pct": cloud_pct,
+            "local_count": local_decisions,
+            "cloud_count": cloud_decisions,
+        },
+        "circuit_breaker": {
+            "trips": breaker_trips,
+        },
+        "last_recall": {
+            "ts": last_recall_ts,
+            "hits": last_hits,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+def _print_rollup(metrics: dict, plugin: str) -> None:
+    m = metrics
+    r = m["recalls"]
+    s = m["saves"]
+    ms = m["mode_split"]
+    cb = m["circuit_breaker"]
+    lr = m["last_recall"]
+
+    print("cognee-plugin metrics  [{}]".format(plugin))
+    print("=" * 46)
+    print("  Sessions            : {}".format(m["sessions"]))
+    print()
+    print("  Recalls             : {}".format(r["total"]))
+    print("  Recall hits         : {}".format(r["hits"]))
+    print("  Hit rate            : {}%".format(r["hit_rate_pct"]))
+    if lr.get("ts"):
+        hits_str = "  ".join(
+            "{}={}".format(k, v) for k, v in (lr.get("hits") or {}).items()
+        )
+        print("  Last recall ts      : {}".format(lr["ts"]))
+        if hits_str:
+            print("  Last recall hits    : {}".format(hits_str))
+    print()
+    print("  Saves (prompt)      : {}".format(s["prompt"]))
+    print("  Saves (trace)       : {}".format(s["trace"]))
+    print("  Saves (answer)      : {}".format(s["answer"]))
+    print("  Saves (total)       : {}".format(sum(s.values())))
+    print()
+    print("  Mode — local        : {}%  ({} decisions)".format(ms["local_pct"], ms["local_count"]))
+    print("  Mode — cloud        : {}%  ({} decisions)".format(ms["cloud_pct"], ms["cloud_count"]))
+    print()
+    print("  Breaker trips       : {}".format(cb["trips"]))
+    print("=" * 46)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cognee-plugin",
+        description="Cognee plugin CLI utilities",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    metrics_p = sub.add_parser(
+        "metrics",
+        help="Print a usage rollup derived purely from local plugin files (no network).",
+    )
+    metrics_p.add_argument(
+        "--json",
+        dest="as_json",
+        action="store_true",
+        help="Output metrics as a JSON object instead of a human-readable rollup.",
+    )
+    metrics_p.add_argument(
+        "--plugin",
+        default="claude-code",
+        choices=["claude-code", "codex"],
+        help="Which plugin state directory to read (default: claude-code).",
+    )
+    return parser
+
+
+def main(argv=None):
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help(sys.stderr)
+        return 1
+
+    if args.command == "metrics":
+        plugin_name = args.plugin
+        if plugin_name == "codex":
+            plugin_dir = Path.home() / ".cognee-plugin" / "codex"
+        else:
+            plugin_dir = Path.home() / ".cognee-plugin" / "claude-code"
+
+        metrics = _compute_metrics(plugin_dir)
+
+        if args.as_json:
+            print(json.dumps(metrics, indent=2))
+        else:
+            _print_rollup(metrics, plugin_name)
+
+        return 0
+
+    parser.print_help(sys.stderr)
+    return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/claude-code/tests/test_metrics.py
+++ b/integrations/claude-code/tests/test_metrics.py
@@ -1,0 +1,200 @@
+"""Unit tests for the cognee-plugin metrics command.
+
+Tests parse mock log files in a temp directory — no network, no real plugin state.
+
+Run:
+    pytest integrations/claude-code/tests/test_metrics.py
+    python integrations/claude-code/tests/test_metrics.py  # standalone
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+import time
+
+# ---- resolve imports -------------------------------------------------------
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+import cognee_plugin  # type: ignore
+
+_compute_metrics = cognee_plugin._compute_metrics
+_parse_jsonl     = cognee_plugin._parse_jsonl
+_read_json_file  = cognee_plugin._read_json_file
+main             = cognee_plugin.main
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_dir():
+    """Return a fresh temp directory Path."""
+    return pathlib.Path(tempfile.mkdtemp(prefix="cognee-metrics-test-"))
+
+
+def _jsonl(*dicts):
+    return "\n".join(json.dumps(d) for d in dicts) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_empty_dir_returns_zeros():
+    """No files exist → every metric is zero / empty, no crash."""
+    d = _make_dir()
+    m = _compute_metrics(d)
+    assert m["sessions"] == 0
+    assert m["recalls"]["total"] == 0
+    assert m["recalls"]["hits"] == 0
+    assert m["recalls"]["hit_rate_pct"] == 0.0
+    assert m["saves"]["prompt"] == 0
+    assert m["saves"]["trace"] == 0
+    assert m["saves"]["answer"] == 0
+    assert m["mode_split"]["local_pct"] == 0.0
+    assert m["mode_split"]["cloud_pct"] == 0.0
+    assert m["circuit_breaker"]["trips"] == 0
+
+
+def test_session_counting_from_hook_log():
+    d = _make_dir()
+    (d / "hook.log").write_text(
+        _jsonl(
+            {"ts": "2025-01-01T00:00:00Z", "event": "mode_decision",
+             "detail": {"mode": "local", "session_id": "sess-aaa"}},
+            {"ts": "2025-01-01T00:01:00Z", "event": "prompt_pending",
+             "detail": {"session_id": "sess-aaa"}},
+            {"ts": "2025-01-01T01:00:00Z", "event": "mode_decision",
+             "detail": {"mode": "http",  "session_id": "sess-bbb"}},
+        ),
+        encoding="utf-8",
+    )
+    m = _compute_metrics(d)
+    assert m["sessions"] == 2
+    assert m["mode_split"]["local_count"] == 1
+    assert m["mode_split"]["cloud_count"] == 1
+    assert m["mode_split"]["local_pct"] == 50.0
+    assert m["mode_split"]["cloud_pct"] == 50.0
+
+
+def test_save_counter_json_aggregated():
+    d = _make_dir()
+    (d / "save_counter.json").write_text(json.dumps({
+        "sess-1": {"prompt": 3, "trace": 1, "answer": 2},
+        "sess-2": {"prompt": 1, "trace": 0, "answer": 1},
+    }), encoding="utf-8")
+    m = _compute_metrics(d)
+    # Both sessions should be summed
+    assert m["saves"]["prompt"] == 4
+    assert m["saves"]["trace"] == 1
+    assert m["saves"]["answer"] == 3
+
+
+def test_recall_audit_hit_rate():
+    d = _make_dir()
+    audit_entries = [
+        # 2 hits  → counted as a hit
+        {"ts": "T1", "session_id": "s", "prompt": "q1", "hits": {"session": 2, "graph": 0}},
+        # 0 hits  → counted as miss
+        {"ts": "T2", "session_id": "s", "prompt": "q2", "hits": {"session": 0, "graph": 0}},
+        # 1 hit   → counted as hit
+        {"ts": "T3", "session_id": "s", "prompt": "q3", "hits": {"session": 0, "graph": 1}},
+    ]
+    (d / "recall-audit.log").write_text(
+        _jsonl(*audit_entries), encoding="utf-8"
+    )
+    m = _compute_metrics(d)
+    assert m["recalls"]["total"] == 3
+    assert m["recalls"]["hits"] == 2
+    assert m["recalls"]["hit_rate_pct"] == round(100.0 * 2 / 3, 1)
+
+
+def test_breaker_trips_from_hook_log():
+    d = _make_dir()
+    (d / "hook.log").write_text(
+        _jsonl(
+            {"ts": "T1", "event": "recall_breaker_open", "detail": {"retry_in": 90}},
+            {"ts": "T2", "event": "recall_breaker_open", "detail": {"retry_in": 45}},
+            {"ts": "T3", "event": "mode_decision",       "detail": {"mode": "local"}},
+        ),
+        encoding="utf-8",
+    )
+    m = _compute_metrics(d)
+    assert m["circuit_breaker"]["trips"] == 2
+
+
+def test_last_recall_json_surfaced():
+    d = _make_dir()
+    (d / "last_recall.json").write_text(json.dumps({
+        "session_id": "s1",
+        "ts": "2025-06-01T10:00:00+00:00",
+        "hits": {"session": 3, "trace": 1, "graph_context": 0},
+        "saves_last_turn": {"prompt": 1, "trace": 0, "answer": 1},
+    }), encoding="utf-8")
+    m = _compute_metrics(d)
+    assert m["last_recall"]["ts"] == "2025-06-01T10:00:00+00:00"
+    assert m["last_recall"]["hits"]["session"] == 3
+
+
+def test_json_output_flag(capsys=None):
+    """--json flag should produce parseable JSON."""
+    d = _make_dir()
+    import io, contextlib
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        # Call compute directly and dump JSON (mirrors main() flow)
+        m = _compute_metrics(d)
+        print(json.dumps(m, indent=2))
+
+    parsed = json.loads(buf.getvalue())
+    assert "sessions" in parsed
+    assert "recalls" in parsed
+    assert "saves" in parsed
+    assert "mode_split" in parsed
+    assert "circuit_breaker" in parsed
+
+
+def test_malformed_log_lines_skipped():
+    """Bad JSON lines in hook.log should be silently skipped."""
+    d = _make_dir()
+    content = (
+        '{"ts":"T1","event":"prompt_pending","detail":{"session_id":"s1"}}\n'
+        'NOT VALID JSON\n'
+        '{"ts":"T2","event":"stop_stored","detail":{"session_id":"s1"}}\n'
+    )
+    (d / "hook.log").write_text(content, encoding="utf-8")
+    # Should not raise
+    m = _compute_metrics(d)
+    assert m["saves"]["prompt"] == 1
+    assert m["saves"]["answer"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Standalone runner (no pytest required)
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    failures = 0
+    tests = [
+        test_empty_dir_returns_zeros,
+        test_session_counting_from_hook_log,
+        test_save_counter_json_aggregated,
+        test_recall_audit_hit_rate,
+        test_breaker_trips_from_hook_log,
+        test_last_recall_json_surfaced,
+        test_json_output_flag,
+        test_malformed_log_lines_skipped,
+    ]
+    for fn in tests:
+        try:
+            fn()
+            print("PASS", fn.__name__)
+        except Exception as e:
+            failures += 1
+            print("FAIL", fn.__name__, "-", e)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/scripts/cognee-plugin
+++ b/integrations/codex/plugins/cognee/scripts/cognee-plugin
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+# Add script directory to Python path to import cognee_plugin
+sys.path.insert(0, str(Path(__file__).parent))
+
+import cognee_plugin
+
+if __name__ == "__main__":
+    sys.exit(cognee_plugin.main())

--- a/integrations/codex/plugins/cognee/scripts/cognee_plugin.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_plugin.py
@@ -1,0 +1,283 @@
+"""cognee-plugin — CLI utility for the cognee Claude-Code / Codex plugin.
+
+Usage:
+    cognee-plugin metrics [--json] [--plugin <claude-code|codex>]
+
+Computes usage rollup purely from local files — no network required:
+    ~/.cognee-plugin/<plugin>/hook.log
+    ~/.cognee-plugin/<plugin>/save_counter.json
+    ~/.cognee-plugin/<plugin>/last_recall.json
+    ~/.cognee-plugin/<plugin>/recall-audit.log
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_jsonl(path: Path) -> list:
+    """Read a JSON-Lines file; skip malformed lines silently."""
+    if not path.exists():
+        return []
+    lines = []
+    try:
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                obj = json.loads(raw)
+                if isinstance(obj, dict):
+                    lines.append(obj)
+            except json.JSONDecodeError:
+                pass
+    except OSError:
+        pass
+    return lines
+
+
+def _read_json_file(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return data
+    except (OSError, json.JSONDecodeError):
+        pass
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Metric computation
+# ---------------------------------------------------------------------------
+
+def _compute_metrics(plugin_dir: Path) -> dict:
+    hook_log_path     = plugin_dir / "hook.log"
+    save_counter_path = plugin_dir / "save_counter.json"
+    last_recall_path  = plugin_dir / "last_recall.json"
+    recall_audit_path = plugin_dir / "recall-audit.log"
+
+    # -----------------------------------------------------------------------
+    # 1. hook.log — sessions, mode split, breaker trips, save events
+    # -----------------------------------------------------------------------
+    hook_lines = _parse_jsonl(hook_log_path)
+
+    unique_sessions: set = set()
+    local_decisions = 0
+    cloud_decisions = 0
+    breaker_trips = 0
+    saves_from_log = {"prompt": 0, "trace": 0, "answer": 0}
+
+    for line in hook_lines:
+        ev = line.get("event", "")
+        detail = line.get("detail") or {}
+
+        # Collect session ids from any log line
+        for key in ("session_id", "session"):
+            sid = detail.get(key) or line.get(key)
+            if sid and isinstance(sid, str):
+                unique_sessions.add(sid)
+
+        # Mode decisions
+        if ev == "mode_decision":
+            mode = detail.get("mode", "")
+            if mode == "http":
+                cloud_decisions += 1
+            elif mode in ("local", "loopback"):
+                local_decisions += 1
+
+        # Breaker trips recorded via hook_log
+        if ev == "recall_breaker_open":
+            breaker_trips += 1
+
+        # Save events that appear in hook.log
+        if ev == "prompt_pending":
+            saves_from_log["prompt"] += 1
+        if ev == "trace_stored":
+            saves_from_log["trace"] += 1
+        if ev == "stop_stored":
+            saves_from_log["answer"] += 1
+
+    # -----------------------------------------------------------------------
+    # 2. save_counter.json — live per-session save counts
+    # -----------------------------------------------------------------------
+    save_data = _read_json_file(save_counter_path)
+    saves_counter = {"prompt": 0, "trace": 0, "answer": 0}
+    for _sid, counts in save_data.items():
+        if isinstance(counts, dict):
+            for kind in ("prompt", "trace", "answer"):
+                saves_counter[kind] += int(counts.get(kind, 0))
+        
+        # In case a session exists in save_counter but wasn't in hook.log
+        if isinstance(_sid, str):
+            unique_sessions.add(_sid)
+
+    # Prefer log-derived totals (historical) and supplement with live counter
+    total_saves = {
+        kind: saves_from_log[kind] + saves_counter[kind]
+        for kind in ("prompt", "trace", "answer")
+    }
+
+    # -----------------------------------------------------------------------
+    # 3. last_recall.json — most-recent recall hit counts
+    # -----------------------------------------------------------------------
+    last_recall = _read_json_file(last_recall_path)
+    last_hits = last_recall.get("hits") or {}
+    last_recall_ts = last_recall.get("ts", "")
+    if last_recall.get("session_id"):
+        unique_sessions.add(last_recall.get("session_id"))
+
+    # -----------------------------------------------------------------------
+    # 4. recall-audit.log — total recalls + hit rate
+    # -----------------------------------------------------------------------
+    audit_lines = _parse_jsonl(recall_audit_path)
+    total_recalls = len(audit_lines)
+    recall_hits = 0
+    for entry in audit_lines:
+        hits = entry.get("hits") or {}
+        total_hit_count = sum(int(v) for v in hits.values() if isinstance(v, (int, float)))
+        if total_hit_count > 0:
+            recall_hits += 1
+        
+        # Extract session ID from audit logs as well
+        sid = entry.get("session_id")
+        if sid and isinstance(sid, str):
+            unique_sessions.add(sid)
+
+    hit_rate_pct = round(100.0 * recall_hits / total_recalls, 1) if total_recalls > 0 else 0.0
+
+    total_sessions = len(unique_sessions)
+    total_decisions = local_decisions + cloud_decisions
+    local_pct = round(100.0 * local_decisions / total_decisions, 1) if total_decisions > 0 else 0.0
+    cloud_pct = round(100.0 * cloud_decisions / total_decisions, 1) if total_decisions > 0 else 0.0
+
+    return {
+        "sessions": total_sessions,
+        "recalls": {
+            "total": total_recalls,
+            "hits": recall_hits,
+            "hit_rate_pct": hit_rate_pct,
+        },
+        "saves": total_saves,
+        "mode_split": {
+            "local_pct": local_pct,
+            "cloud_pct": cloud_pct,
+            "local_count": local_decisions,
+            "cloud_count": cloud_decisions,
+        },
+        "circuit_breaker": {
+            "trips": breaker_trips,
+        },
+        "last_recall": {
+            "ts": last_recall_ts,
+            "hits": last_hits,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+def _print_rollup(metrics: dict, plugin: str) -> None:
+    m = metrics
+    r = m["recalls"]
+    s = m["saves"]
+    ms = m["mode_split"]
+    cb = m["circuit_breaker"]
+    lr = m["last_recall"]
+
+    print("cognee-plugin metrics  [{}]".format(plugin))
+    print("=" * 46)
+    print("  Sessions            : {}".format(m["sessions"]))
+    print()
+    print("  Recalls             : {}".format(r["total"]))
+    print("  Recall hits         : {}".format(r["hits"]))
+    print("  Hit rate            : {}%".format(r["hit_rate_pct"]))
+    if lr.get("ts"):
+        hits_str = "  ".join(
+            "{}={}".format(k, v) for k, v in (lr.get("hits") or {}).items()
+        )
+        print("  Last recall ts      : {}".format(lr["ts"]))
+        if hits_str:
+            print("  Last recall hits    : {}".format(hits_str))
+    print()
+    print("  Saves (prompt)      : {}".format(s["prompt"]))
+    print("  Saves (trace)       : {}".format(s["trace"]))
+    print("  Saves (answer)      : {}".format(s["answer"]))
+    print("  Saves (total)       : {}".format(sum(s.values())))
+    print()
+    print("  Mode — local        : {}%  ({} decisions)".format(ms["local_pct"], ms["local_count"]))
+    print("  Mode — cloud        : {}%  ({} decisions)".format(ms["cloud_pct"], ms["cloud_count"]))
+    print()
+    print("  Breaker trips       : {}".format(cb["trips"]))
+    print("=" * 46)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cognee-plugin",
+        description="Cognee plugin CLI utilities",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    metrics_p = sub.add_parser(
+        "metrics",
+        help="Print a usage rollup derived purely from local plugin files (no network).",
+    )
+    metrics_p.add_argument(
+        "--json",
+        dest="as_json",
+        action="store_true",
+        help="Output metrics as a JSON object instead of a human-readable rollup.",
+    )
+    metrics_p.add_argument(
+        "--plugin",
+        default="claude-code",
+        choices=["claude-code", "codex"],
+        help="Which plugin state directory to read (default: claude-code).",
+    )
+    return parser
+
+
+def main(argv=None):
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help(sys.stderr)
+        return 1
+
+    if args.command == "metrics":
+        plugin_name = args.plugin
+        if plugin_name == "codex":
+            plugin_dir = Path.home() / ".cognee-plugin" / "codex"
+        else:
+            plugin_dir = Path.home() / ".cognee-plugin" / "claude-code"
+
+        metrics = _compute_metrics(plugin_dir)
+
+        if args.as_json:
+            print(json.dumps(metrics, indent=2))
+        else:
+            _print_rollup(metrics, plugin_name)
+
+        return 0
+
+    parser.print_help(sys.stderr)
+    return 1
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR implements the local offline `metrics` CLI command (`cognee-plugin metrics`) for both the Claude Code and Codex integrations. 

#### Context & Goal
When evaluating local plugins, we need a simple way to track resource usage (like sessions, recalls, and hit-rates) completely offline without making external calls, querying remote DBs, or importing the core `cognee` package. 

To solve this, I built a lightweight metrics compiler that reads local files.

#### Implementation Details
1. **Offline-first metrics**: Created a CLI utility that parses local state files in `~/.cognee-plugin/`:
   - **Sessions**: Aggregated uniquely across all tracking logs.
   - **Recalls**: Computed total recalls, hits, and calculated the overall query hit rate from `recall-audit.log`.
   - **Saves**: Combines the active live counter (`save_counter.json`) with historical save logs to report total counts for prompt, trace, and answer saves.
   - **Mode Split**: Determines how many query decisions were routed to local/loopback vs. cloud (http) mode.
   - **Breaker Trips**: Tracks total circuit breaker occurrences purely from logs.
   
2. **Guaranteed isolation**: To adhere strictly to requirements, the logic parses *only* the four authorized files (`hook.log`, `save_counter.json`, `last_recall.json`, and `recall-audit.log`). Files like `recall-breaker.json` or external directories are completely ignored.

3. **Dual integration support**: Mirrored the core CLI logic and entry points across both the Claude Code (`integrations/claude-code`) and Codex (`integrations/codex`) directories.

4. **Testing**: Added a suite of 8 robust unit tests covering edge cases like missing files, empty logs, and malformed/truncated JSON lines.

#### Verification Done
I verified the implementation locally:
* **Manual CLI verification**: Verified both the rollup output and `--json` format output work as expected.
* **Automated Tests**: Ran the 8 unit tests in the suite, and all passed cleanly:
  ```bash
  pytest integrations/claude-code/tests/test_metrics.py
  ```
  Output:
  ```text
  integrations/claude-code/tests/test_metrics.py ........                  [100%]
  ========================= 8 passed, 1 warning in 0.04s =========================
  ```

---
*Part of the Q3 Integrations Hackathon.*

closes topoteretes/cognee#3682