### PR TITLE
feat(openclaw): show plugin version and update hint on cognee status

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -13,7 +13,8 @@ OpenClaw plugin that adds Cognee-backed memory with **multi-scope support** (com
 - **Auto-index**: Syncs memory markdown files to Cognee via `/remember` (add new, update changed, forget removed, skip unchanged). The `/remember` endpoint runs ingest, graph build, and graph enrichment in one server-side call.
 - **In-session memory**: each recall call auto-captures the turn as a `QAEntry` in Cognee's session cache; with `AUTO_FEEDBACK=true` set on the Cognee container, follow-up messages are auto-classified as feedback and attached to the previous QA; `session_end` triggers `/improve` to bridge the session cache into the graph
 - **One-command setup**: `openclaw cognee setup` configures Cognee as the sole memory provider
-- **CLI commands**: `openclaw cognee setup`, `openclaw cognee index`, `openclaw cognee status`, `openclaw cognee health`, `openclaw cognee scopes`, `openclaw cognee forget`, `openclaw cognee improve`
+- **CLI commands**: `openclaw cognee setup`, `openclaw cognee index`, `openclaw cognee status`, `openclaw cognee version`, `openclaw cognee health`, `openclaw cognee scopes`, `openclaw cognee forget`, `openclaw cognee improve`
+- **Version display**: `openclaw cognee status` (and `openclaw cognee version`) shows the installed plugin version and, when a newer version is published on npm, an "update available" badge
 
 ## Security: Recommended Plugin Allowlist
 
@@ -272,7 +273,16 @@ openclaw cognee setup --hybrid     # Keep built-ins enabled in config (runtime c
 openclaw cognee index
 
 # Check sync status (files indexed, dataset info, per-scope breakdown)
+# The first line shows the installed plugin version, plus an "update available"
+# badge when a newer version is published on npm.
 openclaw cognee status
+
+# Show the installed plugin version on its own
+openclaw cognee version
+
+# Force a live npm check for a newer version (bypasses the cached result)
+openclaw cognee status --check-updates
+openclaw cognee version --check-updates
 
 # Verify Cognee API connectivity
 openclaw cognee health
@@ -299,6 +309,18 @@ openclaw cognee improve --session-id <id>     # scope to one session
    - `~/.openclaw/memory/cognee/datasets.json` — dataset ID mapping
    - `~/.openclaw/memory/cognee/scoped-sync-indexes.json` — per-scope file hashes and data IDs
    - `~/.openclaw/memory/cognee/sync-index.json` — legacy single-scope index
+   - `~/.openclaw/memory/cognee/update-check.json` — cached result of the plugin-version update check
+
+## Version & Update Check
+
+`openclaw cognee status` prints the installed plugin version on its first line. On startup the plugin also runs a background, best-effort check against the npm registry for a newer published version and caches the result. When a newer version exists, `status` (and `openclaw cognee version`) shows an "update available" badge pointing at `openclaw plugins install @cognee/cognee-openclaw@latest`.
+
+The check is cached and rate-limited so it never blocks a command or the gateway, and a network failure is silently ignored (it never reports a false update). Use `--check-updates` to force a live check now.
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `COGNEE_UPDATE_CHECK` | `true` | Set to `false`/`0`/`no`/`off` to disable the update check entirely |
+| `COGNEE_UPDATE_CHECK_INTERVAL_HOURS` | `24` | Minimum hours between background npm checks |
 
 Memory files detected at: `MEMORY.md` and `memory/**/*.md` (recursive)
 

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -14,7 +14,7 @@ OpenClaw plugin that adds Cognee-backed memory with **multi-scope support** (com
 - **In-session memory**: each recall call auto-captures the turn as a `QAEntry` in Cognee's session cache; with `AUTO_FEEDBACK=true` set on the Cognee container, follow-up messages are auto-classified as feedback and attached to the previous QA; `session_end` triggers `/improve` to bridge the session cache into the graph
 - **One-command setup**: `openclaw cognee setup` configures Cognee as the sole memory provider
 - **CLI commands**: `openclaw cognee setup`, `openclaw cognee index`, `openclaw cognee status`, `openclaw cognee version`, `openclaw cognee health`, `openclaw cognee scopes`, `openclaw cognee forget`, `openclaw cognee improve`
-- **Version display**: `openclaw cognee status` (and `openclaw cognee version`) shows the installed plugin version and, when a newer version is published on npm, an "update available" badge
+- **Version display**: `openclaw cognee status` (and `openclaw cognee version`) shows the installed plugin version, plus an update hint when a newer version is published on npm
 
 ## Security: Recommended Plugin Allowlist
 
@@ -273,8 +273,8 @@ openclaw cognee setup --hybrid     # Keep built-ins enabled in config (runtime c
 openclaw cognee index
 
 # Check sync status (files indexed, dataset info, per-scope breakdown)
-# The first line shows the installed plugin version, plus an "update available"
-# badge when a newer version is published on npm.
+# The first line shows the installed plugin version, plus an update hint
+# when a newer version is published on npm.
 openclaw cognee status
 
 # Show the installed plugin version on its own
@@ -313,9 +313,9 @@ openclaw cognee improve --session-id <id>     # scope to one session
 
 ## Version & Update Check
 
-`openclaw cognee status` prints the installed plugin version on its first line. On startup the plugin also runs a background, best-effort check against the npm registry for a newer published version and caches the result. When a newer version exists, `status` (and `openclaw cognee version`) shows an "update available" badge pointing at `openclaw plugins install @cognee/cognee-openclaw@latest`.
+`openclaw cognee status` prints the installed plugin version on its first line. On startup the plugin runs a background check against the npm registry for a newer published version and caches the result. When a newer version is available, `status` and `openclaw cognee version` print an update hint that points to `openclaw plugins install @cognee/cognee-openclaw@latest`.
 
-The check is cached and rate-limited so it never blocks a command or the gateway, and a network failure is silently ignored (it never reports a false update). Use `--check-updates` to force a live check now.
+The check is cached and rate-limited so it never blocks a command or the gateway. A network failure is ignored, so the check never reports a false update. Use `--check-updates` to force a live check now.
 
 | Env var | Default | Description |
 |---------|---------|-------------|

--- a/integrations/openclaw/__tests__/test_version.ts
+++ b/integrations/openclaw/__tests__/test_version.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import {
   PLUGIN_VERSION,
   compareVersions,
-  formatUpdateBadge,
+  formatUpdateHint,
   isNewer,
   parseVersion,
   readUpdateCache,
@@ -93,11 +93,11 @@ describe("isNewer", () => {
   });
 });
 
-describe("formatUpdateBadge", () => {
+describe("formatUpdateHint", () => {
   it("mentions the version and the install command", () => {
-    const badge = formatUpdateBadge("2026.7.2");
-    expect(badge).toContain("2026.7.2");
-    expect(badge).toContain("@cognee/cognee-openclaw@latest");
+    const hint = formatUpdateHint("2026.7.2");
+    expect(hint).toContain("2026.7.2");
+    expect(hint).toContain("@cognee/cognee-openclaw@latest");
   });
 });
 

--- a/integrations/openclaw/__tests__/test_version.ts
+++ b/integrations/openclaw/__tests__/test_version.ts
@@ -193,10 +193,46 @@ describe("runUpdateCheck", () => {
     expect(record?.latest).toBe("2026.9.9");
     expect(record?.updateAvailable).toBe(true);
   });
+
+  it("recomputes updateAvailable within the TTL when the installed version changed", async () => {
+    const statePath = tmpStatePath();
+    // Cache written while on 2026.6.11, when 2026.7.0 was a real update.
+    writeFileSync(
+      statePath,
+      JSON.stringify({ checkedAt: 1_000_000, installed: "2026.6.11", latest: "2026.7.0", updateAvailable: true }),
+    );
+    const fetchImpl = jest.fn(() => {
+      throw new Error("should not hit the network within the TTL");
+    }) as unknown as typeof fetch;
+
+    // The plugin was upgraded to 2026.7.0 since the cache was written.
+    const record = await runUpdateCheck({
+      installed: "2026.7.0",
+      statePath,
+      env: enabledEnv,
+      now: () => 1_000_000 + 60_000,
+      fetchImpl,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(record?.installed).toBe("2026.7.0");
+    expect(record?.updateAvailable).toBe(false);
+    // The corrected record is persisted so the stale hint does not linger.
+    const onDisk = JSON.parse(readFileSync(statePath, "utf8")) as UpdateCheckRecord;
+    expect(onDisk.installed).toBe("2026.7.0");
+    expect(onDisk.updateAvailable).toBe(false);
+  });
 });
 
 describe("readUpdateCache", () => {
   it("returns null when the cache file is missing", async () => {
     expect(await readUpdateCache(join(tmpdir(), "does-not-exist-cognee.json"))).toBeNull();
+  });
+
+  it("returns null for a malformed record", async () => {
+    const statePath = tmpStatePath();
+    // latest is not a string and checkedAt is missing.
+    writeFileSync(statePath, JSON.stringify({ latest: 123, updateAvailable: "yes" }));
+    expect(await readUpdateCache(statePath)).toBeNull();
   });
 });

--- a/integrations/openclaw/__tests__/test_version.ts
+++ b/integrations/openclaw/__tests__/test_version.ts
@@ -1,0 +1,202 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  PLUGIN_VERSION,
+  compareVersions,
+  formatUpdateBadge,
+  isNewer,
+  parseVersion,
+  readUpdateCache,
+  runUpdateCheck,
+  type UpdateCheckRecord,
+} from "../src/version";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Locate this package's package.json regardless of the jest working dir. */
+function readPackageJson(): { name?: string; version?: string } {
+  const candidates = [
+    join(process.cwd(), "package.json"),
+    join(process.cwd(), "integrations", "openclaw", "package.json"),
+  ];
+  for (const path of candidates) {
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf8"));
+      if (parsed?.name === "@cognee/cognee-openclaw") return parsed;
+    } catch {
+      /* try next candidate */
+    }
+  }
+  throw new Error("could not locate @cognee/cognee-openclaw package.json");
+}
+
+function tmpStatePath(): string {
+  return join(mkdtempSync(join(tmpdir(), "cognee-version-")), "update-check.json");
+}
+
+/** A fetch stub that resolves to a registry-shaped `{ version }` body. */
+function okFetch(version: string): typeof fetch {
+  return jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ version }),
+  }) as unknown as typeof fetch;
+}
+
+// ---------------------------------------------------------------------------
+// Drift guard
+// ---------------------------------------------------------------------------
+
+describe("PLUGIN_VERSION", () => {
+  it("matches package.json (fallback must never drift from the real version)", () => {
+    expect(PLUGIN_VERSION).toBe(readPackageJson().version);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Version parsing / comparison
+// ---------------------------------------------------------------------------
+
+describe("parseVersion", () => {
+  it("tolerates a leading v and a pre-release suffix", () => {
+    expect(parseVersion("v2026.6.11")).toEqual([2026, 6, 11]);
+    expect(parseVersion("2026.6.11-rc1")).toEqual([2026, 6, 11]);
+  });
+});
+
+describe("compareVersions", () => {
+  it("orders numerically, not lexically", () => {
+    expect(compareVersions("2026.4.2", "2026.4.12")).toBe(-1);
+    expect(compareVersions("2026.4.12", "2026.4.2")).toBe(1);
+  });
+
+  it("handles equality and rollover", () => {
+    expect(compareVersions("2026.6.11", "2026.6.11")).toBe(0);
+    expect(compareVersions("2026.7.0", "2026.6.11")).toBe(1);
+    expect(compareVersions("2025.12.9", "2026.1.0")).toBe(-1);
+  });
+});
+
+describe("isNewer", () => {
+  it("is true only when latest is strictly newer", () => {
+    expect(isNewer("2026.7.0", "2026.6.11")).toBe(true);
+    expect(isNewer("2026.6.11", "2026.6.11")).toBe(false);
+    expect(isNewer("2026.5.0", "2026.6.11")).toBe(false);
+  });
+
+  it("never reports an update when either version is unknown", () => {
+    expect(isNewer("", "2026.6.11")).toBe(false);
+    expect(isNewer("2026.7.0", "")).toBe(false);
+  });
+});
+
+describe("formatUpdateBadge", () => {
+  it("mentions the version and the install command", () => {
+    const badge = formatUpdateBadge("2026.7.2");
+    expect(badge).toContain("2026.7.2");
+    expect(badge).toContain("@cognee/cognee-openclaw@latest");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runUpdateCheck
+// ---------------------------------------------------------------------------
+
+describe("runUpdateCheck", () => {
+  const enabledEnv = {} as NodeJS.ProcessEnv;
+
+  it("writes an available update from the registry", async () => {
+    const statePath = tmpStatePath();
+    const fetchImpl = okFetch("2099.1.1");
+    const record = await runUpdateCheck({
+      installed: "2026.6.11",
+      statePath,
+      force: true,
+      env: enabledEnv,
+      fetchImpl,
+    });
+
+    expect(record).toMatchObject({
+      installed: "2026.6.11",
+      latest: "2099.1.1",
+      updateAvailable: true,
+    });
+    const onDisk = JSON.parse(readFileSync(statePath, "utf8")) as UpdateCheckRecord;
+    expect(onDisk.updateAvailable).toBe(true);
+  });
+
+  it("reports no update when versions are equal", async () => {
+    const record = await runUpdateCheck({
+      installed: "2026.6.11",
+      statePath: tmpStatePath(),
+      force: true,
+      env: enabledEnv,
+      fetchImpl: okFetch("2026.6.11"),
+    });
+    expect(record?.updateAvailable).toBe(false);
+  });
+
+  it("returns null (and does nothing) when disabled", async () => {
+    const fetchImpl = jest.fn() as unknown as typeof fetch;
+    const record = await runUpdateCheck({
+      installed: "2026.6.11",
+      statePath: tmpStatePath(),
+      force: true,
+      env: { COGNEE_UPDATE_CHECK: "false" } as NodeJS.ProcessEnv,
+      fetchImpl,
+    });
+    expect(record).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("skips the network within the TTL", async () => {
+    const statePath = tmpStatePath();
+    writeFileSync(
+      statePath,
+      JSON.stringify({ checkedAt: 1_000_000, installed: "2026.6.11", latest: "9.9.9", updateAvailable: true }),
+    );
+    const fetchImpl = jest.fn(() => {
+      throw new Error("should not hit the network within the TTL");
+    }) as unknown as typeof fetch;
+
+    const record = await runUpdateCheck({
+      installed: "2026.6.11",
+      statePath,
+      env: enabledEnv,
+      now: () => 1_000_000 + 60_000, // one minute later, well within 24h
+      fetchImpl,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(record?.latest).toBe("9.9.9");
+  });
+
+  it("preserves the previous latest on a network failure", async () => {
+    const statePath = tmpStatePath();
+    writeFileSync(
+      statePath,
+      JSON.stringify({ checkedAt: 0, installed: "2026.6.11", latest: "2026.9.9", updateAvailable: true }),
+    );
+    const fetchImpl = jest.fn().mockRejectedValue(new Error("offline")) as unknown as typeof fetch;
+
+    const record = await runUpdateCheck({
+      installed: "2026.6.11",
+      statePath,
+      force: true,
+      env: enabledEnv,
+      fetchImpl,
+    });
+
+    expect(record?.latest).toBe("2026.9.9");
+    expect(record?.updateAvailable).toBe(true);
+  });
+});
+
+describe("readUpdateCache", () => {
+  it("returns null when the cache file is missing", async () => {
+    expect(await readUpdateCache(join(tmpdir(), "does-not-exist-cognee.json"))).toBeNull();
+  });
+});

--- a/integrations/openclaw/index.ts
+++ b/integrations/openclaw/index.ts
@@ -19,15 +19,8 @@ export { matchGlob, routeFileToScope, datasetNameForScope, isMultiScopeEnabled }
 // Config
 export { resolveConfig } from "./src/config.js";
 
-// Version + update check
-export {
-  PLUGIN_VERSION,
-  compareVersions,
-  formatUpdateBadge,
-  isNewer,
-  runUpdateCheck,
-  readUpdateCache,
-} from "./src/version.js";
+// Version
+export { PLUGIN_VERSION } from "./src/version.js";
 
 // Files
 export { collectMemoryFiles, hashText } from "./src/files.js";

--- a/integrations/openclaw/index.ts
+++ b/integrations/openclaw/index.ts
@@ -19,6 +19,16 @@ export { matchGlob, routeFileToScope, datasetNameForScope, isMultiScopeEnabled }
 // Config
 export { resolveConfig } from "./src/config.js";
 
+// Version + update check
+export {
+  PLUGIN_VERSION,
+  compareVersions,
+  formatUpdateBadge,
+  isNewer,
+  runUpdateCheck,
+  readUpdateCache,
+} from "./src/version.js";
+
 // Files
 export { collectMemoryFiles, hashText } from "./src/files.js";
 

--- a/integrations/openclaw/src/persistence.ts
+++ b/integrations/openclaw/src/persistence.ts
@@ -12,6 +12,7 @@ export const STATE_PATH = join(STATE_DIR, "datasets.json");
 export const SYNC_INDEX_PATH = join(STATE_DIR, "sync-index.json");
 export const SCOPED_SYNC_INDEX_PATH = join(STATE_DIR, "scoped-sync-indexes.json");
 export const AGENT_SYNC_INDEX_PATH = join(STATE_DIR, "agent-sync-indexes.json");
+export const UPDATE_CHECK_PATH = join(STATE_DIR, "update-check.json");
 
 // ---------------------------------------------------------------------------
 // Dataset state (maps dataset name -> dataset ID)

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -23,6 +23,7 @@ import {
 } from "./persistence.js";
 import { cogneeSessionId, datasetNameForScope, isMultiScopeEnabled, normalizeAgentId, routeFileToScope } from "./scope.js";
 import { syncFiles, syncFilesScoped } from "./sync.js";
+import { PLUGIN_VERSION, formatUpdateBadge, readUpdateCache, runUpdateCheck } from "./version.js";
 
 /** Expand a leading `~` in a workspace path to the user's home directory. */
 function expandHome(p: string | undefined): string | undefined {
@@ -53,6 +54,12 @@ const memoryCogneePlugin = {
   kind: "memory" as const,
   register(api: OpenClawPluginApi) {
     const cfg = resolveConfig(api.pluginConfig);
+
+    // Installed plugin version. OpenClaw populates `api.version` from the
+    // plugin's package.json at load time; PLUGIN_VERSION is the fallback for
+    // load paths that leave it unset.
+    const pluginVersion = api.version ?? PLUGIN_VERSION;
+    api.logger.info?.(`cognee-openclaw: v${pluginVersion} loaded`);
 
     // Auto-enable per-agent memory when the gateway hosts more than one agent,
     // unless the plugin config set `perAgentMemory` explicitly. This keeps
@@ -403,6 +410,20 @@ const memoryCogneePlugin = {
 
       autoSyncStarted = true;
 
+      // Print the installed version and an "update available" badge. Reads the
+      // local cache by default; with `checkNow` it forces a live npm check first.
+      async function printVersionLine(checkNow?: boolean): Promise<void> {
+        console.log(`Plugin: cognee-openclaw v${pluginVersion}`);
+        const record = checkNow
+          ? await runUpdateCheck({ installed: pluginVersion, force: true })
+          : await readUpdateCache();
+        if (record?.updateAvailable && record.latest) {
+          console.log(formatUpdateBadge(record.latest));
+        } else if (checkNow) {
+          console.log("No newer version found.");
+        }
+      }
+
       cognee
         .command("index")
         .description("Sync memory files to Cognee (add new, update changed, skip unchanged)")
@@ -434,8 +455,10 @@ const memoryCogneePlugin = {
       cognee
         .command("status")
         .description("Show Cognee sync state")
-        .action(async () => {
+        .option("--check-updates", "Check npm for a newer plugin version now")
+        .action(async (opts: { checkUpdates?: boolean }) => {
           await stateReady;
+          await printVersionLine(opts.checkUpdates);
           const files = await collectMemoryFiles(cliWorkspaceDir);
 
           if (multiScope) {
@@ -498,6 +521,15 @@ const memoryCogneePlugin = {
               `Sync index: ${SYNC_INDEX_PATH}`,
             ].join("\n"));
           }
+          process.exit(0);
+        });
+
+      cognee
+        .command("version")
+        .description("Show the installed plugin version (add --check-updates to check npm)")
+        .option("--check-updates", "Check npm for a newer plugin version now")
+        .action(async (opts: { checkUpdates?: boolean }) => {
+          await printVersionLine(opts.checkUpdates);
           process.exit(0);
         });
 
@@ -700,6 +732,11 @@ const memoryCogneePlugin = {
           logger.warn?.(`cognee-openclaw: Cognee API unreachable at ${cfg.baseUrl} — auto-sync disabled for this session. Error: ${String(error)}`);
           return;
         }
+
+        // Background, TTL-gated check for a newer published version. Fail-silent
+        // and cached; the `cognee status`/`version` surface reads the cache
+        // locally without ever hitting the network.
+        runUpdateCheck({ installed: pluginVersion }).catch(() => {});
 
         try {
           const result = await runSync(resolvedWorkspaceDir, logger);

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -23,7 +23,7 @@ import {
 } from "./persistence.js";
 import { cogneeSessionId, datasetNameForScope, isMultiScopeEnabled, normalizeAgentId, routeFileToScope } from "./scope.js";
 import { syncFiles, syncFilesScoped } from "./sync.js";
-import { PLUGIN_VERSION, formatUpdateHint, readUpdateCache, runUpdateCheck } from "./version.js";
+import { PLUGIN_VERSION, formatUpdateHint, isNewer, readUpdateCache, runUpdateCheck } from "./version.js";
 
 /** Expand a leading `~` in a workspace path to the user's home directory. */
 function expandHome(p: string | undefined): string | undefined {
@@ -417,8 +417,11 @@ const memoryCogneePlugin = {
         const record = checkNow
           ? await runUpdateCheck({ installed: pluginVersion, force: true })
           : await readUpdateCache();
-        if (record?.updateAvailable && record.latest) {
-          console.log(formatUpdateHint(record.latest));
+        // Decide from the cached latest against the running version, not the
+        // stored updateAvailable, which can be stale after a plugin upgrade.
+        const latest = record?.latest ?? "";
+        if (isNewer(latest, pluginVersion)) {
+          console.log(formatUpdateHint(latest));
         } else if (checkNow) {
           console.log("No newer version found.");
         }

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -23,7 +23,7 @@ import {
 } from "./persistence.js";
 import { cogneeSessionId, datasetNameForScope, isMultiScopeEnabled, normalizeAgentId, routeFileToScope } from "./scope.js";
 import { syncFiles, syncFilesScoped } from "./sync.js";
-import { PLUGIN_VERSION, formatUpdateBadge, readUpdateCache, runUpdateCheck } from "./version.js";
+import { PLUGIN_VERSION, formatUpdateHint, readUpdateCache, runUpdateCheck } from "./version.js";
 
 /** Expand a leading `~` in a workspace path to the user's home directory. */
 function expandHome(p: string | undefined): string | undefined {
@@ -410,15 +410,15 @@ const memoryCogneePlugin = {
 
       autoSyncStarted = true;
 
-      // Print the installed version and an "update available" badge. Reads the
-      // local cache by default; with `checkNow` it forces a live npm check first.
+      // Print the installed version and, when one is available, an update hint.
+      // Reads the cached result by default; checkNow forces a live npm check.
       async function printVersionLine(checkNow?: boolean): Promise<void> {
         console.log(`Plugin: cognee-openclaw v${pluginVersion}`);
         const record = checkNow
           ? await runUpdateCheck({ installed: pluginVersion, force: true })
           : await readUpdateCache();
         if (record?.updateAvailable && record.latest) {
-          console.log(formatUpdateBadge(record.latest));
+          console.log(formatUpdateHint(record.latest));
         } else if (checkNow) {
           console.log("No newer version found.");
         }
@@ -733,9 +733,9 @@ const memoryCogneePlugin = {
           return;
         }
 
-        // Background, TTL-gated check for a newer published version. Fail-silent
-        // and cached; the `cognee status`/`version` surface reads the cache
-        // locally without ever hitting the network.
+        // Refresh the cached update check in the background. It is rate-limited
+        // and best effort, so a failure here is ignored; the status command
+        // reads the cached result without hitting the network itself.
         runUpdateCheck({ installed: pluginVersion }).catch(() => {});
 
         try {

--- a/integrations/openclaw/src/version.ts
+++ b/integrations/openclaw/src/version.ts
@@ -1,0 +1,218 @@
+// ---------------------------------------------------------------------------
+// Plugin version + "update available" check.
+//
+// Ported from the claude-code integration's version_check pattern:
+//   - installed version comes from the plugin manifest (here: api.version, which
+//     OpenClaw populates from package.json; PLUGIN_VERSION is the fallback);
+//   - the latest published version comes from the plugin's distribution channel
+//     (here: the npm registry, since OpenClaw installs via
+//     `openclaw plugins install @cognee/cognee-openclaw`);
+//   - the network check is TTL-gated and fail-silent, writing a small cache file
+//     so the status surface reads it locally without ever hitting the network;
+//   - a transient network error preserves the last known `latest` (never a false
+//     "up to date", never a thrown error in a status command).
+//
+// Env knobs (shared with the claude-code integration for uniform behaviour):
+//   COGNEE_UPDATE_CHECK=false             disable the check entirely
+//   COGNEE_UPDATE_CHECK_INTERVAL_HOURS    re-check interval (default 24)
+// ---------------------------------------------------------------------------
+
+import { promises as fs } from "node:fs";
+import { dirname } from "node:path";
+import { UPDATE_CHECK_PATH } from "./persistence.js";
+
+/**
+ * Fallback version, surfaced only when `api.version` is undefined (some load
+ * paths leave it unset). `__tests__/test_version.ts` asserts this equals
+ * package.json's version so the two can never drift apart.
+ */
+export const PLUGIN_VERSION = "2026.6.11";
+
+/** npm registry endpoint returning the latest published `{ version }`. */
+export const NPM_LATEST_URL = "https://registry.npmjs.org/@cognee/cognee-openclaw/latest";
+
+const DEFAULT_TTL_HOURS = 24;
+const DEFAULT_TIMEOUT_MS = 2500;
+
+export interface UpdateCheckRecord {
+  /** Epoch millis of the last completed check. */
+  checkedAt: number;
+  installed: string;
+  latest: string;
+  updateAvailable: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Version parsing / comparison
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a dotted version into comparable integer segments. Tolerates a leading
+ * `v` and a pre-release/build suffix (e.g. `v1.2.3-rc1` -> [1, 2, 3]) by
+ * stopping each segment at the first non-digit.
+ */
+export function parseVersion(version: string): number[] {
+  const parts: number[] = [];
+  for (const chunk of String(version).trim().replace(/^[vV]/, "").split(".")) {
+    let digits = "";
+    for (const ch of chunk) {
+      if (ch >= "0" && ch <= "9") digits += ch;
+      else break;
+    }
+    parts.push(digits ? parseInt(digits, 10) : 0);
+  }
+  return parts;
+}
+
+/** Compare two versions numerically (so 4.2 < 4.12). Returns -1, 0, or 1. */
+export function compareVersions(a: string, b: string): -1 | 0 | 1 {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i] ?? 0;
+    const y = pb[i] ?? 0;
+    if (x > y) return 1;
+    if (x < y) return -1;
+  }
+  return 0;
+}
+
+/** True only when both versions are known and `latest` is strictly newer. */
+export function isNewer(latest: string, installed: string): boolean {
+  if (!latest || !installed) return false;
+  return compareVersions(latest, installed) > 0;
+}
+
+/** A compact one-line badge pointing at the npm update command. */
+export function formatUpdateBadge(latest: string): string {
+  return `⬆ v${latest} available — openclaw plugins install @cognee/cognee-openclaw@latest`;
+}
+
+// ---------------------------------------------------------------------------
+// Env knobs
+// ---------------------------------------------------------------------------
+
+/** Whether the update check is enabled (COGNEE_UPDATE_CHECK not falsey). */
+export function updateCheckEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const value = (env.COGNEE_UPDATE_CHECK ?? "").trim().toLowerCase();
+  return !["0", "false", "no", "off"].includes(value);
+}
+
+/** Re-check interval in hours (COGNEE_UPDATE_CHECK_INTERVAL_HOURS, default 24). */
+export function ttlHours(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = (env.COGNEE_UPDATE_CHECK_INTERVAL_HOURS ?? "").trim();
+  const parsed = raw ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_HOURS;
+}
+
+// ---------------------------------------------------------------------------
+// Cache read + check runner
+// ---------------------------------------------------------------------------
+
+/** Read the cached check result. Pure-local, returns null on any failure. */
+export async function readUpdateCache(
+  statePath: string = UPDATE_CHECK_PATH,
+): Promise<UpdateCheckRecord | null> {
+  try {
+    const raw = await fs.readFile(statePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    return parsed as UpdateCheckRecord;
+  } catch {
+    return null;
+  }
+}
+
+/** Fetch the latest published version from npm. Throws on network/non-2xx. */
+async function fetchLatestVersion(
+  url: string,
+  timeoutMs: number,
+  fetchImpl: typeof fetch,
+): Promise<string> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(url, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) throw new Error(`registry responded ${res.status}`);
+    const body = (await res.json()) as { version?: unknown };
+    return typeof body.version === "string" ? body.version.trim() : "";
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface RunUpdateCheckOptions {
+  /** Installed version to compare against (api.version ?? PLUGIN_VERSION). */
+  installed: string;
+  statePath?: string;
+  timeoutMs?: number;
+  /** Bypass the TTL gate and check now. */
+  force?: boolean;
+  env?: NodeJS.ProcessEnv;
+  /** Injectable clock (millis) for testing. */
+  now?: () => number;
+  /** Injectable fetch for testing. */
+  fetchImpl?: typeof fetch;
+  registryUrl?: string;
+}
+
+/**
+ * Run the (TTL-gated, fail-silent) update check and refresh the cache.
+ *
+ * Returns null only when the check is disabled. On a recent check it returns the
+ * cached record without any network call. On a network error it preserves the
+ * previously-known `latest` so a transient outage never clears a real
+ * notification.
+ */
+export async function runUpdateCheck(
+  opts: RunUpdateCheckOptions,
+): Promise<UpdateCheckRecord | null> {
+  const {
+    installed,
+    statePath = UPDATE_CHECK_PATH,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    force = false,
+    env = process.env,
+    now = Date.now,
+    fetchImpl = fetch,
+    registryUrl = NPM_LATEST_URL,
+  } = opts;
+
+  if (!updateCheckEnabled(env)) return null;
+
+  const prev = await readUpdateCache(statePath);
+
+  // TTL gate: a recent check is a no-op — no network.
+  if (!force && prev && now() - (prev.checkedAt ?? 0) < ttlHours(env) * 3600_000) {
+    return prev;
+  }
+
+  let latest: string;
+  try {
+    latest = await fetchLatestVersion(registryUrl, timeoutMs, fetchImpl);
+  } catch {
+    // Network/parse failure: keep the last known `latest` so a transient outage
+    // doesn't clear a real notification (and we still refresh checkedAt below,
+    // so we don't hammer the registry on every trigger).
+    latest = prev?.latest ?? "";
+  }
+
+  const record: UpdateCheckRecord = {
+    checkedAt: now(),
+    installed,
+    latest,
+    updateAvailable: isNewer(latest, installed),
+  };
+
+  try {
+    await fs.mkdir(dirname(statePath), { recursive: true });
+    await fs.writeFile(statePath, JSON.stringify(record), "utf-8");
+  } catch {
+    // best-effort cache write; a failure here must not break the caller
+  }
+
+  return record;
+}

--- a/integrations/openclaw/src/version.ts
+++ b/integrations/openclaw/src/version.ts
@@ -87,15 +87,25 @@ function ttlHours(env: NodeJS.ProcessEnv): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_HOURS;
 }
 
-/** Read the cached check result. Returns null when the file is missing or invalid. */
+function isUpdateCheckRecord(value: unknown): value is UpdateCheckRecord {
+  if (!value || typeof value !== "object") return false;
+  const r = value as Record<string, unknown>;
+  return (
+    typeof r.checkedAt === "number" &&
+    Number.isFinite(r.checkedAt) &&
+    typeof r.installed === "string" &&
+    typeof r.latest === "string" &&
+    typeof r.updateAvailable === "boolean"
+  );
+}
+
+/** Read the cached check result. Returns null when the file is missing or malformed. */
 export async function readUpdateCache(
   statePath: string = UPDATE_CHECK_PATH,
 ): Promise<UpdateCheckRecord | null> {
   try {
-    const raw = await fs.readFile(statePath, "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object") return null;
-    return parsed as UpdateCheckRecord;
+    const parsed = JSON.parse(await fs.readFile(statePath, "utf-8"));
+    return isUpdateCheckRecord(parsed) ? parsed : null;
   } catch {
     return null;
   }
@@ -161,16 +171,27 @@ export async function runUpdateCheck(
   if (!updateCheckEnabled(env)) return null;
 
   const prev = await readUpdateCache(statePath);
-  if (!force && prev && now() - (prev.checkedAt ?? 0) < ttlHours(env) * 3_600_000) {
-    return prev;
+
+  // Within the interval, reuse the cached latest without a network call. The
+  // installed version can change (a plugin upgrade) while that latest is still
+  // valid, so recompute updateAvailable against the current installed version
+  // rather than trusting the stored value, which would be stale.
+  if (!force && prev && now() - prev.checkedAt < ttlHours(env) * 3_600_000) {
+    const updateAvailable = isNewer(prev.latest, installed);
+    if (prev.installed === installed && prev.updateAvailable === updateAvailable) {
+      return prev;
+    }
+    const refreshed: UpdateCheckRecord = { ...prev, installed, updateAvailable };
+    await persistRecord(statePath, refreshed);
+    return refreshed;
   }
 
   let latest: string;
   try {
     latest = await fetchLatestVersion(registryUrl, timeoutMs, fetchImpl);
   } catch {
-    // Keep the last known latest version and refresh the timestamp, so a
-    // temporary outage neither clears the notice nor triggers repeated retries.
+    // Keep the last known latest version, so a temporary outage neither clears
+    // the notice nor triggers repeated retries before the next interval.
     latest = prev?.latest ?? "";
   }
 
@@ -180,13 +201,16 @@ export async function runUpdateCheck(
     latest,
     updateAvailable: isNewer(latest, installed),
   };
+  await persistRecord(statePath, record);
+  return record;
+}
 
+/** Best-effort cache write. A failure here must not fail the caller. */
+async function persistRecord(statePath: string, record: UpdateCheckRecord): Promise<void> {
   try {
     await fs.mkdir(dirname(statePath), { recursive: true });
     await fs.writeFile(statePath, JSON.stringify(record), "utf-8");
   } catch {
-    // The cache write is best effort and must not fail the caller.
+    // ignore
   }
-
-  return record;
 }

--- a/integrations/openclaw/src/version.ts
+++ b/integrations/openclaw/src/version.ts
@@ -1,55 +1,43 @@
-// ---------------------------------------------------------------------------
-// Plugin version + "update available" check.
+// Plugin version reporting and a background npm update check.
 //
-// Ported from the claude-code integration's version_check pattern:
-//   - installed version comes from the plugin manifest (here: api.version, which
-//     OpenClaw populates from package.json; PLUGIN_VERSION is the fallback);
-//   - the latest published version comes from the plugin's distribution channel
-//     (here: the npm registry, since OpenClaw installs via
-//     `openclaw plugins install @cognee/cognee-openclaw`);
-//   - the network check is TTL-gated and fail-silent, writing a small cache file
-//     so the status surface reads it locally without ever hitting the network;
-//   - a transient network error preserves the last known `latest` (never a false
-//     "up to date", never a thrown error in a status command).
+// The installed version comes from api.version, which OpenClaw fills in from
+// package.json when it loads the plugin. PLUGIN_VERSION is only a fallback for
+// the load paths that leave api.version unset.
 //
-// Env knobs (shared with the claude-code integration for uniform behaviour):
-//   COGNEE_UPDATE_CHECK=false             disable the check entirely
-//   COGNEE_UPDATE_CHECK_INTERVAL_HOURS    re-check interval (default 24)
-// ---------------------------------------------------------------------------
+// The update check queries the npm registry, since the plugin installs with
+// `openclaw plugins install @cognee/cognee-openclaw`. It is rate-limited and
+// writes its result to a cache file, so the status command reads that result
+// locally and never blocks on the network. A failed check keeps the last known
+// result rather than clearing it.
+//
+// Environment variables:
+//   COGNEE_UPDATE_CHECK=false            turn the check off
+//   COGNEE_UPDATE_CHECK_INTERVAL_HOURS   hours between checks (default 24)
 
 import { promises as fs } from "node:fs";
 import { dirname } from "node:path";
 import { UPDATE_CHECK_PATH } from "./persistence.js";
 
 /**
- * Fallback version, surfaced only when `api.version` is undefined (some load
- * paths leave it unset). `__tests__/test_version.ts` asserts this equals
- * package.json's version so the two can never drift apart.
+ * Fallback version used when api.version is unset. The test in
+ * __tests__/test_version.ts asserts this stays equal to package.json.
  */
 export const PLUGIN_VERSION = "2026.6.11";
 
-/** npm registry endpoint returning the latest published `{ version }`. */
-export const NPM_LATEST_URL = "https://registry.npmjs.org/@cognee/cognee-openclaw/latest";
-
+const NPM_LATEST_URL = "https://registry.npmjs.org/@cognee/cognee-openclaw/latest";
 const DEFAULT_TTL_HOURS = 24;
 const DEFAULT_TIMEOUT_MS = 2500;
 
 export interface UpdateCheckRecord {
-  /** Epoch millis of the last completed check. */
   checkedAt: number;
   installed: string;
   latest: string;
   updateAvailable: boolean;
 }
 
-// ---------------------------------------------------------------------------
-// Version parsing / comparison
-// ---------------------------------------------------------------------------
-
 /**
- * Parse a dotted version into comparable integer segments. Tolerates a leading
- * `v` and a pre-release/build suffix (e.g. `v1.2.3-rc1` -> [1, 2, 3]) by
- * stopping each segment at the first non-digit.
+ * Split a version into integer parts for comparison. A leading "v" and any
+ * pre-release suffix are ignored, so "v1.2.3-rc1" becomes [1, 2, 3].
  */
 export function parseVersion(version: string): number[] {
   const parts: number[] = [];
@@ -64,7 +52,7 @@ export function parseVersion(version: string): number[] {
   return parts;
 }
 
-/** Compare two versions numerically (so 4.2 < 4.12). Returns -1, 0, or 1. */
+/** Compare two versions numerically, so that 4.2 sorts below 4.12. */
 export function compareVersions(a: string, b: string): -1 | 0 | 1 {
   const pa = parseVersion(a);
   const pb = parseVersion(b);
@@ -77,39 +65,29 @@ export function compareVersions(a: string, b: string): -1 | 0 | 1 {
   return 0;
 }
 
-/** True only when both versions are known and `latest` is strictly newer. */
+/** True only when both versions are known and latest is strictly newer. */
 export function isNewer(latest: string, installed: string): boolean {
   if (!latest || !installed) return false;
   return compareVersions(latest, installed) > 0;
 }
 
-/** A compact one-line badge pointing at the npm update command. */
-export function formatUpdateBadge(latest: string): string {
-  return `⬆ v${latest} available — openclaw plugins install @cognee/cognee-openclaw@latest`;
+/** One-line notice shown when a newer version is available. */
+export function formatUpdateHint(latest: string): string {
+  return `Update available: v${latest}. Run: openclaw plugins install @cognee/cognee-openclaw@latest`;
 }
 
-// ---------------------------------------------------------------------------
-// Env knobs
-// ---------------------------------------------------------------------------
-
-/** Whether the update check is enabled (COGNEE_UPDATE_CHECK not falsey). */
-export function updateCheckEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+function updateCheckEnabled(env: NodeJS.ProcessEnv): boolean {
   const value = (env.COGNEE_UPDATE_CHECK ?? "").trim().toLowerCase();
   return !["0", "false", "no", "off"].includes(value);
 }
 
-/** Re-check interval in hours (COGNEE_UPDATE_CHECK_INTERVAL_HOURS, default 24). */
-export function ttlHours(env: NodeJS.ProcessEnv = process.env): number {
+function ttlHours(env: NodeJS.ProcessEnv): number {
   const raw = (env.COGNEE_UPDATE_CHECK_INTERVAL_HOURS ?? "").trim();
   const parsed = raw ? Number(raw) : NaN;
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_HOURS;
 }
 
-// ---------------------------------------------------------------------------
-// Cache read + check runner
-// ---------------------------------------------------------------------------
-
-/** Read the cached check result. Pure-local, returns null on any failure. */
+/** Read the cached check result. Returns null when the file is missing or invalid. */
 export async function readUpdateCache(
   statePath: string = UPDATE_CHECK_PATH,
 ): Promise<UpdateCheckRecord | null> {
@@ -123,7 +101,7 @@ export async function readUpdateCache(
   }
 }
 
-/** Fetch the latest published version from npm. Throws on network/non-2xx. */
+/** Fetch the latest published version from npm. Throws on a network or non-2xx error. */
 async function fetchLatestVersion(
   url: string,
   timeoutMs: number,
@@ -149,23 +127,22 @@ export interface RunUpdateCheckOptions {
   installed: string;
   statePath?: string;
   timeoutMs?: number;
-  /** Bypass the TTL gate and check now. */
+  /** Skip the interval gate and check now. */
   force?: boolean;
   env?: NodeJS.ProcessEnv;
-  /** Injectable clock (millis) for testing. */
+  /** Clock override for tests. */
   now?: () => number;
-  /** Injectable fetch for testing. */
+  /** fetch override for tests. */
   fetchImpl?: typeof fetch;
   registryUrl?: string;
 }
 
 /**
- * Run the (TTL-gated, fail-silent) update check and refresh the cache.
+ * Run the update check and refresh the cache.
  *
- * Returns null only when the check is disabled. On a recent check it returns the
- * cached record without any network call. On a network error it preserves the
- * previously-known `latest` so a transient outage never clears a real
- * notification.
+ * Returns null when the check is disabled. Within the interval it returns the
+ * cached record without any network call. If the fetch fails it keeps the last
+ * known latest version so a temporary outage does not clear a real notice.
  */
 export async function runUpdateCheck(
   opts: RunUpdateCheckOptions,
@@ -184,9 +161,7 @@ export async function runUpdateCheck(
   if (!updateCheckEnabled(env)) return null;
 
   const prev = await readUpdateCache(statePath);
-
-  // TTL gate: a recent check is a no-op — no network.
-  if (!force && prev && now() - (prev.checkedAt ?? 0) < ttlHours(env) * 3600_000) {
+  if (!force && prev && now() - (prev.checkedAt ?? 0) < ttlHours(env) * 3_600_000) {
     return prev;
   }
 
@@ -194,9 +169,8 @@ export async function runUpdateCheck(
   try {
     latest = await fetchLatestVersion(registryUrl, timeoutMs, fetchImpl);
   } catch {
-    // Network/parse failure: keep the last known `latest` so a transient outage
-    // doesn't clear a real notification (and we still refresh checkedAt below,
-    // so we don't hammer the registry on every trigger).
+    // Keep the last known latest version and refresh the timestamp, so a
+    // temporary outage neither clears the notice nor triggers repeated retries.
     latest = prev?.latest ?? "";
   }
 
@@ -211,7 +185,7 @@ export async function runUpdateCheck(
     await fs.mkdir(dirname(statePath), { recursive: true });
     await fs.writeFile(statePath, JSON.stringify(record), "utf-8");
   } catch {
-    // best-effort cache write; a failure here must not break the caller
+    // The cache write is best effort and must not fail the caller.
   }
 
   return record;


### PR DESCRIPTION
Resolves the task tracked in topoteretes/cognee#3688

## What this does

OpenClaw's `openclaw plugins list` already shows the version from the plugin's package.json but the plugin's own status surface, `openclaw cognee status`, did not. This adds the version there.

- `openclaw cognee status` now prints the installed plugin version on its first line.
- A new `openclaw cognee version` command shows the version on its own.
- On startup the plugin runs a background check against the npm registry for a newer published version and caches the result. When a newer version is available, `status` and `version` print an update hint pointing to `openclaw plugins install @cognee/cognee-openclaw@latest`.
- `--check-updates` forces a live check now instead of reading the cache.

The version is read from `api.version`, which OpenClaw fills in from package.json at load time. `PLUGIN_VERSION` in `src/version.ts` is a fallback for the load paths that leave `api.version` unset, and a test asserts it stays equal to package.json so the two cannot drift apart.

## Design notes

This follows the pattern from the claude-code integration's update check mapped to OpenClaw's setup:

- Latest version comes from the npm registry, since OpenClaw installs the plugin from npm (claude-code reads its marketplace manifest because that is its own channel).
- The network check is rate-limited and cached to `~/.openclaw/memory/cognee/update-check.json`, so the status command reads the result locally and never blocks on the network.
- A network failure keeps the last known result, so the check never reports a false update and never throws inside a command.
- Same environment variables as claude-code for consistent behavior: `COGNEE_UPDATE_CHECK` and `COGNEE_UPDATE_CHECK_INTERVAL_HOURS`.

## Tests

New `__tests__/test_version.ts` covers version parsing and comparison, the update hint, the drift guard against package.json, the cache read, the interval gate, and the network-failure path (injected fetch and clock). It also verifies a disabled check is a no-op.

- `npx tsc --noEmit --skipLibCheck` passes.
- `npm test` passes (58 tests).
- Verified end to end against the live npm registry.

## Files

- `src/version.ts` (new): version constant, parsing/comparison, update-check runner, cache read.
- `src/plugin.ts`: version capture, startup log, background check, status line, `version` command.
- `src/persistence.ts`: cache file path.
- `index.ts`: export `PLUGIN_VERSION`.
- `__tests__/test_version.ts` (new): unit tests.
- `README.md`: document the command, the flag, and the two environment variables.