### PR TITLE
Sanitize configured dataset names in integrations

### DIFF
--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -23,18 +23,26 @@ _BREAKER_PATH = _SHARED_ROOT / "recall-breaker.json"
 _DEFAULT_DATASET = "agent_sessions"
 
 
+def _sanitize_dataset_name(value: object) -> str:
+    safe = "".join(
+        ch if ch.isalnum() or ch in ("-", "_", ".") else "_"
+        for ch in str(value or "").strip()
+    )
+    return safe.strip("._")[:120] or _DEFAULT_DATASET
+
+
 def _active_dataset() -> str:
     # 1. env var (inherited from the shell that launched Claude Code)
     v = os.environ.get("COGNEE_PLUGIN_DATASET", "").strip()
     if v:
-        return v
+        return _sanitize_dataset_name(v)
     # 2. config file
     try:
         data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
         if isinstance(data, dict):
             v = str(data.get("dataset") or "").strip()
             if v:
-                return v
+                return _sanitize_dataset_name(v)
     except Exception:
         pass
     # 3. default

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -101,6 +101,14 @@ _ENV_MAP = {
 }
 
 
+def sanitize_dataset_name(value: object, default: str = _DEFAULTS["dataset"]) -> str:
+    safe = "".join(
+        ch if ch.isalnum() or ch in ("-", "_", ".") else "_"
+        for ch in str(value or "").strip()
+    )
+    return safe.strip("._")[:120] or default
+
+
 def load_config() -> dict:
     """Load merged config: defaults → file → env vars."""
     config = dict(_DEFAULTS)
@@ -135,6 +143,7 @@ def load_config() -> dict:
             config["api_key"] = ""
             config["base_url"] = ""
 
+    config["dataset"] = sanitize_dataset_name(config.get("dataset"))
     return config
 
 
@@ -173,7 +182,7 @@ def get_session_id(config: dict, cwd: Optional[str] = None) -> str:
 
 def get_dataset(config: dict) -> str:
     """Get the dataset name from config."""
-    return config.get("dataset", "agent_sessions")
+    return sanitize_dataset_name(config.get("dataset"))
 
 
 def is_cloud_mode(config: dict) -> bool:

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -42,6 +42,7 @@ from config import (
     get_session_id,
     load_config,
     persist_session_cache_to_graph,
+    sanitize_dataset_name,
     sync_graph_context_to_session,
 )
 
@@ -197,7 +198,8 @@ def _load_resolved() -> tuple:
     """
     session_key = set_session_key(get_session_key())
     env_session_id = str(os.environ.get("COGNEE_SYNC_SESSION_ID", "") or "").strip()
-    env_dataset = str(os.environ.get("COGNEE_SYNC_DATASET", "") or "").strip()
+    raw_env_dataset = str(os.environ.get("COGNEE_SYNC_DATASET", "") or "").strip()
+    env_dataset = sanitize_dataset_name(raw_env_dataset) if raw_env_dataset else ""
     env_agent_session_name = str(os.environ.get("COGNEE_AGENT_SESSION_NAME", "") or "").strip()
     env_api_key = str(os.environ.get("COGNEE_API_KEY", "") or "").strip()
     env_service_url = str(os.environ.get("COGNEE_BASE_URL", "") or "").strip()

--- a/integrations/claude-code/tests/test_claude_dataset_name.py
+++ b/integrations/claude-code/tests/test_claude_dataset_name.py
@@ -1,0 +1,72 @@
+"""Dataset-name sanitization tests for the Claude Code integration."""
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+
+def _load_config_module():
+    spec = importlib.util.spec_from_file_location(
+        "claude_code_dataset_config", SCRIPTS / "config.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+cfg = _load_config_module()
+
+
+def test_sanitize_dataset_name_matches_session_rule():
+    assert cfg.sanitize_dataset_name("valid-Name_1.2") == "valid-Name_1.2"
+    assert cfg.sanitize_dataset_name(" project/name!* ") == "project_name"
+    assert cfg.sanitize_dataset_name("..__project__..") == "project"
+    assert cfg.sanitize_dataset_name("a" * 130) == "a" * 120
+    assert cfg.sanitize_dataset_name(" !!! ") == "agent_sessions"
+
+
+def test_get_dataset_normalizes_config_value():
+    assert cfg.get_dataset({"dataset": " ../bad dataset!* "}) == "bad_dataset"
+    assert cfg.get_dataset({"dataset": "..."}) == "agent_sessions"
+
+
+def test_load_config_normalizes_file_and_env_dataset():
+    old_file = cfg._CONFIG_FILE
+    old_env = os.environ.get("COGNEE_PLUGIN_DATASET")
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg._CONFIG_FILE = pathlib.Path(tmp) / "config.json"
+            cfg._CONFIG_FILE.write_text(
+                json.dumps({"dataset": " file/dataset! "}), encoding="utf-8"
+            )
+            os.environ.pop("COGNEE_PLUGIN_DATASET", None)
+            assert cfg.load_config()["dataset"] == "file_dataset"
+
+            os.environ["COGNEE_PLUGIN_DATASET"] = " env/dataset! "
+            assert cfg.load_config()["dataset"] == "env_dataset"
+    finally:
+        cfg._CONFIG_FILE = old_file
+        if old_env is None:
+            os.environ.pop("COGNEE_PLUGIN_DATASET", None)
+        else:
+            os.environ["COGNEE_PLUGIN_DATASET"] = old_env
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print("PASS", name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
@@ -23,18 +23,26 @@ _BREAKER_PATH = _SHARED_ROOT / "recall-breaker.json"
 _DEFAULT_DATASET = "agent_sessions"
 
 
+def _sanitize_dataset_name(value: object) -> str:
+    safe = "".join(
+        ch if ch.isalnum() or ch in ("-", "_", ".") else "_"
+        for ch in str(value or "").strip()
+    )
+    return safe.strip("._")[:120] or _DEFAULT_DATASET
+
+
 def _active_dataset() -> str:
     # 1. env var (inherited from the shell that launched Codex)
     v = os.environ.get("COGNEE_PLUGIN_DATASET", "").strip()
     if v:
-        return v
+        return _sanitize_dataset_name(v)
     # 2. config file
     try:
         data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
         if isinstance(data, dict):
             v = str(data.get("dataset") or "").strip()
             if v:
-                return v
+                return _sanitize_dataset_name(v)
     except Exception:
         pass
     # 3. default

--- a/integrations/codex/plugins/cognee/scripts/config.py
+++ b/integrations/codex/plugins/cognee/scripts/config.py
@@ -81,6 +81,14 @@ _ENV_MAP = {
 }
 
 
+def sanitize_dataset_name(value: object, default: str = _DEFAULTS["dataset"]) -> str:
+    safe = "".join(
+        ch if ch.isalnum() or ch in ("-", "_", ".") else "_"
+        for ch in str(value or "").strip()
+    )
+    return safe.strip("._")[:120] or default
+
+
 def load_config() -> dict:
     """Load merged config: defaults → file → env vars."""
     config = dict(_DEFAULTS)
@@ -115,6 +123,7 @@ def load_config() -> dict:
             config["api_key"] = ""
             config["base_url"] = ""
 
+    config["dataset"] = sanitize_dataset_name(config.get("dataset"))
     return config
 
 
@@ -153,7 +162,7 @@ def get_session_id(config: dict, cwd: Optional[str] = None) -> str:
 
 def get_dataset(config: dict) -> str:
     """Get the dataset name from config."""
-    return config.get("dataset", "agent_sessions")
+    return sanitize_dataset_name(config.get("dataset"))
 
 
 def is_cloud_mode(config: dict) -> bool:

--- a/integrations/codex/plugins/cognee/scripts/sync-session-to-graph.py
+++ b/integrations/codex/plugins/cognee/scripts/sync-session-to-graph.py
@@ -42,6 +42,7 @@ from config import (
     get_session_id,
     load_config,
     persist_session_cache_to_graph,
+    sanitize_dataset_name,
     sync_graph_context_to_session,
 )
 
@@ -197,7 +198,8 @@ def _load_resolved() -> tuple:
     """
     session_key = set_session_key(get_session_key())
     env_session_id = str(os.environ.get("COGNEE_SYNC_SESSION_ID", "") or "").strip()
-    env_dataset = str(os.environ.get("COGNEE_SYNC_DATASET", "") or "").strip()
+    raw_env_dataset = str(os.environ.get("COGNEE_SYNC_DATASET", "") or "").strip()
+    env_dataset = sanitize_dataset_name(raw_env_dataset) if raw_env_dataset else ""
     env_agent_session_name = str(os.environ.get("COGNEE_AGENT_SESSION_NAME", "") or "").strip()
     env_api_key = str(os.environ.get("COGNEE_API_KEY", "") or "").strip()
     env_service_url = str(os.environ.get("COGNEE_BASE_URL", "") or "").strip()

--- a/integrations/codex/tests/test_codex_dataset_name.py
+++ b/integrations/codex/tests/test_codex_dataset_name.py
@@ -1,0 +1,70 @@
+"""Dataset-name sanitization tests for the Codex integration."""
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "plugins" / "cognee" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+
+def _load_config_module():
+    spec = importlib.util.spec_from_file_location("codex_dataset_config", SCRIPTS / "config.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+cfg = _load_config_module()
+
+
+def test_sanitize_dataset_name_matches_session_rule():
+    assert cfg.sanitize_dataset_name("valid-Name_1.2") == "valid-Name_1.2"
+    assert cfg.sanitize_dataset_name(" project/name!* ") == "project_name"
+    assert cfg.sanitize_dataset_name("..__project__..") == "project"
+    assert cfg.sanitize_dataset_name("a" * 130) == "a" * 120
+    assert cfg.sanitize_dataset_name(" !!! ") == "agent_sessions"
+
+
+def test_get_dataset_normalizes_config_value():
+    assert cfg.get_dataset({"dataset": " ../bad dataset!* "}) == "bad_dataset"
+    assert cfg.get_dataset({"dataset": "..."}) == "agent_sessions"
+
+
+def test_load_config_normalizes_file_and_env_dataset():
+    old_file = cfg._CONFIG_FILE
+    old_env = os.environ.get("COGNEE_PLUGIN_DATASET")
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg._CONFIG_FILE = pathlib.Path(tmp) / "config.json"
+            cfg._CONFIG_FILE.write_text(
+                json.dumps({"dataset": " file/dataset! "}), encoding="utf-8"
+            )
+            os.environ.pop("COGNEE_PLUGIN_DATASET", None)
+            assert cfg.load_config()["dataset"] == "file_dataset"
+
+            os.environ["COGNEE_PLUGIN_DATASET"] = " env/dataset! "
+            assert cfg.load_config()["dataset"] == "env_dataset"
+    finally:
+        cfg._CONFIG_FILE = old_file
+        if old_env is None:
+            os.environ.pop("COGNEE_PLUGIN_DATASET", None)
+        else:
+            os.environ["COGNEE_PLUGIN_DATASET"] = old_env
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print("PASS", name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/hermes-agent/cognee_integration_hermes/config.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/config.py
@@ -12,6 +12,14 @@ DEFAULT_IDENTITY_EMAIL = "hermes-agent@cognee.local"
 DEFAULT_IDENTITY_PASSWORD = "hermes-agent-plugin"
 
 
+def sanitize_dataset_name(value: Any, default: str = DEFAULT_DATASET) -> str:
+    safe = "".join(
+        ch if ch.isalnum() or ch in ("-", "_", ".") else "_"
+        for ch in str(value or "").strip()
+    )
+    return safe.strip("._")[:120] or default
+
+
 def str_to_bool(value: Any, default: bool = False) -> bool:
     if isinstance(value, bool):
         return value
@@ -104,6 +112,7 @@ def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
     config["auto_route"] = str_to_bool(config.get("auto_route"), True)
     config["improve_on_end"] = str_to_bool(config.get("improve_on_end"), True)
     config["embedded"] = str_to_bool(config.get("embedded"), False)
+    config["dataset"] = sanitize_dataset_name(config.get("dataset"))
     return config
 
 

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 from .config import (
     DEFAULT_DATASET,
     load_config,
+    sanitize_dataset_name,
     str_to_bool,
     write_env_vars,
 )
@@ -282,7 +283,7 @@ class CogneeMemoryProvider(MemoryProvider):
         self._hermes_home = kwargs.get("hermes_home")
         self._config = load_config(self._hermes_home)
         self._session_id = session_id
-        self._dataset = str(self._config.get("dataset") or DEFAULT_DATASET)
+        self._dataset = sanitize_dataset_name(self._config.get("dataset"))
         self._top_k = int(self._config.get("top_k") or 5)
         self._auto_route = str_to_bool(self._config.get("auto_route"), True)
         self._improve_on_end = str_to_bool(self._config.get("improve_on_end"), True)
@@ -741,7 +742,7 @@ class CogneeMemoryProvider(MemoryProvider):
         content = str(args.get("content") or "").strip()
         if not content:
             return json.dumps({"error": "Missing required parameter: content"})
-        dataset = str(args.get("dataset") or self._dataset)
+        dataset = sanitize_dataset_name(args.get("dataset") or self._dataset)
 
         try:
             result = self._bridge.run(

--- a/integrations/hermes-agent/tests/test_smoke.py
+++ b/integrations/hermes-agent/tests/test_smoke.py
@@ -61,6 +61,32 @@ def test_save_and_load_config(tmp_path, monkeypatch):
     assert config["auto_route"] is False
 
 
+def test_dataset_name_sanitization():
+    from cognee_integration_hermes.config import sanitize_dataset_name
+
+    assert sanitize_dataset_name("valid-Name_1.2") == "valid-Name_1.2"
+    assert sanitize_dataset_name(" project/name!* ") == "project_name"
+    assert sanitize_dataset_name("..__project__..") == "project"
+    assert sanitize_dataset_name("a" * 130) == "a" * 120
+    assert sanitize_dataset_name(" !!! ") == "hermes"
+
+
+def test_load_config_normalizes_dataset(tmp_path, monkeypatch):
+    from cognee_integration_hermes.config import load_config, save_config
+
+    monkeypatch.delenv("COGNEE_SERVICE_URL", raising=False)
+    monkeypatch.delenv("COGNEE_BASE_URL", raising=False)
+    monkeypatch.delenv("COGNEE_DATASET", raising=False)
+    save_config({"dataset": " file/dataset! "}, tmp_path)
+    assert load_config(tmp_path)["dataset"] == "file_dataset"
+
+    env_only_home = tmp_path / "env_only"
+    env_only_home.mkdir()
+    monkeypatch.setenv("COGNEE_DATASET", " env/dataset! ")
+    assert load_config(env_only_home)["dataset"] == "env_dataset"
+    assert load_config(tmp_path)["dataset"] == "file_dataset"
+
+
 def test_empty_service_url_clears_remote_mode(tmp_path, monkeypatch):
     from cognee_integration_hermes.config import load_config, save_config
 

--- a/integrations/openclaw/__tests__/test_syncFiles.ts
+++ b/integrations/openclaw/__tests__/test_syncFiles.ts
@@ -1,6 +1,7 @@
 import { CogneeHttpClient } from "../src/client";
+import { resolveConfig } from "../src/config";
 import { syncFiles, syncFilesScoped } from "../src/sync";
-import { matchGlob, routeFileToScope, datasetNameForScope, isMultiScopeEnabled } from "../src/scope";
+import { matchGlob, routeFileToScope, datasetNameForScope, isMultiScopeEnabled, sanitizeDatasetName } from "../src/scope";
 import type { MemoryFile, SyncIndex, CogneePluginConfig, ScopedSyncIndexes, MemoryScope, ScopeRoute } from "../src/types";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -180,6 +181,19 @@ describe("routeFileToScope", () => {
 // ---------------------------------------------------------------------------
 
 describe("datasetNameForScope", () => {
+  it("sanitizes dataset names with the shared session-id rule", () => {
+    expect(sanitizeDatasetName("valid-Name_1.2")).toBe("valid-Name_1.2");
+    expect(sanitizeDatasetName(" project/name!* ")).toBe("project_name");
+    expect(sanitizeDatasetName("..__project__..")).toBe("project");
+    expect(sanitizeDatasetName("a".repeat(130))).toBe("a".repeat(120));
+    expect(sanitizeDatasetName(" !!! ")).toBe("openclaw");
+  });
+
+  it("normalizes configured datasetName at config resolution", () => {
+    expect(resolveConfig({ datasetName: " ../bad dataset!* " }).datasetName).toBe("bad_dataset");
+    expect(resolveConfig({ datasetName: " !!! " }).datasetName).toBe("openclaw");
+  });
+
   it("uses companyDataset when configured", () => {
     expect(datasetNameForScope("company", baseCfg({ companyDataset: "acme-shared" }))).toBe("acme-shared");
   });
@@ -230,6 +244,12 @@ describe("datasetNameForScope", () => {
     const cfg = baseCfg({ agentDatasetTemplate: "ds-{agentId}", agentId: "static" });
     expect(datasetNameForScope("agent", cfg)).toBe("ds-static");
     expect(datasetNameForScope("agent", cfg, "")).toBe("ds-static");
+  });
+
+  it("sanitizes final scoped dataset names after suffixes and templates are composed", () => {
+    expect(datasetNameForScope("company", baseCfg({ companyDataset: " ../Company! " }))).toBe("Company");
+    expect(datasetNameForScope("user", baseCfg({ userDatasetPrefix: "user space", userId: "alice/bob" }))).toBe("user_space-alice_bob");
+    expect(datasetNameForScope("agent", baseCfg({ agentDatasetTemplate: "memory/{agentId}!*" }), "Coder One")).toBe("memory_Coder_One");
   });
 });
 

--- a/integrations/openclaw/src/config.ts
+++ b/integrations/openclaw/src/config.ts
@@ -1,4 +1,5 @@
 import type { CogneeMode, CogneePluginConfig, CogneeSearchType, MemoryScope, ScopeRoute } from "./types.js";
+import { sanitizeDatasetName } from "./scope.js";
 
 // ---------------------------------------------------------------------------
 // Defaults
@@ -61,7 +62,7 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
 
   const mode: CogneeMode = raw.mode === "cloud" || process.env.COGNEE_MODE === "cloud" ? "cloud" : "local";
   const baseUrl = raw.baseUrl?.trim() || process.env.COGNEE_BASE_URL?.trim() || DEFAULT_BASE_URL;
-  const datasetName = raw.datasetName?.trim() || DEFAULT_DATASET_NAME;
+  const datasetName = sanitizeDatasetName(raw.datasetName?.trim() || DEFAULT_DATASET_NAME);
   const searchType = raw.searchType || DEFAULT_SEARCH_TYPE;
   const searchPrompt = raw.searchPrompt || "";
   const deleteMode = raw.deleteMode === "hard" ? "hard" : DEFAULT_DELETE_MODE;

--- a/integrations/openclaw/src/scope.ts
+++ b/integrations/openclaw/src/scope.ts
@@ -133,6 +133,14 @@ function sanitizeSessionKey(value: string): string {
   return safe.replace(/^[._]+/, "").replace(/[._]+$/, "").slice(0, 120);
 }
 
+export function sanitizeDatasetName(value: string | undefined, fallback = "openclaw"): string {
+  let safe = "";
+  for (const ch of (value ?? "").trim()) {
+    safe += /[A-Za-z0-9\-_.]/.test(ch) ? ch : "_";
+  }
+  return safe.replace(/^[._]+/, "").replace(/[._]+$/, "").slice(0, 120) || fallback;
+}
+
 /**
  * Build the Cognee session id from the host (OpenClaw) session id, following the
  * cross-integration convention `{agent}_{native_session_id}` —
@@ -158,13 +166,16 @@ export function datasetNameForScope(
   cfg: Required<CogneePluginConfig>,
   runtimeAgentId?: string,
 ): string {
+  let name: string;
   switch (scope) {
     case "company":
-      return cfg.companyDataset || `${cfg.datasetName}-company`;
+      name = cfg.companyDataset || `${cfg.datasetName}-company`;
+      break;
     case "user":
-      return cfg.userDatasetPrefix
+      name = cfg.userDatasetPrefix
         ? `${cfg.userDatasetPrefix}-${cfg.userId || "default"}`
         : `${cfg.datasetName}-user-${cfg.userId || "default"}`;
+      break;
     case "agent": {
       const rawId = runtimeAgentId?.trim() || cfg.agentId || "default";
       // Lowercase ONLY in per-agent mode, so existing single-agent / non-per-agent
@@ -173,11 +184,14 @@ export function datasetNameForScope(
       // stays internally consistent across startup-seed and runtime hooks.
       const id = cfg.perAgentMemory ? rawId.toLowerCase() : rawId;
       if (cfg.agentDatasetTemplate) {
-        return cfg.agentDatasetTemplate.replace(/\{agentId\}/g, id);
+        name = cfg.agentDatasetTemplate.replace(/\{agentId\}/g, id);
+        break;
       }
-      return cfg.agentDatasetPrefix
+      name = cfg.agentDatasetPrefix
         ? `${cfg.agentDatasetPrefix}-${id}`
         : `${cfg.datasetName}-agent-${id}`;
+      break;
     }
   }
+  return sanitizeDatasetName(name);
 }

--- a/integrations/openclaw/src/sync.ts
+++ b/integrations/openclaw/src/sync.ts
@@ -1,7 +1,7 @@
 import type { CogneeHttpClient } from "./client.js";
 import type { CogneePluginConfig, MemoryFile, MemoryScope, ScopedSyncIndexes, SyncIndex, SyncResult } from "./types.js";
 import { loadDatasetState, saveDatasetState, saveScopedSyncIndexes, saveSyncIndex } from "./persistence.js";
-import { datasetNameForScope, routeFileToScope } from "./scope.js";
+import { datasetNameForScope, routeFileToScope, sanitizeDatasetName } from "./scope.js";
 
 // ---------------------------------------------------------------------------
 // Single-scope sync
@@ -30,7 +30,7 @@ export async function syncFiles(
   persistIndex = true,
 ): Promise<SyncResult & { datasetId?: string }> {
   const result: SyncResult = { added: 0, updated: 0, skipped: 0, errors: 0, deleted: 0 };
-  const dsName = overrideDatasetName || cfg.datasetName;
+  const dsName = sanitizeDatasetName(overrideDatasetName || cfg.datasetName);
   let datasetId = syncIndex.datasetId;
 
   // Partition changed files into "needs add" vs "needs update".


### PR DESCRIPTION
## What changed

This normalizes configured dataset names in the Claude Code, Codex, Hermes Agent, and OpenClaw integrations.

The rule matches the existing session-id sanitizer: keep letters, numbers, `-`, `_`, and `.`, replace other characters with `_`, trim leading/trailing `.` and `_`, cap at 120 chars, and fall back to the integration default when the result is empty.

I kept the normalization at the config boundary so remember/recall/sync paths receive the same dataset name. OpenClaw also normalizes the composed scoped dataset names so user/company/agent templates behave consistently.

For topoteretes/cognee#3549.

## Why

Right now dataset names can come straight from config/env values. Names with spaces, slashes, or punctuation can leak into later API calls and storage paths. Normalizing once near config resolution keeps the downstream code boring and avoids changing the request payload shape.

## Checks

- `python3 integrations/claude-code/tests/test_claude_dataset_name.py`
- `python3 integrations/codex/tests/test_codex_dataset_name.py`
- `python -m pytest tests/test_smoke.py -q` in `integrations/hermes-agent`
- `npm test -- --runTestsByPath __tests__/test_syncFiles.ts` in `integrations/openclaw`
- `npx tsc --noEmit --skipLibCheck` in `integrations/openclaw`
- `python3 -m py_compile` on the changed Python modules
- `git diff --check`

I also ran a local Cognee API smoke test with `COGNEE_PLUGIN_DATASET=' ../bad dataset!* '`. The integration sent `bad_dataset`, `/remember/entry` returned `session_stored`, and `/recall` returned the saved QA from the live local server.
