### PR TITLE
feat(claude-code): env-configurable recall/injection budget (OpenClaw parity)

### DIFF
--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -45,11 +45,20 @@ def _float_env(name: str, default: float) -> float:
         return default
 
 
-TOP_K = 5
-TRUNCATE_ANSWER = 500
-TRUNCATE_RETURN = 400
-TRUNCATE_GRAPH_CTX = 1500
-RECENT_TRACE_FALLBACK_TOP_K = 5
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, "") or default)
+    except (TypeError, ValueError):
+        return default
+
+
+# Recall/injection budget — env-configurable (parity with the OpenClaw plugin's
+# maxResults/maxTokens config schema); defaults preserve prior hardcoded behavior.
+TOP_K = _int_env("COGNEE_RECALL_TOP_K", 5)
+TRUNCATE_ANSWER = _int_env("COGNEE_RECALL_TRUNCATE_ANSWER", 500)
+TRUNCATE_RETURN = _int_env("COGNEE_RECALL_TRUNCATE_RETURN", 400)
+TRUNCATE_GRAPH_CTX = _int_env("COGNEE_RECALL_TRUNCATE_GRAPH_CTX", 1500)
+RECENT_TRACE_FALLBACK_TOP_K = _int_env("COGNEE_RECALL_TRACE_FALLBACK_TOP_K", 5)
 
 
 def _load_session_id() -> str:


### PR DESCRIPTION
The claude-code plugin's UserPromptSubmit recall injects ~14-17KB per prompt (measured across 6 consecutive prompts), with the budget hardcoded (TOP_K=5, TRUNCATE_ANSWER=500, TRUNCATE_RETURN=400, TRUNCATE_GRAPH_CTX=1500). The OpenClaw integration in this repo already exposes this budget as first-class config (maxResults/maxTokens/minScore/searchType). This PR brings the claude-code plugin to parity minimally: the five existing constants become env-configurable (COGNEE_RECALL_*) via an _int_env twin of the existing _float_env helper. Defaults preserve current behavior exactly - pure additive config. Happy to follow up with maxTokens/minScore/searchType parity if wanted.