### PR TITLE
docs: standardize runtime modes across integrations

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -16,16 +16,16 @@ Install from the Claude Code marketplace. You can do this interactively by typin
 /plugin install cognee-memory@cognee
 ```
 
-Then set environment variables for your runtime mode.
+Then set environment variables for your runtime mode. See [Runtime modes](#runtime-modes) for the shared mode model and safety notes.
 
-**Cognee Cloud or a remote server** — set both:
+**Cloud or remote server:**
 
 ```bash
 export COGNEE_BASE_URL="https://your-instance.cognee.ai"
 export COGNEE_API_KEY="ck_..."
 ```
 
-**Local mode** (default when `COGNEE_BASE_URL` is not set) — the plugin bootstraps a local Cognee API at `http://localhost:8011`. Only `LLM_API_KEY` is required; `COGNEE_API_KEY` is auto-minted if absent:
+**Local server:**
 
 ```bash
 export LLM_API_KEY="sk-..."
@@ -51,17 +51,19 @@ Key resolution order:
 2. `~/.cognee-plugin/api_key.json` (cached from a previous mint)
 3. Auto-mint from the default local user (local mode only), then cache to `api_key.json`
 
-## Mode selection rules
+## Runtime modes
 
-At startup (`SessionStart`):
-- `COGNEE_BASE_URL` set → `managed_endpoint`, either local, or on Cognee Cloud (API key needed in cloud case)
-- otherwise → `integration_local` (local API bootstrap)
+Cognee integrations use the same runtime model:
 
-At hook runtime:
-- hooks resolve mode through runtime endpoint auth (env + `api_key.json`), not only config intent
-- `http` mode skips local SDK initialization
+| Mode | When to use it | How it talks to Cognee |
+| --- | --- | --- |
+| **local-server** (default) | You want local data with safe concurrent access | Starts or connects to a local Cognee server, then uses HTTP as a thin client |
+| **cloud** | `COGNEE_BASE_URL` points to a managed or remote Cognee service | Uses HTTP as a thin client with `COGNEE_API_KEY` |
+| **embedded** | You explicitly choose in-process Cognee for a single process or offline run | Runs Cognee inside the integration process |
 
-The hooks emit `mode_decision` logs with `mode`, `service_url`, `url_source`, `key_source`, `api_key_present`.
+**Why local-server is the safe default.** Cognee local stores, including SQLite, Kuzu, Ladybug, and LanceDB, are single-writer stores. If hooks, multiple terminals, or another integration use the same data root in embedded mode, they can hit `database is locked` errors or corrupt local state. A local Cognee server avoids that by owning the stores and serializing access. Each integration talks to it over HTTP.
+
+**No silent fallbacks.** A configured cloud endpoint should fail clearly if it is unreachable. A local server should fail clearly if it cannot start. Falling back to another mode can hide configuration errors or write data to the wrong store. Use embedded mode only when you accept the single-process tradeoff.
 
 ## Sessions
 

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -30,16 +30,16 @@ codex plugin marketplace add topoteretes/cognee-integrations --ref main
 codex plugin add cognee@cognee
 ```
 
-Then set environment variables for your runtime mode.
+Then set environment variables for your runtime mode. See [Runtime modes](#runtime-modes) for the shared mode model and safety notes.
 
-**Cognee Cloud or a remote server** — set both:
+**Cloud or remote server:**
 
 ```bash
 export COGNEE_BASE_URL="https://your-instance.cognee.ai"
 export COGNEE_API_KEY="ck_..."
 ```
 
-**Local mode** (default when `COGNEE_BASE_URL` is not set) — the plugin bootstraps a local Cognee API at `http://localhost:8011`. Only `LLM_API_KEY` is required; `COGNEE_API_KEY` is auto-minted if absent:
+**Local server:**
 
 ```bash
 export LLM_API_KEY="sk-..."
@@ -65,17 +65,19 @@ Key resolution order:
 2. `~/.cognee-plugin/api_key.json` (cached from a previous mint)
 3. Auto-mint from the default local user (local mode only), then cache to `api_key.json`
 
-## Mode selection rules
+## Runtime modes
 
-At startup (`SessionStart`):
-- `COGNEE_BASE_URL` set → `managed_endpoint`
-- otherwise → `integration_local` (local API bootstrap)
+Cognee integrations use the same runtime model:
 
-At hook runtime:
-- hooks resolve mode through runtime endpoint auth (env + `api_key.json`), not only config intent
-- `http` mode skips local SDK initialization
+| Mode | When to use it | How it talks to Cognee |
+| --- | --- | --- |
+| **local-server** (default) | You want local data with safe concurrent access | Starts or connects to a local Cognee server, then uses HTTP as a thin client |
+| **cloud** | `COGNEE_BASE_URL` points to a managed or remote Cognee service | Uses HTTP as a thin client with `COGNEE_API_KEY` |
+| **embedded** | You explicitly choose in-process Cognee for a single process or offline run | Runs Cognee inside the integration process |
 
-The hooks emit `mode_decision` logs with `mode`, `service_url`, `url_source`, `key_source`, `api_key_present`.
+**Why local-server is the safe default.** Cognee local stores, including SQLite, Kuzu, Ladybug, and LanceDB, are single-writer stores. If hooks, multiple terminals, or another integration use the same data root in embedded mode, they can hit `database is locked` errors or corrupt local state. A local Cognee server avoids that by owning the stores and serializing access. Each integration talks to it over HTTP.
+
+**No silent fallbacks.** A configured cloud endpoint should fail clearly if it is unreachable. A local server should fail clearly if it cannot start. Falling back to another mode can hide configuration errors or write data to the wrong store. Use embedded mode only when you accept the single-process tradeoff.
 
 ## Sessions
 

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -48,50 +48,40 @@ cognee = "cognee_integration_hermes"
 The setup wizard writes non-secret settings to `$HERMES_HOME/cognee.json` and
 secrets to `$HERMES_HOME/.env`.
 
-### Modes
+### Runtime modes
 
-The provider connects to cognee in one of three modes. It picks the mode
-automatically from your config:
+Cognee integrations use the same runtime model:
 
-| Mode | When it's used | How it talks to cognee |
+| Mode | When to use it | How it talks to Cognee |
 | --- | --- | --- |
-| **local-server** (default) | no `COGNEE_BASE_URL`, `COGNEE_EMBEDDED` unset | ensures a local cognee server is running and connects as a thin client |
-| **remote** | `COGNEE_BASE_URL` is set | thin client to your managed / cloud cognee |
-| **embedded** | `COGNEE_EMBEDDED=true` | runs cognee in-process |
+| **local-server** (default) | You want local data with safe concurrent access | Starts or connects to a local Cognee server, then uses HTTP as a thin client |
+| **cloud** | `COGNEE_BASE_URL` points to a managed or remote Cognee service | Uses HTTP as a thin client with `COGNEE_API_KEY` |
+| **embedded** | You explicitly choose in-process Cognee for a single process or offline run | Runs Cognee inside the integration process |
 
-**Why local-server is the default.** cognee's local stores (SQLite, Kuzu/Ladybug,
-LanceDB) are single-writer. Driving them in-process from the agent's background
-threads — or from a second Hermes process sharing the same `data_root` — risks
-`database is locked` errors and corruption. A local cognee server is the single
-owner that serializes all access, so the agent just makes HTTP calls. This is the
-same design the Claude Code and Codex plugins use. **`embedded` is opt-in and is
-safe for single-process / offline use only.**
+**Why local-server is the safe default.** Cognee local stores, including SQLite, Kuzu, Ladybug, and LanceDB, are single-writer stores. If hooks, multiple terminals, or another integration use the same data root in embedded mode, they can hit `database is locked` errors or corrupt local state. A local Cognee server avoids that by owning the stores and serializing access. Each integration talks to it over HTTP.
 
-**No silent fallbacks.** The provider never downgrades modes behind your back. If
-`COGNEE_BASE_URL` is set but unreachable, or the local server fails to start,
-initialization raises rather than quietly switching to a different mode — silent
-fallback would either mask a config error (remote → local data divergence) or
-reintroduce the very DB-lock risk this design removes (local-server → embedded).
-To accept the single-process trade-off, set `COGNEE_EMBEDDED=true` explicitly.
+**No silent fallbacks.** A configured cloud endpoint should fail clearly if it is unreachable. A local server should fail clearly if it cannot start. Falling back to another mode can hide configuration errors or write data to the wrong store. Use embedded mode only when you accept the single-process tradeoff.
 
-local-server mode (default — just set your LLM creds):
+### Runtime mode examples
+
+local-server mode:
 
 ```bash
 LLM_API_KEY=sk-...
 LLM_MODEL=gpt-4o-mini
 COGNEE_DATASET=hermes
-# COGNEE_LOCAL_PORT=8000   # optional; point at a shared server for a unified brain
+# COGNEE_LOCAL_PORT=8000
 ```
 
-Remote / cloud mode:
+cloud mode:
 
 ```bash
-COGNEE_BASE_URL=https://your-cognee-service.example   # canonical name
+COGNEE_BASE_URL=https://your-cognee-service.example
 COGNEE_API_KEY=...
 COGNEE_DATASET=hermes
 ```
 
-Embedded (in-process) mode — single-process / offline only:
+embedded mode:
 
 ```bash
 COGNEE_EMBEDDED=true

--- a/integrations/n8n/README.md
+++ b/integrations/n8n/README.md
@@ -48,6 +48,20 @@ Create credentials of type `Cognee API` in n8n. The node uses these values to au
 - **Base URL**: The base URL of your Cognee Cloud tenant, e.g. `https://tenant-xxx.aws.cognee.ai`. Do not include a trailing `/api` — the node appends it automatically.
 - **API Key**: Your Cognee API key, sent via the `X-Api-Key` header.
 
+## Runtime modes
+
+Cognee integrations use the same runtime model:
+
+| Mode | When to use it | How it talks to Cognee |
+| --- | --- | --- |
+| **local-server** (default) | You want local data with safe concurrent access | Starts or connects to a local Cognee server, then uses HTTP as a thin client |
+| **cloud** | `COGNEE_BASE_URL` points to a managed or remote Cognee service | Uses HTTP as a thin client with `COGNEE_API_KEY` |
+| **embedded** | You explicitly choose in-process Cognee for a single process or offline run | Runs Cognee inside the integration process |
+
+**Why local-server is the safe default.** Cognee local stores, including SQLite, Kuzu, Ladybug, and LanceDB, are single-writer stores. If hooks, multiple terminals, or another integration use the same data root in embedded mode, they can hit `database is locked` errors or corrupt local state. A local Cognee server avoids that by owning the stores and serializing access. Each integration talks to it over HTTP.
+
+**No silent fallbacks.** A configured cloud endpoint should fail clearly if it is unreachable. A local server should fail clearly if it cannot start. Falling back to another mode can hide configuration errors or write data to the wrong store. Use embedded mode only when you accept the single-process tradeoff.
+
 ## Operations
 
 The node exposes five resources. Each operation maps to a Cognee API endpoint.

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -80,6 +80,20 @@ plugins:
 
 > `hooks.allowConversationAccess` -> OpenClaw ≥ 2026.4.27 blocks non-bundled plugins from registering the `agent_end` hook unless this flag is set. Without it, file sync memory operations after each agent turn is silently disabled. The gateway still loads the plugin, but file changes the agent makes won't reach Cognee until the next manual `openclaw cognee index` or gateway start. Restart the gateway after adding the flag: `openclaw gateway stop && openclaw gateway start`.
 
+## Runtime modes
+
+Cognee integrations use the same runtime model:
+
+| Mode | When to use it | How it talks to Cognee |
+| --- | --- | --- |
+| **local-server** (default) | You want local data with safe concurrent access | Starts or connects to a local Cognee server, then uses HTTP as a thin client |
+| **cloud** | `COGNEE_BASE_URL` points to a managed or remote Cognee service | Uses HTTP as a thin client with `COGNEE_API_KEY` |
+| **embedded** | You explicitly choose in-process Cognee for a single process or offline run | Runs Cognee inside the integration process |
+
+**Why local-server is the safe default.** Cognee local stores, including SQLite, Kuzu, Ladybug, and LanceDB, are single-writer stores. If hooks, multiple terminals, or another integration use the same data root in embedded mode, they can hit `database is locked` errors or corrupt local state. A local Cognee server avoids that by owning the stores and serializing access. Each integration talks to it over HTTP.
+
+**No silent fallbacks.** A configured cloud endpoint should fail clearly if it is unreachable. A local server should fail clearly if it cannot start. Falling back to another mode can hide configuration errors or write data to the wrong store. Use embedded mode only when you accept the single-process tradeoff.
+
 ### Cognee Cloud
 
 To use Cognee Cloud instead of a local instance, set `mode` to `"cloud"`:


### PR DESCRIPTION
## Summary
- Standardize the runtime modes section across Claude Code, Codex, Hermes Agent, OpenClaw, and n8n.
- Keep the mode table and local-store safety notes consistent across the integration READMEs.
- Keep Hermes Agent examples after the shared runtime modes section.

## Testing
- Ran `git diff --check`.
- Reviewed the updated Markdown sections locally.

Refs topoteretes/cognee#3550