### PR TITLE
feat(claude-code): show plugin version in statusline

### DIFF
--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -6,7 +6,7 @@ pipes a JSON context on stdin. Deliberately standalone and pure-local: reads
 only env vars and ``~/.cognee-plugin/config.json`` — no network calls, no
 ``_plugin_common`` import.
 
-Output: ``cognee: <dataset-name> · local`` or ``cognee: <dataset-name> · cloud``
+Output: ``cognee: <dataset-name> · local · v0.2.0`` or ``cognee: <dataset-name> · cloud · v0.2.0``
 """
 
 import json
@@ -51,6 +51,28 @@ def _active_mode() -> str:
     return "local" if (urlparse(url).hostname or "") in _LOOPBACK else "cloud"
 
 
+def _plugin_version() -> str:
+    """Read the installed plugin version from the plugin manifest.
+
+    Returns a compact string like ``v0.2.0``, or ``""`` when the
+    manifest is missing or unreadable (fail-silent, same contract as
+    :func:`_active_dataset` and :func:`_health_prefix`).
+    """
+    try:
+        root = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
+        if not root:
+            return ""
+        manifest = Path(root) / ".claude-plugin" / "plugin.json"
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            ver = str(data.get("version") or "").strip()
+            if ver:
+                return f"v{ver}"
+    except Exception:
+        pass
+    return ""
+
+
 def _health_prefix() -> str:
     try:
         raw = json.loads(_BREAKER_PATH.read_text(encoding="utf-8"))
@@ -69,7 +91,11 @@ def main() -> None:
         json.load(sys.stdin)  # consume stdin as required by Claude Code
     except Exception:
         pass
-    sys.stdout.write(f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}")
+    ver = _plugin_version()
+    ver_suffix = f" · {ver}" if ver else ""
+    sys.stdout.write(
+        f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}{ver_suffix}"
+    )
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/tests/test_statusline_version.py
+++ b/integrations/claude-code/tests/test_statusline_version.py
@@ -1,0 +1,114 @@
+"""Tests for the plugin-version segment in the status line.
+
+Verifies that ``_plugin_version()`` reads the ``version`` field from
+``CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json`` and that the status
+line renders it as ``… · v<installed>``.
+
+Missing/unreadable manifests must not crash; they just omit the version.
+
+Run: python integrations/claude-code/tests/test_statusline_version.py
+"""
+
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import cognee_statusline_render as slr  # noqa: E402
+
+
+def test_reads_version_from_manifest():
+    """Happy path: valid plugin.json → 'v<version>'."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        manifest_dir = pathlib.Path(tmpdir) / ".claude-plugin"
+        manifest_dir.mkdir()
+        manifest = manifest_dir / "plugin.json"
+        manifest.write_text(json.dumps({"version": "0.3.0"}), encoding="utf-8")
+
+        old = os.environ.get("CLAUDE_PLUGIN_ROOT")
+        os.environ["CLAUDE_PLUGIN_ROOT"] = tmpdir
+        try:
+            assert slr._plugin_version() == "v0.3.0"
+        finally:
+            if old is None:
+                os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+            else:
+                os.environ["CLAUDE_PLUGIN_ROOT"] = old
+
+
+def test_missing_env_var_returns_empty():
+    """No CLAUDE_PLUGIN_ROOT → empty string, no crash."""
+    old = os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+    try:
+        assert slr._plugin_version() == ""
+    finally:
+        if old is not None:
+            os.environ["CLAUDE_PLUGIN_ROOT"] = old
+
+
+def test_missing_manifest_returns_empty():
+    """CLAUDE_PLUGIN_ROOT set but no plugin.json → empty string, no crash."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        old = os.environ.get("CLAUDE_PLUGIN_ROOT")
+        os.environ["CLAUDE_PLUGIN_ROOT"] = tmpdir
+        try:
+            assert slr._plugin_version() == ""
+        finally:
+            if old is None:
+                os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+            else:
+                os.environ["CLAUDE_PLUGIN_ROOT"] = old
+
+
+def test_invalid_json_returns_empty():
+    """Corrupt plugin.json → empty string, no crash."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        manifest_dir = pathlib.Path(tmpdir) / ".claude-plugin"
+        manifest_dir.mkdir()
+        manifest = manifest_dir / "plugin.json"
+        manifest.write_text("{not valid json", encoding="utf-8")
+
+        old = os.environ.get("CLAUDE_PLUGIN_ROOT")
+        os.environ["CLAUDE_PLUGIN_ROOT"] = tmpdir
+        try:
+            assert slr._plugin_version() == ""
+        finally:
+            if old is None:
+                os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+            else:
+                os.environ["CLAUDE_PLUGIN_ROOT"] = old
+
+
+def test_missing_version_key_returns_empty():
+    """plugin.json without 'version' key → empty string."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        manifest_dir = pathlib.Path(tmpdir) / ".claude-plugin"
+        manifest_dir.mkdir()
+        manifest = manifest_dir / "plugin.json"
+        manifest.write_text(json.dumps({"name": "test"}), encoding="utf-8")
+
+        old = os.environ.get("CLAUDE_PLUGIN_ROOT")
+        os.environ["CLAUDE_PLUGIN_ROOT"] = tmpdir
+        try:
+            assert slr._plugin_version() == ""
+        finally:
+            if old is None:
+                os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+            else:
+                os.environ["CLAUDE_PLUGIN_ROOT"] = old
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
Fixes topoteretes/cognee#3675

What does this PR do?
This PR updates the Claude Code integration's status line script so that it displays the installed version of the plugin alongside the dataset and mode.

Before: cognee: agent_sessions · local

After: cognee: agent_sessions · local · v0.2.0

How was this implemented?
I added a new helper function _plugin_version() in cognee_statusline_render.py that reads the version directly from the plugin.json manifest. It resolves the path using the CLAUDE_PLUGIN_ROOT environment variable set by Claude Code.

To ensure the script remains fast and reliable, this was implemented with a fail-silent design matching the existing code pattern. The script will simply omit the version and fall back to the original display without crashing in the following edge cases:
The CLAUDE_PLUGIN_ROOT environment variable is missing.
The plugin.json manifest file does not exist or cannot be read.
The plugin.json file is corrupted or contains invalid JSON.
The version key is missing from the JSON data.