### PR TITLE
feat(claude-code): show installed plugin version in statusline

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -188,21 +188,22 @@ risk a duplicate). Only a genuine connection failure falls back.
 
 ## Status line
 
-The status line displays `cognee: <dataset> · <mode>`, for example:
+The status line displays `cognee: <dataset> · <mode> · v<version>`, for example:
 
 ```
-cognee: agent_sessions · local
-cognee: my-project · cloud
+cognee: agent_sessions · local · v1.0.0
+cognee: my-project · cloud · v1.0.0
 ```
 
-`<dataset>` is the active Cognee dataset. `<mode>` is `local` when no `COGNEE_BASE_URL` is set or when it points to localhost, and `cloud` when it points to a remote host.
+`<dataset>` is the active Cognee dataset. `<mode>` is `local` when no `COGNEE_BASE_URL` is set or when it points to localhost, and `cloud` when it points to a remote host. `<version>` is the installed plugin version from `CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json` (omitted if the manifest is missing or unreadable).
 
 It is configured automatically on first launch when no custom status line is already configured. SessionStart writes the correct path into `~/.claude/settings.json` and Claude Code hot-reloads it, so the status line appears from your first interaction onward. Existing non-Cognee `statusLine` settings are preserved; set `COGNEE_STATUSLINE=false` before launching Claude Code to opt out entirely.
 
 The status line reads only local state — no network calls on every refresh:
 1. Dataset: `COGNEE_PLUGIN_DATASET` env var, otherwise `agent_sessions`
 2. Mode: `COGNEE_BASE_URL` env var, then `~/.cognee-plugin/claude-code/config.json` (`base_url`)
-3. Default mode: `local`
+3. Version: `CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json` (`version`)
+4. Default mode: `local`
 
 ## Auto-clear demo hook
 

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -3,10 +3,13 @@
 
 Invoked by Claude Code's ``statusLine`` (via ``cognee-statusline.sh``), which
 pipes a JSON context on stdin. Deliberately standalone and pure-local: reads
-only env vars and ``~/.cognee-plugin/config.json`` — no network calls, no
+only env vars, ``~/.cognee-plugin`` markers, and the plugin manifest under
+``CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json`` — no network calls, no
 ``_plugin_common`` import.
 
-Output: ``cognee: <dataset-name> · local`` or ``cognee: <dataset-name> · cloud``
+Output: ``cognee: <dataset-name> · local · v0.3.0`` or
+``cognee: <dataset-name> · cloud · v0.3.0`` (version omitted when the
+manifest is missing or unreadable).
 """
 
 import json
@@ -76,6 +79,32 @@ def _health_prefix() -> str:
     if _SERVER_READY_PATH.exists():
         return "● "
     return ""
+
+
+def _plugin_version() -> str:
+    """Installed plugin version from the local manifest, or empty string.
+
+    Pure-local and fail-silent (same contract as :func:`_health_prefix`):
+    reads ``CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json`` and returns the
+    ``version`` field when present. A missing env var, missing file,
+    unreadable/malformed JSON, or empty ``version`` all yield an empty
+    string with no raise.
+    """
+    root = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
+    if not root:
+        return ""
+    try:
+        data = _read_json(Path(root) / ".claude-plugin" / "plugin.json")
+        version = str(data.get("version") or "").strip()
+        return version
+    except Exception:
+        return ""
+
+
+def _version_suffix() -> str:
+    """Compact `` · v<installed>`` segment, or empty when unavailable."""
+    version = _plugin_version()
+    return f" · v{version}" if version else ""
 
 
 def _update_segment() -> str:
@@ -179,7 +208,8 @@ def main() -> None:
         return
 
     sys.stdout.write(
-        f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}{_update_segment()}"
+        f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}"
+        f"{_version_suffix()}{_update_segment()}"
     )
 
 

--- a/integrations/claude-code/tests/test_statusline_version.py
+++ b/integrations/claude-code/tests/test_statusline_version.py
@@ -1,0 +1,184 @@
+"""Unit tests for the statusline plugin-version segment.
+
+Acceptance for topoteretes/cognee#3675:
+- status line shows ``v<installed>`` when the plugin manifest is readable
+- missing / unreadable manifest → no crash, no version segment
+- pure-local read of ``CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json``
+
+Run: python integrations/claude-code/tests/test_statusline_version.py
+(or via pytest).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import pathlib
+import sys
+import tempfile
+from typing import Any, Iterator, Optional
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import cognee_statusline_render as sr  # noqa: E402
+
+
+@contextlib.contextmanager
+def _plugin_root(manifest: Optional[Any]) -> Iterator[pathlib.Path]:
+    """Temp CLAUDE_PLUGIN_ROOT; ``manifest`` is JSON-serializable data or None.
+
+    When ``manifest`` is None the ``.claude-plugin`` dir is created but no
+    ``plugin.json`` is written. When ``manifest`` is a string it is written
+    raw (for malformed-JSON cases).
+    """
+    with tempfile.TemporaryDirectory(prefix="cognee-statusline-ver-") as tmp:
+        root = pathlib.Path(tmp)
+        plugin_dir = root / ".claude-plugin"
+        plugin_dir.mkdir()
+        if manifest is not None:
+            path = plugin_dir / "plugin.json"
+            if isinstance(manifest, str):
+                path.write_text(manifest, encoding="utf-8")
+            else:
+                path.write_text(json.dumps(manifest), encoding="utf-8")
+        old = os.environ.get("CLAUDE_PLUGIN_ROOT")
+        os.environ["CLAUDE_PLUGIN_ROOT"] = str(root)
+        try:
+            yield root
+        finally:
+            if old is None:
+                os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+            else:
+                os.environ["CLAUDE_PLUGIN_ROOT"] = old
+
+
+@contextlib.contextmanager
+def _cleared_plugin_root() -> Iterator[None]:
+    old = os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+    try:
+        yield
+    finally:
+        if old is not None:
+            os.environ["CLAUDE_PLUGIN_ROOT"] = old
+
+
+def test_reads_plugin_version_from_claude_plugin_root():
+    with _plugin_root({"version": "0.3.0", "name": "cognee-memory"}):
+        assert sr._plugin_version() == "0.3.0"
+        assert sr._version_suffix() == " · v0.3.0"
+
+
+def test_missing_plugin_root_hides_version():
+    with _cleared_plugin_root():
+        assert sr._plugin_version() == ""
+        assert sr._version_suffix() == ""
+
+
+def test_missing_manifest_hides_version():
+    with _plugin_root(None):
+        assert sr._plugin_version() == ""
+        assert sr._version_suffix() == ""
+
+
+def test_malformed_manifest_hides_version():
+    with _plugin_root("{"):
+        assert sr._plugin_version() == ""
+        assert sr._version_suffix() == ""
+
+
+def test_missing_version_field_hides_version():
+    with _plugin_root({"name": "cognee-memory"}):
+        assert sr._plugin_version() == ""
+        assert sr._version_suffix() == ""
+
+
+def test_null_or_blank_version_hides_version():
+    with _plugin_root({"version": None}):
+        assert sr._plugin_version() == ""
+    with _plugin_root({"version": "   "}):
+        assert sr._plugin_version() == ""
+        assert sr._version_suffix() == ""
+
+
+def test_non_dict_manifest_hides_version():
+    with _plugin_root(["not", "a", "dict"]):
+        assert sr._plugin_version() == ""
+        assert sr._version_suffix() == ""
+
+
+def test_numeric_version_is_stringified():
+    with _plugin_root({"version": 1}):
+        assert sr._plugin_version() == "1"
+        assert sr._version_suffix() == " · v1"
+
+
+@contextlib.contextmanager
+def _patched_main_deps():
+    """Force enabled plugin and blank health/update segments for main() tests."""
+    originals = {
+        "plugin_enabled": sr._plugin_enabled,
+        "health_prefix": sr._health_prefix,
+        "update_segment": sr._update_segment,
+        "stdout": sys.stdout,
+        "stdin": sys.stdin,
+    }
+    old_dataset = os.environ.get("COGNEE_PLUGIN_DATASET")
+    old_base = os.environ.get("COGNEE_BASE_URL")
+    os.environ["COGNEE_PLUGIN_DATASET"] = "agent_sessions"
+    os.environ.pop("COGNEE_BASE_URL", None)
+    sr._plugin_enabled = lambda _cwd: True  # type: ignore[assignment]
+    sr._health_prefix = lambda: ""  # type: ignore[assignment]
+    sr._update_segment = lambda: ""  # type: ignore[assignment]
+    buf = io.StringIO()
+    sys.stdout = buf
+    try:
+        yield buf
+    finally:
+        sr._plugin_enabled = originals["plugin_enabled"]
+        sr._health_prefix = originals["health_prefix"]
+        sr._update_segment = originals["update_segment"]
+        sys.stdout = originals["stdout"]
+        sys.stdin = originals["stdin"]
+        if old_dataset is None:
+            os.environ.pop("COGNEE_PLUGIN_DATASET", None)
+        else:
+            os.environ["COGNEE_PLUGIN_DATASET"] = old_dataset
+        if old_base is None:
+            os.environ.pop("COGNEE_BASE_URL", None)
+        else:
+            os.environ["COGNEE_BASE_URL"] = old_base
+
+
+def test_main_appends_version_when_plugin_enabled():
+    """End-to-end: enabled plugin + manifest → version in stdout."""
+    with _plugin_root({"version": "1.0.0"}):
+        with _patched_main_deps() as buf:
+            sys.stdin = io.StringIO("{}")
+            sr.main()
+            assert buf.getvalue() == "cognee: agent_sessions · local · v1.0.0"
+
+
+def test_main_omits_version_when_manifest_missing():
+    with _plugin_root(None):
+        with _patched_main_deps() as buf:
+            sys.stdin = io.StringIO("{}")
+            sr.main()
+            assert buf.getvalue() == "cognee: agent_sessions · local"
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+            except Exception as exc:  # pragma: no cover
+                failures += 1
+                print("ERROR", _name, type(exc).__name__, exc)
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Summary

Shows the installed Claude Code plugin version on the Cognee status line.

**Before:** `cognee: agent_sessions · local`  
**After:** `cognee: agent_sessions · local · v1.0.0`

Closes topoteretes/cognee#3675

## Changes

- Read `version` from `CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json` in `cognee_statusline_render.py`
- Append compact ` · v<installed>` after dataset/mode (before any update segment)
- Fail-silent when env var/manifest is missing, unreadable, malformed, or has no version (same contract as `_health_prefix`)
- Docs: update status line section in `integrations/claude-code/README.md`
- Tests: `integrations/claude-code/tests/test_statusline_version.py`

## Why this PR (vs existing open PRs)

Several earlier PRs (#140, #151, #154, #209, #223, #238) target the same issue but were cut against older `main` and conflict with current self-eviction / update-segment statusline code. This branch is based on current `main` and preserves those behaviors.

## Test plan

- [x] `python integrations/claude-code/tests/test_statusline_version.py` (10 passed)
- [x] `python -m pytest integrations/claude-code/tests/test_statusline_version.py` (10 passed)
- [x] `python -m ruff check` + `ruff format --check` on touched files
- [ ] Manual: with plugin installed, status line shows `· v<version>` from plugin.json
- [ ] Manual: with `CLAUDE_PLUGIN_ROOT` unset / bad manifest, status line still renders without version and without crash

## Acceptance (issue #3675)

| Criterion | Status |
|-----------|--------|
| Status line shows `v<installed>` | ✅ |
| Missing/unreadable manifest → no crash, no version | ✅ |
| Unit test for the read | ✅ |
| Pure-local (no network / no `_plugin_common` import) | ✅ |