### PR TITLE
feat(integrations): add compact status one-liner for claude-code and codex plugins (SDK-297)

### DIFF
--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1331,19 +1331,6 @@ def _plugin_version() -> str:
         return "unknown"
 
 
-def _server_version() -> str:
-    """Cognee server version from the shared readiness marker, else ``""``.
-
-    ``mark_server_ready`` records this when the local server is up; empty means
-    no server has reported in yet.
-    """
-    try:
-        raw = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
-        return str(raw.get("version") or "").strip()
-    except Exception:
-        return ""
-
-
 def runtime_status_line() -> str:
     """One-line view of the resolved runtime state, e.g.::
 
@@ -1351,19 +1338,14 @@ def runtime_status_line() -> str:
 
     Reuses the same resolvers the hooks run with (``resolve_runtime_mode``) so
     the reported state matches real runtime behaviour. The API key value is
-    never printed — only ``key=set`` or ``key=missing``. When the local server
-    has reported its version, a trailing ``server=<version>`` field is appended.
-    Pure-local: reads env vars and ``~/.cognee-plugin`` files, no network call.
+    never printed — only ``key=set`` or ``key=missing``. Pure-local: reads env
+    vars and ``~/.cognee-plugin`` files, no network call.
     """
     runtime = resolve_runtime_mode()
     mode = str(runtime.get("mode") or "unknown")
     url = str(runtime.get("base_url") or _local_api_url())
     key = "set" if runtime.get("api_key_present") else "missing"
-    line = f"mode={mode} url={url} key={key} version={_plugin_version()}"
-    server_version = _server_version()
-    if server_version:
-        line += f" server={server_version}"
-    return line
+    return f"mode={mode} url={url} key={key} version={_plugin_version()}"
 
 
 def set_agent_registration(registered: bool, session_key: str = "") -> None:

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -31,6 +31,9 @@ _ACTIVITY_LOG = _PLUGIN_DIR / "activity.log"
 _SAVE_COUNTER = _PLUGIN_DIR / "save_counter.json"
 _SERVER_READY_MARKER = _SHARED_PLUGIN_ROOT / "server-ready.json"
 _SERVER_READY_TTL_SECONDS = 30
+# Plugin manifest shipped beside this scripts/ dir. Read by the status one-liner
+# to report the installed plugin version (never fatal if absent).
+_PLUGIN_MANIFEST = Path(__file__).resolve().parent.parent / ".claude-plugin" / "plugin.json"
 _SYNC_LOCK = _PLUGIN_DIR / "sync.lock"
 # Per-agent-session buffer dirs. Each agent session (one Claude/Codex terminal)
 # owns its own file under these dirs, so two concurrent agents never
@@ -1313,6 +1316,54 @@ def resolve_runtime_mode() -> dict:
         "url_source": url_source,
         "key_source": key_source,
     }
+
+
+def _plugin_version() -> str:
+    """Installed plugin version from the sibling ``plugin.json`` manifest.
+
+    Returns ``"unknown"`` when the manifest is missing or unreadable so the
+    status one-liner never fails on a partial install.
+    """
+    try:
+        raw = json.loads(_PLUGIN_MANIFEST.read_text(encoding="utf-8"))
+        return str(raw.get("version") or "").strip() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _server_version() -> str:
+    """Cognee server version from the shared readiness marker, else ``""``.
+
+    ``mark_server_ready`` records this when the local server is up; empty means
+    no server has reported in yet.
+    """
+    try:
+        raw = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
+        return str(raw.get("version") or "").strip()
+    except Exception:
+        return ""
+
+
+def runtime_status_line() -> str:
+    """One-line view of the resolved runtime state, e.g.::
+
+        mode=http url=http://localhost:8011 key=missing version=0.2.0
+
+    Reuses the same resolvers the hooks run with (``resolve_runtime_mode``) so
+    the reported state matches real runtime behaviour. The API key value is
+    never printed — only ``key=set`` or ``key=missing``. When the local server
+    has reported its version, a trailing ``server=<version>`` field is appended.
+    Pure-local: reads env vars and ``~/.cognee-plugin`` files, no network call.
+    """
+    runtime = resolve_runtime_mode()
+    mode = str(runtime.get("mode") or "unknown")
+    url = str(runtime.get("base_url") or _local_api_url())
+    key = "set" if runtime.get("api_key_present") else "missing"
+    line = f"mode={mode} url={url} key={key} version={_plugin_version()}"
+    server_version = _server_version()
+    if server_version:
+        line += f" server={server_version}"
+    return line
 
 
 def set_agent_registration(registered: bool, session_key: str = "") -> None:

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -31,9 +31,6 @@ _ACTIVITY_LOG = _PLUGIN_DIR / "activity.log"
 _SAVE_COUNTER = _PLUGIN_DIR / "save_counter.json"
 _SERVER_READY_MARKER = _SHARED_PLUGIN_ROOT / "server-ready.json"
 _SERVER_READY_TTL_SECONDS = 30
-# Plugin manifest shipped beside this scripts/ dir. Read by the status one-liner
-# to report the installed plugin version (never fatal if absent).
-_PLUGIN_MANIFEST = Path(__file__).resolve().parent.parent / ".claude-plugin" / "plugin.json"
 _SYNC_LOCK = _PLUGIN_DIR / "sync.lock"
 # Per-agent-session buffer dirs. Each agent session (one Claude/Codex terminal)
 # owns its own file under these dirs, so two concurrent agents never
@@ -1318,26 +1315,14 @@ def resolve_runtime_mode() -> dict:
     }
 
 
-def _plugin_version() -> str:
-    """Installed plugin version from the sibling ``plugin.json`` manifest.
-
-    Returns ``"unknown"`` when the manifest is missing or unreadable so the
-    status one-liner never fails on a partial install.
-    """
-    try:
-        raw = json.loads(_PLUGIN_MANIFEST.read_text(encoding="utf-8"))
-        return str(raw.get("version") or "").strip() or "unknown"
-    except Exception:
-        return "unknown"
-
-
 def runtime_status_line() -> str:
     """One-line view of the resolved runtime state, e.g.::
 
-        mode=http url=http://localhost:8011 key=missing version=0.2.0
+        mode=http url=http://localhost:8011 key=missing version=1.0.0
 
-    Reuses the same resolvers the hooks run with (``resolve_runtime_mode``) so
-    the reported state matches real runtime behaviour. The API key value is
+    Reuses the resolvers the hooks run with — ``resolve_runtime_mode`` for
+    mode/url/key and the shared ``_installed_plugin_version`` for the version —
+    so the reported state matches real runtime behaviour. The API key value is
     never printed — only ``key=set`` or ``key=missing``. Pure-local: reads env
     vars and ``~/.cognee-plugin`` files, no network call.
     """
@@ -1345,7 +1330,8 @@ def runtime_status_line() -> str:
     mode = str(runtime.get("mode") or "unknown")
     url = str(runtime.get("base_url") or _local_api_url())
     key = "set" if runtime.get("api_key_present") else "missing"
-    return f"mode={mode} url={url} key={key} version={_plugin_version()}"
+    version = _installed_plugin_version() or "unknown"
+    return f"mode={mode} url={url} key={key} version={version}"
 
 
 def set_agent_registration(registered: bool, session_key: str = "") -> None:

--- a/integrations/claude-code/scripts/cognee-status.py
+++ b/integrations/claude-code/scripts/cognee-status.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Print the resolved Cognee plugin runtime state as one line, then exit 0.
+
+    mode=<http|local_sdk> url=<service-url> key=<set|missing> version=<plugin-version>
+
+A quick "what am I actually running with?" check. Reuses the same resolvers the
+hooks run with (see ``_plugin_common.resolve_runtime_mode``) so the reported
+state matches real runtime behaviour. The API key value is never printed — only
+whether one is set. Pure-local: reads env vars and ``~/.cognee-plugin`` files,
+makes no network call.
+
+Run: python3 integrations/claude-code/scripts/cognee-status.py
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import _plugin_common as pc  # noqa: E402
+
+
+def main() -> int:
+    sys.stdout.write(pc.runtime_status_line() + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/claude-code/scripts/cognee-status.py
+++ b/integrations/claude-code/scripts/cognee-status.py
@@ -12,16 +12,15 @@ makes no network call.
 Run: python3 integrations/claude-code/scripts/cognee-status.py
 """
 
-import pathlib
+import os
 import sys
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
-
-import _plugin_common as pc  # noqa: E402
+sys.path.insert(0, os.path.dirname(__file__))
+from _plugin_common import runtime_status_line
 
 
 def main() -> int:
-    sys.stdout.write(pc.runtime_status_line() + "\n")
+    sys.stdout.write(runtime_status_line() + "\n")
     return 0
 
 

--- a/integrations/claude-code/tests/test_status.py
+++ b/integrations/claude-code/tests/test_status.py
@@ -17,16 +17,15 @@ import _plugin_common as pc  # noqa: E402
 
 
 @contextlib.contextmanager
-def _patched(runtime, plugin_version="0.2.0", server_version=""):
+def _patched(runtime, plugin_version="0.2.0"):
     """Swap the resolvers so the line is deterministic regardless of host env."""
-    saved = (pc.resolve_runtime_mode, pc._plugin_version, pc._server_version)
+    saved = (pc.resolve_runtime_mode, pc._plugin_version)
     pc.resolve_runtime_mode = lambda: dict(runtime)
     pc._plugin_version = lambda: plugin_version
-    pc._server_version = lambda: server_version
     try:
         yield
     finally:
-        pc.resolve_runtime_mode, pc._plugin_version, pc._server_version = saved
+        pc.resolve_runtime_mode, pc._plugin_version = saved
 
 
 def _fields(line):
@@ -50,14 +49,6 @@ def test_reports_missing_key():
     runtime = {"mode": "local_sdk", "base_url": "", "api_key_present": False}
     with _patched(runtime):
         assert _fields(pc.runtime_status_line())["key"] == "missing"
-
-
-def test_appends_server_version_when_known():
-    runtime = {"mode": "http", "base_url": "http://localhost:8011", "api_key_present": False}
-    with _patched(runtime, server_version="1.2.2"):
-        fields = _fields(pc.runtime_status_line())
-    assert fields["version"] == "0.2.0"
-    assert fields["server"] == "1.2.2"
 
 
 def test_never_prints_raw_key():

--- a/integrations/claude-code/tests/test_status.py
+++ b/integrations/claude-code/tests/test_status.py
@@ -1,0 +1,85 @@
+"""Tests for the compact `status` one-liner: `mode=… url=… key=set|missing version=…`.
+
+The line reuses the same runtime resolvers the hooks run with and must never
+print the API key value — only whether one is set.
+
+Run: python integrations/claude-code/tests/test_status.py
+"""
+
+import contextlib
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+
+@contextlib.contextmanager
+def _patched(runtime, plugin_version="0.2.0", server_version=""):
+    """Swap the resolvers so the line is deterministic regardless of host env."""
+    saved = (pc.resolve_runtime_mode, pc._plugin_version, pc._server_version)
+    pc.resolve_runtime_mode = lambda: dict(runtime)
+    pc._plugin_version = lambda: plugin_version
+    pc._server_version = lambda: server_version
+    try:
+        yield
+    finally:
+        pc.resolve_runtime_mode, pc._plugin_version, pc._server_version = saved
+
+
+def _fields(line):
+    return dict(part.split("=", 1) for part in line.split(" "))
+
+
+def test_shape_and_masks_key_when_present():
+    runtime = {"mode": "http", "base_url": "http://localhost:8011", "api_key_present": True}
+    with _patched(runtime):
+        line = pc.runtime_status_line()
+    assert "\n" not in line
+    assert _fields(line) == {
+        "mode": "http",
+        "url": "http://localhost:8011",
+        "key": "set",
+        "version": "0.2.0",
+    }
+
+
+def test_reports_missing_key():
+    runtime = {"mode": "local_sdk", "base_url": "", "api_key_present": False}
+    with _patched(runtime):
+        assert _fields(pc.runtime_status_line())["key"] == "missing"
+
+
+def test_appends_server_version_when_known():
+    runtime = {"mode": "http", "base_url": "http://localhost:8011", "api_key_present": False}
+    with _patched(runtime, server_version="1.2.2"):
+        fields = _fields(pc.runtime_status_line())
+    assert fields["version"] == "0.2.0"
+    assert fields["server"] == "1.2.2"
+
+
+def test_never_prints_raw_key():
+    """End-to-end through the real resolver: an env key must stay masked."""
+    secret = "sk-super-secret-value"
+    os.environ["COGNEE_API_KEY"] = secret
+    try:
+        line = pc.runtime_status_line()
+    finally:
+        os.environ.pop("COGNEE_API_KEY", None)
+    assert secret not in line
+    assert "key=set" in line
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/claude-code/tests/test_status.py
+++ b/integrations/claude-code/tests/test_status.py
@@ -17,15 +17,15 @@ import _plugin_common as pc  # noqa: E402
 
 
 @contextlib.contextmanager
-def _patched(runtime, plugin_version="0.2.0"):
+def _patched(runtime, plugin_version="1.0.0"):
     """Swap the resolvers so the line is deterministic regardless of host env."""
-    saved = (pc.resolve_runtime_mode, pc._plugin_version)
+    saved = (pc.resolve_runtime_mode, pc._installed_plugin_version)
     pc.resolve_runtime_mode = lambda: dict(runtime)
-    pc._plugin_version = lambda: plugin_version
+    pc._installed_plugin_version = lambda: plugin_version
     try:
         yield
     finally:
-        pc.resolve_runtime_mode, pc._plugin_version = saved
+        pc.resolve_runtime_mode, pc._installed_plugin_version = saved
 
 
 def _fields(line):
@@ -41,7 +41,7 @@ def test_shape_and_masks_key_when_present():
         "mode": "http",
         "url": "http://localhost:8011",
         "key": "set",
-        "version": "0.2.0",
+        "version": "1.0.0",
     }
 
 

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -31,6 +31,9 @@ _ACTIVITY_LOG = _PLUGIN_DIR / "activity.log"
 _SAVE_COUNTER = _PLUGIN_DIR / "save_counter.json"
 _SERVER_READY_MARKER = _SHARED_PLUGIN_ROOT / "server-ready.json"
 _SERVER_READY_TTL_SECONDS = 30
+# Plugin manifest shipped beside this scripts/ dir. Read by the status one-liner
+# to report the installed plugin version (never fatal if absent).
+_PLUGIN_MANIFEST = Path(__file__).resolve().parent.parent / ".codex-plugin" / "plugin.json"
 _SYNC_LOCK = _PLUGIN_DIR / "sync.lock"
 # Per-agent-session buffer dirs. Each agent session (one Claude/Codex terminal)
 # owns its own file under these dirs, so two concurrent agents never
@@ -1276,6 +1279,54 @@ def resolve_runtime_mode() -> dict:
         "base_url": service_url,
         "api_key_present": bool(api_key),
     }
+
+
+def _plugin_version() -> str:
+    """Installed plugin version from the sibling ``plugin.json`` manifest.
+
+    Returns ``"unknown"`` when the manifest is missing or unreadable so the
+    status one-liner never fails on a partial install.
+    """
+    try:
+        raw = json.loads(_PLUGIN_MANIFEST.read_text(encoding="utf-8"))
+        return str(raw.get("version") or "").strip() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _server_version() -> str:
+    """Cognee server version from the shared readiness marker, else ``""``.
+
+    ``mark_server_ready`` records this when the local server is up; empty means
+    no server has reported in yet.
+    """
+    try:
+        raw = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
+        return str(raw.get("version") or "").strip()
+    except Exception:
+        return ""
+
+
+def runtime_status_line() -> str:
+    """One-line view of the resolved runtime state, e.g.::
+
+        mode=http url=http://localhost:8011 key=missing version=1.0.3-local
+
+    Reuses the same resolvers the hooks run with (``resolve_runtime_mode``) so
+    the reported state matches real runtime behaviour. The API key value is
+    never printed — only ``key=set`` or ``key=missing``. When the local server
+    has reported its version, a trailing ``server=<version>`` field is appended.
+    Pure-local: reads env vars and ``~/.cognee-plugin`` files, no network call.
+    """
+    runtime = resolve_runtime_mode()
+    mode = str(runtime.get("mode") or "unknown")
+    url = str(runtime.get("base_url") or _local_api_url())
+    key = "set" if runtime.get("api_key_present") else "missing"
+    line = f"mode={mode} url={url} key={key} version={_plugin_version()}"
+    server_version = _server_version()
+    if server_version:
+        line += f" server={server_version}"
+    return line
 
 
 def set_agent_registration(registered: bool, session_key: str = "") -> None:

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -1294,19 +1294,6 @@ def _plugin_version() -> str:
         return "unknown"
 
 
-def _server_version() -> str:
-    """Cognee server version from the shared readiness marker, else ``""``.
-
-    ``mark_server_ready`` records this when the local server is up; empty means
-    no server has reported in yet.
-    """
-    try:
-        raw = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
-        return str(raw.get("version") or "").strip()
-    except Exception:
-        return ""
-
-
 def runtime_status_line() -> str:
     """One-line view of the resolved runtime state, e.g.::
 
@@ -1314,19 +1301,14 @@ def runtime_status_line() -> str:
 
     Reuses the same resolvers the hooks run with (``resolve_runtime_mode``) so
     the reported state matches real runtime behaviour. The API key value is
-    never printed — only ``key=set`` or ``key=missing``. When the local server
-    has reported its version, a trailing ``server=<version>`` field is appended.
-    Pure-local: reads env vars and ``~/.cognee-plugin`` files, no network call.
+    never printed — only ``key=set`` or ``key=missing``. Pure-local: reads env
+    vars and ``~/.cognee-plugin`` files, no network call.
     """
     runtime = resolve_runtime_mode()
     mode = str(runtime.get("mode") or "unknown")
     url = str(runtime.get("base_url") or _local_api_url())
     key = "set" if runtime.get("api_key_present") else "missing"
-    line = f"mode={mode} url={url} key={key} version={_plugin_version()}"
-    server_version = _server_version()
-    if server_version:
-        line += f" server={server_version}"
-    return line
+    return f"mode={mode} url={url} key={key} version={_plugin_version()}"
 
 
 def set_agent_registration(registered: bool, session_key: str = "") -> None:

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -31,9 +31,6 @@ _ACTIVITY_LOG = _PLUGIN_DIR / "activity.log"
 _SAVE_COUNTER = _PLUGIN_DIR / "save_counter.json"
 _SERVER_READY_MARKER = _SHARED_PLUGIN_ROOT / "server-ready.json"
 _SERVER_READY_TTL_SECONDS = 30
-# Plugin manifest shipped beside this scripts/ dir. Read by the status one-liner
-# to report the installed plugin version (never fatal if absent).
-_PLUGIN_MANIFEST = Path(__file__).resolve().parent.parent / ".codex-plugin" / "plugin.json"
 _SYNC_LOCK = _PLUGIN_DIR / "sync.lock"
 # Per-agent-session buffer dirs. Each agent session (one Claude/Codex terminal)
 # owns its own file under these dirs, so two concurrent agents never
@@ -1281,26 +1278,14 @@ def resolve_runtime_mode() -> dict:
     }
 
 
-def _plugin_version() -> str:
-    """Installed plugin version from the sibling ``plugin.json`` manifest.
-
-    Returns ``"unknown"`` when the manifest is missing or unreadable so the
-    status one-liner never fails on a partial install.
-    """
-    try:
-        raw = json.loads(_PLUGIN_MANIFEST.read_text(encoding="utf-8"))
-        return str(raw.get("version") or "").strip() or "unknown"
-    except Exception:
-        return "unknown"
-
-
 def runtime_status_line() -> str:
     """One-line view of the resolved runtime state, e.g.::
 
-        mode=http url=http://localhost:8011 key=missing version=1.0.3-local
+        mode=http url=http://localhost:8011 key=missing version=1.1.0
 
-    Reuses the same resolvers the hooks run with (``resolve_runtime_mode``) so
-    the reported state matches real runtime behaviour. The API key value is
+    Reuses the resolvers the hooks run with — ``resolve_runtime_mode`` for
+    mode/url/key and the shared ``_installed_plugin_version`` for the version —
+    so the reported state matches real runtime behaviour. The API key value is
     never printed — only ``key=set`` or ``key=missing``. Pure-local: reads env
     vars and ``~/.cognee-plugin`` files, no network call.
     """
@@ -1308,7 +1293,8 @@ def runtime_status_line() -> str:
     mode = str(runtime.get("mode") or "unknown")
     url = str(runtime.get("base_url") or _local_api_url())
     key = "set" if runtime.get("api_key_present") else "missing"
-    return f"mode={mode} url={url} key={key} version={_plugin_version()}"
+    version = _installed_plugin_version() or "unknown"
+    return f"mode={mode} url={url} key={key} version={version}"
 
 
 def set_agent_registration(registered: bool, session_key: str = "") -> None:

--- a/integrations/codex/plugins/cognee/scripts/cognee-status.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee-status.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Print the resolved Cognee plugin runtime state as one line, then exit 0.
+
+    mode=<http|local_sdk> url=<service-url> key=<set|missing> version=<plugin-version>
+
+A quick "what am I actually running with?" check. Reuses the same resolvers the
+hooks run with (see ``_plugin_common.resolve_runtime_mode``) so the reported
+state matches real runtime behaviour. The API key value is never printed — only
+whether one is set. Pure-local: reads env vars and ``~/.cognee-plugin`` files,
+makes no network call.
+
+Run: python3 integrations/codex/plugins/cognee/scripts/cognee-status.py
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import _plugin_common as pc  # noqa: E402
+
+
+def main() -> int:
+    sys.stdout.write(pc.runtime_status_line() + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/codex/plugins/cognee/scripts/cognee-status.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee-status.py
@@ -12,16 +12,15 @@ makes no network call.
 Run: python3 integrations/codex/plugins/cognee/scripts/cognee-status.py
 """
 
-import pathlib
+import os
 import sys
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
-
-import _plugin_common as pc  # noqa: E402
+sys.path.insert(0, os.path.dirname(__file__))
+from _plugin_common import runtime_status_line
 
 
 def main() -> int:
-    sys.stdout.write(pc.runtime_status_line() + "\n")
+    sys.stdout.write(runtime_status_line() + "\n")
     return 0
 
 

--- a/integrations/codex/plugins/cognee/tests/test_status.py
+++ b/integrations/codex/plugins/cognee/tests/test_status.py
@@ -17,15 +17,15 @@ import _plugin_common as pc  # noqa: E402
 
 
 @contextlib.contextmanager
-def _patched(runtime, plugin_version="1.0.3-local"):
+def _patched(runtime, plugin_version="1.1.0"):
     """Swap the resolvers so the line is deterministic regardless of host env."""
-    saved = (pc.resolve_runtime_mode, pc._plugin_version)
+    saved = (pc.resolve_runtime_mode, pc._installed_plugin_version)
     pc.resolve_runtime_mode = lambda: dict(runtime)
-    pc._plugin_version = lambda: plugin_version
+    pc._installed_plugin_version = lambda: plugin_version
     try:
         yield
     finally:
-        pc.resolve_runtime_mode, pc._plugin_version = saved
+        pc.resolve_runtime_mode, pc._installed_plugin_version = saved
 
 
 def _fields(line):
@@ -41,7 +41,7 @@ def test_shape_and_masks_key_when_present():
         "mode": "http",
         "url": "http://localhost:8011",
         "key": "set",
-        "version": "1.0.3-local",
+        "version": "1.1.0",
     }
 
 

--- a/integrations/codex/plugins/cognee/tests/test_status.py
+++ b/integrations/codex/plugins/cognee/tests/test_status.py
@@ -1,0 +1,85 @@
+"""Tests for the compact `status` one-liner: `mode=… url=… key=set|missing version=…`.
+
+The line reuses the same runtime resolvers the hooks run with and must never
+print the API key value — only whether one is set.
+
+Run: python integrations/codex/plugins/cognee/tests/test_status.py
+"""
+
+import contextlib
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+
+@contextlib.contextmanager
+def _patched(runtime, plugin_version="1.0.3-local", server_version=""):
+    """Swap the resolvers so the line is deterministic regardless of host env."""
+    saved = (pc.resolve_runtime_mode, pc._plugin_version, pc._server_version)
+    pc.resolve_runtime_mode = lambda: dict(runtime)
+    pc._plugin_version = lambda: plugin_version
+    pc._server_version = lambda: server_version
+    try:
+        yield
+    finally:
+        pc.resolve_runtime_mode, pc._plugin_version, pc._server_version = saved
+
+
+def _fields(line):
+    return dict(part.split("=", 1) for part in line.split(" "))
+
+
+def test_shape_and_masks_key_when_present():
+    runtime = {"mode": "http", "base_url": "http://localhost:8011", "api_key_present": True}
+    with _patched(runtime):
+        line = pc.runtime_status_line()
+    assert "\n" not in line
+    assert _fields(line) == {
+        "mode": "http",
+        "url": "http://localhost:8011",
+        "key": "set",
+        "version": "1.0.3-local",
+    }
+
+
+def test_reports_missing_key():
+    runtime = {"mode": "local_sdk", "base_url": "", "api_key_present": False}
+    with _patched(runtime):
+        assert _fields(pc.runtime_status_line())["key"] == "missing"
+
+
+def test_appends_server_version_when_known():
+    runtime = {"mode": "http", "base_url": "http://localhost:8011", "api_key_present": False}
+    with _patched(runtime, server_version="1.2.2"):
+        fields = _fields(pc.runtime_status_line())
+    assert fields["version"] == "1.0.3-local"
+    assert fields["server"] == "1.2.2"
+
+
+def test_never_prints_raw_key():
+    """End-to-end through the real resolver: an env key must stay masked."""
+    secret = "sk-super-secret-value"
+    os.environ["COGNEE_API_KEY"] = secret
+    try:
+        line = pc.runtime_status_line()
+    finally:
+        os.environ.pop("COGNEE_API_KEY", None)
+    assert secret not in line
+    assert "key=set" in line
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/tests/test_status.py
+++ b/integrations/codex/plugins/cognee/tests/test_status.py
@@ -17,16 +17,15 @@ import _plugin_common as pc  # noqa: E402
 
 
 @contextlib.contextmanager
-def _patched(runtime, plugin_version="1.0.3-local", server_version=""):
+def _patched(runtime, plugin_version="1.0.3-local"):
     """Swap the resolvers so the line is deterministic regardless of host env."""
-    saved = (pc.resolve_runtime_mode, pc._plugin_version, pc._server_version)
+    saved = (pc.resolve_runtime_mode, pc._plugin_version)
     pc.resolve_runtime_mode = lambda: dict(runtime)
     pc._plugin_version = lambda: plugin_version
-    pc._server_version = lambda: server_version
     try:
         yield
     finally:
-        pc.resolve_runtime_mode, pc._plugin_version, pc._server_version = saved
+        pc.resolve_runtime_mode, pc._plugin_version = saved
 
 
 def _fields(line):
@@ -50,14 +49,6 @@ def test_reports_missing_key():
     runtime = {"mode": "local_sdk", "base_url": "", "api_key_present": False}
     with _patched(runtime):
         assert _fields(pc.runtime_status_line())["key"] == "missing"
-
-
-def test_appends_server_version_when_known():
-    runtime = {"mode": "http", "base_url": "http://localhost:8011", "api_key_present": False}
-    with _patched(runtime, server_version="1.2.2"):
-        fields = _fields(pc.runtime_status_line())
-    assert fields["version"] == "1.0.3-local"
-    assert fields["server"] == "1.2.2"
 
 
 def test_never_prints_raw_key():


### PR DESCRIPTION
## Summary

Adds a one-shot `status` command to the **claude-code** and **codex** plugins that prints the plugin's resolved runtime state on a single line and exits `0`:

```
mode=<http|local_sdk> url=<service-url> key=<set|missing> version=<plugin-version>
```

A quick "what am I actually running with?" check — mode, endpoint, whether a key is present, and the installed plugin version — without digging through config files, logs, or the status-line UI. Pure-local: it reads env vars and `~/.cognee-plugin` marker files and makes no network call. **The API key value is never printed** — only `key=set` or `key=missing`.

Resolves the hackathon task in topoteretes/cognee#3552. Linear: SDK-297.

## Attribution

Reworked from community hackathon PR #172 by @zainAwan9175 — the original commit is preserved as the base of this branch, with maintainer improvements layered on top as separate single-concern commits.

## What changed

- **`_plugin_common.py`** (both plugins): add `runtime_status_line()`, built on the same resolvers the hooks actually run with — `resolve_runtime_mode()` for mode/url/key and the module's existing `_installed_plugin_version()` for the version — so the reported state matches real runtime behaviour rather than a second config derivation that could drift.
- **`scripts/cognee-status.py`** (both plugins): a tiny entry point that prints the line and exits `0`.
- **`tests/test_status.py`** (both plugins): assert the one-line shape, that a present key renders `key=set` (and the raw key value never appears), and that a missing key renders `key=missing`. Each file also runs standalone (`python3 .../test_status.py`), matching the existing test convention.

## Maintainer rework (separate commits on top of the original)

- **Drop the out-of-scope, dead `server=` field.** The issue asks for exactly `mode url key version`. The original also appended a fifth `server=<version>` field, but it could never appear at runtime: every real caller of `mark_server_ready()` passes no version, so `server-ready.json` never carries one and the branch never executes. Its test only passed by monkeypatching a state the system cannot produce. Removed the field, its helper, and the dead-code test.
- **Reuse `_installed_plugin_version()` for the version field.** The original added a new `_plugin_version()` plus a `_PLUGIN_MANIFEST` constant that re-implemented — more weakly — a helper already in the module, one that first honors the `CLAUDE_PLUGIN_ROOT` / `PLUGIN_ROOT` install-root env before the sibling manifest (so it stays correct in a marketplace-managed install). Reused the existing helper, deleted the duplicate, and corrected the stale docstring version examples.
- **Align the entry script with the repo's import convention** (`sys.path.insert(0, os.path.dirname(__file__))` + `from _plugin_common import …`, dropping the `# noqa: E402`).

Net effect: the feature is exactly the four fields the issue asked for, reading the real runtime state, applied identically to both plugin copies (`330` → `246` added lines).

## Testing

- `python3 integrations/claude-code/tests/test_status.py` → pass
- `python3 integrations/codex/plugins/cognee/tests/test_status.py` → pass
- Both entry scripts print one line and exit `0`.
- `ruff format --check integrations/` and `ruff check integrations/` → clean (line-length 100, `select = E,F,I,W`).

Note: CI's `test-python` matrix skips these plugins (they ship no `pyproject.toml`); the real gate is `lint.yml` (ruff), which passes.

## Out of scope

- A skill/slash-command wrapper for discoverability — the issue's "done when" is satisfied by a script that prints one line and exits `0`; a wrapper mirroring `cognee-search` can be a separate follow-up.
- Changing `mark_server_ready` callers to actually populate a server version (its own issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
