### PR TITLE
CLO-443: correct PR-review reviewer roster

### DIFF
--- a/.github/core-team.txt
+++ b/.github/core-team.txt
@@ -6,7 +6,9 @@ dexters1
 hajdul88
 hande-k
 lxobr
-pazone
+pazonex
 NMZivkovic
 siillee
 vasilije1990
+goran-radonic
+LStromann


### PR DESCRIPTION
Adds `goran-radonic` and `LStromann` to `.github/core-team.txt` and fixes the `pazone` → `pazonex` login typo, so all three receive the advisory Claude review + Slack DM.

Linear: CLO-443