### PR TITLE
feat: COGNEE_MANAGED_ENDPOINT — fail loudly instead of shadow-booting over managed loopback deployments

### DIFF
--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,6 +10,24 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **`COGNEE_MANAGED_ENDPOINT` — never boot over a managed endpoint.** When
+  `COGNEE_BASE_URL` points at a self-hosted deployment that lives on a loopback
+  address (docker compose stack, systemd service, reverse proxy), an outage at
+  session start used to silently boot the embedded local server on the
+  deployment's own port. The shadow instance then squats the port, answers 401
+  to the deployment's API keys (which reads as a baffling auth failure on the
+  real stack), and captures memory into an embedded database nobody reads.
+  Setting `COGNEE_MANAGED_ENDPOINT=true` (env var, `~/.cognee/.env`, or config
+  key `managed_endpoint`) declares the endpoint externally managed: when it is
+  unreachable, `SessionStart` reports **Cognee Memory OFFLINE** loudly (system
+  message + agent context) and refuses to install or boot anything. Extends the
+  forced-cloud misconfiguration surfacing and the present-but-busy boot refusal
+  to configured-URL deployments that are cleanly down. Default behavior without
+  the flag is unchanged.
+
 ## [1.4.1]
 
 ### Changed

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -104,6 +104,8 @@ At startup (`SessionStart`):
 
 A forced-local switch also scrubs `COGNEE_BASE_URL`/`COGNEE_API_KEY` from the process environment, so the per-prompt recall/remember calls and every spawned worker resolve the same local endpoint — not just `SessionStart`. A forced-cloud switch with no URL configured never boots the local server; the connection attempt fails visibly instead (status line + doctor).
 
+**Self-hosted deployments on loopback:** when the configured URL is a loopback address (`127.0.0.1`, `localhost`) and the server is down at session start, the plugin normally boots its embedded local server on that port. If the URL actually belongs to an externally managed deployment (docker compose stack, systemd service), set `COGNEE_MANAGED_ENDPOINT=true`: an outage then makes `SessionStart` report **Cognee Memory OFFLINE** loudly instead of silently booting an unrelated fallback instance over the deployment's port.
+
 At hook runtime:
 - hooks resolve mode through runtime endpoint auth (env + `api_key.json`), not only config intent
 - `http` mode skips local SDK initialization
@@ -634,6 +636,7 @@ Keys are letters, digits, and underscores. Values are taken literally — no `$V
 | `session_strategy` | `COGNEE_SESSION_STRATEGY` | `per-directory` | `per-directory`, `git-branch`, `static` |
 | `session_prefix` | `COGNEE_SESSION_PREFIX` | `cc` | Prefix for auto-generated session IDs |
 | `base_url` | `COGNEE_BASE_URL` | unset | Set to enable managed endpoint mode |
+| `managed_endpoint` | `COGNEE_MANAGED_ENDPOINT` | unset | `true` = the URL is an externally managed deployment: never boot a local fallback on its port; outages fail loudly |
 | `api_key` | `COGNEE_API_KEY` | unset | API key; auto-minted if absent in local mode |
 | mode switch | `COGNEE_BACKEND` | unset | `local` or `cloud` — pins the terminal's mode, overriding the URL rule; flips the Claude Code **and** Codex plugins |
 | plugin-only mode switch | `COGNEE_CLAUDE_BACKEND` | unset | Same, for this plugin only; beats `COGNEE_BACKEND` |

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -106,6 +106,9 @@ _ENV_MAP = {
     "COGNEE_SESSION_PREFIX": "session_prefix",
     "COGNEE_BASE_URL": "base_url",
     "COGNEE_API_KEY": "api_key",
+    # base_url is an externally managed deployment: never boot a local fallback
+    # server on its port; fail loudly when it is unreachable.
+    "COGNEE_MANAGED_ENDPOINT": "managed_endpoint",
     "COGNEE_USER_EMAIL": "user_email",
     "COGNEE_USER_PASSWORD": "user_password",
     "LLM_API_KEY": "llm_api_key",

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -350,6 +350,19 @@ def _is_local_url(url: str) -> bool:
     return host in ("localhost", "127.0.0.1", "0.0.0.0", "::1")
 
 
+def _managed_endpoint_enabled(config: dict) -> bool:
+    """True when base_url is an externally managed deployment (docker stack,
+    systemd service, ...) that happens to live on a loopback address. In that
+    case the plugin must NEVER boot its own fallback server on that port — a
+    fallback would shadow the real deployment with a second, unrelated brain.
+    Set COGNEE_MANAGED_ENDPOINT=true (env or config) to opt in; outages then
+    fail loudly instead of silently forking."""
+    val = os.environ.get("COGNEE_MANAGED_ENDPOINT", "") or str(
+        config.get("managed_endpoint", "") or ""
+    )
+    return val.strip().lower() in ("1", "true", "yes", "on")
+
+
 def _with_scheme(url: str) -> str:
     """Ensure the URL has a scheme so urllib + downstream HTTP helpers accept it."""
     url = str(url or "").strip()
@@ -429,6 +442,15 @@ def _ensure_local_server_running(
     if _require_absent("pre_install"):
         _ready()
         return
+
+    if _managed_endpoint_enabled(config):
+        # Hard stop at the single spawn/install choke point so no call path —
+        # present or future — can boot a shadow server over a managed endpoint.
+        hook_log("managed_endpoint_boot_refused", {"base_url": service_url})
+        raise RuntimeError(
+            f"managed Cognee endpoint {service_url} is unreachable and "
+            "COGNEE_MANAGED_ENDPOINT forbids booting a local fallback server"
+        )
 
     # The server is positively absent and we're at a boot point: ensure the
     # venv holds the latest cognee BEFORE booting, so the server's lifespan
@@ -1572,13 +1594,17 @@ async def _start(payload: dict | None = None) -> dict:
         server_live = presence_verdict == PRESENCE_READY
     else:
         server_live = bool(target_url) and _health_ok(_health_url(target_url))
-    will_boot = (not server_live) and bool(target_url) and _is_local_url(target_url)
+    managed_locked = _managed_endpoint_enabled(config)
+    will_boot = (
+        (not server_live) and bool(target_url) and _is_local_url(target_url) and not managed_locked
+    )
     hook_log(
         "endpoint_mode_selected",
         {
             "base_url": target_url,
             "server_live": server_live,
             "will_boot": will_boot,
+            "managed_endpoint": managed_locked,
             **(
                 {"presence": presence_verdict, "evidence": presence_evidence}
                 if presence_verdict
@@ -1586,6 +1612,32 @@ async def _start(payload: dict | None = None) -> dict:
             ),
         },
     )
+    if managed_locked and target_url and not server_live:
+        # Managed deployment is down: fail loudly, never fork a fallback brain.
+        hook_log("managed_endpoint_down", {"base_url": target_url})
+        print(
+            f"cognee-plugin: managed endpoint {target_url} unreachable — memory OFFLINE",
+            file=sys.stderr,
+        )
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "systemMessage": (
+                    "## ⚠ Cognee Memory OFFLINE\n"
+                    f"The managed Cognee endpoint {target_url} is unreachable. "
+                    "COGNEE_MANAGED_ENDPOINT is set, so no local fallback server was "
+                    "started — memory recall and capture are disabled for this session.\n"
+                    "Start the deployment, then start a new session (or /clear)."
+                ),
+                "additionalContext": (
+                    "Cognee memory is OFFLINE for this session: the managed endpoint "
+                    f"{target_url} is unreachable and local fallback is disabled by "
+                    "COGNEE_MANAGED_ENDPOINT. Nothing is being recalled or captured. "
+                    "If durable memory matters for the current task, remind the user "
+                    "that the Cognee stack is down before proceeding."
+                ),
+            }
+        }
     if will_boot and _LAZY_BOOTSTRAP:
         _spawn_bootstrap(config, cwd, session_id, agent_session_name, session_key, dataset)
         user_id = os.environ.get("COGNEE_USER_ID", "")
@@ -1601,7 +1653,7 @@ async def _start(payload: dict | None = None) -> dict:
             boot_timeout=_HEALTH_TIMEOUT_SECONDS,
         )
         if not ok:
-            if _LAZY_BOOTSTRAP and target_url and _is_local_url(target_url):
+            if _LAZY_BOOTSTRAP and target_url and _is_local_url(target_url) and not managed_locked:
                 # Inline attempt failed; retry the heavy path out of band.
                 _spawn_bootstrap(config, cwd, session_id, agent_session_name, session_key, dataset)
             else:

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -121,6 +121,8 @@ At startup (`SessionStart`):
 
 A forced-local switch also scrubs `COGNEE_BASE_URL`/`COGNEE_API_KEY` from the process environment, so the per-prompt recall/remember calls and every spawned worker resolve the same local endpoint — not just `SessionStart`. A forced-cloud switch with no URL configured never boots the local server; the connection attempt fails visibly instead (status + doctor).
 
+**Self-hosted deployments on loopback:** when the configured URL is a loopback address (`127.0.0.1`, `localhost`) and the server is down at session start, the plugin normally boots its embedded local server on that port. If the URL actually belongs to an externally managed deployment (docker compose stack, systemd service), set `COGNEE_MANAGED_ENDPOINT=true`: an outage then makes `SessionStart` report **Cognee Memory OFFLINE** loudly instead of silently booting an unrelated fallback instance over the deployment's port.
+
 At hook runtime:
 - hooks resolve the endpoint from env, with localhost as the default
 - hooks resolve auth from env, then the URL-scoped `api_key.json` cache
@@ -486,6 +488,7 @@ Keys are letters, digits, and underscores. Values are taken literally — no `$V
 | `session_strategy` | `COGNEE_SESSION_STRATEGY` | `per-directory` | `per-directory`, `git-branch`, `static` |
 | `session_prefix` | `COGNEE_SESSION_PREFIX` | `codex` | Prefix for auto-generated session IDs |
 | `base_url` | `COGNEE_BASE_URL` | unset | Set to enable managed endpoint mode |
+| `managed_endpoint` | `COGNEE_MANAGED_ENDPOINT` | unset | `true` = the URL is an externally managed deployment: never boot a local fallback on its port; outages fail loudly |
 | `api_key` | `COGNEE_API_KEY` | unset | API key; auto-minted if absent in local mode |
 | mode switch | `COGNEE_BACKEND` | unset | `local` or `cloud` — pins the terminal's mode, overriding the URL rule; flips the Codex **and** Claude Code plugins |
 | plugin-only mode switch | `COGNEE_CODEX_BACKEND` | unset | Same, for this plugin only; beats `COGNEE_BACKEND` |

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,6 +10,24 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **`COGNEE_MANAGED_ENDPOINT` — never boot over a managed endpoint.** When
+  `COGNEE_BASE_URL` points at a self-hosted deployment that lives on a loopback
+  address (docker compose stack, systemd service, reverse proxy), an outage at
+  session start used to silently boot the embedded local server on the
+  deployment's own port. The shadow instance then squats the port, answers 401
+  to the deployment's API keys (which reads as a baffling auth failure on the
+  real stack), and captures memory into an embedded database nobody reads.
+  Setting `COGNEE_MANAGED_ENDPOINT=true` (env var, `~/.cognee/.env`, or config
+  key `managed_endpoint`) declares the endpoint externally managed: when it is
+  unreachable, `SessionStart` reports **Cognee Memory OFFLINE** loudly (system
+  message + agent context) and refuses to install or boot anything. Extends the
+  forced-cloud misconfiguration surfacing and the present-but-busy boot refusal
+  to configured-URL deployments that are cleanly down. Default behavior without
+  the flag is unchanged.
+
 ## [1.5.1]
 
 ### Changed

--- a/integrations/codex/plugins/cognee/scripts/config.py
+++ b/integrations/codex/plugins/cognee/scripts/config.py
@@ -95,6 +95,9 @@ _ENV_MAP = {
     "COGNEE_SESSION_PREFIX": "session_prefix",
     "COGNEE_BASE_URL": "base_url",
     "COGNEE_API_KEY": "api_key",
+    # base_url is an externally managed deployment: never boot a local fallback
+    # server on its port; fail loudly when it is unreachable.
+    "COGNEE_MANAGED_ENDPOINT": "managed_endpoint",
     "COGNEE_USER_EMAIL": "user_email",
     "COGNEE_USER_PASSWORD": "user_password",
     "LLM_API_KEY": "llm_api_key",

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -349,6 +349,19 @@ def _is_local_url(url: str) -> bool:
     return host in ("localhost", "127.0.0.1", "0.0.0.0", "::1")
 
 
+def _managed_endpoint_enabled(config: dict) -> bool:
+    """True when base_url is an externally managed deployment (docker stack,
+    systemd service, ...) that happens to live on a loopback address. In that
+    case the plugin must NEVER boot its own fallback server on that port — a
+    fallback would shadow the real deployment with a second, unrelated brain.
+    Set COGNEE_MANAGED_ENDPOINT=true (env or config) to opt in; outages then
+    fail loudly instead of silently forking."""
+    val = os.environ.get("COGNEE_MANAGED_ENDPOINT", "") or str(
+        config.get("managed_endpoint", "") or ""
+    )
+    return val.strip().lower() in ("1", "true", "yes", "on")
+
+
 def _with_scheme(url: str) -> str:
     """Ensure the URL has a scheme so urllib + downstream HTTP helpers accept it."""
     url = str(url or "").strip()
@@ -428,6 +441,15 @@ def _ensure_local_server_running(
     if _require_absent("pre_install"):
         _ready()
         return
+
+    if _managed_endpoint_enabled(config):
+        # Hard stop at the single spawn/install choke point so no call path —
+        # present or future — can boot a shadow server over a managed endpoint.
+        hook_log("managed_endpoint_boot_refused", {"base_url": service_url})
+        raise RuntimeError(
+            f"managed Cognee endpoint {service_url} is unreachable and "
+            "COGNEE_MANAGED_ENDPOINT forbids booting a local fallback server"
+        )
 
     # The server is positively absent and we're at a boot point: ensure the
     # shared venv holds the latest cognee BEFORE booting, so the server's
@@ -1379,13 +1401,17 @@ async def _start(payload: dict | None = None) -> dict:
         server_live = presence_verdict == PRESENCE_READY
     else:
         server_live = bool(target_url) and _health_ok(_health_url(target_url))
-    will_boot = (not server_live) and bool(target_url) and _is_local_url(target_url)
+    managed_locked = _managed_endpoint_enabled(config)
+    will_boot = (
+        (not server_live) and bool(target_url) and _is_local_url(target_url) and not managed_locked
+    )
     hook_log(
         "endpoint_mode_selected",
         {
             "base_url": target_url,
             "server_live": server_live,
             "will_boot": will_boot,
+            "managed_endpoint": managed_locked,
             **(
                 {"presence": presence_verdict, "evidence": presence_evidence}
                 if presence_verdict
@@ -1393,6 +1419,32 @@ async def _start(payload: dict | None = None) -> dict:
             ),
         },
     )
+    if managed_locked and target_url and not server_live:
+        # Managed deployment is down: fail loudly, never fork a fallback brain.
+        hook_log("managed_endpoint_down", {"base_url": target_url})
+        print(
+            f"cognee-plugin: managed endpoint {target_url} unreachable — memory OFFLINE",
+            file=sys.stderr,
+        )
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "systemMessage": (
+                    "## ⚠ Cognee Memory OFFLINE\n"
+                    f"The managed Cognee endpoint {target_url} is unreachable. "
+                    "COGNEE_MANAGED_ENDPOINT is set, so no local fallback server was "
+                    "started — memory recall and capture are disabled for this session.\n"
+                    "Start the deployment, then start a new session (or /clear)."
+                ),
+                "additionalContext": (
+                    "Cognee memory is OFFLINE for this session: the managed endpoint "
+                    f"{target_url} is unreachable and local fallback is disabled by "
+                    "COGNEE_MANAGED_ENDPOINT. Nothing is being recalled or captured. "
+                    "If durable memory matters for the current task, remind the user "
+                    "that the Cognee stack is down before proceeding."
+                ),
+            }
+        }
     if will_boot and _LAZY_BOOTSTRAP:
         _spawn_bootstrap(config, cwd, session_id, agent_session_name, session_key, dataset)
         user_id = os.environ.get("COGNEE_USER_ID", "")
@@ -1408,7 +1460,7 @@ async def _start(payload: dict | None = None) -> dict:
             boot_timeout=_HEALTH_TIMEOUT_SECONDS,
         )
         if not ok:
-            if _LAZY_BOOTSTRAP and target_url and _is_local_url(target_url):
+            if _LAZY_BOOTSTRAP and target_url and _is_local_url(target_url) and not managed_locked:
                 # Inline attempt failed; retry the heavy path out of band.
                 _spawn_bootstrap(config, cwd, session_id, agent_session_name, session_key, dataset)
             else:


### PR DESCRIPTION
## Problem

When `COGNEE_BASE_URL` points at a **loopback** address and the server is down at session start, the plugin silently boots its embedded local server on that same port (`will_boot = (not server_live) and bool(target_url) and _is_local_url(target_url)`).

That is the right default for pure local mode — but self-hosted deployments (docker compose stack, systemd service, reverse proxy) also commonly live on loopback. For those users, any outage at session start (docker not up yet after reboot, maintenance window) silently forks a second, unrelated brain:

- the shadow instance squats the deployment's port, so the real stack can't bind when it comes back;
- the deployment's API keys get 401s from the shadow instance — indistinguishable from stack auth breakage, very confusing to debug;
- captured memory lands in the embedded database nobody reads: silent memory loss.

We hit exactly this in production use: a multi-day capture outage where the plugin's shadow uvicorn on the stack's port masqueraded as stack auth failure.

## Prior art already on main

Two existing mechanisms are adjacent but leave this exact gap open:

- `COGNEE_BACKEND` forced-cloud (1.3.0/1.4.0): surfaces the misconfiguration instead of falling back to local — but only when **no URL is configured**; with a configured loopback URL, `_forced_backend` is never consulted by the boot decision.
- `server_presence()` (1.4.1): refuses to install/boot over a server that is **present but not serving** — but a managed deployment that is *cleanly down* (docker stopped, host rebooted) reads as positively absent and still gets booted over.

This PR extends the same surface-not-fallback principle to the remaining case: a configured loopback URL whose deployment is down.

## Change

Opt-in `COGNEE_MANAGED_ENDPOINT=true` (env var, `~/.cognee/.env`, or config key `managed_endpoint`) declaring the endpoint externally managed:

- **session-start decision site**: never boots a fallback; when the endpoint is down it returns a loud `## ⚠ Cognee Memory OFFLINE` `systemMessage` plus `additionalContext`, so both the user and the agent know recall/capture is disabled for the session.
- **`_ensure_local_server_running`**: raises instead of installing the venv / spawning uvicorn — a belt-and-suspenders stop at the single spawn choke point, covering any other call path.
- the out-of-band bootstrap retry is suppressed likewise.

**Default behavior is unchanged**: without the flag the plugin boots the local fallback exactly as before.

Applied to both the claude-code and codex plugin flavors, with CHANGELOG entries under `[Unreleased]` and README docs (mode-rules section + env table). No version bumps this time — versioning left to release time (the previous revision's bumps went stale twice against your release cadence).

## Testing (rebased on current main)

- Shared pytest suite (`integrations/tests`): **1322 passed, 92 skipped, 2 xfailed** on this branch.
- `ruff format --check` / `ruff check` clean on all touched files (ruff 0.16.0).
- Manual: dead endpoint + flag → OFFLINE systemMessage returned, exit 0, no venv install, no uvicorn spawned; live endpoint + flag → normal "Cognee Memory Connected" flow; no flag → boot path untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)