### PR TITLE
docs: track community Pi coding agent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ Memory apps and editor tooling that talk to a running **cognee server**
 | Second brain | `cognee-integration-second-brain` | cross-transport personal memory (Telegram + web), `/link` identity merge |
 | VS Code | `cognee-vscode` | remember/recall + "ask my project memory" with source-file citations |
 
+### Community integrations
+
+Maintained by the community in their own repos — tracked here in
+[`integrations/inventory.yml`](integrations/inventory.yml) so they're easy to find.
+
+| Integration | Package | Install |
+|---|---|---|
+| [Pi coding agent](https://github.com/kerryhatcher/pi-cognee) | `@kerryhatcher/pi-cognee` | `pi install npm:@kerryhatcher/pi-cognee` |
+
 ## Claude Code Quickstart
 
 The Claude Code integration is a **plugin** — it gives Claude Code persistent memory

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -258,6 +258,25 @@ integrations:
     migration_status: done
     notes: "Aider CLI memory tools – sessionized add/cognify/search with per-project isolation (CHUNKS-scoped recall)"
 
+  # ── Community integrations (maintained outside this monorepo) ──────
+
+  - slug: pi
+    name: "Cognee Extension for Pi Coding Agent"
+    owner: kerryhatcher
+    language: typescript
+    registry: npm
+    package_name: "@kerryhatcher/pi-cognee"
+    cognee_dependency: sdk
+    current_version: "0.1.0"
+    migration_status: skipped
+    source_repo: https://github.com/kerryhatcher/pi-cognee
+    notes: >-
+      Community-maintained Pi extension (MIT, Kerry Hatcher) — remember, recall,
+      forget, and knowledge-graph management from the Pi coding agent. Two backends:
+      in-process via @cognee/cognee-ts (default, zero infrastructure) or a remote
+      Cognee MCP server (/cognee-mode mcp). Install with
+      `pi install npm:@kerryhatcher/pi-cognee`. Code stays in the author's repo.
+
   # ── Pending migrations ─────────────────────────────────────────────
 
   - slug: claude


### PR DESCRIPTION
## Summary
- Adds a **Community integrations** section to the root README, listing the [Pi coding agent extension](https://github.com/kerryhatcher/pi-cognee) (`@kerryhatcher/pi-cognee`, install with `pi install npm:@kerryhatcher/pi-cognee`).
- Tracks the integration in `integrations/inventory.yml` with `migration_status: skipped` — the code stays in Kerry Hatcher's repo; we list it here for discoverability.

No code is vendored into the monorepo, so CI/tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)