### PR TITLE
Expose Cognee status on Codex session start

### DIFF
--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,6 +10,13 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **SessionStart status envelope in Codex.** The startup status now also emits as
+  a top-level `systemMessage`, matching the Codex `UserPromptSubmit` envelope,
+  instead of living only in `additionalContext`.
+
 ## [1.4.0]
 
 ### Added

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -1283,10 +1283,12 @@ async def _start(payload: dict | None = None) -> dict:
     )
 
     status_line = render_status_for_host(session_key)
+    context = status_line + _update_nudge_suffix()
     return {
+        "systemMessage": status_line,
         "hookSpecificOutput": {
             "hookEventName": "SessionStart",
-            "additionalContext": status_line + _update_nudge_suffix(),
+            "additionalContext": context,
         },
     }
 

--- a/integrations/tests/tests/e2e/test_session_start_status.py
+++ b/integrations/tests/tests/e2e/test_session_start_status.py
@@ -1,0 +1,31 @@
+"""SessionStart status envelope.
+
+Codex-compatible hook status belongs in top-level ``systemMessage``. Keep the
+same text in ``additionalContext`` so it is still available as model context.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def test_codex_session_start_emits_top_level_status(
+    suite, run_hook, mock_server, payloads, project_dir
+):
+    if suite.name != "codex":
+        pytest.skip(f"{suite.name}: statusMessage is nested in hookSpecificOutput")
+
+    result = run_hook(
+        suite,
+        "session-start.py",
+        stdin=payloads.session_start(cwd=str(project_dir)),
+        service_url=mock_server.url,
+    )
+    assert result.returncode == 0, result.stderr
+
+    output = json.loads(result.stdout.strip())
+    assert output["systemMessage"].startswith("● cognee:")
+    assert output["hookSpecificOutput"]["additionalContext"].startswith(output["systemMessage"])
+    assert "systemMessage" not in output["hookSpecificOutput"]


### PR DESCRIPTION
## Summary
- emit Codex SessionStart status as a top-level systemMessage
- keep the existing additionalContext payload for model context/update nudges
- add an e2e regression test for the Codex startup status envelope

## Tests
- uv run --project integrations/tests pytest integrations/tests/tests/e2e/test_session_start_status.py integrations/tests/tests/unit/test_user_prompt_envelope.py integrations/tests/tests/e2e/test_statusline_bar.py integrations/tests/tests/unit/test_hooks_contract.py -q