### PR TITLE
fix: more robust health check for cognee server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": {
         "name": "Cognee"
       },

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "Cognee"
   },

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,6 +10,24 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.1]
+
+### Fixed
+- **Boot points no longer mistake a busy server for an absent one.** The boot
+  decision previously rested on a single 2s `/health` probe, so a server busy
+  cognifying could miss the deadline, be declared absent, and have the venv
+  upgraded and migrations run underneath it while it still held the graph
+  store's file lock (2026-08-13 incident). Server presence is now judged from
+  three evidence sources — the classified HTTP probe, the bare TCP handshake
+  (a busy server still accepts it; a dead one refuses), and a server pidfile
+  written at uvicorn spawn — and only a positively-absent verdict (refused
+  port, no live server pid, confirmed by a delayed re-probe) licenses
+  installing or booting. The verdict and its evidence are recorded on every
+  `endpoint_mode_selected` decision, the license is re-verified after the
+  (minutes-long) install and again under the boot lock, and a spawned server
+  that dies before becoming healthy (e.g. lost port-bind race) is detected
+  instead of being waited out.
+
 ## [1.3.0]
 
 ### Added

--- a/integrations/claude-code/scripts/_env_file.py
+++ b/integrations/claude-code/scripts/_env_file.py
@@ -176,7 +176,7 @@ def forced_backend_with_source() -> tuple[str, str]:
 
 
 def forced_backend() -> str:
-    """"local", "cloud", or "" — the exported backend switch, if any."""
+    """ "local", "cloud", or "" — the exported backend switch, if any."""
     return forced_backend_with_source()[0]
 
 

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -6,10 +6,13 @@ they run on every user prompt / tool call.
 """
 
 import asyncio
+import errno
 import hashlib
 import json
 import os
+import socket
 import ssl
+import subprocess
 import sys
 import threading
 import time
@@ -1381,6 +1384,211 @@ def server_health_ok(service_url: str = "", timeout: float = 1.0) -> bool:
     (no verdict — keep prior state).
     """
     return probe_health(service_url, timeout=timeout) == "ready"
+
+
+# --- Server presence (boot-point evidence) -------------------------------------
+# probe_health cannot tell a BUSY server from an ABSENT one: both miss the HTTP
+# deadline, but only one of them may be installed/booted over. A server that is
+# busy (event loop saturated by a pipeline) misses a 2s probe exactly like a
+# dead one — and treating that as absence lets a boot point upgrade the venv
+# and run migrations UNDER a live server that still holds the graph store's
+# file lock. Presence is therefore judged from three evidence sources:
+#
+#   * HTTP probe    — probe_health; only a 200 is a self-sufficient verdict.
+#   * TCP listener  — a busy server still completes the TCP handshake in
+#     microseconds even when it cannot serve HTTP; a dead one refuses the
+#     connection. This is the busy-vs-dead discriminator.
+#   * server pidfile — written at uvicorn spawn; covers the window between
+#     spawn and port bind, when neither probe nor listener sees the server.
+#
+# The asymmetry is deliberate: extra evidence only ever ADDS presence (vetoing
+# a boot), and absence is only concluded from a positively refused port with no
+# live server pid — never from a timeout. A wrong "busy" delays a boot until
+# the next boot point; a wrong "absent" corrupts databases.
+
+PRESENCE_READY = "ready"  # HTTP 200: serving (lifespan migrations are done)
+PRESENCE_BUSY = "busy"  # evidence of a live server that is not serving
+PRESENCE_ABSENT = "absent"  # positively absent — the only install/boot license
+PRESENCE_UNKNOWN = "unknown"  # conflicting/insufficient evidence: treat as busy
+
+# Second-chance probe budget when confirming absence (see server_presence).
+_PRESENCE_REPROBE_TIMEOUT_SECONDS = 5.0
+
+
+def _presence_reprobe_delay() -> float:
+    """Pause before the absence-confirming re-probe. Read per call so tests
+    (and unusual deployments) can shrink it without re-importing the module."""
+    try:
+        return float(os.environ.get("COGNEE_PRESENCE_REPROBE_DELAY", "") or 3.0)
+    except ValueError:
+        return 3.0
+
+
+def _server_pidfile(port: int) -> Path:
+    # Shared root, not the per-integration dir: the server itself is
+    # machine-wide (one per port), whichever integration's boot point spawned it.
+    return _SHARED_PLUGIN_ROOT / f"server-{int(port)}.pid"
+
+
+def write_server_pidfile(port: int, pid: int, version: str = "") -> None:
+    """Record the uvicorn server spawned on ``port`` (presence evidence)."""
+    try:
+        _write_json_file(
+            _server_pidfile(port),
+            {
+                "pid": int(pid),
+                "port": int(port),
+                "version": version,
+                "created_at": datetime.now(timezone.utc).timestamp(),
+            },
+        )
+    except Exception as exc:
+        hook_log("server_pidfile_write_failed", {"error": str(exc)[:200]})
+
+
+def clear_server_pidfile(port: int) -> None:
+    try:
+        _server_pidfile(port).unlink()
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        hook_log("server_pidfile_clear_failed", {"error": str(exc)[:200]})
+
+
+def _pid_looks_like_server(pid: int) -> bool:
+    """Best-effort check that ``pid``'s command line still looks like the
+    cognee server (guards against OS pid reuse). When the command line cannot
+    be inspected (no ``ps``, permission trouble) err toward presence: pidfile
+    evidence is veto-only, so the cost of a wrong True is a delayed boot, and
+    it self-heals when the reused pid exits (``pid_alive`` gates before this)."""
+    try:
+        out = subprocess.run(
+            ["ps", "-p", str(int(pid)), "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        command = (out.stdout or "").strip().lower()
+        if not command:
+            return False
+        return "uvicorn" in command or "cognee" in command
+    except Exception:
+        return True
+
+
+def _live_server_pid(port: int) -> int:
+    """PID from the port's pidfile iff that process is alive and still looks
+    like the server; 0 otherwise. Stale records (dead or reused pid) are
+    reaped here so they can never veto boots forever."""
+    path = _server_pidfile(port)
+    try:
+        pid = int(json.loads(path.read_text(encoding="utf-8")).get("pid", 0) or 0)
+    except FileNotFoundError:
+        return 0
+    except Exception:
+        pid = 0
+    if pid > 0 and _proc.pid_alive(pid) and _pid_looks_like_server(pid):
+        return pid
+    try:
+        path.unlink()
+    except Exception:
+        pass
+    return 0
+
+
+def tcp_probe(host: str, port: int, timeout: float = 0.5) -> str:
+    """Classify the bare TCP handshake: 'listening' | 'refused' | 'no_verdict'.
+
+    'refused' is a positive signal from the OS that nothing holds the port —
+    the only transport answer that may contribute to an absence verdict.
+    Timeouts and filtered/odd socket states give no verdict, same as the HTTP
+    probe's rules.
+    """
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return "listening"
+    except ConnectionRefusedError:
+        return "refused"
+    except OSError as exc:
+        if getattr(exc, "errno", None) == errno.ECONNREFUSED:
+            return "refused"
+        return "no_verdict"
+    except Exception:
+        return "no_verdict"
+
+
+def _is_loopback_host(host: str) -> bool:
+    host = (host or "").lower()
+    return host in ("localhost", "::1") or host.startswith("127.")
+
+
+def server_presence(
+    service_url: str = "",
+    probe_timeout: float = 2.0,
+    confirm_absent: bool = True,
+) -> tuple[str, dict]:
+    """Classify whether a server exists at ``service_url`` from all local
+    evidence. Returns ``(verdict, evidence)``; the evidence dict is shaped for
+    hook_log so every boot decision records WHY it was made.
+
+    Only PRESENCE_ABSENT licenses installing or booting. ``confirm_absent``
+    adds one delayed, longer-budget re-probe before concluding absence — for
+    boot points about to install; pass False where a rigorous check follows
+    later anyway (e.g. mode selection, whose boot path re-verifies).
+
+    Local evidence (TCP, pidfile) only applies to loopback hosts: for remote
+    URLs the HTTP probe is all there is, and a non-ready remote is UNKNOWN —
+    never absent (nothing can boot a remote host anyway).
+    """
+    base = _normalize_service_url(service_url or _local_api_url())
+    evidence: dict = {"base_url": base}
+    if not base:
+        return PRESENCE_UNKNOWN, evidence
+    if "://" not in base:
+        base = f"http://{base}"
+
+    http_verdict = probe_health(base, timeout=probe_timeout)
+    evidence["http"] = http_verdict
+    if http_verdict == "ready":
+        return PRESENCE_READY, evidence
+
+    parsed = urllib.parse.urlsplit(base)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    if not _is_loopback_host(host):
+        return PRESENCE_UNKNOWN, evidence
+
+    tcp_verdict = tcp_probe(host, port)
+    evidence["tcp"] = tcp_verdict
+    if tcp_verdict == "listening":
+        # Alive but not serving HTTP within budget (busy, wedged, or answering
+        # non-200): a server exists. Never boot over it.
+        return PRESENCE_BUSY, evidence
+
+    pid = _live_server_pid(port)
+    if pid:
+        # Spawned but not (yet) bound to the port — starting up or tearing
+        # down. Either way a server process exists right now.
+        evidence["pid"] = pid
+        return PRESENCE_BUSY, evidence
+
+    if tcp_verdict != "refused":
+        return PRESENCE_UNKNOWN, evidence
+
+    if confirm_absent:
+        # Positively refused with no live pid. Give a recovering/just-starting
+        # server one more chance before licensing an install: the original
+        # incident had 37s between "live" and the probe that booted over it.
+        time.sleep(_presence_reprobe_delay())
+        retry_verdict = probe_health(base, timeout=_PRESENCE_REPROBE_TIMEOUT_SECONDS)
+        evidence["http_retry"] = retry_verdict
+        if retry_verdict == "ready":
+            return PRESENCE_READY, evidence
+        retry_tcp = tcp_probe(host, port)
+        if retry_tcp == "listening":
+            evidence["tcp_retry"] = retry_tcp
+            return PRESENCE_BUSY, evidence
+    return PRESENCE_ABSENT, evidence
 
 
 # Connection states recorded in the (shared) server-ready marker. "ready" means

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -33,18 +33,23 @@ from _plugin_common import (
     _VENV_DIR,
     _VENV_PYTHON,
     _VENV_READY_MARKER,
+    PRESENCE_ABSENT,
+    PRESENCE_READY,
     _https_context,
     _reexec_into_venv,
     apply_cognee_env,
+    clear_server_pidfile,
     ensure_launch_record,
     hook_log,
     probe_health,
     quiet_hook_output,
     resolve_session_key_from_payload,
+    server_presence,
     server_ready_hint,
     set_session_key,
     touch_activity,
     write_connection_state,
+    write_server_pidfile,
 )
 from _proc import find_host_ancestor_windows
 from _proc import pid_alive as _pid_alive
@@ -181,9 +186,12 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
     """Ensure the plugin venv exists and holds the pinned cognee version.
 
     Called from the server-boot critical section (so it is already
-    single-flighted) and only at boot points — i.e. when no healthy server is
-    serving. Always installs the exact pinned version (_PINNED_COGNEE_VERSION) so the
-    server's FastAPI lifespan migrations run on a known-good release.
+    single-flighted) and only at boot points where the server is POSITIVELY
+    absent (see server_presence) — a merely unresponsive server may be busy and
+    still holding the graph store's file lock, and upgrading the venv under it
+    corrupts the databases. Always installs the exact pinned version
+    (_PINNED_COGNEE_VERSION) so the server's FastAPI lifespan migrations run on
+    a known-good release.
 
     Fails soft: if the install can't run (e.g. offline) but a usable cognee is
     already present, returns True with whatever version is there. Returns False
@@ -378,12 +386,46 @@ def _ensure_local_server_running(
         _ready()
         return
 
-    # No server is serving and we're at a boot point: ensure the venv holds the
-    # latest cognee BEFORE booting, so the server's lifespan migrations run on
-    # the upgraded code. Single-flighted on its own (long) lock, separate from
-    # the short boot lock below, since a cold install can take minutes.
+    # A missed probe is NOT absence: a server that is busy (cognifying, event
+    # loop saturated) misses the health deadline exactly like a dead one, but
+    # only a dead one may be installed/booted over — a busy server still holds
+    # the graph store's file lock, and upgrading + migrating under it corrupts
+    # the databases (2026-08-13 incident). Only a positively-absent verdict
+    # from the full-evidence presence check licenses going further.
+    def _require_absent(stage: str) -> bool:
+        """True when the server turned out to be serving (caller returns);
+        raises unless it is positively absent."""
+        verdict, evidence = server_presence(service_url, confirm_absent=(stage == "pre_install"))
+        if verdict == PRESENCE_READY:
+            return True
+        if verdict != PRESENCE_ABSENT:
+            hook_log(
+                "boot_refused_server_present",
+                {"stage": stage, "verdict": verdict, **evidence},
+            )
+            raise RuntimeError(
+                f"server at {service_url} is present but not serving "
+                f"(verdict={verdict}, stage={stage}); refusing to install or boot over it"
+            )
+        return False
+
+    if _require_absent("pre_install"):
+        _ready()
+        return
+
+    # The server is positively absent and we're at a boot point: ensure the
+    # venv holds the latest cognee BEFORE booting, so the server's lifespan
+    # migrations run on the upgraded code. Single-flighted on its own (long)
+    # lock, separate from the short boot lock below, since a cold install can
+    # take minutes.
     if not ensure_cognee_installed():
         raise RuntimeError("cognee runtime unavailable (install/upgrade failed)")
+
+    # A cold install can take minutes — long enough for the world to change.
+    # Re-verify the premise before proceeding to the boot lock.
+    if _require_absent("post_install"):
+        _ready()
+        return
 
     owner = f"session-start:{os.getpid()}"
     acquired = False
@@ -425,7 +467,9 @@ def _ensure_local_server_running(
                     raise RuntimeError("server bootstrap lock timeout")
                 time.sleep(_SERVER_BOOT_LOCK_POLL_SECONDS)
 
-        if _health_ok(health_url):
+        # Final re-check under the lock: waiting for it may have taken a while,
+        # and only a still-absent server may be spawned over the port.
+        if _require_absent("in_lock"):
             _ready()
             return
 
@@ -435,17 +479,33 @@ def _ensure_local_server_running(
         # Run in agent mode: the server tears itself down once all registered
         # agents disconnect.
         server_env["COGNEE_AGENT_MODE"] = "true"
-        subprocess.Popen(
+        server_proc = subprocess.Popen(
             [str(_VENV_PYTHON), "-m", "uvicorn", "cognee.api.client:app", "--port", str(port)],
             env=server_env,
             start_new_session=True,
         )
+        # Presence evidence for future boot points: covers the spawn-to-bind
+        # window where neither the health probe nor the TCP listener sees it.
+        write_server_pidfile(port, server_proc.pid, version=_PINNED_COGNEE_VERSION)
 
         health_deadline = time.monotonic() + health_timeout
         while time.monotonic() < health_deadline:
             if _health_ok(health_url):
                 _ready()
                 return
+            exit_code = server_proc.poll()
+            if exit_code is not None:
+                clear_server_pidfile(port)
+                # An immediate exit is usually a failed port bind — something
+                # claimed the port between our absence check and the spawn. If
+                # that something is serving, connect to it instead of failing.
+                if _health_ok(health_url):
+                    _ready()
+                    return
+                raise RuntimeError(
+                    f"server process exited (rc={exit_code}) before becoming "
+                    f"healthy at {health_url}"
+                )
             time.sleep(_HEALTH_POLL_SECONDS)
 
         raise RuntimeError(
@@ -1408,11 +1468,32 @@ async def _start(payload: dict | None = None) -> dict:
     agent_api_key = ""
     # An empty target (forced cloud, no URL) must never boot: _is_local_url("")
     # parses to localhost, so gate on the URL being present at all.
-    server_live = bool(target_url) and _health_ok(_health_url(target_url))
+    # Local endpoints get the full-evidence presence check (quick form — the
+    # boot path re-verifies rigorously before any install), so the recorded
+    # decision distinguishes a busy server from an absent one. Remote endpoints
+    # keep the plain HTTP probe: there is no local evidence for them, and they
+    # are never booted. will_boot means "enter the local bootstrap path" — the
+    # actual install/boot license is enforced inside _ensure_local_server_running,
+    # so a busy server still gets a worker that waits for it instead of a boot.
+    presence_verdict, presence_evidence = "", {}
+    if target_url and _is_local_url(target_url):
+        presence_verdict, presence_evidence = server_presence(target_url, confirm_absent=False)
+        server_live = presence_verdict == PRESENCE_READY
+    else:
+        server_live = bool(target_url) and _health_ok(_health_url(target_url))
     will_boot = (not server_live) and bool(target_url) and _is_local_url(target_url)
     hook_log(
         "endpoint_mode_selected",
-        {"base_url": target_url, "server_live": server_live, "will_boot": will_boot},
+        {
+            "base_url": target_url,
+            "server_live": server_live,
+            "will_boot": will_boot,
+            **(
+                {"presence": presence_verdict, "evidence": presence_evidence}
+                if presence_verdict
+                else {}
+            ),
+        },
     )
     if will_boot and _LAZY_BOOTSTRAP:
         _spawn_bootstrap(config, cwd, session_id, agent_session_name, session_key, dataset)

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,6 +10,24 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.4.1]
+
+### Fixed
+- **Boot points no longer mistake a busy server for an absent one.** The boot
+  decision previously rested on a single 2s `/health` probe, so a server busy
+  cognifying could miss the deadline, be declared absent, and have the venv
+  upgraded and migrations run underneath it while it still held the graph
+  store's file lock (2026-08-13 incident). Server presence is now judged from
+  three evidence sources — the classified HTTP probe, the bare TCP handshake
+  (a busy server still accepts it; a dead one refuses), and a server pidfile
+  written at uvicorn spawn — and only a positively-absent verdict (refused
+  port, no live server pid, confirmed by a delayed re-probe) licenses
+  installing or booting. The verdict and its evidence are recorded on every
+  `endpoint_mode_selected` decision, the license is re-verified after the
+  (minutes-long) install and again under the boot lock, and a spawned server
+  that dies before becoming healthy (e.g. lost port-bind race) is detected
+  instead of being waited out.
+
 ## [1.4.0]
 
 ### Added

--- a/integrations/codex/plugins/cognee/scripts/_env_file.py
+++ b/integrations/codex/plugins/cognee/scripts/_env_file.py
@@ -176,7 +176,7 @@ def forced_backend_with_source() -> tuple[str, str]:
 
 
 def forced_backend() -> str:
-    """"local", "cloud", or "" — the exported backend switch, if any."""
+    """ "local", "cloud", or "" — the exported backend switch, if any."""
     return forced_backend_with_source()[0]
 
 

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -6,10 +6,13 @@ they run on every user prompt / tool call.
 """
 
 import asyncio
+import errno
 import hashlib
 import json
 import os
+import socket
 import ssl
+import subprocess
 import sys
 import threading
 import time
@@ -1363,6 +1366,211 @@ def server_health_ok(service_url: str = "", timeout: float = 1.0) -> bool:
     (no verdict — keep prior state).
     """
     return probe_health(service_url, timeout=timeout) == "ready"
+
+
+# --- Server presence (boot-point evidence) -------------------------------------
+# probe_health cannot tell a BUSY server from an ABSENT one: both miss the HTTP
+# deadline, but only one of them may be installed/booted over. A server that is
+# busy (event loop saturated by a pipeline) misses a 2s probe exactly like a
+# dead one — and treating that as absence lets a boot point upgrade the venv
+# and run migrations UNDER a live server that still holds the graph store's
+# file lock. Presence is therefore judged from three evidence sources:
+#
+#   * HTTP probe    — probe_health; only a 200 is a self-sufficient verdict.
+#   * TCP listener  — a busy server still completes the TCP handshake in
+#     microseconds even when it cannot serve HTTP; a dead one refuses the
+#     connection. This is the busy-vs-dead discriminator.
+#   * server pidfile — written at uvicorn spawn; covers the window between
+#     spawn and port bind, when neither probe nor listener sees the server.
+#
+# The asymmetry is deliberate: extra evidence only ever ADDS presence (vetoing
+# a boot), and absence is only concluded from a positively refused port with no
+# live server pid — never from a timeout. A wrong "busy" delays a boot until
+# the next boot point; a wrong "absent" corrupts databases.
+
+PRESENCE_READY = "ready"  # HTTP 200: serving (lifespan migrations are done)
+PRESENCE_BUSY = "busy"  # evidence of a live server that is not serving
+PRESENCE_ABSENT = "absent"  # positively absent — the only install/boot license
+PRESENCE_UNKNOWN = "unknown"  # conflicting/insufficient evidence: treat as busy
+
+# Second-chance probe budget when confirming absence (see server_presence).
+_PRESENCE_REPROBE_TIMEOUT_SECONDS = 5.0
+
+
+def _presence_reprobe_delay() -> float:
+    """Pause before the absence-confirming re-probe. Read per call so tests
+    (and unusual deployments) can shrink it without re-importing the module."""
+    try:
+        return float(os.environ.get("COGNEE_PRESENCE_REPROBE_DELAY", "") or 3.0)
+    except ValueError:
+        return 3.0
+
+
+def _server_pidfile(port: int) -> Path:
+    # Shared root, not the per-integration dir: the server itself is
+    # machine-wide (one per port), whichever integration's boot point spawned it.
+    return _SHARED_PLUGIN_ROOT / f"server-{int(port)}.pid"
+
+
+def write_server_pidfile(port: int, pid: int, version: str = "") -> None:
+    """Record the uvicorn server spawned on ``port`` (presence evidence)."""
+    try:
+        _write_json_file(
+            _server_pidfile(port),
+            {
+                "pid": int(pid),
+                "port": int(port),
+                "version": version,
+                "created_at": datetime.now(timezone.utc).timestamp(),
+            },
+        )
+    except Exception as exc:
+        hook_log("server_pidfile_write_failed", {"error": str(exc)[:200]})
+
+
+def clear_server_pidfile(port: int) -> None:
+    try:
+        _server_pidfile(port).unlink()
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        hook_log("server_pidfile_clear_failed", {"error": str(exc)[:200]})
+
+
+def _pid_looks_like_server(pid: int) -> bool:
+    """Best-effort check that ``pid``'s command line still looks like the
+    cognee server (guards against OS pid reuse). When the command line cannot
+    be inspected (no ``ps``, permission trouble) err toward presence: pidfile
+    evidence is veto-only, so the cost of a wrong True is a delayed boot, and
+    it self-heals when the reused pid exits (``pid_alive`` gates before this)."""
+    try:
+        out = subprocess.run(
+            ["ps", "-p", str(int(pid)), "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        command = (out.stdout or "").strip().lower()
+        if not command:
+            return False
+        return "uvicorn" in command or "cognee" in command
+    except Exception:
+        return True
+
+
+def _live_server_pid(port: int) -> int:
+    """PID from the port's pidfile iff that process is alive and still looks
+    like the server; 0 otherwise. Stale records (dead or reused pid) are
+    reaped here so they can never veto boots forever."""
+    path = _server_pidfile(port)
+    try:
+        pid = int(json.loads(path.read_text(encoding="utf-8")).get("pid", 0) or 0)
+    except FileNotFoundError:
+        return 0
+    except Exception:
+        pid = 0
+    if pid > 0 and _proc.pid_alive(pid) and _pid_looks_like_server(pid):
+        return pid
+    try:
+        path.unlink()
+    except Exception:
+        pass
+    return 0
+
+
+def tcp_probe(host: str, port: int, timeout: float = 0.5) -> str:
+    """Classify the bare TCP handshake: 'listening' | 'refused' | 'no_verdict'.
+
+    'refused' is a positive signal from the OS that nothing holds the port —
+    the only transport answer that may contribute to an absence verdict.
+    Timeouts and filtered/odd socket states give no verdict, same as the HTTP
+    probe's rules.
+    """
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return "listening"
+    except ConnectionRefusedError:
+        return "refused"
+    except OSError as exc:
+        if getattr(exc, "errno", None) == errno.ECONNREFUSED:
+            return "refused"
+        return "no_verdict"
+    except Exception:
+        return "no_verdict"
+
+
+def _is_loopback_host(host: str) -> bool:
+    host = (host or "").lower()
+    return host in ("localhost", "::1") or host.startswith("127.")
+
+
+def server_presence(
+    service_url: str = "",
+    probe_timeout: float = 2.0,
+    confirm_absent: bool = True,
+) -> tuple[str, dict]:
+    """Classify whether a server exists at ``service_url`` from all local
+    evidence. Returns ``(verdict, evidence)``; the evidence dict is shaped for
+    hook_log so every boot decision records WHY it was made.
+
+    Only PRESENCE_ABSENT licenses installing or booting. ``confirm_absent``
+    adds one delayed, longer-budget re-probe before concluding absence — for
+    boot points about to install; pass False where a rigorous check follows
+    later anyway (e.g. mode selection, whose boot path re-verifies).
+
+    Local evidence (TCP, pidfile) only applies to loopback hosts: for remote
+    URLs the HTTP probe is all there is, and a non-ready remote is UNKNOWN —
+    never absent (nothing can boot a remote host anyway).
+    """
+    base = _normalize_service_url(service_url or _local_api_url())
+    evidence: dict = {"base_url": base}
+    if not base:
+        return PRESENCE_UNKNOWN, evidence
+    if "://" not in base:
+        base = f"http://{base}"
+
+    http_verdict = probe_health(base, timeout=probe_timeout)
+    evidence["http"] = http_verdict
+    if http_verdict == "ready":
+        return PRESENCE_READY, evidence
+
+    parsed = urllib.parse.urlsplit(base)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    if not _is_loopback_host(host):
+        return PRESENCE_UNKNOWN, evidence
+
+    tcp_verdict = tcp_probe(host, port)
+    evidence["tcp"] = tcp_verdict
+    if tcp_verdict == "listening":
+        # Alive but not serving HTTP within budget (busy, wedged, or answering
+        # non-200): a server exists. Never boot over it.
+        return PRESENCE_BUSY, evidence
+
+    pid = _live_server_pid(port)
+    if pid:
+        # Spawned but not (yet) bound to the port — starting up or tearing
+        # down. Either way a server process exists right now.
+        evidence["pid"] = pid
+        return PRESENCE_BUSY, evidence
+
+    if tcp_verdict != "refused":
+        return PRESENCE_UNKNOWN, evidence
+
+    if confirm_absent:
+        # Positively refused with no live pid. Give a recovering/just-starting
+        # server one more chance before licensing an install: the original
+        # incident had 37s between "live" and the probe that booted over it.
+        time.sleep(_presence_reprobe_delay())
+        retry_verdict = probe_health(base, timeout=_PRESENCE_REPROBE_TIMEOUT_SECONDS)
+        evidence["http_retry"] = retry_verdict
+        if retry_verdict == "ready":
+            return PRESENCE_READY, evidence
+        retry_tcp = tcp_probe(host, port)
+        if retry_tcp == "listening":
+            evidence["tcp_retry"] = retry_tcp
+            return PRESENCE_BUSY, evidence
+    return PRESENCE_ABSENT, evidence
 
 
 # Connection states recorded in the (shared) server-ready marker. "ready" means

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -32,17 +32,22 @@ from _plugin_common import (
     _VENV_DIR,
     _VENV_PYTHON,
     _VENV_READY_MARKER,
+    PRESENCE_ABSENT,
+    PRESENCE_READY,
     _https_context,
     _reexec_into_venv,
     apply_cognee_env,
+    clear_server_pidfile,
     ensure_launch_record,
     hook_log,
     probe_health,
     quiet_hook_output,
     resolve_session_key_from_payload,
+    server_presence,
     set_session_key,
     touch_activity,
     write_connection_state,
+    write_server_pidfile,
 )
 from _proc import find_host_ancestor_windows
 from _proc import pid_alive as _pid_alive
@@ -180,9 +185,12 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
     """Ensure the shared plugin venv exists and holds the pinned cognee version.
 
     Called from the server-boot critical section (so it is already
-    single-flighted) and only at boot points — i.e. when no healthy server is
-    serving. Always installs the exact pinned version (_PINNED_COGNEE_VERSION) so the
-    server's FastAPI lifespan migrations run on a known-good release.
+    single-flighted) and only at boot points where the server is POSITIVELY
+    absent (see server_presence) — a merely unresponsive server may be busy and
+    still holding the graph store's file lock, and upgrading the venv under it
+    corrupts the databases. Always installs the exact pinned version
+    (_PINNED_COGNEE_VERSION) so the server's FastAPI lifespan migrations run on
+    a known-good release.
 
     Fails soft: if the install can't run (e.g. offline) but a usable cognee is
     already present, returns True with whatever version is there. Returns False
@@ -377,13 +385,46 @@ def _ensure_local_server_running(
         _ready()
         return
 
-    # No server is serving and we're at a boot point: ensure the shared venv
-    # holds the latest cognee BEFORE booting, so the server's lifespan
-    # migrations run on the upgraded code. Single-flighted on its own (long)
-    # lock, separate from the short boot lock below, since a cold install can
-    # take minutes.
+    # A missed probe is NOT absence: a server that is busy (cognifying, event
+    # loop saturated) misses the health deadline exactly like a dead one, but
+    # only a dead one may be installed/booted over — a busy server still holds
+    # the graph store's file lock, and upgrading + migrating under it corrupts
+    # the databases (2026-08-13 incident). Only a positively-absent verdict
+    # from the full-evidence presence check licenses going further.
+    def _require_absent(stage: str) -> bool:
+        """True when the server turned out to be serving (caller returns);
+        raises unless it is positively absent."""
+        verdict, evidence = server_presence(service_url, confirm_absent=(stage == "pre_install"))
+        if verdict == PRESENCE_READY:
+            return True
+        if verdict != PRESENCE_ABSENT:
+            hook_log(
+                "boot_refused_server_present",
+                {"stage": stage, "verdict": verdict, **evidence},
+            )
+            raise RuntimeError(
+                f"server at {service_url} is present but not serving "
+                f"(verdict={verdict}, stage={stage}); refusing to install or boot over it"
+            )
+        return False
+
+    if _require_absent("pre_install"):
+        _ready()
+        return
+
+    # The server is positively absent and we're at a boot point: ensure the
+    # shared venv holds the latest cognee BEFORE booting, so the server's
+    # lifespan migrations run on the upgraded code. Single-flighted on its own
+    # (long) lock, separate from the short boot lock below, since a cold
+    # install can take minutes.
     if not ensure_cognee_installed():
         raise RuntimeError("cognee runtime unavailable (install/upgrade failed)")
+
+    # A cold install can take minutes — long enough for the world to change.
+    # Re-verify the premise before proceeding to the boot lock.
+    if _require_absent("post_install"):
+        _ready()
+        return
 
     owner = f"session-start:{os.getpid()}"
     acquired = False
@@ -425,7 +466,9 @@ def _ensure_local_server_running(
                     raise RuntimeError("server bootstrap lock timeout")
                 time.sleep(_SERVER_BOOT_LOCK_POLL_SECONDS)
 
-        if _health_ok(health_url):
+        # Final re-check under the lock: waiting for it may have taken a while,
+        # and only a still-absent server may be spawned over the port.
+        if _require_absent("in_lock"):
             _ready()
             return
 
@@ -435,17 +478,33 @@ def _ensure_local_server_running(
         # We are spawning the server, so run it in agent mode: it tears itself
         # down once all registered agents disconnect.
         server_env["COGNEE_AGENT_MODE"] = "true"
-        subprocess.Popen(
+        server_proc = subprocess.Popen(
             [str(_VENV_PYTHON), "-m", "uvicorn", "cognee.api.client:app", "--port", str(port)],
             env=server_env,
             start_new_session=True,
         )
+        # Presence evidence for future boot points: covers the spawn-to-bind
+        # window where neither the health probe nor the TCP listener sees it.
+        write_server_pidfile(port, server_proc.pid, version=_PINNED_COGNEE_VERSION)
 
         health_deadline = time.monotonic() + health_timeout
         while time.monotonic() < health_deadline:
             if _health_ok(health_url):
                 _ready()
                 return
+            exit_code = server_proc.poll()
+            if exit_code is not None:
+                clear_server_pidfile(port)
+                # An immediate exit is usually a failed port bind — something
+                # claimed the port between our absence check and the spawn. If
+                # that something is serving, connect to it instead of failing.
+                if _health_ok(health_url):
+                    _ready()
+                    return
+                raise RuntimeError(
+                    f"server process exited (rc={exit_code}) before becoming "
+                    f"healthy at {health_url}"
+                )
             time.sleep(_HEALTH_POLL_SECONDS)
 
         raise RuntimeError(
@@ -1216,11 +1275,32 @@ async def _start(payload: dict | None = None) -> dict:
     agent_api_key = ""
     # An empty target (forced cloud, no URL) must never boot: _is_local_url("")
     # parses to localhost, so gate on the URL being present at all.
-    server_live = bool(target_url) and _health_ok(_health_url(target_url))
+    # Local endpoints get the full-evidence presence check (quick form — the
+    # boot path re-verifies rigorously before any install), so the recorded
+    # decision distinguishes a busy server from an absent one. Remote endpoints
+    # keep the plain HTTP probe: there is no local evidence for them, and they
+    # are never booted. will_boot means "enter the local bootstrap path" — the
+    # actual install/boot license is enforced inside _ensure_local_server_running,
+    # so a busy server still gets a worker that waits for it instead of a boot.
+    presence_verdict, presence_evidence = "", {}
+    if target_url and _is_local_url(target_url):
+        presence_verdict, presence_evidence = server_presence(target_url, confirm_absent=False)
+        server_live = presence_verdict == PRESENCE_READY
+    else:
+        server_live = bool(target_url) and _health_ok(_health_url(target_url))
     will_boot = (not server_live) and bool(target_url) and _is_local_url(target_url)
     hook_log(
         "endpoint_mode_selected",
-        {"base_url": target_url, "server_live": server_live, "will_boot": will_boot},
+        {
+            "base_url": target_url,
+            "server_live": server_live,
+            "will_boot": will_boot,
+            **(
+                {"presence": presence_verdict, "evidence": presence_evidence}
+                if presence_verdict
+                else {}
+            ),
+        },
     )
     if will_boot and _LAZY_BOOTSTRAP:
         _spawn_bootstrap(config, cwd, session_id, agent_session_name, session_key, dataset)

--- a/integrations/tests/tests/integration/test_server_presence.py
+++ b/integrations/tests/tests/integration/test_server_presence.py
@@ -1,0 +1,173 @@
+"""server_presence — the boot-point busy-vs-dead discriminator.
+
+Regression suite for the 2026-08-13 incident: a server busy cognifying missed
+one 2s health probe, was declared absent, and the boot point upgraded the venv
+and ran migrations under it while it held the graph store's file lock. The
+presence check exists so that a missed probe is never treated as absence:
+absence must be positively proven (refused port, no live server pid, confirmed
+by a delayed re-probe), while any evidence of a live server — a TCP listener,
+a non-200 answer, a live spawned pid — vetoes installing or booting.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import threading
+
+import pytest
+
+
+@pytest.fixture
+def pc(suite, isolated_modules, monkeypatch):
+    common = isolated_modules(suite, "_plugin_common")
+    monkeypatch.setattr(common, "hook_log", lambda *a, **k: None)
+    # Keep the absence-confirming re-probe fast (read per call, not at import).
+    monkeypatch.setenv("COGNEE_PRESENCE_REPROBE_DELAY", "0.05")
+    return common
+
+
+@pytest.fixture
+def stalled_server_url():
+    """A TCP listener that accepts connections but never answers HTTP —
+    a saturated/wedged server as the probe sees it."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("127.0.0.1", 0))
+    server.listen(5)
+    accepted: list[socket.socket] = []
+
+    def _accept_forever():
+        while True:
+            try:
+                conn, _ = server.accept()
+                accepted.append(conn)
+            except OSError:
+                return
+
+    threading.Thread(target=_accept_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{server.getsockname()[1]}"
+    for conn in accepted:
+        conn.close()
+    server.close()
+
+
+def _port_of(url: str) -> int:
+    return int(url.rsplit(":", 1)[1])
+
+
+def test_serving_server_is_ready(pc, mock_server):
+    verdict, evidence = pc.server_presence(mock_server.url)
+    assert verdict == pc.PRESENCE_READY
+    assert evidence["http"] == "ready"
+
+
+def test_stalled_server_is_busy_never_absent(pc, stalled_server_url):
+    """The incident case: HTTP probe times out, but the listener proves a
+    server exists. Must be BUSY (boot veto), not ABSENT (boot license)."""
+    verdict, evidence = pc.server_presence(stalled_server_url, probe_timeout=0.2)
+    assert verdict == pc.PRESENCE_BUSY
+    assert evidence["http"] == "slow"
+    assert evidence["tcp"] == "listening"
+
+
+def test_erroring_server_is_busy_not_absent(pc, mock_server):
+    """A 500 from /health means alive-but-unwell: never a boot license."""
+    mock_server.set_health_status(500)
+    verdict, evidence = pc.server_presence(mock_server.url)
+    assert verdict == pc.PRESENCE_BUSY
+    assert evidence["tcp"] == "listening"
+
+
+def test_refused_port_is_absent_after_confirmation(pc, closed_port_url):
+    verdict, evidence = pc.server_presence(closed_port_url, probe_timeout=0.2)
+    assert verdict == pc.PRESENCE_ABSENT
+    assert evidence["tcp"] == "refused"
+    # Absence was confirmed by the delayed second probe, not assumed from one.
+    assert "http_retry" in evidence
+
+
+def test_quick_form_skips_the_confirming_reprobe(pc, closed_port_url):
+    verdict, evidence = pc.server_presence(closed_port_url, probe_timeout=0.2, confirm_absent=False)
+    assert verdict == pc.PRESENCE_ABSENT
+    assert "http_retry" not in evidence
+
+
+def test_remote_host_is_never_absent(pc):
+    """No local evidence exists for remote hosts: a non-answering remote is
+    UNKNOWN (degrade), never ABSENT (nothing can boot a remote host)."""
+    verdict, _ = pc.server_presence("http://cognee-nonexistent.invalid:9", probe_timeout=0.2)
+    assert verdict == pc.PRESENCE_UNKNOWN
+
+
+def test_live_spawned_pid_vetoes_boot_before_port_bind(pc, closed_port_url, monkeypatch):
+    """Between uvicorn spawn and port bind, the pidfile is the only evidence."""
+    port = _port_of(closed_port_url)
+    pc.write_server_pidfile(port, os.getpid())
+    monkeypatch.setattr(pc, "_pid_looks_like_server", lambda pid: True)
+    verdict, evidence = pc.server_presence(closed_port_url, probe_timeout=0.2, confirm_absent=False)
+    assert verdict == pc.PRESENCE_BUSY
+    assert evidence["pid"] == os.getpid()
+
+
+def test_dead_pidfile_cannot_veto_and_is_reaped(pc, closed_port_url):
+    dead_pid = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead_pid.wait()
+    port = _port_of(closed_port_url)
+    pc.write_server_pidfile(port, dead_pid.pid)
+    verdict, _ = pc.server_presence(closed_port_url, probe_timeout=0.2, confirm_absent=False)
+    assert verdict == pc.PRESENCE_ABSENT
+    assert not pc._server_pidfile(port).exists()
+
+
+def test_reused_pid_running_something_else_is_ignored(pc, closed_port_url, monkeypatch):
+    """OS pid reuse: a live pid whose command line is not the server must not
+    veto boots (a stale record vetoing forever would strand the plugin)."""
+    port = _port_of(closed_port_url)
+    pc.write_server_pidfile(port, os.getpid())
+    monkeypatch.setattr(pc, "_pid_looks_like_server", lambda pid: False)
+    verdict, _ = pc.server_presence(closed_port_url, probe_timeout=0.2, confirm_absent=False)
+    assert verdict == pc.PRESENCE_ABSENT
+    assert not pc._server_pidfile(port).exists()
+
+
+# --- The boot point itself ----------------------------------------------------
+
+
+@pytest.fixture
+def session_start(suite, hook_module, monkeypatch):
+    module = hook_module(suite, "session-start.py")
+    monkeypatch.setattr(module, "hook_log", lambda *a, **k: None)
+    monkeypatch.setenv("COGNEE_PRESENCE_REPROBE_DELAY", "0.05")
+    return module
+
+
+def test_boot_point_refuses_install_over_busy_server(
+    session_start, stalled_server_url, monkeypatch
+):
+    """THE regression test: a live-but-unresponsive server at a boot point must
+    abort — never upgrade the venv (and so never run migrations) under it."""
+    installs: list[int] = []
+    monkeypatch.setattr(
+        session_start, "ensure_cognee_installed", lambda *a, **k: installs.append(1) or True
+    )
+    with pytest.raises(RuntimeError, match="present but not serving"):
+        session_start._ensure_local_server_running(
+            {"base_url": stalled_server_url}, health_timeout=1.0
+        )
+    assert not installs
+
+
+def test_boot_point_proceeds_when_positively_absent(session_start, closed_port_url, monkeypatch):
+    """A genuinely absent server still licenses the install path (returning
+    False there stops the flow before any uvicorn spawn)."""
+    installs: list[int] = []
+    monkeypatch.setattr(
+        session_start, "ensure_cognee_installed", lambda *a, **k: installs.append(1) or False
+    )
+    with pytest.raises(RuntimeError, match="install/upgrade failed"):
+        session_start._ensure_local_server_running(
+            {"base_url": closed_port_url}, health_timeout=1.0
+        )
+    assert installs


### PR DESCRIPTION
This PR makes a more robust check for server liveness, and uses it in more places, crucially in session-start.