### PR TITLE
fix(hermes-agent): prevent and surface Ollama embedding-context overflow

### DIFF
--- a/integrations/hermes-agent/.env.example
+++ b/integrations/hermes-agent/.env.example
@@ -1,0 +1,31 @@
+# Cognee memory for Hermes — copy these lines into $HERMES_HOME/.env.
+# Hermes loads that file every session, so the cognee server the plugin spawns
+# inherits them. cognee reads these at runtime.
+# Defaults to OpenAI (cognee's default provider); fill in your key.
+LLM_API_KEY=
+LLM_MODEL=gpt-4o-mini
+
+# --- Optional: run locally and for free via Ollama (`ollama serve`) ---
+# Requires cognee's ollama extra: pip install "cognee[ollama]"
+# LLM_PROVIDER=ollama
+# LLM_MODEL=llama3.2:1b
+# LLM_ENDPOINT=http://localhost:11434/v1
+# LLM_API_KEY=ollama
+# EMBEDDING_PROVIDER=ollama
+# EMBEDDING_MODEL=all-minilm
+# EMBEDDING_ENDPOINT=http://localhost:11434/api/embed
+# EMBEDDING_DIMENSIONS=384
+# The two below are pinned automatically for recognized Ollama models — set them
+# yourself for anything else. The token ceiling MUST stay at or below the
+# embedding model's context length (`ollama show <model>`): above it, cognee
+# mean-pools overflowing texts into lossy vectors while reporting success, and
+# retrieval quietly degrades. See README "Local models via Ollama".
+# EMBEDDING_MAX_COMPLETION_TOKENS=256
+# HUGGINGFACE_TOKENIZER=sentence-transformers/all-MiniLM-L6-v2
+
+# --- Optional: per-operation deadlines (seconds) ---
+# GRAPH_COMPLETION recall runs an LLM per query and can be slow on local models;
+# search_type=CHUNKS is the fast alternative before raising this.
+# COGNEE_RECALL_TIMEOUT=120
+# COGNEE_WRITE_TIMEOUT=120
+# COGNEE_IMPROVE_TIMEOUT=300

--- a/integrations/hermes-agent/CHANGELOG.md
+++ b/integrations/hermes-agent/CHANGELOG.md
@@ -10,6 +10,40 @@ The version must match the `version` field in both `pyproject.toml` and
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0]
+
+Hardens the plugin against silently corrupted search indexes with local Ollama
+embedding models (live-diagnosed on a meeting-notes ingestion: the pipeline
+reported success on every document while all retrieval timed out). cognee sizes
+its chunks from `EMBEDDING_MAX_COMPLETION_TOKENS`, whose 8191 default is far
+above any local embedding model's context; every substantial text overflowed
+Ollama, and cognee mean-pooled the pieces into lossy vectors while still
+reporting success — the only trace an `Ollama embedding error` line in the
+server log.
+
+### Added
+
+- **Safe embedding defaults at server spawn.** With `EMBEDDING_PROVIDER=ollama`,
+  the spawned server (and embedded mode) now gets a context-matched
+  `EMBEDDING_MAX_COMPLETION_TOKENS` for recognized models (`all-minilm`,
+  `nomic-embed-text`, `mxbai-embed-large`, `bge-m3`, and others — a conservative
+  512 for anything unrecognized) plus the matching `HUGGINGFACE_TOKENIZER`, so
+  cognee chunks within the model's real limits. Explicit values always win; no
+  effect on other providers.
+- **Overflow surfacing.** The HTTP transport tails the spawned server's log
+  between calls; a fresh embedding-context overflow now lands in the tool
+  envelope — a `warning` on results/successful writes, an `error` on an empty
+  recall — naming the env levers and the recovery runbook, instead of degrading
+  silently.
+- **Timeout advice.** A timed-out recall error now says why it is likely slow
+  (GRAPH_COMPLETION runs an LLM per query) and what to do (`search_type=CHUNKS`,
+  `scope=session`, or `COGNEE_RECALL_TIMEOUT`); the `search_type` tool schema
+  explains the CHUNKS/GRAPH_COMPLETION trade-off so the model can self-route.
+- **Docs.** `RUNBOOK.md` (pause ingestion → fix env → restart server → rebuild
+  dataset → verify → resume), `.env.example`, a README section on Ollama
+  embedding settings, and README rows for the previously undocumented
+  `COGNEE_RECALL_TIMEOUT` / `COGNEE_WRITE_TIMEOUT` / `COGNEE_IMPROVE_TIMEOUT`.
+
 ## [1.0.0]
 
 First stable release, published to PyPI. Moves the provider onto cognee's REST

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -263,6 +263,9 @@ LLM_API_KEY=sk-...
 | `server_boot_timeout` | `COGNEE_SERVER_BOOT_TIMEOUT` | `600` |
 | `data_root` | `COGNEE_DATA_ROOT` | `~/.cognee/data` |
 | `system_root` | `COGNEE_SYSTEM_ROOT` | `~/.cognee/system` |
+| `recall_timeout` | `COGNEE_RECALL_TIMEOUT` | `120` (seconds) |
+| `write_timeout` | `COGNEE_WRITE_TIMEOUT` | `120` (seconds) |
+| `improve_timeout` | `COGNEE_IMPROVE_TIMEOUT` | `300` (seconds) |
 
 > **Storage is shared, and a server is per port.** The roots above are the ones
 > every cognee agent plugin pins, so the store is the same no matter which plugin
@@ -293,6 +296,55 @@ LLM_API_KEY=sk-...
 > cloud/remote server nothing here can shut down; on a local server it
 > reintroduces the race above), `false` blocks Hermes' exit until the build
 > finishes.
+
+## Local models via Ollama: embedding settings
+
+Ollama embeddings need cognee's `ollama` extra — `pip install "cognee[ollama]"`
+— which brings the `transformers` package the token counting depends on; with
+plain `cognee` the embedding engine fails to construct at all.
+
+cognee reads these standard variables (put them in `$HERMES_HOME/.env` — Hermes
+loads it every session, so the spawned server inherits them; see
+[.env.example](./.env.example)):
+
+| Env var | Meaning |
+| --- | --- |
+| `EMBEDDING_PROVIDER` | `ollama` for a local embedder |
+| `EMBEDDING_MODEL` | e.g. `all-minilm`, `nomic-embed-text` |
+| `EMBEDDING_ENDPOINT` | usually `http://localhost:11434/api/embed` |
+| `EMBEDDING_DIMENSIONS` | the model's vector size (e.g. `384` for all-minilm) |
+| `EMBEDDING_MAX_COMPLETION_TOKENS` | **must be ≤ the model's context length** |
+| `HUGGINGFACE_TOKENIZER` | the HF tokenizer matching the model, used to count tokens |
+
+**Why the token ceiling matters.** cognee sizes its text chunks from
+`EMBEDDING_MAX_COMPLETION_TOKENS`, and its default (8191) is far above any local
+embedding model's real context. Every substantial document then overflows the
+model; cognee splits the text and **mean-pools the vectors while still reporting
+success**, so the pipeline completes but the search index quietly fills with
+lossy embeddings and retrieval degrades — the only trace is an
+`Ollama embedding error` line in `~/.cognee-plugin/hermes/server.log`. Worse,
+recent Ollama versions default to *silently truncating* oversized inputs, so
+depending on the Ollama version the index degrades with no log line at all —
+which is why a correct token ceiling matters even when the log is clean.
+
+The plugin therefore pins safe defaults at server spawn when
+`EMBEDDING_PROVIDER=ollama`: a context-matched
+`EMBEDDING_MAX_COMPLETION_TOKENS` (a conservative 512 for models it does not
+recognize) and, for recognized models, the matching `HUGGINGFACE_TOKENIZER`.
+Explicit values always win over the pins. When the plugin detects an overflow in
+the server log anyway, recall/remember results carry a `warning`/`error` naming
+these levers.
+
+> **Pins apply at server spawn.** A cognee server already running on the port
+> keeps the environment it was started with — after changing embedding settings,
+> stop that server (it is shared with the other cognee plugins) so the next
+> session respawns it. An index written with wrong settings stays wrong until
+> the dataset is rebuilt: follow [RUNBOOK.md](./RUNBOOK.md).
+
+**If recall is slow or times out**: the default `GRAPH_COMPLETION` search runs
+an LLM per query, which local models make slow. `search_type=CHUNKS` returns
+matching stored text directly with no LLM in the loop; `COGNEE_RECALL_TIMEOUT`
+raises the deadline.
 
 ## Hermes Commands
 

--- a/integrations/hermes-agent/RUNBOOK.md
+++ b/integrations/hermes-agent/RUNBOOK.md
@@ -1,0 +1,74 @@
+# Runbook: recovering from a degraded search index (Ollama embedding overflow)
+
+**Symptoms.** Ingestion reports success and the dataset says processing
+completed, but semantic retrieval returns nothing useful or times out, and the
+server log shows repeated `Ollama embedding error: input length exceeds …`
+lines:
+
+```bash
+grep -i "ollama embedding error" ~/.cognee-plugin/hermes/server.log
+```
+
+**Cause.** cognee sized its chunks from an `EMBEDDING_MAX_COMPLETION_TOKENS`
+above the embedding model's real context length. Every oversized text overflowed
+the model; cognee split it and mean-pooled the vectors while still reporting
+success, so the vector index filled with lossy embeddings. Writes made after the
+env is fixed are fine — but everything already written with the wrong settings
+stays wrong until re-embedded, which is why the rebuild below is not optional.
+
+## Recovery
+
+1. **Pause ingestion.** Stop any backfill cron/batch job feeding the affected
+   dataset before touching anything else — new writes during the rebuild would
+   mix good and bad vectors again.
+
+2. **Fix the embedding env** in `$HERMES_HOME/.env` (see
+   [.env.example](./.env.example)). The ceiling must be at or below the model's
+   context length (`ollama show <model>`), and the tokenizer must match the
+   model:
+
+   ```bash
+   EMBEDDING_MAX_COMPLETION_TOKENS=256   # all-minilm; 2048 for nomic-embed-text
+   HUGGINGFACE_TOKENIZER=sentence-transformers/all-MiniLM-L6-v2
+   ```
+
+   For the models the plugin recognizes, these pins are applied automatically at
+   server spawn — this step is only needed for other models, or to override.
+
+3. **Stop the running cognee server** so the new env applies at respawn — a
+   server keeps the environment it was started with:
+
+   ```bash
+   curl -s http://127.0.0.1:8011/health   # confirm which port your server owns
+   lsof -ti :8011 | xargs kill            # adjust the port if you changed COGNEE_LOCAL_PORT
+   ```
+
+   > The 8011 server is **shared with the other cognee plugins** (Claude Code,
+   > Codex, OpenClaw). Stop it when their sessions are idle; they respawn it on
+   > their next use.
+
+4. **Rebuild the affected dataset.** Delete it and re-ingest the sources —
+   re-running ingestion without deleting re-embeds nothing:
+
+   - via the tool: `cognee_forget` with the dataset name, then re-`remember`
+     each source record;
+   - or over HTTP: `POST /api/v1/forget` with `{"dataset": "<name>"}`, then
+     `POST /api/v1/remember` per record.
+
+5. **Verify before resuming.** All three must hold:
+
+   - no new `Ollama embedding error` lines appear in
+     `~/.cognee-plugin/hermes/server.log` during re-ingestion;
+   - a `cognee_recall` with `search_type=CHUNKS` for known content returns the
+     stored text within seconds;
+   - a default (`GRAPH_COMPLETION`) recall returns a cited answer within your
+     `COGNEE_RECALL_TIMEOUT`.
+
+6. **Resume ingestion** (restart the backfill job) only once step 5 passes.
+
+## If recall is slow but the index is healthy
+
+The default `GRAPH_COMPLETION` search runs an LLM per query — slow on local
+models even with a good index. Use `search_type=CHUNKS` for fast raw-text
+retrieval, scope the query with `scope=session` when the answer is in the
+current conversation, or raise `COGNEE_RECALL_TIMEOUT`.

--- a/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/plugin.yaml
+++ b/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/plugin.yaml
@@ -1,6 +1,6 @@
 name: cognee
 kind: exclusive
-version: 1.0.0
+version: 1.1.0
 description: "Cognee memory provider for Hermes Agent: session-aware graph memory, recall, forget, and session-end improvement."
 pip_dependencies:
   # Floor 1.2.1: the HTTP wire contract this plugin depends on

--- a/integrations/hermes-agent/cognee_integration_hermes/backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/backend.py
@@ -25,7 +25,7 @@ import os
 import threading
 from typing import Any, Optional
 
-from .config import str_to_bool
+from .config import ollama_embedding_pins, str_to_bool
 
 logger = logging.getLogger(__name__)
 
@@ -144,6 +144,17 @@ class MemoryBackend:
         """
         return None
 
+    def overflow_hint(self) -> Optional[str]:
+        """Evidence the server's embedder is truncating/pooling oversized inputs,
+        or None. Best-effort: never raises.
+
+        Only the HTTP transport against a *local* server can answer — it reads
+        the server log this plugin spawned. In-process transports keep the
+        default: an embedding failure there raises in this process and needs no
+        after-the-fact detection.
+        """
+        return None
+
 
 class _AsyncBridge:
     """Run cognee's async SDK from the provider's synchronous interface."""
@@ -219,6 +230,12 @@ class SdkBackend(MemoryBackend):
         # server gets the same flags in server_bootstrap._spawn. setdefault so an
         # explicit user value wins.
         for key, value in (("CACHING", "true"), ("AUTO_FEEDBACK", "true")):
+            os.environ.setdefault(key, value)
+        # Embedded mode builds cognee's (lru-cached) embedding config in this
+        # process, so the Ollama overflow protection has to land before the
+        # first cognee call — same pins the spawned server gets in
+        # server_bootstrap._spawn, see ollama_embedding_pins.
+        for key, value in ollama_embedding_pins(os.environ).items():
             os.environ.setdefault(key, value)
         try:
             import cognee

--- a/integrations/hermes-agent/cognee_integration_hermes/config.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +48,100 @@ def str_to_int(value: Any, default: int) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+# Context-length ceilings for the Ollama embedding models we recognize, verified
+# against ``ollama show <model>`` ("context length"). Values may sit below a
+# model's true context (e.g. sfr-embedding-mistral takes 32k): a low ceiling only
+# makes chunks smaller, which is always safe — see ollama_embedding_pins.
+_OLLAMA_MODEL_CONTEXT = {
+    "all-minilm": 256,
+    "nomic-embed-text": 2048,
+    "mxbai-embed-large": 512,
+    "bge-m3": 8192,
+    "embeddinggemma": 2048,
+    "qwen3-embedding": 8192,
+    "snowflake-arctic-embed": 512,
+    "snowflake-arctic-embed2": 8192,
+    "sfr-embedding-mistral": 2048,
+}
+# What a model NOT in this table gets: cognee's own OllamaEmbeddingEngine default,
+# small enough for every embedding model Ollama distributes.
+_OLLAMA_UNKNOWN_MODEL_CONTEXT = 512
+
+# The HuggingFace tokenizer matching each recognized model, used by cognee to
+# count tokens when sizing chunks. Only models whose tokenizer repo is public and
+# unambiguous are listed — a wrong tokenizer miscounts tokens and can reintroduce
+# the very overflow these pins exist to prevent, so unknown models get
+# documentation, never a guess.
+_OLLAMA_MODEL_TOKENIZER = {
+    "all-minilm": "sentence-transformers/all-MiniLM-L6-v2",
+    "nomic-embed-text": "nomic-ai/nomic-embed-text-v1.5",
+    "mxbai-embed-large": "mixedbread-ai/mxbai-embed-large-v1",
+    "bge-m3": "BAAI/bge-m3",
+    "qwen3-embedding": "Qwen/Qwen3-Embedding-0.6B",
+    "sfr-embedding-mistral": "Salesforce/SFR-Embedding-Mistral",
+}
+
+
+def _normalize_ollama_model(model: str) -> str:
+    """``ollama/nomic-embed-text:latest`` -> ``nomic-embed-text``."""
+    name = str(model or "").strip().lower()
+    if name.startswith("ollama/"):
+        name = name[len("ollama/") :]
+    return name.rsplit(":", 1)[0]
+
+
+def _lookup_ollama_model(table: dict[str, Any], model: str) -> Any:
+    """Exact table hit, else the longest key contained in the model name.
+
+    Substring matching absorbs registry namespaces (``avr/sfr-embedding-mistral``)
+    and size suffixes (``nomic-embed-text-v1.5``); longest-first keeps
+    ``snowflake-arctic-embed2`` from resolving to ``snowflake-arctic-embed``.
+    """
+    if model in table:
+        return table[model]
+    for key in sorted(table, key=len, reverse=True):
+        if key in model:
+            return table[key]
+    return None
+
+
+def ollama_embedding_pins(env: Mapping[str, str]) -> dict[str, str]:
+    """Embedding env defaults that keep a local Ollama embedder from silently
+    corrupting the search index. Empty unless ``EMBEDDING_PROVIDER=ollama``.
+
+    Why these exist (live-diagnosed on a meeting-notes ingestion): with
+    ``EMBEDDING_PROVIDER=ollama`` and nothing else set, cognee sizes cognify
+    chunks from ``EMBEDDING_MAX_COMPLETION_TOKENS`` (default 8191) — far above
+    any local embedding model's real context — so every substantial document
+    overflows. Ollama answers "input exceeds context length"; cognee's
+    OllamaEmbeddingEngine then splits the text into overlapping thirds and
+    MEAN-POOLS the two vectors, returning success. The pipeline reports
+    completed while the vector index quietly fills with lossy embeddings, and
+    retrieval degrades with no error anywhere but the server log. Capping the
+    token ceiling at the model's true context (the tokenizer pin makes the
+    token *count* trustworthy) makes cognee chunk within the model's limits
+    instead. A ceiling below the model's context only makes chunks smaller —
+    safe — which is why unknown models get a conservative 512 rather than
+    nothing.
+
+    Keys the caller's ``env`` already has are omitted (callers also apply these
+    with ``setdefault``): an explicit user value always wins.
+    """
+    provider = str(env.get("EMBEDDING_PROVIDER") or "").strip().lower()
+    if provider != "ollama":
+        return {}
+    model = _normalize_ollama_model(env.get("EMBEDDING_MODEL") or "")
+    pins: dict[str, str] = {}
+    if "EMBEDDING_MAX_COMPLETION_TOKENS" not in env:
+        context = _lookup_ollama_model(_OLLAMA_MODEL_CONTEXT, model)
+        pins["EMBEDDING_MAX_COMPLETION_TOKENS"] = str(context or _OLLAMA_UNKNOWN_MODEL_CONTEXT)
+    if "HUGGINGFACE_TOKENIZER" not in env:
+        tokenizer = _lookup_ollama_model(_OLLAMA_MODEL_TOKENIZER, model)
+        if tokenizer:
+            pins["HUGGINGFACE_TOKENIZER"] = str(tokenizer)
+    return pins
 
 
 def resolve_hermes_home(hermes_home: str | Path | None = None) -> Path | None:

--- a/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
@@ -69,6 +69,34 @@ DEFAULT_USER_EMAIL = "default_user@example.com"
 DEFAULT_USER_PASSWORD = "default_password"
 _API_KEY_NAME = "hermes-owner-bootstrap"
 
+# Log lines that betray an embedding-context overflow on the server. Grounded in
+# cognee's OllamaEmbeddingEngine: it logs "Ollama embedding error: <msg>" for the
+# raw Ollama refusal (whose msg says the input/context length was exceeded) and
+# raises "Text too long for embedding model" — then splits the text and
+# mean-pools the vectors, reporting success. The log line is the only trace.
+# Matched case-insensitively. Deliberately narrow: generic phrases like
+# "context window" would also match LLM-side errors this hint misdescribes.
+_OVERFLOW_MARKERS = (
+    "ollama embedding error",
+    "text too long for embedding model",
+    "exceeds context length",
+    "input length exceeds",
+)
+# At most this many appended bytes are scanned per call, so a log that exploded
+# between calls (uvicorn tracebacks, request logging) stays cheap to check.
+_OVERFLOW_SCAN_CAP = 512 * 1024
+
+_OVERFLOW_HINT = (
+    "The cognee server logged an embedding-context overflow: input sent to the "
+    "Ollama embedding model exceeded its context length. cognee splits and "
+    "mean-pools such texts into lossy vectors while the write still reports "
+    "success, so the search index degrades silently. Set "
+    "EMBEDDING_MAX_COMPLETION_TOKENS to at most the embedding model's context "
+    "length (and HUGGINGFACE_TOKENIZER to its matching tokenizer), restart the "
+    "cognee server so the new values apply, and rebuild affected datasets — see "
+    "RUNBOOK.md in the cognee-integration-hermes-agent package."
+)
+
 
 class CogneeHttpError(RuntimeError):
     """The server was reached and rejected the request.
@@ -147,6 +175,7 @@ class HttpBackend(MemoryBackend):
         cache_dir: Optional[str] = None,
         opener=None,
         agent_session_name: str = "hermes",
+        server_log_path: Optional[str] = None,
     ):
         self.url = ""
         self.api_key = ""
@@ -156,6 +185,10 @@ class HttpBackend(MemoryBackend):
         self._agent_session_name = agent_session_name
         self._ssl_context: Optional[ssl.SSLContext] = None
         self._warned: set[str] = set()
+        # Overflow scan state (see overflow_hint). The log path is injectable for
+        # tests; None means "resolve the spawned server's default at connect()".
+        self._server_log_path = server_log_path
+        self._log_offset: Optional[int] = None
 
     # -- transport ---------------------------------------------------------
 
@@ -242,6 +275,7 @@ class HttpBackend(MemoryBackend):
         """
         self.url = url.rstrip("/")
         self.api_key = ""
+        self._init_overflow_scan()
 
         health = self._request("GET", "/health", timeout=min(timeout, 10.0))
         del health  # any 2xx is healthy; body shape is not part of the contract
@@ -312,6 +346,62 @@ class HttpBackend(MemoryBackend):
             logger.debug("cognee agent unregistration failed: %s", exc)
         finally:
             self.registered = False
+
+    # -- diagnostics ---------------------------------------------------------
+
+    def _init_overflow_scan(self) -> None:
+        """Arm the overflow scan for a local server; disarm it for anything else.
+
+        The offset starts at the log's current end, so errors left behind by
+        earlier sessions can never fire a hint in this one — only what the
+        server logs from now on counts. Never raises.
+        """
+        self._log_offset = None
+        if not _is_local_url(self.url):
+            # A remote server's log is not on this filesystem — nothing to scan.
+            return
+        try:
+            if self._server_log_path is None:
+                from .server_bootstrap import default_server_log_path
+
+                self._server_log_path = default_server_log_path()
+            try:
+                self._log_offset = os.path.getsize(self._server_log_path)
+            except OSError:
+                self._log_offset = 0  # no log yet; scan from its first byte
+        except Exception:
+            self._log_offset = None
+
+    def overflow_hint(self) -> Optional[str]:
+        """An actionable warning when the server logged an embedding-context
+        overflow since the last check, else None.
+
+        cognee reports success for the write while the vector index quietly
+        degrades (see _OVERFLOW_MARKERS), so the server log is the only place
+        the failure is visible — and the provider surfaces this hint in the
+        tool envelope instead. The offset advances every call, so one batch of
+        errors produces exactly one hint. Best-effort: never raises.
+        """
+        if self._log_offset is None or not self._server_log_path:
+            return None
+        try:
+            size = os.path.getsize(self._server_log_path)
+            offset = self._log_offset
+            if size < offset:
+                offset = 0  # the log was truncated or rotated; rescan from the top
+            if size == offset:
+                return None
+            start = max(offset, size - _OVERFLOW_SCAN_CAP)
+            with open(self._server_log_path, "rb") as log:
+                log.seek(start)
+                appended = log.read(size - start)
+            self._log_offset = size
+            text = appended.decode("utf-8", errors="replace").lower()
+            if any(marker in text for marker in _OVERFLOW_MARKERS):
+                return _OVERFLOW_HINT
+            return None
+        except Exception:
+            return None
 
     # -- auth --------------------------------------------------------------
 

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import logging
 import os
@@ -87,6 +88,26 @@ def _result_text(value: Any) -> str:
         if found:
             return str(found)
     return str(value)
+
+
+def _recall_failure_advice(exc: Exception) -> str:
+    """One actionable sentence appended to a timeout-shaped recall failure.
+
+    The default GRAPH_COMPLETION search runs an LLM per query, so on a local
+    model a timeout is usually the search strategy, not an outage — and the
+    model reading this error can fix it on the retry. Covers the HTTP
+    transport (CogneeUnreachable wraps urllib's "timed out") and the SDK
+    bridge (concurrent.futures.TimeoutError, empty message on 3.10).
+    """
+    if not isinstance(exc, (TimeoutError, concurrent.futures.TimeoutError)):
+        text = str(exc).lower()
+        if "timed out" not in text and "timeout" not in text:
+            return ""
+    return (
+        " The default GRAPH_COMPLETION search runs an LLM per query and can be "
+        "slow on local models — retry with search_type='CHUNKS' (fast raw-text "
+        "retrieval) or scope='session', or raise COGNEE_RECALL_TIMEOUT."
+    )
 
 
 class CogneeMemoryProvider(MemoryProvider):
@@ -827,6 +848,7 @@ class CogneeMemoryProvider(MemoryProvider):
             )
             self._record_success()
             items = [self._normalize_recall_item(item) for item in results]
+            overflow = self._backend.overflow_hint()
             if not items:
                 # Distinguish a genuine miss from a backend condition that makes
                 # recall structurally unable to match (e.g. an embedder change
@@ -835,11 +857,21 @@ class CogneeMemoryProvider(MemoryProvider):
                 dim_message = self._backend.empty_recall_hint()
                 if dim_message:
                     return json.dumps({"error": dim_message, "count": 0})
+                if overflow:
+                    return json.dumps({"error": overflow, "count": 0})
                 return json.dumps({"result": "No relevant Cognee memory found.", "count": 0})
-            return json.dumps({"results": items, "count": len(items)})
+            envelope: dict[str, Any] = {"results": items, "count": len(items)}
+            if overflow:
+                # Non-empty results still warn: mean-pooled vectors match
+                # *something*, so plausible-but-wrong hits are the overflow's
+                # most misleading symptom.
+                envelope["warning"] = overflow
+            return json.dumps(envelope)
         except Exception as exc:
             self._record_failure()
-            return json.dumps({"error": f"Cognee recall failed: {exc}"})
+            return json.dumps(
+                {"error": f"Cognee recall failed: {exc}{_recall_failure_advice(exc)}"}
+            )
 
     def _handle_remember(self, args: dict[str, Any]) -> str:
         content = str(args.get("content") or "").strip()
@@ -851,7 +883,14 @@ class CogneeMemoryProvider(MemoryProvider):
             result = self._remember_permanent(content, dataset)
             self._record_success()
             status = getattr(result, "status", "completed")
-            return json.dumps({"result": "Content stored in Cognee.", "status": str(status)})
+            envelope = {"result": "Content stored in Cognee.", "status": str(status)}
+            # Embedding runs server-side after this write returns, so a hint here
+            # usually reports the *previous* write's overflow — still worth
+            # surfacing, since the index is already degrading either way.
+            overflow = self._backend.overflow_hint()
+            if overflow:
+                envelope["warning"] = overflow
+            return json.dumps(envelope)
         except Exception as exc:
             self._record_failure()
             return json.dumps({"error": f"Cognee remember failed: {exc}"})

--- a/integrations/hermes-agent/cognee_integration_hermes/schemas.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/schemas.py
@@ -23,7 +23,11 @@ RECALL_SCHEMA = {
                 "type": "string",
                 "description": (
                     "Optional Cognee SearchType override, for example GRAPH_COMPLETION, "
-                    "RAG_COMPLETION, CHUNKS, CHUNKS_LEXICAL, TEMPORAL, or FEELING_LUCKY."
+                    "RAG_COMPLETION, CHUNKS, CHUNKS_LEXICAL, TEMPORAL, or FEELING_LUCKY. "
+                    "CHUNKS returns matching stored text directly — fast, no LLM in the "
+                    "loop. GRAPH_COMPLETION (the default) synthesizes an answer with an "
+                    "LLM per query, which can be slow on local models; prefer CHUNKS "
+                    "when a query times out or raw excerpts are enough."
                 ),
             },
             "top_k": {

--- a/integrations/hermes-agent/cognee_integration_hermes/server_bootstrap.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/server_bootstrap.py
@@ -22,7 +22,12 @@ import time
 import urllib.error
 import urllib.request
 
-from .config import DEFAULT_SERVER_BOOT_TIMEOUT, SHARED_COGNEE_HOME, SHARED_PLUGIN_STATE_DIR
+from .config import (
+    DEFAULT_SERVER_BOOT_TIMEOUT,
+    SHARED_COGNEE_HOME,
+    SHARED_PLUGIN_STATE_DIR,
+    ollama_embedding_pins,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +79,11 @@ def _spawn(port, data_root, system_root, log_path):
         ("COGNEE_IMPROVE_SUBMIT_TIMEOUT", "420"),
     ):
         env.setdefault(key, value)
+    # A local Ollama embedder inherits a token ceiling far above its real
+    # context and silently mean-pools every overflowing text into a lossy
+    # vector — see ollama_embedding_pins for the incident this pins away.
+    for key, value in ollama_embedding_pins(env).items():
+        env.setdefault(key, value)
     if data_root:
         env["DATA_ROOT_DIRECTORY"] = data_root
     if system_root:
@@ -106,6 +116,21 @@ def _spawn(port, data_root, system_root, log_path):
             log.close()
 
 
+def default_server_log_path() -> str:
+    """Where the spawned server's output lands when no log path is given.
+
+    Same state root as the other cognee plugins (they keep per-host logs in
+    ~/.cognee-plugin/<host>/), so diagnostics live in one predictable place.
+    Also read back by the HTTP transport's overflow scan.
+    """
+    log_dir = SHARED_PLUGIN_STATE_DIR / "hermes"
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass  # _spawn falls back to DEVNULL if the file cannot be opened
+    return str(log_dir / "server.log")
+
+
 def ensure_local_server(
     port,
     *,
@@ -129,14 +154,7 @@ def ensure_local_server(
     if health_ok(url):
         return url
     if log_path is None:
-        # Same state root as the other cognee plugins (they keep per-host logs in
-        # ~/.cognee-plugin/<host>/), so diagnostics live in one predictable place.
-        log_dir = SHARED_PLUGIN_STATE_DIR / "hermes"
-        try:
-            log_dir.mkdir(parents=True, exist_ok=True)
-        except OSError:
-            pass  # _spawn falls back to DEVNULL if the file cannot be opened
-        log_path = str(log_dir / "server.log")
+        log_path = default_server_log_path()
     proc = None
     spawn_error = None
     try:

--- a/integrations/hermes-agent/plugin.yaml
+++ b/integrations/hermes-agent/plugin.yaml
@@ -1,6 +1,6 @@
 name: cognee
 kind: exclusive
-version: 1.0.0
+version: 1.1.0
 description: "Cognee memory provider for Hermes Agent: session-aware graph memory, recall, forget, and session-end improvement."
 pip_dependencies:
   # Floor 1.2.1: the HTTP wire contract this plugin depends on

--- a/integrations/hermes-agent/pyproject.toml
+++ b/integrations/hermes-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cognee-integration-hermes-agent"
-version = "1.0.0"
+version = "1.1.0"
 description = "Standalone Cognee memory provider plugin for Hermes Agent."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/hermes-agent/tests/_char_helpers.py
+++ b/integrations/hermes-agent/tests/_char_helpers.py
@@ -233,6 +233,7 @@ class FakeBackend(MemoryBackend):
             "resolve_identity": "USER",
         }
         self.empty_recall_hint_value = None
+        self.overflow_hint_value = None
 
     # Recorder passthrough ------------------------------------------------
 
@@ -302,6 +303,10 @@ class FakeBackend(MemoryBackend):
     def empty_recall_hint(self, **kwargs):
         self._recorder.record("empty_recall_hint", kwargs)
         return self.empty_recall_hint_value
+
+    def overflow_hint(self, **kwargs):
+        self._recorder.record("overflow_hint", kwargs)
+        return self.overflow_hint_value
 
 
 _CURRENT_FAKE_BACKEND = None

--- a/integrations/hermes-agent/tests/test_overflow_hint.py
+++ b/integrations/hermes-agent/tests/test_overflow_hint.py
@@ -1,0 +1,122 @@
+"""The overflow scan: the server log is the only trace of a lossy embedding.
+
+cognee's OllamaEmbeddingEngine mean-pools a text that overflows the embedding
+model's context and reports success — the write looks fine while the vector
+index quietly degrades. The only evidence is an "Ollama embedding error" line in
+the spawned server's log, so ``HttpBackend`` tails that log between calls and
+``overflow_hint()`` turns a fresh error into an actionable message the provider
+puts in the tool envelope (envelope shapes: ``test_tool_contract.py``).
+
+Runs standalone with ``python3 tests/test_overflow_hint.py``; needs no cognee.
+"""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from cognee_integration_hermes import http_backend as hb  # noqa: E402
+from cognee_integration_hermes.http_backend import HttpBackend  # noqa: E402
+
+_LOCAL_URL = "http://127.0.0.1:8011"
+_OVERFLOW_LINE = b"ERROR Ollama embedding error: input length exceeds maximum context length\n"
+
+
+class TestOverflowHint(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.log = Path(tmp.name) / "server.log"
+
+    def _armed(self, *, url=_LOCAL_URL, prior=b""):
+        """A backend whose scan was armed (as ``connect()`` does) at the current
+        end of a log holding *prior* bytes."""
+        self.log.write_bytes(prior)
+        backend = HttpBackend(server_log_path=str(self.log))
+        backend.url = url
+        backend._init_overflow_scan()
+        return backend
+
+    def _append(self, data):
+        with open(self.log, "ab") as log:
+            log.write(data)
+
+    def test_a_fresh_overflow_line_fires_an_actionable_hint(self):
+        backend = self._armed()
+        self._append(_OVERFLOW_LINE)
+        hint = backend.overflow_hint()
+        self.assertIsNotNone(hint)
+        # The hint must name the levers that fix it, not just describe the problem.
+        self.assertIn("EMBEDDING_MAX_COMPLETION_TOKENS", hint)
+        self.assertIn("HUGGINGFACE_TOKENIZER", hint)
+
+    def test_unrelated_log_lines_do_not_fire(self):
+        backend = self._armed()
+        self._append(b"INFO uvicorn running\nINFO cognify pipeline completed\n")
+        self.assertIsNone(backend.overflow_hint())
+
+    def test_errors_from_before_the_connect_never_fire(self):
+        # The offset snapshots the log's end when the scan is armed, so damage
+        # left behind by earlier sessions cannot fire a hint in this one.
+        backend = self._armed(prior=_OVERFLOW_LINE)
+        self.assertIsNone(backend.overflow_hint())
+
+    def test_the_snapshot_sits_at_the_current_end_of_the_log(self):
+        backend = self._armed(prior=b"12345")
+        self.assertEqual(backend._log_offset, 5)
+
+    def test_one_error_batch_fires_exactly_once(self):
+        backend = self._armed()
+        self._append(b"Text too long for embedding model: 4000 tokens\n")
+        self.assertIsNotNone(backend.overflow_hint())
+        self.assertIsNone(backend.overflow_hint())
+        self._append(_OVERFLOW_LINE)
+        self.assertIsNotNone(backend.overflow_hint())
+
+    def test_a_clean_scan_still_advances_the_offset(self):
+        backend = self._armed()
+        self._append(b"INFO noise\n")
+        self.assertIsNone(backend.overflow_hint())
+        self._append(_OVERFLOW_LINE)
+        self.assertIsNotNone(backend.overflow_hint())
+
+    def test_matching_is_case_insensitive(self):
+        backend = self._armed()
+        self._append(b"OLLAMA EMBEDDING ERROR: boom\n")
+        self.assertIsNotNone(backend.overflow_hint())
+
+    def test_a_missing_log_is_a_quiet_none(self):
+        backend = HttpBackend(server_log_path=str(self.log.parent / "nope" / "server.log"))
+        backend.url = _LOCAL_URL
+        backend._init_overflow_scan()
+        self.assertIsNone(backend.overflow_hint())
+
+    def test_a_remote_url_never_scans(self):
+        # A remote server's log is not on this filesystem; scanning a local file
+        # would attribute someone else's errors to it.
+        backend = self._armed(url="https://cloud.example")
+        self._append(_OVERFLOW_LINE)
+        self.assertIsNone(backend.overflow_hint())
+
+    def test_an_unarmed_backend_returns_none(self):
+        backend = HttpBackend(server_log_path=str(self.log))
+        self.assertIsNone(backend.overflow_hint())
+
+    def test_a_truncated_log_rescans_from_the_top(self):
+        backend = self._armed(prior=b"x" * 100)
+        self.log.write_bytes(_OVERFLOW_LINE)  # rotation: smaller than the offset
+        self.assertIsNotNone(backend.overflow_hint())
+
+    def test_a_giant_append_is_capped_but_the_tail_is_still_scanned(self):
+        backend = self._armed()
+        self._append(b"a" * (hb._OVERFLOW_SCAN_CAP + 4096))
+        self._append(_OVERFLOW_LINE)
+        self.assertIsNotNone(backend.overflow_hint())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/integrations/hermes-agent/tests/test_server_mode.py
+++ b/integrations/hermes-agent/tests/test_server_mode.py
@@ -203,6 +203,80 @@ class TestSpawnEnvironment(unittest.TestCase):
         self.assertNotEqual(env.get("DATA_ROOT_DIRECTORY", "unset"), "")
 
 
+class TestOllamaEmbeddingPins(unittest.TestCase):
+    """The spawn env caps a local Ollama embedder at its real context length.
+
+    Without these, cognee sizes chunks from EMBEDDING_MAX_COMPLETION_TOKENS'
+    8191 default, every substantial document overflows the model, and cognee
+    mean-pools the pieces into lossy vectors while reporting success.
+
+    ``clear=True``: pins are ``setdefault``s, so ambient EMBEDDING_* values in
+    the developer's shell would otherwise leak in and flip the assertions.
+    """
+
+    def _spawn_env(self, **env_overrides):
+        captured = {}
+
+        def fake_popen(args, env=None, **kwargs):
+            captured.update(env or {})
+            return mock.MagicMock()
+
+        with (
+            mock.patch.dict("os.environ", env_overrides, clear=True),
+            mock.patch.object(sb.subprocess, "Popen", side_effect=fake_popen),
+        ):
+            sb._spawn(9999, "", "", "/dev/null")
+        return captured
+
+    def test_a_known_model_gets_its_context_and_tokenizer(self):
+        env = self._spawn_env(EMBEDDING_PROVIDER="ollama", EMBEDDING_MODEL="all-minilm")
+        self.assertEqual(env["EMBEDDING_MAX_COMPLETION_TOKENS"], "256")
+        self.assertEqual(env["HUGGINGFACE_TOKENIZER"], "sentence-transformers/all-MiniLM-L6-v2")
+
+    def test_model_names_are_normalized(self):
+        env = self._spawn_env(
+            EMBEDDING_PROVIDER="ollama", EMBEDDING_MODEL="ollama/nomic-embed-text:latest"
+        )
+        self.assertEqual(env["EMBEDDING_MAX_COMPLETION_TOKENS"], "2048")
+
+    def test_registry_namespaces_still_match(self):
+        # cognee's own Ollama default model ships under the avr/ namespace.
+        env = self._spawn_env(
+            EMBEDDING_PROVIDER="ollama", EMBEDDING_MODEL="avr/sfr-embedding-mistral:latest"
+        )
+        self.assertEqual(env["EMBEDDING_MAX_COMPLETION_TOKENS"], "2048")
+        self.assertEqual(env["HUGGINGFACE_TOKENIZER"], "Salesforce/SFR-Embedding-Mistral")
+
+    def test_the_longest_table_key_wins(self):
+        # snowflake-arctic-embed2 must not resolve to snowflake-arctic-embed's 512.
+        env = self._spawn_env(
+            EMBEDDING_PROVIDER="ollama", EMBEDDING_MODEL="snowflake-arctic-embed2"
+        )
+        self.assertEqual(env["EMBEDDING_MAX_COMPLETION_TOKENS"], "8192")
+
+    def test_an_unknown_model_gets_the_conservative_ceiling_and_no_tokenizer_guess(self):
+        env = self._spawn_env(EMBEDDING_PROVIDER="ollama", EMBEDDING_MODEL="mystery-embed")
+        self.assertEqual(env["EMBEDDING_MAX_COMPLETION_TOKENS"], "512")
+        # A wrong tokenizer miscounts tokens and can reintroduce the overflow.
+        self.assertNotIn("HUGGINGFACE_TOKENIZER", env)
+
+    def test_no_pins_without_the_ollama_provider(self):
+        for provider in ("", "openai", "openai_compatible"):
+            env = self._spawn_env(EMBEDDING_PROVIDER=provider, EMBEDDING_MODEL="all-minilm")
+            self.assertNotIn("EMBEDDING_MAX_COMPLETION_TOKENS", env)
+            self.assertNotIn("HUGGINGFACE_TOKENIZER", env)
+
+    def test_an_explicit_user_value_wins(self):
+        env = self._spawn_env(
+            EMBEDDING_PROVIDER="ollama",
+            EMBEDDING_MODEL="all-minilm",
+            EMBEDDING_MAX_COMPLETION_TOKENS="9000",
+            HUGGINGFACE_TOKENIZER="my/tokenizer",
+        )
+        self.assertEqual(env["EMBEDDING_MAX_COMPLETION_TOKENS"], "9000")
+        self.assertEqual(env["HUGGINGFACE_TOKENIZER"], "my/tokenizer")
+
+
 class _Recorder(dict):
     """Reads the mode-routing decisions off a fake backend.
 

--- a/integrations/hermes-agent/tests/test_tool_contract.py
+++ b/integrations/hermes-agent/tests/test_tool_contract.py
@@ -82,6 +82,93 @@ class TestRecallEnvelope(unittest.TestCase):
         self.assertIn("boom", out["error"])
 
 
+class TestOverflowHintEnvelope(unittest.TestCase):
+    """A backend that saw an embedding overflow gets it into the model's hands.
+
+    The scan itself lives in ``test_overflow_hint.py``; here the contract is
+    where the hint lands in the envelope: an ``error`` when recall came back
+    empty, a ``warning`` when there are results — mean-pooled vectors match
+    *something*, so plausible-but-wrong hits are the symptom worth flagging.
+    """
+
+    def test_non_empty_recall_carries_the_hint_as_a_warning(self):
+        with fake_backend() as fake:
+            fake.results["recall"] = [{"text": "alpha"}]
+            fake.overflow_hint_value = "index degrading"
+            provider = make_provider()
+            out = _call(provider, "cognee_recall", {"query": "q"})
+        self.assertEqual(out["count"], 1)
+        self.assertEqual(out["warning"], "index degrading")
+
+    def test_empty_recall_with_a_hint_is_a_hard_error(self):
+        with fake_backend() as fake:
+            fake.results["recall"] = []
+            fake.overflow_hint_value = "index degrading"
+            provider = make_provider()
+            out = _call(provider, "cognee_recall", {"query": "q"})
+        self.assertEqual(out, {"error": "index degrading", "count": 0})
+
+    def test_the_dim_mismatch_hint_wins_on_an_empty_recall(self):
+        # A dimension mismatch means recall can never match — the more specific
+        # diagnosis, so it outranks the overflow hint.
+        with fake_backend() as fake:
+            fake.results["recall"] = []
+            fake.empty_recall_hint_value = "dim mismatch"
+            fake.overflow_hint_value = "index degrading"
+            provider = make_provider()
+            out = _call(provider, "cognee_recall", {"query": "q"})
+        self.assertEqual(out["error"], "dim mismatch")
+
+    def test_no_warning_key_without_a_hint(self):
+        with fake_backend() as fake:
+            fake.results["recall"] = [{"text": "alpha"}]
+            provider = make_provider()
+            out = _call(provider, "cognee_recall", {"query": "q"})
+        self.assertNotIn("warning", out)
+
+    def test_remember_success_carries_the_hint_as_a_warning(self):
+        with fake_backend() as fake:
+            fake.overflow_hint_value = "index degrading"
+            provider = make_provider()
+            out = _call(provider, "cognee_remember", {"content": "fact"})
+        self.assertEqual(out["result"], "Content stored in Cognee.")
+        self.assertEqual(out["warning"], "index degrading")
+
+    def test_remember_success_has_no_warning_without_a_hint(self):
+        with fake_backend():
+            provider = make_provider()
+            out = _call(provider, "cognee_remember", {"content": "fact"})
+        self.assertNotIn("warning", out)
+
+
+class TestRecallTimeoutAdvice(unittest.TestCase):
+    """A timed-out recall tells the model the fast way out, inline in the error."""
+
+    def test_a_timeout_error_names_the_faster_search_type(self):
+        with fake_backend() as fake:
+            fake.errors["recall"] = TimeoutError()
+            provider = make_provider()
+            out = _call(provider, "cognee_recall", {"query": "q"})
+        self.assertIn("CHUNKS", out["error"])
+        self.assertIn("COGNEE_RECALL_TIMEOUT", out["error"])
+
+    def test_a_timed_out_message_gets_the_advice_too(self):
+        # The HTTP transport wraps urllib timeouts in CogneeUnreachable, whose
+        # type says nothing — the message is the only timeout signal.
+        with fake_backend() as fake:
+            fake.errors["recall"] = RuntimeError("cognee unreachable at http://x: timed out")
+            provider = make_provider()
+            out = _call(provider, "cognee_recall", {"query": "q"})
+        self.assertIn("CHUNKS", out["error"])
+
+    def test_a_non_timeout_failure_stays_unadorned(self):
+        with fake_backend() as fake:
+            fake.errors["recall"] = RuntimeError("boom")
+            provider = make_provider()
+            out = _call(provider, "cognee_recall", {"query": "q"})
+        self.assertNotIn("CHUNKS", out["error"])
+
+
 class TestRememberEnvelope(unittest.TestCase):
     def test_success_envelope(self):
         with fake_backend() as fake:

--- a/integrations/hermes-agent/uv.lock
+++ b/integrations/hermes-agent/uv.lock
@@ -753,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "cognee-integration-hermes-agent"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -67,7 +67,7 @@ integrations:
     registry: pypi
     package_name: "cognee-integration-hermes-agent"
     cognee_dependency: http-api
-    current_version: "1.0.0"
+    current_version: "1.1.0"
     migration_status: done
     source_repo: https://github.com/NousResearch/hermes-agent/pull/7418
     notes: >-


### PR DESCRIPTION
This PR fixes an issue users had with the Hermes integration with Ollama as the embedding model. Not setting max completion tokens defaulted to a large value, so in this PR we are careful about this, and use the value that makes sense, in case it is not explicitly stated.