### PR TITLE
fix: buffer failed writes, codex improve polling, openclaw guards

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "author": {
         "name": "Cognee"
       },

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": {
     "name": "Cognee"
   },

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,6 +10,32 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.2]
+
+### Fixed
+- **A turn captured while the server is down is no longer lost.** Writes were
+  buffered to the warmup spillway only when `server_usable()` already reported
+  False. That check relies on a ready marker with a 30s TTL, so a server dying
+  inside that window left it returning True: the write was attempted for real,
+  it raised, and the `except` branch only logged `stop_store_error` — the entry
+  was buffered nowhere and the turn was gone. Both the Stop (QA) and PostToolUse
+  (trace) paths now buffer on failure and replay when the server returns.
+
+  Failures that cannot succeed on replay are *not* buffered. A 4xx is dropped
+  with `"buffered": false` in the log, because the drain stops at the first entry
+  it cannot send and only removes what it drained — a permanently rejected entry
+  would sit at the head of the queue and block everything behind it. Transport
+  failures and 5xx are retried; new events: `store_buffered_after_error`,
+  `trace_buffered_after_error`.
+
+### Known issues
+- **The PreCompact anchor is empty in server mode.** `pre-compact.py` now recalls
+  over HTTP, but its seed recall deliberately sends an empty query (there is no
+  user question at compaction time) and the server matches nothing on one, so no
+  session or trace entries come back and no anchor is printed. Per-prompt recall
+  is unaffected — this costs the summary carried across a compaction, not memory
+  itself. Tracked as SDK-424; the fix is server-side.
+
 ## [1.3.1]
 
 ### Fixed

--- a/integrations/claude-code/scripts/pre-compact.py
+++ b/integrations/claude-code/scripts/pre-compact.py
@@ -21,10 +21,11 @@ sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
     hook_log,
     load_resolved,
+    recall_via_http,
     resolve_session_key_from_payload,
     set_session_key,
 )
-from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
+from config import ensure_cognee_ready, get_dataset, get_session_id, is_cloud_mode, load_config
 
 _MIN_WORD_LEN = 3
 _SESSION_TOP_K = 5
@@ -42,6 +43,28 @@ def _load_resolved_fields() -> tuple[str, str]:
         session_id = session_id or get_session_id(config)
         dataset = dataset or get_dataset(config)
     return session_id, dataset
+
+
+def _as_dict(entry):
+    """Coerce one recall result to a plain dict.
+
+    The two backends return different shapes: the local SDK can hand back pydantic
+    models, while ``recall_via_http`` returns already-decoded JSON. Normalising here
+    means the filters below can just read keys.
+    """
+    if hasattr(entry, "model_dump"):
+        try:
+            return entry.model_dump()
+        except Exception as exc:
+            hook_log("precompact_model_dump_failed", {"error": str(exc)[:200]})
+    if hasattr(entry, "dict"):
+        try:
+            return entry.dict()
+        except Exception as exc:
+            hook_log("precompact_dict_dump_failed", {"error": str(exc)[:200]})
+    if hasattr(entry, "__dict__"):
+        return dict(entry.__dict__)
+    return entry
 
 
 def _extract_query_words(entries: list, max_words: int = 20) -> str:
@@ -62,18 +85,49 @@ def _extract_query_words(entries: list, max_words: int = 20) -> str:
     return " ".join(words)
 
 
-async def _recall(session_id: str, dataset: str, query: str, scope: list[str], top_k: int) -> list:
-    """Thin wrapper around cognee.recall; tolerates empty/failed recalls."""
-    import cognee
+async def _recall(
+    session_id: str,
+    dataset: str,
+    query: str,
+    scope: list[str],
+    top_k: int,
+    config: dict,
+) -> list:
+    """Recall for the anchor, over HTTP in server mode and the SDK locally.
 
+    Server mode is not optional here: the session cache lives on the server, so
+    ``cognee.recall`` has nothing local to read and every scope comes back empty.
+    Without this branch the hook logs ``precompact_empty`` and prints nothing —
+    silently, since a compaction is not something the user triggered — so anyone
+    running against a server loses their anchor at exactly the moment compaction
+    throws the transcript away.
+
+    Mirrors codex's pre-compact, which has had the branch since it was written.
+    """
     try:
-        results = await cognee.recall(
-            query,
-            session_id=session_id,
-            datasets=[dataset] if "graph" in scope else None,
-            top_k=top_k,
-            scope=scope,
-        )
+        if is_cloud_mode(config):
+            # GRAPH_COMPLETION only for the graph scope; the session/trace scopes
+            # read the cache and must not force a graph query.
+            query_type = "GRAPH_COMPLETION" if "graph" in scope else None
+            results = recall_via_http(
+                query,
+                session_id=session_id,
+                top_k=top_k,
+                scope=scope,
+                only_context=True,
+                search_type=query_type,
+                dataset=get_dataset(config),
+            )
+        else:
+            import cognee
+
+            results = await cognee.recall(
+                query,
+                session_id=session_id,
+                datasets=[dataset] if "graph" in scope else None,
+                top_k=top_k,
+                scope=scope,
+            )
         return list(results) if results else []
     except Exception as exc:
         hook_log("precompact_recall_error", {"scope": scope, "error": str(exc)[:200]})
@@ -149,16 +203,39 @@ async def _run():
     # since we don't have a specific user question at compact time.
     # First pull session+trace so we can derive a query from them.
     seed_results = await _recall(
-        session_id, dataset, query="", scope=["session", "trace"], top_k=_TRACE_TOP_K
+        session_id, dataset, query="", scope=["session", "trace"], top_k=_TRACE_TOP_K, config=config
     )
+    # The two backends tag the origin scope differently: recall_via_http returns
+    # `source`, the local SDK returns `_source`. Reading only `_source` silently
+    # filtered out every HTTP result, which is why adding the transport branch
+    # alone still produced an empty anchor — the recall worked and its results were
+    # then discarded here.
+    normalized_seed = [_as_dict(r) for r in seed_results]
     session_entries = [
-        r for r in seed_results if isinstance(r, dict) and r.get("_source") == "session"
+        r
+        for r in normalized_seed
+        if isinstance(r, dict) and (r.get("source") or r.get("_source")) == "session"
     ]
-    trace_entries = [r for r in seed_results if isinstance(r, dict) and r.get("_source") == "trace"]
+    trace_entries = [
+        r
+        for r in normalized_seed
+        if isinstance(r, dict) and (r.get("source") or r.get("_source")) == "trace"
+    ]
 
     # Fall back: if recall returned nothing (keyword-miss on empty query),
     # pull entries directly. This keeps the anchor useful mid-session
     # before any user prompts have landed in the cache.
+    # NOT guarded by is_cloud_mode, deliberately. The seed recall above passes an
+    # empty query (there is no user question at compact time) and the server's
+    # /recall matches nothing on an empty string — verified directly: query="" -> 0
+    # results, query="ZEBRA-1" -> 1. So over HTTP the seed is always empty and this
+    # fallback is the only thing that produces an anchor.
+    #
+    # It works for a *local* server because the plugin boots it under the same HOME,
+    # so the session manager reads the very storage the server writes. Against a
+    # remote tenant the import fails and the except swallows it, leaving no anchor —
+    # the real remaining gap, which needs a server-side way to read recent session
+    # entries without a query rather than more client-side branching.
     if not session_entries and not trace_entries:
         try:
             from cognee.infrastructure.session.get_session_manager import get_session_manager
@@ -187,10 +264,14 @@ async def _run():
     graph_context_entries: list = []
     graph_entries: list = []
     if query:
-        ctx = await _recall(session_id, dataset, query=query, scope=["graph_context"], top_k=1)
-        graph_context_entries = [r for r in ctx if isinstance(r, dict)]
-        g = await _recall(session_id, dataset, query=query, scope=["graph"], top_k=_GRAPH_TOP_K)
-        graph_entries = [r for r in g if isinstance(r, dict)]
+        ctx = await _recall(
+            session_id, dataset, query=query, scope=["graph_context"], top_k=1, config=config
+        )
+        graph_context_entries = [d for d in (_as_dict(r) for r in ctx) if isinstance(d, dict)]
+        g = await _recall(
+            session_id, dataset, query=query, scope=["graph"], top_k=_GRAPH_TOP_K, config=config
+        )
+        graph_entries = [d for d in (_as_dict(r) for r in g) if isinstance(d, dict)]
 
     sections = []
     if session_entries:

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -17,6 +17,7 @@ import json
 import os
 import sys
 import time
+import urllib.error
 
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
@@ -245,8 +246,39 @@ async def _store_tool_call(payload: dict) -> None:
                 user=user,
             )
     except Exception as exc:
-        hook_log("trace_store_error", {"tool": tool_name, "error": str(exc)[:200]})
-        notify(f"trace store failed ({exc})")
+        # Same reasoning as the Stop path: the server_usable() guard above only
+        # catches an outage already known about, so a server that dies inside the
+        # ready marker's 30s TTL lands here with a real, failed write. Buffer the
+        # retryable cases so the trace survives; drop a 4xx loudly, because the
+        # drain stops at the first entry it cannot send and a permanently
+        # rejected one would block every entry behind it.
+        status_code = exc.code if isinstance(exc, urllib.error.HTTPError) else None
+        retryable = status_code is None or status_code >= 500
+        if retryable:
+            append_warmup_entry(dataset, session_id, entry)
+            trace_text = (
+                f"{tool_name} [{status}]\n"
+                f"Params: {json.dumps(params, ensure_ascii=False)}\n"
+                f"Return: {return_value}"
+            )
+            append_http_bridge_entry(dataset, session_id, trace=trace_text)
+            bump_save_counter(session_id, "trace")
+            hook_log(
+                "trace_buffered_after_error",
+                {"tool": tool_name, "status": status_code, "error": str(exc)[:200]},
+            )
+            notify(f"trace store failed, buffered for replay ({exc})")
+        else:
+            hook_log(
+                "trace_store_error",
+                {
+                    "tool": tool_name,
+                    "error": str(exc)[:200],
+                    "status": status_code,
+                    "buffered": False,
+                },
+            )
+            notify(f"trace store failed ({exc})")
         return
 
     if result:
@@ -359,8 +391,41 @@ async def _store_assistant_stop(payload: dict) -> None:
                 user=user,
             )
     except Exception as exc:
-        hook_log("stop_store_error", {"error": str(exc)[:200]})
-        notify(f"stop store failed ({exc})")
+        # A write that FAILED must still be buffered, or the turn is simply lost.
+        # The `server_usable()` guard above only catches an outage the plugin
+        # already knows about: the ready marker has a 30s TTL, so a server that
+        # dies inside that window leaves server_usable() returning True, the write
+        # is attempted for real, and this is where it lands. Logging alone here is
+        # what the warmup spillway exists to prevent.
+        #
+        # Not every failure is worth replaying, though. The drain stops at the
+        # first entry it cannot send and only trims what it drained, so an entry
+        # that can never succeed would sit at the head of the queue and block
+        # everything behind it forever. A 4xx is exactly that: the same bytes will
+        # be rejected the same way next time. Transport failures and 5xx are
+        # retryable, so those are buffered and anything else is dropped loudly.
+        status = exc.code if isinstance(exc, urllib.error.HTTPError) else None
+        retryable = status is None or status >= 500
+        if retryable:
+            append_warmup_entry(dataset, session_id, entry)
+            append_http_bridge_entry(
+                dataset,
+                session_id,
+                question=pending.get("prompt", ""),
+                answer=msg,
+            )
+            bump_save_counter(session_id, "answer")
+            hook_log(
+                "store_buffered_after_error",
+                {"hook": "stop", "status": status, "error": str(exc)[:200]},
+            )
+            notify(f"stop store failed, buffered for replay ({exc})")
+        else:
+            hook_log(
+                "stop_store_error",
+                {"error": str(exc)[:200], "status": status, "buffered": False},
+            )
+            notify(f"stop store failed ({exc})")
         return
 
     if result:

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,6 +10,33 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.4.2]
+
+### Fixed
+- **A turn captured while the server is down is no longer lost.** Writes were
+  buffered to the warmup spillway only when `server_usable()` already reported
+  False. That check relies on a ready marker with a 30s TTL, so a server dying
+  inside that window left it returning True: the write was attempted for real,
+  it raised, and the `except` branch only logged `stop_store_error` — the entry
+  was buffered nowhere and the turn was gone. Both the Stop (QA) and PostToolUse
+  (trace) paths now buffer on failure and replay when the server returns.
+
+  Failures that cannot succeed on replay are *not* buffered. A 4xx is dropped
+  with `"buffered": false` in the log, because the drain stops at the first entry
+  it cannot send and only removes what it drained — a permanently rejected entry
+  would sit at the head of the queue and block everything behind it. Transport
+  failures and 5xx are retried; new events: `store_buffered_after_error`,
+  `trace_buffered_after_error`.
+
+- **`improve` now reports whether the graph actually finished building.**
+  `improve_session_via_http` submitted and returned `ok` without polling, so a
+  caller could not tell an accepted bridge from a completed one — the graph could
+  still be empty while the result said success. It now polls the cognify and
+  memify pipelines (`COGNEE_IMPROVE_POLL_DEADLINE`, default 600s, split between
+  the two) and reports `cognify_status` / `memify_status`. Best-effort: a poll
+  that times out never turns a successful submit into a failure. This was the one
+  piece of the background-remember work that did not travel with the rest.
+
 ## [1.4.1]
 
 ### Fixed

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -3268,7 +3268,28 @@ def improve_session_via_http(dataset: str, session_id: str, *, timeout: float = 
         # caller must retry once the lock frees.
         return {"ok": False, "busy": True}
 
-    return {"ok": True, "result": result if isinstance(result, dict) else {}}
+    outcome = {"ok": True, "result": result if isinstance(result, dict) else {}}
+    # Best-effort observability: the submit already succeeded, so a poll that
+    # times out or errors must never turn that into a failure. Reporting the
+    # pipeline states is what lets a caller (and the tests) distinguish "the
+    # bridge was accepted" from "the graph actually finished building" — without
+    # it, improve returns ok while the graph is still empty, which reads as a
+    # silent data-loss bug from the outside.
+    #
+    # Parity with claude-code, which gained this in the background-remember
+    # refactor; the rest of that work was ported here but the improve path was
+    # missed, so codex reported no cognify_status at all.
+    poll_deadline = _float_env("COGNEE_IMPROVE_POLL_DEADLINE", 600.0)
+    dataset_id = ""
+    if isinstance(result, dict):
+        dataset_id = str(result.get("dataset_id") or "")
+    if dataset_id and poll_deadline > 0:
+        half = poll_deadline / 2
+        outcome["cognify_status"] = wait_for_cognify(dataset_id, deadline_seconds=half)
+        outcome["memify_status"] = wait_for_cognify(
+            dataset_id, deadline_seconds=half, pipeline="memify_pipeline"
+        )
+    return outcome
 
 
 def ensure_dataset_via_http(dataset: str) -> None:

--- a/integrations/codex/plugins/cognee/scripts/store-to-session.py
+++ b/integrations/codex/plugins/cognee/scripts/store-to-session.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import os
 import sys
+import urllib.error
 
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
@@ -220,8 +221,39 @@ async def _store_tool_call(payload: dict) -> None:
                 user=user,
             )
     except Exception as exc:
-        hook_log("trace_store_error", {"tool": tool_name, "error": str(exc)[:200]})
-        notify(f"trace store failed ({exc})")
+        # Same reasoning as the Stop path: the server_usable() guard above only
+        # catches an outage already known about, so a server that dies inside the
+        # ready marker's 30s TTL lands here with a real, failed write. Buffer the
+        # retryable cases so the trace survives; drop a 4xx loudly, because the
+        # drain stops at the first entry it cannot send and a permanently
+        # rejected one would block every entry behind it.
+        status_code = exc.code if isinstance(exc, urllib.error.HTTPError) else None
+        retryable = status_code is None or status_code >= 500
+        if retryable:
+            append_warmup_entry(dataset, session_id, entry)
+            trace_text = (
+                f"{tool_name} [{status}]\n"
+                f"Params: {json.dumps(params, ensure_ascii=False)}\n"
+                f"Return: {return_value}"
+            )
+            append_http_bridge_entry(dataset, session_id, trace=trace_text)
+            bump_save_counter(session_id, "trace")
+            hook_log(
+                "trace_buffered_after_error",
+                {"tool": tool_name, "status": status_code, "error": str(exc)[:200]},
+            )
+            notify(f"trace store failed, buffered for replay ({exc})")
+        else:
+            hook_log(
+                "trace_store_error",
+                {
+                    "tool": tool_name,
+                    "error": str(exc)[:200],
+                    "status": status_code,
+                    "buffered": False,
+                },
+            )
+            notify(f"trace store failed ({exc})")
         return
 
     if result:
@@ -323,8 +355,41 @@ async def _store_assistant_stop(payload: dict) -> None:
                 user=user,
             )
     except Exception as exc:
-        hook_log("stop_store_error", {"error": str(exc)[:200]})
-        notify(f"stop store failed ({exc})")
+        # A write that FAILED must still be buffered, or the turn is simply lost.
+        # The `server_usable()` guard above only catches an outage the plugin
+        # already knows about: the ready marker has a 30s TTL, so a server that
+        # dies inside that window leaves server_usable() returning True, the write
+        # is attempted for real, and this is where it lands. Logging alone here is
+        # what the warmup spillway exists to prevent.
+        #
+        # Not every failure is worth replaying, though. The drain stops at the
+        # first entry it cannot send and only trims what it drained, so an entry
+        # that can never succeed would sit at the head of the queue and block
+        # everything behind it forever. A 4xx is exactly that: the same bytes will
+        # be rejected the same way next time. Transport failures and 5xx are
+        # retryable, so those are buffered and anything else is dropped loudly.
+        status = exc.code if isinstance(exc, urllib.error.HTTPError) else None
+        retryable = status is None or status >= 500
+        if retryable:
+            append_warmup_entry(dataset, session_id, entry)
+            append_http_bridge_entry(
+                dataset,
+                session_id,
+                question=pending.get("prompt", ""),
+                answer=msg,
+            )
+            bump_save_counter(session_id, "answer")
+            hook_log(
+                "store_buffered_after_error",
+                {"hook": "stop", "status": status, "error": str(exc)[:200]},
+            )
+            notify(f"stop store failed, buffered for replay ({exc})")
+        else:
+            hook_log(
+                "stop_store_error",
+                {"error": str(exc)[:200], "status": status, "buffered": False},
+            )
+            notify(f"stop store failed ({exc})")
         return
 
     if result:

--- a/integrations/openclaw/__tests__/e2e/test_cliCommands.ts
+++ b/integrations/openclaw/__tests__/e2e/test_cliCommands.ts
@@ -247,6 +247,20 @@ describe("cognee forget", () => {
     expect(printed()).toMatch(/--dataset <name> or --everything --confirm/);
   });
 
+  it("holds even when process.exit does not terminate", async () => {
+    // The point of the `return` after each `process.exit`: with the permissive
+    // stub (exit records the call and execution continues, as a wrapper or spy
+    // would) the guard must STILL prevent the delete. Before the return was
+    // added this fell through and called client.forget on a bare invocation.
+    exitSpy.mockImplementation((() => undefined) as never);
+
+    const harness = createPluginApi(plugin);
+    await harness.runCli("forget");
+
+    expect(stub.forget).not.toHaveBeenCalled();
+    expect(exitCodes()).toContain(1);
+  });
+
   it("refuses --everything without --confirm", async () => {
     const harness = createPluginApi(plugin);
     await expect(harness.runCli("forget", { everything: true })).rejects.toThrow(/process\.exit\(1\)/);

--- a/integrations/openclaw/__tests__/e2e/test_pluginLifecycle.ts
+++ b/integrations/openclaw/__tests__/e2e/test_pluginLifecycle.ts
@@ -72,7 +72,11 @@ describe("session_start", () => {
     expect(harness.handlerCount("session_start")).toBe(1);
 
     await harness.emit("session_start", { sessionId: "host-session-9" }, {});
-    await harness.emit("llm_output", { text: "an answer" }, { agentId: "will", sessionId: "host-session-9" });
+    await harness.emit(
+      "llm_output",
+      { assistantTexts: ["an answer"] },
+      { agentId: "will", sessionId: "host-session-9" },
+    );
     await flush();
 
     // The adopted id has to reach the server, or the turn lands under a different
@@ -85,23 +89,56 @@ describe("session_start", () => {
   });
 
   /**
-   * Surprising coupling, pinned deliberately rather than worked around.
+   * Regression guard for a coupling that has been removed.
    *
-   * `session_start` is registered inside `if (cfg.autoIndex)` — the same block as
-   * `agent_end` — even though its body independently checks `cfg.enableSessions`.
-   * So a user running `enableSessions: true, autoIndex: false` never adopts the
-   * host's session id from this event.
+   * `session_start` used to be registered inside `if (cfg.autoIndex)` — the same
+   * block as `agent_end` — even though its body independently checks
+   * `cfg.enableSessions`. So `enableSessions: true, autoIndex: false` never adopted
+   * the host session id from this event.
    *
-   * Not filed as a bug: `session_end` is always-on and resolves the session from
-   * its own ctx, so capture still works. But the two flags read as independent and
-   * are not, which is exactly the kind of thing that gets "fixed" by accident —
-   * this test makes that a decision instead.
+   * It was never a visible bug, because the always-on `session_end` handler
+   * resolves the session from its own ctx and capture kept working. That is
+   * precisely why it survived: two flags that read as independent were not, with
+   * no symptom to give it away.
    */
-  it("is NOT registered when autoIndex is off, even with sessions enabled", () => {
-    const harness = createPluginApi(plugin, { autoIndex: false, enableSessions: true });
-    expect(harness.handlerCount("session_start")).toBe(0);
-    // The always-on final-sync handler is what keeps capture working regardless.
-    expect(harness.handlerCount("session_end")).toBeGreaterThan(0);
+  it("is registered whenever sessions are enabled, regardless of autoIndex", () => {
+    const withoutIndex = createPluginApi(plugin, { autoIndex: false, enableSessions: true });
+    expect(withoutIndex.handlerCount("session_start")).toBe(1);
+
+    const withIndex = createPluginApi(plugin, { autoIndex: true, enableSessions: true });
+    expect(withIndex.handlerCount("session_start")).toBe(1);
+  });
+
+  it("adopts the host session id with autoIndex off — what the fix enables", async () => {
+    // Registration alone is not the point; this is the configuration that
+    // previously never saw a session_start at all.
+    const harness = createPluginApi(plugin, {
+      autoIndex: false,
+      enableSessions: true,
+      captureSession: true,
+    });
+
+    const ctx = { agentId: "will", sessionId: "host-session-42" };
+    await harness.emit("session_start", { sessionId: "host-session-42" }, {});
+    // A QA entry pairs an answer with a pending prompt (`if (!question) return`),
+    // so the prompt has to come first or llm_output captures nothing.
+    await harness.emit("before_prompt_build", { prompt: "what did we decide?" }, ctx);
+    await harness.emit("llm_output", { assistantTexts: ["recorded"] }, ctx);
+    await flush();
+
+    const calls = stub.rememberEntry.mock.calls as unknown[][];
+    expect(calls.length).toBeGreaterThan(0);
+    expect(String((calls[0][0] as { sessionId?: string }).sessionId ?? "")).toContain(
+      "host-session-42",
+    );
+  });
+
+  it("registers exactly one handler, not one per flag combination", () => {
+    // Moving the registration out of the autoIndex block risks registering it
+    // twice if the old call site is ever restored alongside the new one; a
+    // duplicate would adopt the id twice and is invisible except here.
+    const harness = createPluginApi(plugin, { autoIndex: true, enableSessions: true });
+    expect(harness.handlerCount("session_start")).toBe(1);
   });
 });
 

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -737,13 +737,22 @@ const memoryCogneePlugin = {
         .option("--everything", "Wipe all data owned by this user (requires --confirm)")
         .option("--confirm", "Required when using --everything")
         .action(async (opts: { dataset?: string; everything?: boolean; confirm?: boolean }) => {
+          // `return` after each exit is load-bearing, not decoration. This is the
+          // only destructive command, and without it the sole thing standing
+          // between a bare `cognee forget` and the delete below is process.exit
+          // never coming back. That holds in production, but it makes the guard
+          // depend on the runtime rather than on the control flow: anything that
+          // wraps, spies on, or stubs the action walks straight through into the
+          // deletion.
           if (!opts.dataset && !opts.everything) {
             console.log("Specify --dataset <name> or --everything --confirm.");
             process.exit(1);
+            return;
           }
           if (opts.everything && !opts.confirm) {
             console.log("Refusing to wipe everything without --confirm.");
             process.exit(1);
+            return;
           }
           const result = await client.forget({
             dataset: opts.dataset,
@@ -1318,11 +1327,18 @@ const memoryCogneePlugin = {
         }
       });
 
-      api.on("session_start", async (event) => {
-        if (cfg.enableSessions) sessionId = cogneeSessionId(event.sessionId);
-      });
-
     }
+
+    // Registered outside the `if (cfg.autoIndex)` block above, because adopting
+    // the host's session id has nothing to do with auto-indexing. It used to sit
+    // inside it while its body checked `cfg.enableSessions`, so the two flags read
+    // as independent when they were not: `enableSessions: true, autoIndex: false`
+    // never adopted the id from this event. Capture still worked (the always-on
+    // session_end handler resolves the session from its own ctx), which is exactly
+    // why the coupling could survive unnoticed.
+    api.on("session_start", async (event) => {
+      if (cfg.enableSessions) sessionId = cogneeSessionId(event.sessionId);
+    });
 
     // ------------------------------------------------------------------
     // Final session sync: one always-on session_end handler that kicks off a

--- a/integrations/tests/tests/e2e/live/test_resilience.py
+++ b/integrations/tests/tests/e2e/live/test_resilience.py
@@ -70,32 +70,25 @@ def test_hooks_stay_successful_when_the_server_dies_mid_session(
 
 
 def test_writes_during_an_outage_are_buffered_not_dropped(
-    started_session, live_suite, live_home, live_port, live_base_url, nonce, request
+    started_session, live_suite, live_home, live_port, live_base_url, nonce
 ):
     """A turn captured during an outage must survive it.
 
-    KNOWN GAP, not a design choice. ``store-to-session.py`` buffers to the warmup
-    spillway only when ``server_usable()`` is already False — a *stale* ready
-    marker plus a failed probe. The marker has a 30s TTL, so a server that dies
-    inside that window leaves ``server_usable()`` returning True: the hook
-    attempts a real write, the write raises, and the ``except`` branch only logs
-    ``stop_store_error``. The entry is buffered nowhere and the turn is lost,
-    which is precisely what the spillway exists to prevent.
+    The obvious guard is not enough on its own. ``store-to-session.py`` checks
+    ``server_usable()`` before writing, but the ready marker has a 30s TTL, so a
+    server that dies inside that window leaves it returning True: the hook attempts
+    a real write, the write raises, and for a long time the ``except`` branch only
+    logged ``stop_store_error``. The turn was buffered nowhere and lost — precisely
+    what the warmup spillway exists to prevent.
 
-    Strict xfail so this turns red the moment the failure path learns to buffer —
-    the fix is to call ``append_warmup_entry`` in that ``except`` branch, as the
-    not-usable path already does.
+    Both failure paths now buffer, and both discriminate: transport failures and
+    5xx are replayed, a 4xx is dropped loudly. That distinction is not fussiness —
+    ``drain_warmup_entries`` stops at the first entry it cannot send and only trims
+    what it drained, so an entry that can never succeed would sit at the head of the
+    queue and block everything behind it indefinitely.
+
+    Was a strict xfail; the fix made it XPASS on both suites.
     """
-    request.node.add_marker(
-        pytest.mark.xfail(
-            reason=(
-                "mid-outage Stop write is not buffered when the ready marker is "
-                "still fresh (store-to-session.py except branch only logs)"
-            ),
-            strict=True,
-        )
-    )
-
     session = started_session("buffer")
     session.prompt(f"Pre-outage note for {nonce}.", turn_id="t1")
     session.answer("Noted.", turn_id="t1")
@@ -118,7 +111,7 @@ def test_buffered_turns_are_replayed_once_the_server_returns(
 ):
     """The spillway, end to end: buffer while down, replay when back.
 
-    This is the path the mid-outage xfail above does *not* reach.
+    This is the path the mid-outage test above does *not* reach.
     ``server_usable()`` only reports False once the ready marker has gone stale
     (30s TTL, ``_SERVER_READY_TTL_SECONDS``) **and** a probe fails — so the test
     waits out the marker before capturing. That is exactly the real warmup case:

--- a/integrations/tests/tests/e2e/live/test_user_surfaces.py
+++ b/integrations/tests/tests/e2e/live/test_user_surfaces.py
@@ -111,26 +111,21 @@ def test_precompact_produces_an_anchor_carrying_the_session(
 ):
     """Compaction drops the transcript; the anchor is what carries memory across it.
 
-    **The two integrations diverge here, and codex is the one that is right.**
-    codex's ``pre-compact.py`` branches on ``is_cloud_mode`` and recalls via
-    ``recall_via_http``, so it produces an anchor against a server. claude-code's
-    recalls via ``cognee.recall`` with a ``get_session_manager()`` fallback — both
-    local-SDK only — while in server mode the session cache lives on the server. So
-    on claude-code the session and trace entries come back empty, the derived query
-    stays empty, the graph scopes are never queried, and the hook logs
-    ``precompact_empty`` and prints nothing.
+    Both suites now recall over HTTP, so both must produce an anchor against a real
+    server. That was not always true: claude-code's pre-compact was local-SDK only
+    — ``cognee.recall`` plus a ``get_session_manager()`` fallback — while in server
+    mode the session cache lives on the server. Session and trace entries came back
+    empty, the derived query stayed empty, the graph scopes were never queried, and
+    the hook logged ``precompact_empty`` and printed nothing. Anyone running against
+    a server lost their anchor at exactly the moment compaction discarded the
+    transcript, with nothing erroring to say so.
 
-    Since ``is_cloud_mode`` is just ``bool(base_url)``, a loopback server counts:
-    codex takes the HTTP path everywhere this tier runs.
+    This test is what caught it, and the fix was a port of the branch codex had all
+    along. It stays a live test because it is the only place the difference shows:
+    against a mock the local path looks fine.
 
-    The effect on claude-code is that anyone running against a server loses their
-    anchor at exactly the moment compaction throws the transcript away, and nothing
-    errors to say so. The fix does not need designing — it exists in codex and can
-    be ported.
-
-    Strict xfail on claude-code only, so it turns red the moment that port lands.
-    Driving this hook is trivial here and effectively untestable through the real
-    CLI, where triggering a compaction on demand is the hard part.
+    ``has_precompact_http`` is still a flag rather than an assumption — a future
+    integration could arrive without the branch, and this would then say so.
     """
     if not live_suite.has_precompact_http:
         request.node.add_marker(

--- a/integrations/tests/tests/integration/test_improve_http.py
+++ b/integrations/tests/tests/integration/test_improve_http.py
@@ -14,9 +14,9 @@ Contract:
   * an empty {} body means the per-session improve lock skipped the run — busy,
     never success;
   * a dataset_id in the response triggers best-effort cognify+memify polling
-    (gated on ``has_improve_pipeline_polling`` — claude-code only: the port that
-    gave codex the background bridge did NOT cover its improve path, which still
-    reports no cognify_status).
+    (gated on ``has_improve_pipeline_polling``, now true for both suites — codex's
+    improve path was the one piece the background-remember port missed, and it
+    reported no cognify_status until that was fixed).
 
 Migrated from {claude-code,codex}/tests/test_improve_sync.py; the
 run_session_improve orchestration lives in unit/test_improve_orchestration.py.

--- a/integrations/tests/utils/suites.py
+++ b/integrations/tests/utils/suites.py
@@ -67,10 +67,12 @@ class Suite:
     #: it names a real contract that a future integration may not satisfy.
     has_background_remember: bool
     #: Capability: ``improve_session_via_http`` polls the cognify and memify
-    #: pipelines and reports ``cognify_status``/``memify_status``. Split out from
-    #: has_background_remember because the port that landed in main covered the
-    #: bridge, ``wait_for_cognify`` and the bounded ``do_remember`` wait, but NOT
-    #: the improve path — codex has no ``cognify_status`` anywhere.
+    #: pipelines and reports ``cognify_status``/``memify_status``.
+    #:
+    #: True for both suites now. It was split out from has_background_remember
+    #: because the port that landed in main covered the bridge, ``wait_for_cognify``
+    #: and the bounded ``do_remember`` wait but missed the improve path; kept as its
+    #: own flag because those parts demonstrably travel separately.
     has_improve_pipeline_polling: bool
     #: Capability: the host runs ``async`` hooks and emits ``StopFailure``, so
     #: credits can refresh at turn end without adding a prompt of lag. codex skips
@@ -95,11 +97,16 @@ class Suite:
     #: ``_pipeline_health_glyph`` as of the same port. Tests for individual segments
     #: probe for their own symbol, so they pick that up on their own.
     has_rich_statusline: bool
-    #: Capability: ``pre-compact.py`` branches on ``is_cloud_mode`` and recalls via
-    #: ``recall_via_http``. The one place codex is AHEAD: claude-code's pre-compact
-    #: is local-SDK only, so it produces no anchor at all in server mode. Since
-    #: ``is_cloud_mode`` is just ``bool(base_url)``, a loopback server counts, and
-    #: codex takes the HTTP path everywhere the live tier runs.
+    #: Capability: ``pre-compact.py`` produces an anchor against a server.
+    #:
+    #: Still False for claude-code. It now HAS the ``recall_via_http`` branch, but
+    #: that alone is not enough: the seed recall passes an empty query (there is no
+    #: user question at compact time) and the server matches nothing on an empty
+    #: string — verified directly, query="" returns 0 while a real term returns 1.
+    #: codex reaches an anchor only via the local session-manager fallback, which
+    #: works because the plugin boots the server under the same HOME; claude-code
+    #: does not get there. Closing this needs a server-side way to read recent
+    #: session entries without a query, not more client-side branching.
     has_precompact_http: bool
 
 
@@ -144,7 +151,7 @@ CODEX = Suite(
     session_suffix="_codex",
     host_stem="codex",
     has_background_remember=True,
-    has_improve_pipeline_polling=False,
+    has_improve_pipeline_polling=True,
     has_async_hooks=False,
     has_elapsed_ms_helper=True,
     has_recall_latency_metric=False,


### PR DESCRIPTION
store-to-session.py (both suites, Stop + trace): a write failing after the
server_usable() guard logged and returned, losing the turn. Now buffers
transport failures and 5xx, drops 4xx loudly so a permanently-rejected entry
cannot head-block the drain. Strict xfail now XPASSes on both.

Codex improve: added the cognify+memify poll the port missed.

OpenClaw: `return` after process.exit in the forget guards; session_start
moved out of if(cfg.autoIndex) since it checks enableSessions itself.

Pre-compact: HTTP branch + result normalisation, groundwork only — the
anchor is still empty, see SDK-424 (empty-query recall returns nothing).