### PR TITLE
fix(claude-code,codex): support data-plane-only HTTP backends

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "author": {
         "name": "Cognee"
       },

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": {
     "name": "Cognee"
   },

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,6 +10,17 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.4]
+
+### Fixed
+- **Data-plane-only Cognee HTTP servers no longer look like authentication
+  failures.** Backend reachability now uses the public `/health` contract
+  instead of the optional `/docs` page. A missing agent lifecycle surface
+  (`POST /api/v1/agents/register` or `/unregister` returning 404) is treated as
+  unsupported and best-effort, while credential, transport, and server errors
+  remain failures. This lets compatible servers such as `cognee-http-server`
+  run the memory loop without producing a misleading API-key error.
+
 ## [1.3.3]
 
 ### Fixed

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -2756,6 +2756,12 @@ def register_agent_via_http(
         if isinstance(result, dict):
             return True, result
         return True, {}
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            hook_log("agent_register_unsupported", {"status": exc.code})
+            return True, {"lifecycle_supported": False}
+        hook_log("agent_register_failed", {"error": str(exc)[:200]})
+        return False, {}
     except Exception as exc:
         hook_log("agent_register_failed", {"error": str(exc)[:200]})
         return False, {}
@@ -2775,6 +2781,12 @@ def unregister_agent_via_http(
             count = int(result.get("activeAgents", 0) or result.get("active_agents", 0) or 0)
             return True, count
         return True, 0
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            hook_log("agent_unregister_unsupported", {"status": exc.code})
+            return True, 0
+        hook_log("agent_unregister_failed", {"error": str(exc)[:200]})
+        return False, 0
     except Exception as exc:
         hook_log("agent_unregister_failed", {"error": str(exc)[:200]})
         return False, 0
@@ -2820,7 +2832,7 @@ def recall_via_http(
 def _backend_reachable(base_url: str, timeout: float = 1.5) -> bool:
     try:
         with urllib.request.urlopen(
-            f"{base_url.rstrip('/')}/docs", timeout=timeout, context=_https_context()
+            f"{base_url.rstrip('/')}/health", timeout=timeout, context=_https_context()
         ) as resp:
             return 200 <= resp.status < 500
     except (urllib.error.URLError, TimeoutError, OSError):

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,6 +10,17 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.4.4]
+
+### Fixed
+- **Data-plane-only Cognee HTTP servers no longer look like authentication
+  failures.** Backend reachability now uses the public `/health` contract
+  instead of the optional `/docs` page. A missing agent lifecycle surface
+  (`POST /api/v1/agents/register` or `/unregister` returning 404) is treated as
+  unsupported and best-effort, while credential, transport, and server errors
+  remain failures. This lets compatible servers such as `cognee-http-server`
+  run the memory loop without producing a misleading API-key error.
+
 ## [1.4.3]
 
 ### Fixed

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -2670,6 +2670,12 @@ def register_agent_via_http(
         if isinstance(result, dict):
             return True, result
         return True, {}
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            hook_log("agent_register_unsupported", {"status": exc.code})
+            return True, {"lifecycle_supported": False}
+        hook_log("agent_register_failed", {"error": str(exc)[:200]})
+        return False, {}
     except Exception as exc:
         hook_log("agent_register_failed", {"error": str(exc)[:200]})
         return False, {}
@@ -2689,6 +2695,12 @@ def unregister_agent_via_http(
             count = int(result.get("activeAgents", 0) or result.get("active_agents", 0) or 0)
             return True, count
         return True, 0
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            hook_log("agent_unregister_unsupported", {"status": exc.code})
+            return True, 0
+        hook_log("agent_unregister_failed", {"error": str(exc)[:200]})
+        return False, 0
     except Exception as exc:
         hook_log("agent_unregister_failed", {"error": str(exc)[:200]})
         return False, 0
@@ -2732,7 +2744,7 @@ def recall_via_http(
 def _backend_reachable(base_url: str, timeout: float = 1.5) -> bool:
     try:
         with urllib.request.urlopen(
-            f"{base_url.rstrip('/')}/docs", timeout=timeout, context=_https_context()
+            f"{base_url.rstrip('/')}/health", timeout=timeout, context=_https_context()
         ) as resp:
             return 200 <= resp.status < 500
     except (urllib.error.URLError, TimeoutError, OSError):

--- a/integrations/tests/README.md
+++ b/integrations/tests/README.md
@@ -149,8 +149,8 @@ Shared facts that shape the harness:
 
 | Method | Path | Notes |
 |---|---|---|
-| GET | `/health` | configurable via `set_health_status` |
-| GET | `/docs` | reachability probe (`_backend_reachable`) |
+| GET | `/health` | reachability probe (`_backend_reachable`); configurable via `set_health_status` |
+| GET | `/docs` | optional API docs surface; compatibility tests may return 404 |
 | POST | `/api/v1/auth/login` | form `{username,password}` → `{access_token: <jwt>}` |
 | GET/POST | `/api/v1/auth/api-keys` | cookie `auth_token`; list `[{key}]` / mint `{key}` |
 | GET | `/api/v1/users/me` | `X-Api-Key` probe → `{id}` or 401 |

--- a/integrations/tests/tests/integration/test_http_backend_compat.py
+++ b/integrations/tests/tests/integration/test_http_backend_compat.py
@@ -1,0 +1,54 @@
+"""Compatibility with Cognee HTTP backends that expose only the data plane."""
+
+from __future__ import annotations
+
+import pytest
+
+REGISTER = "/api/v1/agents/register"
+UNREGISTER = "/api/v1/agents/unregister"
+
+
+@pytest.fixture
+def pc(suite, isolated_modules, mock_server, monkeypatch):
+    common = isolated_modules(suite, "_plugin_common")
+    monkeypatch.setenv("COGNEE_BASE_URL", mock_server.url)
+    monkeypatch.setattr(common, "hook_log", lambda *a, **kw: None)
+    return common
+
+
+def test_backend_reachability_uses_health_instead_of_optional_docs(pc, mock_server):
+    """A backend without API docs is still usable when its health route is ready."""
+    mock_server.force_response("GET", "/docs", 404, {"detail": "Not Found"})
+
+    assert pc._backend_reachable(mock_server.url) is True
+    mock_server.assert_called("GET", "/health")
+    mock_server.assert_not_called("GET", "/docs")
+
+
+def _register(pc):
+    return pc.register_agent_via_http(
+        agent_session_name="compat-test",
+        session_id="session-test",
+        dataset_names=["agent_sessions"],
+    )
+
+
+def test_missing_agent_registration_route_is_best_effort(pc, mock_server):
+    mock_server.force_response("POST", REGISTER, 404, {"detail": "Not Found"})
+
+    assert _register(pc) == (True, {"lifecycle_supported": False})
+
+
+def test_missing_agent_unregistration_route_is_best_effort(pc, mock_server):
+    mock_server.force_response("POST", UNREGISTER, 404, {"detail": "Not Found"})
+
+    assert pc.unregister_agent_via_http(agent_session_name="compat-test") == (True, 0)
+
+
+@pytest.mark.parametrize("status", [401, 403, 500])
+def test_agent_lifecycle_http_errors_remain_failures(pc, mock_server, status):
+    mock_server.force_response("POST", REGISTER, status, {"detail": "rejected"})
+    mock_server.force_response("POST", UNREGISTER, status, {"detail": "rejected"})
+
+    assert _register(pc) == (False, {})
+    assert pc.unregister_agent_via_http(agent_session_name="compat-test") == (False, 0)

--- a/integrations/tests/tests/unit/test_timing_metrics.py
+++ b/integrations/tests/tests/unit/test_timing_metrics.py
@@ -89,8 +89,9 @@ def run_bridge(pc, suite, tmp_path, monkeypatch):
         monkeypatch.setattr(
             pc,
             "_post_remember_document",
-            lambda *a, **k: post_result
-            or {"ok": True, "dataset_id": "d1", "pipeline_run_id": "p1"},
+            lambda *a, **k: (
+                post_result or {"ok": True, "dataset_id": "d1", "pipeline_run_id": "p1"}
+            ),
         )
         monkeypatch.setattr(pc, "wait_for_cognify", lambda *a, **k: outcome)
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- use the public `/health` contract for `_backend_reachable()` instead of the optional `/docs` page
- treat `404` from agent registration/unregistration as an unsupported optional lifecycle API
- preserve failures for `401`, `403`, `5xx`, and transport errors
- apply the behavior symmetrically to Claude Code and Codex
- add shared hermetic regression coverage and bump both plugin patch versions

## Why

A Cognee-compatible HTTP backend can provide the complete memory data plane without the Python/Cloud agent lifecycle routes. Before this change, Codex SessionStart mapped the missing registration route to `incorrect_cognee_api_key` even though `/health` and the memory routes were ready.

The new tests were run against the pre-fix code first and failed for both integrations. A hermetic Codex SessionStart reproduction now exits 0, writes `ready` markers, and renders `● cognee` while `/api/v1/agents/register` returns 404.

## Verification

- `cd integrations/tests && uv run pytest tests/ -q` — 976 passed, 72 skipped, 36 deselected
- `ruff format --check integrations/` — 287 files already formatted
- `ruff check integrations/` — all checks passed
- plugin and marketplace JSON validated with `jq empty`
- independent review: no Critical or Important findings

## Note

The second commit contains Ruff's AST-preserving formatting of one pre-existing expression in `test_timing_metrics.py`; upstream `main` otherwise fails the repository-wide format check before this patch.

Closes #350