### PR TITLE
feat(qwen): add first-class Cognee memory extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,10 @@ jobs:
 
           for dir in $CHANGED_DIRS; do
             [ ! -d "integrations/$dir" ] && continue
-            # claude-code and codex have no pyproject of their own; their shared
+            # claude-code, codex, and qwen have no pyproject of their own; their shared
             # pytest suite lives in integrations/tests and must run when they change.
             case "$dir" in
-              claude-code|codex|tests) RUN_SHARED=1 ;;
+              claude-code|codex|qwen|tests) RUN_SHARED=1 ;;
             esac
             if [ -f "integrations/$dir/pyproject.toml" ]; then
               PY_LIST="${PY_LIST}\"${dir}\","

--- a/.github/workflows/plugin-windows-tests.yml
+++ b/.github/workflows/plugin-windows-tests.yml
@@ -1,6 +1,6 @@
 name: Plugin Windows Tests
 
-# The claude-code and codex plugins carry genuinely platform-specific paths:
+# The claude-code, codex, and qwen plugins carry genuinely platform-specific paths:
 # _proc.py (Windows liveness via OpenProcess/WaitForSingleObject, process
 # ancestry via CreateToolhelp32Snapshot), a status-line renderer whose stdio
 # encoding is Windows-sensitive (cp1252 cannot encode the health glyphs), and
@@ -20,6 +20,7 @@ on:
     paths:
       - 'integrations/claude-code/**'
       - 'integrations/codex/**'
+      - 'integrations/qwen/**'
       - 'integrations/tests/**'
       - '.github/workflows/plugin-windows-tests.yml'
   push:
@@ -27,6 +28,7 @@ on:
     paths:
       - 'integrations/claude-code/**'
       - 'integrations/codex/**'
+      - 'integrations/qwen/**'
       - 'integrations/tests/**'
       - '.github/workflows/plugin-windows-tests.yml'
 
@@ -44,11 +46,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # integrations/tests holds the shared suite; the other two hold the
+          # integrations/tests holds the shared suite; the other trees hold the
           # hook scripts it imports and runs as subprocesses.
           sparse-checkout: |
             integrations/claude-code
             integrations/codex
+            integrations/qwen
             integrations/tests
 
       - name: Set up Python

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Run these slash commands directly in the Claude Code chat:
 
 In local mode (the default), the plugin bootstraps a local Cognee API on
 `http://localhost:8011`. Cognee extracts knowledge with an LLM, so set `LLM_API_KEY`
-**once** in `~/.cognee/.env` (shared by the Claude Code and Codex plugins) — one
+**once** in `~/.cognee/.env` (shared by the Claude Code, Codex, and Qwen plugins) — one
 paste, no editor needed:
 
 ```bash
@@ -136,6 +136,20 @@ skills explicitly:
 
 For full configuration (datasets, sessions, sync watchers, cloud mode), see
 [`integrations/claude-code/README.md`](integrations/claude-code/README.md).
+
+## Qwen Code Quickstart
+
+Install the Qwen extension from this repository:
+
+```bash
+qwen extensions install /path/to/cognee-integrations/integrations/qwen
+```
+
+It uses Qwen's native extension loader and does not edit
+`~/.qwen/settings.json`. Configure `~/.cognee/.env` as above; use
+`COGNEE_QWEN_BACKEND=local|cloud` when Qwen needs a different backend from
+the other Cognee plugins. See
+[`integrations/qwen/README.md`](integrations/qwen/README.md) for details.
 
 > **Using an agent framework instead?** The Python SDK integrations (Strands, CrewAI,
 > LangGraph, Google ADK, Claude Agent SDK) follow a `pip install` →
@@ -215,6 +229,7 @@ integrations/
   openclaw/           -> @openclaw/memory-cognee (npm)
   claude-code/        -> Cognee plugin for Claude Code
   codex/              -> Cognee plugin marketplace for Codex
+  qwen/               -> Cognee extension for Qwen Code
 ```
 
 ## Adding a New Integration

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -60,6 +60,17 @@ integrations:
     migration_status: done
     notes: "Codex local plugin marketplace with Cognee CLI skills for setup, memory, codebase ingestion, and UI launch"
 
+  - slug: qwen
+    name: "Cognee Memory Extension for Qwen Code"
+    owner: cognee
+    language: python
+    registry: qwen-extension
+    package_name: null
+    cognee_dependency: http-api
+    current_version: "1.4.4"
+    migration_status: done
+    notes: "Qwen Code extension with automatic session capture, recall, graph sync, and bundled Cognee skills"
+
   - slug: hermes-agent
     name: "Cognee Memory Plugin for Hermes Agent"
     owner: cognee

--- a/integrations/openclaw/skills/cognee-memory/SKILL.md
+++ b/integrations/openclaw/skills/cognee-memory/SKILL.md
@@ -42,6 +42,7 @@ AI knowledge engine — a memory system in 6 lines of code.
 import cognee
 import asyncio
 
+
 async def main():
     # Store into the knowledge graph
     await cognee.remember("Cognee turns documents into AI memory.")
@@ -56,6 +57,7 @@ async def main():
 
     # Delete
     await cognee.forget(dataset="main_dataset")
+
 
 asyncio.run(main())
 ```
@@ -172,6 +174,7 @@ See the [plugin README](../../README.md) for required hook permissions
 import cognee
 import asyncio
 
+
 async def memory_loop():
     # 1. Learn new knowledge
     await cognee.remember("The user is learning Python programming")
@@ -185,6 +188,7 @@ async def memory_loop():
 
     # 4. Forget incorrect memories
     await cognee.forget("The incorrect assumption")
+
 
 asyncio.run(memory_loop())
 ```

--- a/integrations/qwen/CHANGELOG.md
+++ b/integrations/qwen/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- Document that Qwen prompt capture and recall require `submitted_prompt`
+  provenance. ACP, headless, `serve`, SDK, remote-input, restored, and Vim-mode
+  inputs are intentionally skipped so `ToolResult`/`Hook` continuations cannot
+  overwrite or query as user prompts; see
+  [Qwen issue #9511](https://github.com/QwenLM/qwen-code/issues/9511). This is
+  not an API-key or configuration problem.
+- Tool trace, assistant-response, `PreCompact`, and session-sync hooks remain
+  active when prompt capture/recall is skipped.
+
 ## 1.4.4
 
 - Add the first Qwen Code extension package.

--- a/integrations/qwen/CHANGELOG.md
+++ b/integrations/qwen/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 1.4.4
+
+- Add the first Qwen Code extension package.
+- Capture prompts, tool traces, and assistant responses through Qwen's
+  Claude-compatible hooks.
+- Recall relevant Cognee context before each prompt and sync at session end.
+- Isolate Qwen runtime state and backend selection from other hosts.
+- Use the required `/health` probe and tolerate missing optional agent
+  lifecycle routes on data-plane-only Cognee servers.

--- a/integrations/qwen/GEMINI.md
+++ b/integrations/qwen/GEMINI.md
@@ -1,0 +1,6 @@
+# Cognee memory for Qwen Code
+
+This Gemini-compatible extension package provides persistent Cognee memory to
+Qwen Code. See `QWEN.md` for the runtime contract and bundled skills.
+
+@./QWEN.md

--- a/integrations/qwen/QWEN.md
+++ b/integrations/qwen/QWEN.md
@@ -1,0 +1,12 @@
+# Cognee memory for Qwen Code
+
+This extension captures prompts, tool traces, and assistant responses in
+Cognee session memory, recalls relevant context before each prompt, and syncs
+completed sessions into graph memory.
+
+Runtime configuration lives in `~/.cognee/.env`, shared with the Claude Code
+and Codex integrations.
+
+@./skills/memory/SKILL.md
+@./skills/setup/SKILL.md
+@./skills/codebase/SKILL.md

--- a/integrations/qwen/QWEN.md
+++ b/integrations/qwen/QWEN.md
@@ -1,8 +1,11 @@
 # Cognee memory for Qwen Code
 
-This extension captures prompts, tool traces, and assistant responses in
-Cognee session memory, recalls relevant context before each prompt, and syncs
-completed sessions into graph memory.
+This extension captures provenanced prompts, tool traces, and assistant
+responses in Cognee session memory, recalls relevant context for provenanced
+prompts, and syncs completed sessions into graph memory. `UserPromptSubmit`
+events without `submitted_prompt` are intentionally skipped for prompt
+capture/recall; tool trace, assistant-response, PreCompact, and sync hooks stay
+active. See [Qwen issue #9511](https://github.com/QwenLM/qwen-code/issues/9511).
 
 Runtime configuration lives in `~/.cognee/.env`, shared with the Claude Code
 and Codex integrations.

--- a/integrations/qwen/README.md
+++ b/integrations/qwen/README.md
@@ -1,0 +1,55 @@
+# Cognee for Qwen Code
+
+This extension adds automatic Cognee memory to
+[Qwen Code](https://github.com/QwenLM/qwen-code):
+
+- session bootstrap on `SessionStart`
+- recall and prompt capture on `UserPromptSubmit`
+- tool and assistant-response capture
+- a pre-compaction memory anchor
+- final session-to-graph sync
+
+Qwen uses Gemini-style extension manifests but Claude-style hook event names.
+Its command-hook timeouts are milliseconds, so this package deliberately uses
+`120000` for a 120-second hook window.
+
+## Install
+
+```bash
+qwen extensions install /path/to/cognee-integrations/integrations/qwen
+```
+
+For local development:
+
+```bash
+qwen extensions link /path/to/cognee-integrations/integrations/qwen
+```
+
+The extension ships both `qwen-extension.json` and
+`gemini-extension.json`. Installation does not edit
+`~/.qwen/settings.json`.
+
+## Configure
+
+Put durable settings in `~/.cognee/.env`, shared with the Claude Code and
+Codex plugins:
+
+```dotenv
+# Remote Cognee server:
+COGNEE_BASE_URL="https://your-instance.cognee.ai"
+COGNEE_API_KEY="ck_..."
+
+# Or local mode:
+LLM_API_KEY="sk-..."
+```
+
+`COGNEE_BACKEND=local|cloud` selects a mode for every Cognee plugin in the
+current shell. `COGNEE_QWEN_BACKEND=local|cloud` selects it for Qwen only.
+Qwen-specific state lives under `~/.cognee-plugin/qwen/`; the default dataset
+is `agent_sessions`.
+
+Update the installed extension with:
+
+```bash
+qwen extensions update cognee
+```

--- a/integrations/qwen/README.md
+++ b/integrations/qwen/README.md
@@ -4,7 +4,7 @@ This extension adds automatic Cognee memory to
 [Qwen Code](https://github.com/QwenLM/qwen-code):
 
 - session bootstrap on `SessionStart`
-- recall and prompt capture on `UserPromptSubmit`
+- provenance-safe recall and prompt capture on `UserPromptSubmit`
 - tool and assistant-response capture
 - a pre-compaction memory anchor
 - final session-to-graph sync
@@ -12,6 +12,18 @@ This extension adds automatic Cognee memory to
 Qwen uses Gemini-style extension manifests but Claude-style hook event names.
 Its command-hook timeouts are milliseconds, so this package deliberately uses
 `120000` for a 120-second hook window.
+
+## UserPromptSubmit coverage
+
+Qwen command hooks provide real-user provenance only through optional
+`submitted_prompt`. Cognee intentionally skips `UserPromptSubmit` events without
+it, so `ToolResult`/`Hook` continuations cannot overwrite a pending question or
+query memory as a user prompt. ACP, headless, `serve`, SDK, remote-input,
+restored, and Vim-mode inputs therefore do not receive prompt capture or recall
+until [Qwen issue #9511](https://github.com/QwenLM/qwen-code/issues/9511) adds a
+send-level discriminator. This is a Qwen hook-payload limitation, not an API-key
+or configuration problem. Tool trace, assistant-response, `PreCompact`, and
+session-sync hooks remain active.
 
 ## Install
 

--- a/integrations/qwen/gemini-extension.json
+++ b/integrations/qwen/gemini-extension.json
@@ -1,0 +1,7 @@
+{
+  "name": "cognee",
+  "description": "Persistent Cognee knowledge-graph memory for Qwen Code.",
+  "version": "1.4.4",
+  "contextFileName": "GEMINI.md",
+  "hooks": "hooks/hooks.json"
+}

--- a/integrations/qwen/hooks/hooks.json
+++ b/integrations/qwen/hooks/hooks.json
@@ -1,0 +1,89 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.py\" || python \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.py\"",
+            "timeout": 120000,
+            "statusMessage": "Initializing Cognee memory..."
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/session-context-lookup.py\" || python \"${CLAUDE_PLUGIN_ROOT}/scripts/session-context-lookup.py\"",
+            "timeout": 120000,
+            "statusMessage": "Searching session memory..."
+          },
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/store-user-prompt.py\" || python \"${CLAUDE_PLUGIN_ROOT}/scripts/store-user-prompt.py\"",
+            "timeout": 120000,
+            "statusMessage": "Saving user prompt..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/store-to-session.py\" || python \"${CLAUDE_PLUGIN_ROOT}/scripts/store-to-session.py\"",
+            "timeout": 120000,
+            "statusMessage": "Saving tool trace..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/store-to-session.py\" --stop || python \"${CLAUDE_PLUGIN_ROOT}/scripts/store-to-session.py\" --stop",
+            "timeout": 120000,
+            "statusMessage": "Saving assistant response..."
+          },
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/credits-refresh.py\" || python \"${CLAUDE_PLUGIN_ROOT}/scripts/credits-refresh.py\"",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.py\" || python \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.py\"",
+            "timeout": 120000,
+            "statusMessage": "Building memory anchor..."
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/sync-session-to-graph.py\" --session-end || python \"${CLAUDE_PLUGIN_ROOT}/scripts/sync-session-to-graph.py\" --session-end",
+            "timeout": 30000,
+            "statusMessage": "Syncing session memory..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrations/qwen/qwen-extension.json
+++ b/integrations/qwen/qwen-extension.json
@@ -1,0 +1,7 @@
+{
+  "name": "cognee",
+  "description": "Persistent Cognee knowledge-graph memory for Qwen Code.",
+  "version": "1.4.4",
+  "contextFileName": "QWEN.md",
+  "hooks": "hooks/hooks.json"
+}

--- a/integrations/qwen/scripts/_cognee_client.py
+++ b/integrations/qwen/scripts/_cognee_client.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Cohesive, resilient cognee recall client for the plugin.
+
+This is the single layer the recall paths route through — the explicit
+`cognee-search.sh` wrapper and (via a shared breaker) the auto-recall hook — so a
+repeatedly-failing backend trips one **circuit breaker** instead of being hammered
+on every call, and every call gets a bounded, named **timeout**.
+
+The recall transport itself lives in `_recall_http.do_recall` (server-first, with
+the list / error-envelope / UNREACHABLE contract); this module adds the breaker +
+timeout policy around it.
+
+The breaker is **file-based** on purpose: each plugin hook/script runs as a
+short-lived process, so in-memory state (as a long-lived provider like Hermes
+uses) would not survive between calls. State lives in the plugin state dir.
+"""
+
+import json
+import os
+import pathlib
+import sys
+import time
+
+from _env_file import load_env_file
+from _recall_http import UNREACHABLE, _error, do_recall
+
+# ~/.cognee/.env must land in os.environ before the module-level reads below.
+load_env_file()
+
+# Tunables (mirror Hermes's provider defaults).
+_THRESHOLD = int(os.environ.get("COGNEE_BREAKER_THRESHOLD", "5"))
+_COOLDOWN = float(os.environ.get("COGNEE_BREAKER_COOLDOWN", "120"))
+# Sliding window: only failures within this many seconds of each other count
+# toward the threshold. Without it, five isolated blips spread over days would
+# open the breaker "out of nowhere" long after the last real problem.
+_WINDOW = float(os.environ.get("COGNEE_BREAKER_WINDOW", "300"))
+_RECALL_TIMEOUT = float(os.environ.get("COGNEE_RECALL_TIMEOUT", "120"))
+
+
+def _state_path():
+    base = os.environ.get("COGNEE_PLUGIN_STATE_DIR") or os.path.expanduser("~/.cognee-plugin")
+    return pathlib.Path(base) / "recall-breaker.json"
+
+
+def _norm_url(service_url):
+    return str(service_url or "").strip().rstrip("/")
+
+
+def _read():
+    """The per-server breaker map {url: entry}. A legacy flat file (top-level
+    ``failures``/``cooldown_until``, not keyed by server) is discarded rather
+    than migrated: it conflated every server on the machine, which is one of
+    the bugs this schema exists to fix."""
+    try:
+        data = json.loads(_state_path().read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    servers = data.get("servers") if isinstance(data, dict) else None
+    return servers if isinstance(servers, dict) else {}
+
+
+def _write(servers):
+    try:
+        path = _state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # pid-suffixed tmp + atomic replace, matching the other marker writers:
+        # readers (other hooks, the status-line renderer) can never see a torn
+        # file. Concurrent writers remain last-write-wins — accepted for this
+        # advisory state; serializing them would need file locking.
+        tmp = path.with_name(".breaker-%d.json.tmp" % os.getpid())
+        tmp.write_text(json.dumps({"servers": servers}), encoding="utf-8")
+        os.replace(tmp, path)
+    except Exception:
+        pass
+
+
+def _entry(servers, url):
+    entry = servers.get(url)
+    return entry if isinstance(entry, dict) else {}
+
+
+def _recent_failures(entry, now):
+    """This server's failure timestamps still inside the sliding window."""
+    stamps = entry.get("failures")
+    if not isinstance(stamps, list):
+        return []
+    out = []
+    for value in stamps:
+        try:
+            ts = float(value)
+        except (TypeError, ValueError):
+            continue
+        if now - ts <= _WINDOW:
+            out.append(ts)
+    return out
+
+
+def breaker_open(service_url="", now=None):
+    """Return (is_open, retry_in_seconds) for this server.
+
+    Open while inside the cooldown window. With no ``service_url`` (doctor /
+    legacy callers), reports the worst open entry across all servers.
+    """
+    now = time.time() if now is None else now
+    servers = _read()
+    urls = [_norm_url(service_url)] if _norm_url(service_url) else list(servers)
+    worst = 0.0
+    for url in urls:
+        try:
+            until = float(_entry(servers, url).get("cooldown_until") or 0.0)
+        except (TypeError, ValueError):
+            until = 0.0
+        worst = max(worst, until)
+    return (True, int(worst - now)) if now < worst else (False, 0)
+
+
+def breaker_reason(service_url=""):
+    """The reason the breaker last tripped for this server ("" if never)."""
+    servers = _read()
+    url = _norm_url(service_url)
+    if not url and servers:
+        url = next(iter(servers))
+    return str(_entry(servers, url).get("reason") or "")
+
+
+def record_failure(error="", now=None, service_url="", reason="unreachable"):
+    """Count a hard backend failure; open the breaker at the windowed threshold.
+
+    Only definitive trouble belongs here — UNREACHABLE (positively absent) or
+    5xx. Timeouts are no-verdict and must NOT be recorded (see the transient
+    envelope handling in ``recall``). When the breaker trips, the counted
+    failures are consumed: after the cooldown the breaker is half-open, and a
+    single new failure starts a fresh count instead of instantly re-opening.
+    """
+    now = time.time() if now is None else now
+    url = _norm_url(service_url)
+    servers = _read()
+    entry = _entry(servers, url)
+    failures = _recent_failures(entry, now)
+    failures.append(now)
+    if len(failures) >= _THRESHOLD:
+        entry = {
+            "failures": [],
+            "cooldown_until": now + _COOLDOWN,
+            "reason": str(reason or "unreachable"),
+            "last_error": str(error)[:200],
+        }
+    else:
+        entry = dict(entry)
+        entry["failures"] = failures
+        entry["last_error"] = str(error)[:200]
+    servers[url] = entry
+    _write(servers)
+
+
+def record_success(service_url=""):
+    """Backend answered — clear this server's breaker entry."""
+    servers = _read()
+    servers.pop(_norm_url(service_url), None)
+    _write(servers)
+
+
+def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *, timeout=None):
+    """Breaker-wrapped recall. Returns a list, an error-envelope dict, or UNREACHABLE.
+
+    Only genuine backend trouble trips the breaker: UNREACHABLE (positively
+    absent — refused/DNS) or a 5xx. A reachable 4xx (e.g. 401/403 auth) is a
+    config problem — surfaced, but it does NOT open the breaker (waiting
+    wouldn't fix it). A transient envelope (timeout / unclassifiable transport
+    error) is no verdict at all: it neither counts as a failure nor clears the
+    window — a busy server must not be branded unreachable by its own latency.
+    """
+    is_open, retry = breaker_open(service_url)
+    if is_open:
+        # We're in cooldown: surface a clear message and do NOT call (and, since
+        # this isn't UNREACHABLE, the wrapper won't fall back to the CLI either —
+        # which would just hammer the same down server).
+        return _error(503, "cognee temporarily unavailable (circuit open, retry in ~%ds)" % retry)
+
+    result = do_recall(
+        service_url,
+        api_key,
+        query,
+        session_id,
+        scope,
+        top_k,
+        dataset,
+        timeout=timeout or _RECALL_TIMEOUT,
+    )
+    if result == UNREACHABLE:
+        record_failure("unreachable", service_url=service_url, reason="unreachable")
+    elif isinstance(result, dict) and int(result.get("status") or 0) >= 500:
+        record_failure(
+            "http %s" % result.get("status"), service_url=service_url, reason="server_error"
+        )
+    elif isinstance(result, dict) and result.get("transient"):
+        pass  # no verdict: leave the breaker exactly as it was
+    else:
+        record_success(service_url)
+    return result
+
+
+def main(argv):
+    # argv: service_url, api_key, query, session_id, scope, top_k[, dataset]
+    a = list(argv) + [""] * 7
+    result = recall(a[0], a[1], a[2], a[3], a[4], a[5], a[6])
+    print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/integrations/qwen/scripts/_env_file.py
+++ b/integrations/qwen/scripts/_env_file.py
@@ -1,0 +1,266 @@
+"""One-time plugin configuration via ~/.cognee/.env.
+
+Users historically had to `export COGNEE_BASE_URL=...`, `export LLM_API_KEY=...`
+in every shell. This module makes that a one-time step: values placed in
+``~/.cognee/.env`` (the durable, venv-rebuild-safe cognee home shared by the
+Claude Code and Qwen plugins) are injected into ``os.environ`` at process
+start with **setdefault** semantics, so:
+
+  real exported env vars  >  ~/.cognee/.env  >  config.json  >  defaults
+
+Every existing ``os.environ.get(...)`` call site — and every child process the
+hooks spawn (the local cognee server, idle/exit watchers) — picks the values up
+unchanged.
+
+Deliberately stdlib-only: hook scripts must run outside the plugin venv on the
+cloud path, so python-dotenv is not an option. The parser accepts a leading
+``export `` so users can paste their existing shell export lines verbatim.
+
+The file may hold BOTH modes' variables at once (cloud connection + local LLM
+key); with nothing exported, cloud wins because ``COGNEE_BASE_URL`` routes the
+connection. One export flips a single terminal: ``COGNEE_BACKEND=local`` (or
+``=cloud``), with the plugin-specific variable (``_PLUGIN_BACKEND_VAR``)
+beating the shared name. A forced-local switch is applied to ``os.environ``
+itself (see ``_apply_backend_switch``) so the HTTP hot paths and spawned
+children — which read ``COGNEE_BASE_URL`` from the environment directly, not
+via ``config.load_config`` — see the same mode.
+
+Loading must never break a hook: any parse or IO problem results in the file
+being (partially) ignored, never an exception.
+"""
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+_COGNEE_HOME = Path.home() / ".cognee"
+_DEFAULT_ENV_FILE = _COGNEE_HOME / ".env"
+
+# Vars that could hijack process behavior if injected from a config file.
+# Everything else (COGNEE_*, LLM_*, EMBEDDING_*, provider keys, ...) is allowed
+# so the values also flow through to the spawned local cognee server.
+_DENYLIST_EXACT = {"PATH", "HOME", "PYTHONPATH", "PYTHONHOME", "SHELL", "USER"}
+_DENYLIST_PREFIXES = ("LD_", "DYLD_")
+
+# Explicit per-terminal mode switch. The shared name flips every Cognee plugin
+# in the terminal; the plugin-specific name beats it when both are set. The
+# plugin var is the ONE line that differs between the Claude Code and Qwen
+# copies of this module.
+_PLUGIN_BACKEND_VAR = "COGNEE_QWEN_BACKEND"
+_SHARED_BACKEND_VAR = "COGNEE_BACKEND"
+_LOCAL_BACKEND_VALUES = ("local", "native", "sdk")
+_CLOUD_BACKEND_VALUES = ("cloud", "http", "api", "server")
+
+_TEMPLATE = """\
+# Cognee plugin configuration — shared by the Claude Code and Qwen plugins.
+# Values here are loaded at session start and act like shell exports, except
+# you only set them once. A real `export` in your shell still wins over this
+# file. Lines starting with `#` are comments; a leading `export ` is allowed.
+#
+# You can fill in BOTH modes below. When both are configured, cloud wins.
+# To pick a mode for a single terminal, export the switch before launching:
+#   export COGNEE_BACKEND=local    # this terminal: local mode
+#   export COGNEE_BACKEND=cloud    # this terminal: cloud mode
+# (COGNEE_CLAUDE_BACKEND / COGNEE_QWEN_BACKEND target one plugin only.)
+
+## Cloud / remote mode — point the plugins at a Cognee instance:
+# COGNEE_BASE_URL="https://your-instance.cognee.ai"
+# COGNEE_API_KEY="ck_..."
+
+## Local mode (default when COGNEE_BASE_URL is unset) — the plugin runs a
+## local Cognee API; only an LLM key is required:
+# LLM_API_KEY="sk-..."
+# LLM_MODEL="openai/gpt-4o-mini"
+
+## Optional:
+# COGNEE_PLUGIN_DATASET="agent_sessions"
+"""
+
+
+def env_file_path() -> Path:
+    """The env file location (COGNEE_ENV_FILE overrides the default)."""
+    override = os.environ.get("COGNEE_ENV_FILE", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return _DEFAULT_ENV_FILE
+
+
+def _unquote(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
+def _blocked(key: str) -> bool:
+    return key in _DENYLIST_EXACT or key.startswith(_DENYLIST_PREFIXES)
+
+
+def parse_env_file(path: Path) -> dict:
+    """Parse a dotenv-style file into a dict. Malformed lines are skipped.
+
+    Supported: ``KEY=VALUE``, blank lines, ``#`` comments, an optional leading
+    ``export ``, and single/double quotes around the value. No interpolation,
+    no multi-line values.
+    """
+    result: dict[str, str] = {}
+    try:
+        # utf-8-sig strips a UTF-8 BOM when present (Windows PowerShell 5.1
+        # writes one) and is a no-op otherwise. A PS5 `>` redirect produces
+        # UTF-16 instead — retry with that before giving up.
+        try:
+            text = path.read_text(encoding="utf-8-sig")
+        except UnicodeDecodeError:
+            text = path.read_text(encoding="utf-16")
+    except Exception:
+        return result
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not key or not all(c.isalnum() or c == "_" for c in key):
+            continue
+        result[key] = _unquote(value)
+    return result
+
+
+_loaded = False
+
+
+def load_env_file() -> None:
+    """Inject env-file values into os.environ (setdefault). Never raises.
+
+    Idempotent per process: repeated calls (this module is imported from
+    several entry-point modules) parse the file at most once. The backend
+    switch is applied afterwards — and also when there is no file at all, so
+    ``COGNEE_BACKEND=local`` beats a ``COGNEE_BASE_URL`` exported in the shell
+    the same way it beats one defined in the file.
+    """
+    global _loaded
+    if _loaded:
+        return
+    _loaded = True
+
+    try:
+        path = env_file_path()
+        if path.is_file():
+            _tighten_permissions(path)
+            for key, value in parse_env_file(path).items():
+                if _blocked(key):
+                    continue
+                os.environ.setdefault(key, value)
+    except Exception:
+        pass
+    _apply_backend_switch()
+
+
+def forced_backend_with_source() -> tuple[str, str]:
+    """The exported backend switch: ("local"|"cloud", var name), or ("", "").
+
+    The plugin-specific variable beats the shared ``COGNEE_BACKEND``; a
+    variable holding an unrecognized value is skipped rather than honored.
+    """
+    for var in (_PLUGIN_BACKEND_VAR, _SHARED_BACKEND_VAR):
+        value = os.environ.get(var, "").strip().lower()
+        if value in _LOCAL_BACKEND_VALUES:
+            return "local", var
+        if value in _CLOUD_BACKEND_VALUES:
+            return "cloud", var
+    return "", ""
+
+
+def forced_backend() -> str:
+    """ "local", "cloud", or "" — the exported backend switch, if any."""
+    return forced_backend_with_source()[0]
+
+
+def _apply_backend_switch() -> None:
+    """Make a forced-local terminal actually local, everywhere.
+
+    ``config.load_config`` clears base_url/api_key on the backend switch, but
+    the HTTP hot paths (``_plugin_common``) and every child process read
+    ``COGNEE_BASE_URL`` from the environment directly — so the switch must land
+    in the environment itself. Overwrite with EMPTY strings rather than
+    deleting: a child re-running this loader must not re-inject the file's
+    cloud values (setdefault skips keys that are present, even when empty).
+
+    Forced cloud scrubs nothing: the cloud connection variables are exactly
+    what that mode needs, and missing ones are surfaced by the status line
+    rather than silently falling back to local.
+    """
+    if forced_backend() != "local":
+        return
+    os.environ["COGNEE_BASE_URL"] = ""
+    os.environ["COGNEE_API_KEY"] = ""
+
+
+def _tighten_permissions(path: Path) -> None:
+    """Best-effort chmod 0600: the file may hold API keys."""
+    if os.name == "nt":
+        return
+    try:
+        mode = stat.S_IMODE(path.stat().st_mode)
+        if mode & 0o077:
+            path.chmod(0o600)
+    except Exception:
+        pass
+
+
+def ensure_env_file_template() -> bool:
+    """Write a commented template to ~/.cognee/.env if no file exists yet.
+
+    Returns True when the template was created. Called from SessionStart so
+    users find a documented file to fill in instead of an empty folder. Only
+    the default location gets a template — an explicit COGNEE_ENV_FILE
+    pointing elsewhere is the user's own file to manage.
+    """
+    if os.environ.get("COGNEE_ENV_FILE", "").strip():
+        return False
+    try:
+        if _DEFAULT_ENV_FILE.exists():
+            return False
+        _COGNEE_HOME.mkdir(parents=True, exist_ok=True)
+        _DEFAULT_ENV_FILE.write_text(_TEMPLATE, encoding="utf-8")
+        if os.name != "nt":
+            _DEFAULT_ENV_FILE.chmod(0o600)
+        return True
+    except Exception:
+        return False
+
+
+def env_file_status() -> dict:
+    """Diagnostics for doctor: existence, perms, and key *names* (no values)."""
+    path = env_file_path()
+    info: dict = {"path": str(path), "exists": path.is_file()}
+    mode, var = forced_backend_with_source()
+    if mode:
+        info["forced_backend"] = {"mode": mode, "var": var}
+    if not info["exists"]:
+        return info
+    try:
+        info["mode"] = oct(stat.S_IMODE(path.stat().st_mode))
+    except Exception:
+        pass
+    values = parse_env_file(path)
+    info["keys"] = sorted(values)
+    info["blocked"] = sorted(k for k in values if _blocked(k))
+    # A shell export (or another source) that set a different value wins over
+    # the file; surface those so mode-selection surprises are debuggable.
+    info["overridden"] = sorted(
+        k for k in values if not _blocked(k) and os.environ.get(k, values[k]) != values[k]
+    )
+    return info
+
+
+if __name__ == "__main__":
+    import json
+
+    load_env_file()
+    json.dump(env_file_status(), sys.stdout, indent=2)
+    print()

--- a/integrations/qwen/scripts/_plugin_common.py
+++ b/integrations/qwen/scripts/_plugin_common.py
@@ -1,0 +1,3616 @@
+"""Shared helpers across plugin hook scripts.
+
+Kept deliberately small: user resolution, runtime-state read, a
+single log-to-disk helper. Hook scripts shouldn't grow heavy because
+they run on every user prompt / tool call.
+"""
+
+import asyncio
+import errno
+import hashlib
+import json
+import os
+import socket
+import ssl
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import _proc
+from _env_file import load_env_file
+from _recall_http import DOWN, SLOW, UNKNOWN, classify_transport_exception
+
+# One-time config: ~/.cognee/.env acts like shell exports (setdefault — a real
+# export still wins). Loaded before any env read below or in importers.
+load_env_file()
+
+_PLUGIN_DIR = Path.home() / ".cognee-plugin" / "qwen"
+_SHARED_PLUGIN_ROOT = Path.home() / ".cognee-plugin"
+_HOOK_LOG = _PLUGIN_DIR / "hook.log"
+_COUNTER_FILE = _PLUGIN_DIR / "counter.json"
+_ACTIVITY_FILE = _PLUGIN_DIR / "activity.ts"
+_ACTIVITY_LOG = _PLUGIN_DIR / "activity.log"
+_SAVE_COUNTER = _PLUGIN_DIR / "save_counter.json"
+_SERVER_READY_MARKER = _SHARED_PLUGIN_ROOT / "server-ready.json"
+_SERVER_READY_TTL_SECONDS = 30
+_SYNC_LOCK = _PLUGIN_DIR / "sync.lock"
+# One lock file per session (see improve_session_lock): the idle watcher, the
+# store hook and the SessionEnd sync all bridge sessions, and only one of them
+# may have an improve in flight for a given session at a time.
+_IMPROVE_LOCK_DIR = _PLUGIN_DIR / "improve-locks"
+# Per-agent-session buffer dirs. Each agent session (one Claude/Qwen terminal)
+# owns its own file under these dirs, so two concurrent agents never
+# read-modify-write the same file — no locks needed, no lost-update races.
+_BRIDGE_DIR = _PLUGIN_DIR / "bridge"
+_PENDING_DIR = _PLUGIN_DIR / "pending"
+_SUBPROCESS_LOG = _PLUGIN_DIR / "subprocess.log"
+# Single-principal model: one API key (user-provided COGNEE_API_KEY or one minted
+# from the default user) is cached here. Replaces the old per-agent agent_keys.json.
+_API_KEY_CACHE = _SHARED_PLUGIN_ROOT / "api_key.json"
+# Host-session-id -> generated Cognee session-id map. The host (Claude/Qwen)
+# session id is used ONLY as a local correlation key so every hook process of a
+# single launch resolves the SAME Cognee session id; it is never sent to Cognee
+# as an identity. A genuinely new launch gets a new host id -> new Cognee session;
+# a `resume` reuses the host id -> continues the same Cognee session.
+_SESSIONS_MAP_DIR = _PLUGIN_DIR / "sessions"
+
+# Save-kinds tracked per turn. Keep this tuple in sync with bump_save_counter callers.
+SAVE_KINDS = ("prompt", "trace", "answer")
+
+# Cap the per-line log size so a noisy tool output doesn't bloat the file.
+_LOG_LINE_CAP = 600
+
+# Default auto-improve threshold (tool calls + stops). Env override.
+AUTO_IMPROVE_EVERY_DEFAULT = 150
+SYNC_LOCK_STALE_SECONDS = 15 * 60
+_DEFAULT_LOCAL_SERVICE_URL = "http://localhost:8011"
+
+# --- Self-managed cognee runtime (SHARED with the Claude Code plugin) --------
+# Deliberately NOT namespaced under ~/.cognee-plugin/qwen: the venv, the local
+# cognee server, and the data store are shared with the Claude Code plugin so
+# cognee is installed once and a single server serves both. Only per-plugin
+# state (logs, buffers) stays under _PLUGIN_DIR; the runtime lives at the root.
+_VENV_DIR = _SHARED_PLUGIN_ROOT / "venv"
+_VENV_PYTHON = _VENV_DIR / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+_VENV_READY_MARKER = _SHARED_PLUGIN_ROOT / "venv-ready.json"
+
+# cognee's own default puts its databases INSIDE the install dir (the venv), so
+# they would be wiped on every venv rebuild/upgrade. Pin them to ~/.cognee.
+_COGNEE_HOME = Path.home() / ".cognee"
+_COGNEE_SYSTEM_DIR = _COGNEE_HOME / "system"
+_COGNEE_DATA_DIR = _COGNEE_HOME / "data"
+_COGNEE_CACHE_DIR = _COGNEE_HOME / "cache"
+
+
+def venv_python() -> Path:
+    """Path to the shared plugin-owned venv interpreter (may not exist yet)."""
+    return _VENV_PYTHON
+
+
+def apply_cognee_env() -> None:
+    """Pin cognee's data dirs + caching into the environment.
+
+    Uses setdefault so an explicit user/env override always wins. Called on
+    import so any process that spawns the cognee server (via os.environ.copy())
+    inherits a stable, upgrade-safe data location. CACHING and AUTO_FEEDBACK are
+    already cognee's defaults but are set explicitly so a future default change
+    can't silently disable session-context distillation.
+    """
+    os.environ.setdefault("SYSTEM_ROOT_DIRECTORY", str(_COGNEE_SYSTEM_DIR))
+    os.environ.setdefault("DATA_ROOT_DIRECTORY", str(_COGNEE_DATA_DIR))
+    os.environ.setdefault("CACHE_ROOT_DIRECTORY", str(_COGNEE_CACHE_DIR))
+    os.environ.setdefault("CACHING", "true")
+    os.environ.setdefault("AUTO_FEEDBACK", "true")
+
+
+apply_cognee_env()
+
+
+def _sanitize_session_key(value: str) -> str:
+    safe = []
+    for ch in str(value or ""):
+        if ch.isalnum() or ch in ("-", "_", "."):
+            safe.append(ch)
+        else:
+            safe.append("_")
+    return "".join(safe).strip("._")[:120]
+
+
+def get_session_key() -> str:
+    candidates = [
+        os.environ.get("COGNEE_SESSION_KEY"),
+    ]
+    for value in candidates:
+        text = _sanitize_session_key(str(value or "").strip())
+        if text:
+            return text
+    return ""
+
+
+def set_session_key(session_key: str) -> str:
+    normalized = _sanitize_session_key(session_key)
+    if normalized:
+        os.environ["COGNEE_SESSION_KEY"] = normalized
+    return normalized
+
+
+def _generate_session_id(cwd: str = "", host_key: str = "") -> str:
+    """Mint the Cognee session id for a launch: ``{agent}_{host_session_id}``.
+
+    The host (Qwen) session id maps 1:1 to the conversation, so embedding it
+    makes the Cognee session id deterministic per conversation and self-describing
+    in the Cognee dashboard. Falls back to ``{agent}_{dirname}_{token}`` only when
+    no host session id is available.
+    """
+    agent = _sanitize_session_key(os.environ.get("COGNEE_SESSION_PREFIX", "") or "qwen") or "qwen"
+    host = _sanitize_session_key(host_key)
+    if host:
+        return f"{agent}_{host}"
+    cwd = cwd or os.environ.get("QWEN_CWD") or os.getcwd()
+    dir_name = _sanitize_session_key(Path(cwd).name) or "session"
+    return f"{agent}_{dir_name}_{uuid.uuid4().hex[:12]}"
+
+
+def _new_conn_uuid() -> str:
+    """A per-launch connection handle (liveness/counting), independent of session."""
+    return f"conn_{uuid.uuid4().hex}"
+
+
+def _session_map_path(host_key: str) -> Path:
+    return _SESSIONS_MAP_DIR / f"{_sanitize_session_key(host_key)}.json"
+
+
+def _read_map_record(host_key: str) -> dict:
+    """Return the launch record for a host session id, or {}.
+
+    Record shape: ``{conn_uuid, session_id, host_key, created_at, touched: [...]}``.
+    ``session_id`` = current Cognee session (switchable); ``conn_uuid`` = the
+    per-launch liveness handle used for registration/counting (never switched).
+    """
+    if not host_key:
+        return {}
+    try:
+        path = _session_map_path(host_key)
+        if path.exists():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return data
+    except Exception as exc:
+        hook_log("session_map_read_failed", {"error": str(exc)[:200]})
+    return {}
+
+
+def _write_map_record(host_key: str, record: dict) -> None:
+    if not host_key or not isinstance(record, dict):
+        return
+    _write_json_file(_session_map_path(host_key), record)
+
+
+def _create_map_record_if_absent(host_key: str, record: dict) -> dict:
+    """Atomically create the launch record, first-writer-wins.
+
+    Uses O_CREAT|O_EXCL so exactly one concurrent creator wins; losers read back
+    the winner's record instead of clobbering it. This is what makes concurrent
+    launches/hooks for the same host_key converge on a single session id rather
+    than diverge. Returns the record now on disk.
+    """
+    if not host_key:
+        return record
+    path = _session_map_path(host_key)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(record, fh, indent=2, sort_keys=True)
+        return record
+    except FileExistsError:
+        return _read_map_record(host_key) or record
+    except Exception as exc:
+        hook_log("map_create_failed", {"error": str(exc)[:200]})
+        # Best-effort fallback: plain write, then read back whatever landed.
+        _write_map_record(host_key, record)
+        return _read_map_record(host_key) or record
+
+
+def resolve_cognee_session_id(host_key: str = "", cwd: str = "") -> str:
+    """Resolve the Cognee session id that scopes all saves/recalls this launch.
+
+    Precedence:
+      1. ``COGNEE_SESSION_ID`` env — explicit launch-time override.
+      2. host-keyed map record — the current session for this launch (stable
+         across the launch's separate hook processes; updated by the picker).
+      3. freshly generated id (new launch), persisted to the map.
+    """
+    explicit = _sanitize_session_key(str(os.environ.get("COGNEE_SESSION_ID", "") or "").strip())
+    if explicit:
+        return explicit
+
+    host_key = _sanitize_session_key(host_key) or get_session_key()
+    rec = _read_map_record(host_key)
+    if rec.get("session_id"):
+        return _sanitize_session_key(str(rec["session_id"]))
+
+    new_id = _generate_session_id(cwd, host_key)
+    if not host_key:
+        return new_id
+    winner = _create_map_record_if_absent(
+        host_key,
+        {
+            "session_id": new_id,
+            "host_key": host_key,
+            "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "touched": [new_id],
+        },
+    )
+    return str(winner.get("session_id") or new_id)
+
+
+def ensure_launch_record(host_key: str = "", cwd: str = "") -> tuple[str, str]:
+    """Create (first-writer-wins) and return this launch's (session_id, conn_uuid).
+
+    Called by SessionStart. The session id honors an explicit ``COGNEE_SESSION_ID``
+    override, else the existing/generated id; the conn_uuid is minted once.
+    """
+    host_key = _sanitize_session_key(host_key) or get_session_key()
+    rec = _read_map_record(host_key)
+    if rec.get("session_id") and rec.get("conn_uuid"):
+        return str(rec["session_id"]), str(rec["conn_uuid"])
+
+    explicit = _sanitize_session_key(str(os.environ.get("COGNEE_SESSION_ID", "") or "").strip())
+    session_id = explicit or str(rec.get("session_id") or "") or _generate_session_id(cwd, host_key)
+    conn_uuid = str(rec.get("conn_uuid") or "") or _new_conn_uuid()
+    record = {
+        "session_id": session_id,
+        "conn_uuid": conn_uuid,
+        "host_key": host_key,
+        "created_at": rec.get("created_at")
+        or datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "touched": rec.get("touched") or [session_id],
+    }
+    if not host_key:
+        return session_id, conn_uuid
+    winner = _create_map_record_if_absent(host_key, record)
+    # If a prior resolve() created a session-only record (no handle), graft our
+    # conn_uuid onto it. SessionStart is the sole writer of conn_uuid, so this
+    # merge isn't contended in practice.
+    if not winner.get("conn_uuid"):
+        merged = dict(winner)
+        merged["conn_uuid"] = conn_uuid
+        merged.setdefault("host_key", host_key)
+        _write_map_record(host_key, merged)
+        winner = _read_map_record(host_key) or merged
+    return str(winner.get("session_id") or session_id), str(winner.get("conn_uuid") or conn_uuid)
+
+
+def resolve_conn_uuid(host_key: str = "") -> str:
+    """Return this launch's connection handle, minting+persisting one if absent."""
+    host_key = _sanitize_session_key(host_key) or get_session_key()
+    rec = _read_map_record(host_key)
+    cu = str(rec.get("conn_uuid") or "")
+    if cu:
+        return cu
+    cu = _new_conn_uuid()
+    if host_key:
+        rec = _read_map_record(host_key)
+        if not rec.get("conn_uuid"):
+            rec["conn_uuid"] = cu
+            rec.setdefault("host_key", host_key)
+            _write_map_record(host_key, rec)
+        return str(_read_map_record(host_key).get("conn_uuid") or cu)
+    return cu
+
+
+def resolve_session_key_from_payload(payload: dict) -> tuple[str, str]:
+    """Resolve session key from a hook payload using known host variants."""
+    if not isinstance(payload, dict):
+        return "", "missing_payload"
+
+    def _read_path(obj: dict, path: list[str]) -> str:
+        cur = obj
+        for key in path[:-1]:
+            nxt = cur.get(key)
+            if not isinstance(nxt, dict):
+                return ""
+            cur = nxt
+        value = cur.get(path[-1])
+        return str(value or "").strip() if value is not None else ""
+
+    candidates: list[tuple[str, list[str]]] = [
+        ("payload.session_id", ["session_id"]),
+        ("payload.sessionId", ["sessionId"]),
+        ("payload.session.id", ["session", "id"]),
+        ("payload.conversation_id", ["conversation_id"]),
+        ("payload.conversationId", ["conversationId"]),
+        ("payload.conversation.id", ["conversation", "id"]),
+        ("payload.chat_id", ["chat_id"]),
+        ("payload.chatId", ["chatId"]),
+        ("payload.thread_id", ["thread_id"]),
+        ("payload.threadId", ["threadId"]),
+        ("payload.transcript.session_id", ["transcript", "session_id"]),
+        ("payload.transcript.sessionId", ["transcript", "sessionId"]),
+    ]
+    for source, path in candidates:
+        value = _read_path(payload, path)
+        if value:
+            return value, source
+    return "", "not_found"
+
+
+def _resolve_agent_name() -> str:
+    def _normalize(name: str) -> str:
+        raw = str(name or "").strip()
+        if raw.endswith("@cognee.agent"):
+            raw = raw[: -len("@cognee.agent")]
+        suffix = "_qwen"
+        if raw.endswith(suffix):
+            return raw
+        return f"{raw}{suffix}"
+
+    env_name = str(os.environ.get("COGNEE_AGENT_NAME") or "").strip()
+    if env_name:
+        return _normalize(env_name)
+    try:
+        from config import load_config  # type: ignore
+
+        configured = str(load_config().get("agent_name") or "").strip()
+        if configured:
+            normalized = _normalize(configured)
+            os.environ["COGNEE_AGENT_NAME"] = normalized
+            return normalized
+    except Exception:
+        pass
+    return _normalize("qwen-agent")
+
+
+def load_resolved(session_key: str = "") -> dict:
+    """Load runtime state from Cognee HTTP endpoints (no file cache)."""
+    resolved: dict = {}
+
+    active_session_key = _sanitize_session_key(session_key) or get_session_key()
+    if active_session_key:
+        resolved["session_key"] = active_session_key
+
+    # session_id = data scoping key (switchable); conn_uuid = registration handle.
+    cognee_session_id = resolve_cognee_session_id(active_session_key)
+    if cognee_session_id:
+        resolved["session_id"] = cognee_session_id
+    conn_uuid = resolve_conn_uuid(active_session_key)
+    if conn_uuid:
+        resolved["agent_session_name"] = conn_uuid
+
+    service_url = _local_api_url().strip()
+    if service_url:
+        resolved["base_url"] = service_url
+
+    api_key = _api_key().strip()
+    if api_key:
+        resolved["api_key"] = api_key
+
+    # Resolve active connection details FIRST — it doubles as the primary
+    # identity source. The connection is registered under the per-launch
+    # conn_uuid handle, so query by that — not the session id (which can change
+    # on a switch) and not the host correlation key. Its agent.user_id is
+    # served by both OSS servers and cloud tenants, whereas /users/me is absent
+    # on some tenants (404 on every hook), so the users/me probe below runs
+    # only when identity is still unresolved.
+    try:
+        query = ""
+        if conn_uuid:
+            query = f"?agent_session_name={urllib.parse.quote(conn_uuid, safe='')}"
+        conn = _json_http_request(
+            f"/api/v1/agents/connections/me{query}",
+            method="GET",
+            timeout=10.0,
+        )
+        if isinstance(conn, dict):
+            agent = conn.get("agent") if isinstance(conn.get("agent"), dict) else {}
+            if isinstance(agent, dict):
+                # Do not overwrite resolved["session_id"] from the connection: the
+                # local map is authoritative for the *current* session (post-switch).
+                agent_session_name = str(agent.get("agent_session_name") or "").strip()
+                if agent_session_name:
+                    resolved["agent_session_name"] = agent_session_name
+                agent_user_id = str(agent.get("user_id") or "").strip()
+                if agent_user_id:
+                    resolved["user_id"] = agent_user_id
+                # Which cloud tenant this connection belongs to (null on local
+                # single-user servers). The credits display keys its balance
+                # entries on this, so multi-tenant machines track each tenant
+                # separately (SDK-355).
+                tenant_id = str(agent.get("tenant_id") or "").strip()
+                if tenant_id:
+                    resolved["tenant_id"] = tenant_id
+                status = str(agent.get("status") or "").strip().lower()
+                resolved["registered"] = status == "active"
+    except Exception as exc:
+        hook_log("runtime_state_connection_lookup_failed", {"error": str(exc)[:200]})
+
+    # Fallback identity probe — only when the connection lookup yielded none
+    # (e.g. before registration on a fresh launch).
+    if not resolved.get("user_id"):
+        try:
+            me = _json_http_request("/api/v1/users/me", method="GET", timeout=10.0)
+            if isinstance(me, dict):
+                user_id = str(me.get("id") or "").strip()
+                if user_id:
+                    resolved["user_id"] = user_id
+        except Exception as exc:
+            hook_log("runtime_state_users_me_failed", {"error": str(exc)[:200]})
+
+    return resolved
+
+
+def write_resolved(data: dict, session_key: str = "", *, mirror_global: bool = True) -> None:
+    # Runtime state now comes from API endpoints, not local resolved files.
+    _ = (data, session_key, mirror_global)
+
+
+def _load_json_file(path: Path) -> dict:
+    if path.exists():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            hook_log("json_load_failed", {"path": str(path), "error": str(exc)[:200]})
+    return {}
+
+
+def _write_json_file(path: Path, data: dict) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic write: a concurrent reader never sees a half-written file.
+        # Per-pid tmp name so two writers can't collide on the tmp path.
+        tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+        os.replace(tmp, path)
+    except Exception as exc:
+        hook_log("json_write_failed", {"path": str(path), "error": str(exc)[:200]})
+
+
+def _strip_surrogates(text: str) -> str:
+    """Remove lone UTF-16 surrogate codepoints (U+D800-U+DFFF).
+
+    A legitimate supplementary-plane character (emoji, etc.) is always ONE code
+    point in Python's str, never a surrogate. Any char in this range in a real
+    str is therefore always broken/unpaired (a bad UTF-16<->UTF-8 boundary
+    upstream -- Windows console/clipboard, mis-decoded tool output), never a
+    valid character. It round-trips silently through json.dumps/loads
+    (ensure_ascii escapes it, loads() reconstitutes it) -- only a raw UTF-8
+    encode downstream (embedding tokenizer, LLM adapter, cognify) catches it,
+    by which point the entry is already persisted. Strip (don't replace) to keep
+    surrounding text readable with no placeholder glyph.
+    """
+    if not text or not any(0xD800 <= ord(ch) <= 0xDFFF for ch in text):
+        return text
+    return "".join(ch for ch in text if not (0xD800 <= ord(ch) <= 0xDFFF))
+
+
+def _sanitize_value(value):
+    """Recursively strip surrogates from every string leaf in a JSON-shaped value.
+    Only string VALUES are touched -- dict keys, ints, bools, None pass through."""
+    if isinstance(value, str):
+        return _strip_surrogates(value)
+    if isinstance(value, dict):
+        return {k: _sanitize_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_value(v) for v in value]
+    return value
+
+
+def _bridge_cache_key(dataset: str, session_id: str) -> str:
+    # Keyed by (dataset, session_id) only — deliberately independent of user_id.
+    # During lazy-bootstrap warmup the agent isn't registered yet, so user_id is
+    # empty at write time but resolves to a real id by drain time; embedding it
+    # would strand warmup-buffered entries under a key the drain never reads.
+    # session_id already scopes the local bridge buffer, and the graph write
+    # still targets the resolved dataset. Avoiding user_id also removes a
+    # blocking load_resolved() HTTP call from this hot path.
+    return f"{dataset}:{session_id}"
+
+
+def _agent_session_scope(fallback: str = "") -> str:
+    """Filesystem-safe identity of the current agent session.
+
+    Each agent session (one Claude/Qwen terminal) owns its own pending and
+    bridge files keyed by this scope, so concurrent agents never share a file
+    (no locks, no lost-update races). Falls back to the cognee session_id, then
+    a constant, so the path is always defined.
+    """
+    scope = _sanitize_session_key(get_session_key()) or _sanitize_session_key(fallback)
+    return scope or "default"
+
+
+def _pending_file(session_id: str = "") -> Path:
+    return _PENDING_DIR / f"{_agent_session_scope(session_id)}.json"
+
+
+def _bridge_file(session_id: str = "") -> Path:
+    return _BRIDGE_DIR / f"{_agent_session_scope(session_id)}.json"
+
+
+# Short mutex for read-modify-write of the per-session buffer file. Appends
+# from concurrent async hooks (and the drain's trim write-back) would otherwise
+# clobber each other: os.replace keeps the file valid but last-writer-wins,
+# silently dropping the other writer's entry. Critical sections are
+# milliseconds, so waiting is cheap.
+_BUFFER_LOCK = _PLUGIN_DIR / "buffer.lock"
+_BUFFER_LOCK_STALE_SECONDS = 15.0
+_BUFFER_LOCK_TIMEOUT_SECONDS = 1.0
+_BUFFER_LOCK_POLL_SECONDS = 0.02
+
+
+@contextmanager
+def _buffer_lock():
+    """Acquire the buffer-file mutex, waiting briefly; fail open on timeout.
+
+    Yields True when the lock was acquired. On timeout/error the caller
+    proceeds WITHOUT the lock — a rare lost update beats a hook that hangs.
+    """
+    deadline = time.monotonic() + _BUFFER_LOCK_TIMEOUT_SECONDS
+    acquired = False
+    while True:
+        try:
+            _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+            if _BUFFER_LOCK.exists():
+                try:
+                    if time.time() - _BUFFER_LOCK.stat().st_mtime > _BUFFER_LOCK_STALE_SECONDS:
+                        _BUFFER_LOCK.unlink()
+                except FileNotFoundError:
+                    pass
+            fd = os.open(str(_BUFFER_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.close(fd)
+            acquired = True
+            break
+        except FileExistsError:
+            if time.monotonic() >= deadline:
+                hook_log("buffer_lock_timeout", {})
+                break
+            time.sleep(_BUFFER_LOCK_POLL_SECONDS)
+        except Exception as exc:
+            hook_log("buffer_lock_error", {"error": str(exc)[:200]})
+            break
+    try:
+        yield acquired
+    finally:
+        if acquired:
+            try:
+                _BUFFER_LOCK.unlink()
+            except FileNotFoundError:
+                pass
+            except Exception as exc:
+                hook_log("buffer_lock_release_failed", {"error": str(exc)[:200]})
+
+
+def append_http_bridge_entry(
+    dataset: str,
+    session_id: str,
+    *,
+    question: str = "",
+    answer: str = "",
+    trace: str = "",
+) -> None:
+    """Keep a tiny local shadow of API-mode session text for graph bridging.
+
+    Local SDK mode already reads Cognee's session cache directly. In API
+    mode the cache lives behind the server, so this mirrors the same text
+    locally without affecting local mode.
+    """
+    if not dataset or not session_id:
+        return
+    if not (question or answer or trace):
+        return
+    question = _strip_surrogates(question)
+    answer = _strip_surrogates(answer)
+    trace = _strip_surrogates(trace)
+
+    with _buffer_lock():
+        cache = _load_json_file(_bridge_file(session_id))
+        key = _bridge_cache_key(dataset, session_id)
+        session_cache = cache.setdefault(key, {"qa": [], "trace": []})
+        if question or answer:
+            session_cache.setdefault("qa", []).append({"question": question, "answer": answer})
+        if trace:
+            session_cache.setdefault("trace", []).append(trace)
+        _write_json_file(_bridge_file(session_id), cache)
+
+
+async def resolve_user(user_id: str):
+    """Resolve cached user ID to a User object, or fall back to default."""
+    if user_id:
+        try:
+            from uuid import UUID
+
+            from cognee.modules.users.methods import get_user
+
+            user = await get_user(UUID(user_id))
+            if user:
+                return user
+        except Exception as exc:
+            hook_log("resolve_user_failed", {"user_id": user_id, "error": str(exc)[:200]})
+    from cognee.modules.users.methods import get_default_user
+
+    return await get_default_user()
+
+
+# --- Embedding-dimension mismatch detection ---------------------------------
+# When the embedding model changes between writing and reading, stored vectors
+# and fresh query vectors have different dimensions, so recall silently matches
+# nothing. These helpers turn that silent miss into a one-line actionable error
+# naming both dimensions and the active embedder. Strictly best-effort and
+# fail-safe: any uncertainty returns None, preserving the normal "no matches"
+# behavior. Only valid against a *local* store this process can introspect
+# (gate callers with ``service_url_is_local``); a remote/cloud store is owned
+# by the server and isn't reflected by the in-process engine here.
+
+
+def service_url_is_local(url: str = "") -> bool:
+    """True when the resolved service URL points at this machine (loopback)."""
+    host = (urllib.parse.urlparse(url or _local_api_url()).hostname or "").lower()
+    return host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
+
+
+async def _sample_stored_vector_dim(engine) -> Optional[int]:
+    """Sample the dimension of a stored vector from any populated collection, or None.
+
+    Enumerates the store's actual collections via the vector interface's
+    ``get_connection().table_names()`` (the same path cognee's own ``has_collection``
+    uses) rather than assuming fixed collection names, so it also covers custom
+    pipelines. Never raises: each collection is probed independently and any
+    unreadable one is skipped. Covers cognee's default local backend (LanceDB); other
+    backends whose connection can't enumerate return None and fall back to the normal
+    empty-recall path.
+    """
+    try:
+        connection = await engine.get_connection()
+        names = await connection.table_names()
+    except Exception:
+        return None
+    for name in names:
+        try:
+            collection = await engine.get_collection(name)
+            rows = await collection.query().limit(1).to_list()
+            if rows:
+                vector = rows[0].get("vector")
+                if vector is not None:
+                    return len(vector)
+        except Exception:
+            continue
+    return None
+
+
+async def embedding_dimension_mismatch_hint(engine=None) -> Optional[str]:
+    """One-line diagnostic when the stored vectors differ in size from the active
+    embedder's query vectors (so recall can never match), else None.
+
+    Best-effort and fail-safe: any error, or an indeterminate/matching dimension,
+    returns None so the caller keeps the normal empty-recall behavior. ``engine``
+    is injectable for testing.
+    """
+    try:
+        if engine is None:
+            from cognee.infrastructure.databases.vector import get_vector_engine
+
+            engine = get_vector_engine()
+        embed = getattr(engine, "embedding_engine", None)
+        if embed is None:
+            return None
+        query_dim = int(embed.get_vector_size())
+        stored_dim = await _sample_stored_vector_dim(engine)
+        if not stored_dim or not query_dim or stored_dim == query_dim:
+            return None
+        model = getattr(embed, "model", None) or "unknown-model"
+        provider = getattr(embed, "provider", None) or "unknown-provider"
+        return (
+            "Cognee recall found nothing because the embedder changed: stored vectors are "
+            f"{stored_dim}-d but the active embedder '{model}' (provider '{provider}') produces "
+            f"{query_dim}-d queries. Re-index this data with the current embedder, or set "
+            f"EMBEDDING_MODEL/EMBEDDING_DIMENSIONS back to the {stored_dim}-d model that wrote it."
+        )
+    except Exception:
+        return None
+
+
+_DIM_MEMO_FILE = _PLUGIN_DIR / "dim_check.json"
+_DIM_MEMO_TTL = 300.0  # seconds; re-probe at most this often per embedder signature
+
+
+def _embedder_signature() -> str:
+    """Cheap identity of the active embedder, read from env WITHOUT importing cognee
+    — the only query-side input to the mismatch check. A change here (model, dimension,
+    or provider) invalidates any cached probe result."""
+    return "|".join(
+        os.getenv(k, "") for k in ("EMBEDDING_MODEL", "EMBEDDING_DIMENSIONS", "EMBEDDING_PROVIDER")
+    )
+
+
+def _read_dim_memo(sig: str) -> Optional[dict]:
+    """Return the cached probe result for ``sig`` if present and fresh, else None.
+    Never raises."""
+    try:
+        data = json.loads(_DIM_MEMO_FILE.read_text(encoding="utf-8"))
+        if data.get("sig") == sig and (time.time() - float(data.get("ts", 0))) < _DIM_MEMO_TTL:
+            return data
+    except Exception:
+        pass
+    return None
+
+
+def _write_dim_memo(sig: str, message: Optional[str]) -> None:
+    """Persist a completed probe result keyed by embedder signature. Never raises."""
+    try:
+        _DIM_MEMO_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _DIM_MEMO_FILE.write_text(
+            json.dumps({"sig": sig, "message": message, "ts": time.time()}),
+            encoding="utf-8",
+        )
+    except Exception:
+        pass
+
+
+async def bounded_dim_mismatch_hint(timeout: float = 2.0) -> Optional[str]:
+    """``embedding_dimension_mismatch_hint`` made safe for the per-prompt hook path.
+
+    The probe's first step is a synchronous ``import cognee`` + ``get_vector_engine()``.
+    In the plugin's default http/local-server mode cognee is not otherwise imported, so
+    that is a cold ~1s import running *before the first await* — which a plain
+    ``asyncio.wait_for`` cannot bound (it blocks the event loop). So we run the whole
+    probe in a daemon thread and bound the *wait*: on timeout we return None and abandon
+    the daemon, so a slow import can never stall the hook or delay its process exit. The
+    completed result is memoized on disk per embedder signature (TTL-bounded) so repeated
+    empty recalls in a session don't each pay the import.
+
+    Fail-safe: any error, timeout, or indeterminate result returns None, so the caller
+    keeps the normal empty-recall behavior.
+    """
+    sig = _embedder_signature()
+    cached = _read_dim_memo(sig)
+    if cached is not None:
+        return cached.get("message")
+
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future = loop.create_future()
+
+    def _settle(value: Optional[str]) -> None:
+        if not future.done():
+            future.set_result(value)
+
+    def _worker() -> None:
+        message: Optional[str] = None
+        try:
+            message = asyncio.run(embedding_dimension_mismatch_hint())
+        except Exception:
+            message = None
+        try:
+            loop.call_soon_threadsafe(_settle, message)
+        except Exception:
+            pass  # loop already closed (we timed out); the daemon's result is discarded
+
+    threading.Thread(target=_worker, name="cognee-dim-probe", daemon=True).start()
+    try:
+        message = await asyncio.wait_for(future, timeout=timeout)
+    except Exception:
+        return None
+    _write_dim_memo(sig, message)
+    return message
+
+
+def hook_log(event: str, detail: Optional[dict] = None) -> None:
+    """Append one structured line to ~/.cognee-plugin/qwen/hook.log.
+
+    Safe to call silently — never raises. Use for forensic debugging
+    of why a hook did (or did not) write something to memory.
+    """
+    try:
+        _HOOK_LOG.parent.mkdir(parents=True, exist_ok=True)
+        line = {
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "pid": os.getpid(),
+            "event": event,
+        }
+        if detail:
+            line["detail"] = detail
+        serialized = json.dumps(line, default=str)
+        if len(serialized) > _LOG_LINE_CAP:
+            serialized = serialized[: _LOG_LINE_CAP - 3] + "..."
+        with _HOOK_LOG.open("a", encoding="utf-8") as fh:
+            fh.write(serialized + "\n")
+    except Exception:
+        pass
+
+
+_SSL_CONTEXT: "ssl.SSLContext | None" = None
+
+
+def _https_context() -> ssl.SSLContext:
+    """Shared TLS context for every urllib HTTPS call (cloud/remote mode).
+
+    macOS Python builds often ship without root CA certs in the default
+    context, so HTTPS verification against Cognee Cloud fails with
+    CERTIFICATE_VERIFY_FAILED. Mirror the recall path's resolution once, here,
+    so all HTTPS traffic shares it: prefer certifi, else walk SSL_CERT_FILE and
+    known system cert bundles. Built once and cached. Passing this to urlopen
+    for an http:// (localhost) URL is harmless — urllib ignores the context for
+    non-HTTPS requests.
+    """
+    global _SSL_CONTEXT
+    if _SSL_CONTEXT is not None:
+        return _SSL_CONTEXT
+    try:
+        import certifi
+
+        ctx = ssl.create_default_context(cafile=certifi.where())
+    except ImportError:
+        ctx = ssl.create_default_context()
+        loaded = False
+        for path in filter(
+            None,
+            [
+                os.environ.get("SSL_CERT_FILE"),
+                "/etc/ssl/cert.pem",
+                "/etc/ssl/certs/ca-certificates.crt",
+            ],
+        ):
+            if os.path.exists(path):
+                try:
+                    ctx.load_verify_locations(path)
+                    loaded = True
+                    break
+                except Exception:
+                    pass
+        if not loaded:
+            hook_log("https_context_no_ca_bundle", {})
+    _SSL_CONTEXT = ctx
+    return ctx
+
+
+def _reexec_into_venv() -> None:
+    """Re-exec the current hook under the shared plugin-owned venv interpreter.
+
+    Hooks are launched by the host as ``python3 <script>`` using whatever
+    python3 is on PATH — which has neither cognee nor aiohttp. The runtime
+    lives in ``~/.cognee-plugin/venv``. Once that venv exists, re-exec into it
+    so every import resolves there. No-op before the venv exists (cold start,
+    pre-install) or when already running inside it.
+    """
+    if os.environ.get("COGNEE_PLUGIN_IN_VENV") == "1":
+        return  # loop guard: this process already re-execed (or opted out)
+    if not sys.argv or not os.path.isfile(sys.argv[0]):
+        return  # not a `python script.py` launch (e.g. -c/-m/stdin) — don't rebuild argv
+    vpy = _VENV_PYTHON
+    if not vpy.exists():
+        return  # cold start — install hasn't built the venv yet
+    os.environ["COGNEE_PLUGIN_IN_VENV"] = "1"
+    try:
+        if os.path.samefile(str(vpy), sys.executable):
+            return  # the host python3 already *is* the venv interpreter
+    except OSError:
+        pass
+    try:
+        # execv inherits os.environ (incl. the loop guard just set above).
+        os.execv(str(vpy), [str(vpy), *sys.argv])
+    except OSError as exc:
+        # Better to run degraded under the host interpreter than to die.
+        hook_log("venv_reexec_failed", {"error": str(exc)[:200]})
+
+
+# Fired on import: every cognee-touching hook imports this module before any
+# aiohttp/cognee import, so this is the single chokepoint that pins all hooks
+# to the venv runtime once it exists.
+_reexec_into_venv()
+
+
+def _verbose_enabled() -> bool:
+    return os.environ.get("COGNEE_PLUGIN_VERBOSE", "").lower() in ("1", "true", "yes")
+
+
+def notify(msg: str) -> None:
+    """Print a status line to stderr (shown under the hook's status indicator).
+
+    When ``COGNEE_PLUGIN_VERBOSE=1`` is set, also append a timestamped
+    line to ``~/.cognee-plugin/qwen/activity.log`` so saves that happen
+    in async hooks are ``tail -f``-visible.
+    """
+    line = f"cognee-plugin: {msg}"
+    print(line, file=sys.stderr)
+    if _verbose_enabled():
+        try:
+            _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+            ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+            with _ACTIVITY_LOG.open("a", encoding="utf-8") as fh:
+                fh.write(f"{ts} {line}\n")
+        except Exception as exc:
+            hook_log("activity_log_write_failed", {"error": str(exc)[:200]})
+
+
+@contextmanager
+def quiet_hook_output(label: str):
+    """Redirect stdout/stderr to a plugin log while a hook does Cognee work.
+
+    Qwen parses stdout for JSON on hooks such as UserPromptSubmit. Some
+    Cognee dependencies write directly to file descriptors, so redirect at
+    the OS fd level instead of relying only on Python's redirect_stdout.
+    """
+    _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+    saved_stdout_fd = os.dup(1)
+    saved_stderr_fd = os.dup(2)
+    log_fd = os.open(_SUBPROCESS_LOG, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        marker = (
+            f"\n--- {datetime.now(timezone.utc).isoformat(timespec='seconds')} "
+            f"{label} pid={os.getpid()} ---\n"
+        )
+        os.write(
+            log_fd,
+            marker.encode("utf-8"),
+        )
+        os.dup2(log_fd, 1)
+        os.dup2(log_fd, 2)
+        yield
+    finally:
+        os.dup2(saved_stdout_fd, 1)
+        os.dup2(saved_stderr_fd, 2)
+        os.close(saved_stdout_fd)
+        os.close(saved_stderr_fd)
+        os.close(log_fd)
+
+
+def bump_save_counter(session_id: str, kind: str) -> None:
+    """Record a save of ``kind`` (one of ``SAVE_KINDS``) for this session.
+
+    Used to surface per-turn save volume back to the user through the
+    next UserPromptSubmit's injected context. Cheap, best-effort file IO —
+    never raises.
+    """
+    if not session_id or kind not in SAVE_KINDS:
+        return
+    try:
+        data = (
+            json.loads(_SAVE_COUNTER.read_text(encoding="utf-8")) if _SAVE_COUNTER.exists() else {}
+        )
+    except Exception as exc:
+        hook_log("save_counter_read_failed", {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]})
+        data = {}
+    sess = data.get(session_id) or {k: 0 for k in SAVE_KINDS}
+    sess[kind] = int(sess.get(kind, 0)) + 1
+    data[session_id] = sess
+    try:
+        _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        _SAVE_COUNTER.write_text(json.dumps(data), encoding="utf-8")
+    except Exception as exc:
+        hook_log("save_counter_write_failed", {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]})
+
+
+def read_and_reset_save_counter(session_id: str) -> dict:
+    """Return the save-kind counts accumulated since the last reset, then zero them."""
+    zero = {k: 0 for k in SAVE_KINDS}
+    if not session_id:
+        return zero
+    try:
+        data = (
+            json.loads(_SAVE_COUNTER.read_text(encoding="utf-8")) if _SAVE_COUNTER.exists() else {}
+        )
+    except Exception as exc:
+        hook_log(
+            "save_counter_reset_read_failed", {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]}
+        )
+        return zero
+    sess = data.get(session_id) or zero
+    data[session_id] = dict(zero)
+    try:
+        _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        _SAVE_COUNTER.write_text(json.dumps(data), encoding="utf-8")
+    except Exception as exc:
+        hook_log(
+            "save_counter_reset_write_failed", {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]}
+        )
+    return {k: int(sess.get(k, 0)) for k in SAVE_KINDS}
+
+
+def _pending_keys(session_id: str, turn_id: str = "") -> tuple[str, str]:
+    # Scope by the host-provided session key (COGNEE_SESSION_KEY, unique per
+    # Claude/Qwen session) rather than the cwd-derived cognee session_id, so
+    # two concurrent agents in the same project don't collide on one pending
+    # slot and scramble each other's prompts. Falls back to session_id.
+    scope = get_session_key() or session_id
+    session_key = f"{scope}:"
+    turn_key = f"{scope}:{turn_id}" if turn_id else session_key
+    return turn_key, session_key
+
+
+def remember_pending_prompt(
+    session_id: str, prompt: str, *, turn_id: str = "", context: str = ""
+) -> None:
+    """Store the current prompt until Qwen Stop provides the assistant answer."""
+    if not session_id or not prompt.strip():
+        return
+    prompt = _strip_surrogates(prompt)
+    context = _strip_surrogates(context)
+    data = _load_json_file(_pending_file(session_id))
+    turn_key, session_key = _pending_keys(session_id, turn_id)
+    entry = {
+        "prompt": prompt[:8000],
+        "context": context[:2000],
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    data[turn_key] = entry
+    data[session_key] = entry
+    _write_json_file(_pending_file(session_id), data)
+
+
+def pop_pending_prompt(session_id: str, *, turn_id: str = "") -> dict:
+    """Return and remove the prompt saved for this Qwen turn."""
+    if not session_id:
+        return {"prompt": "", "context": ""}
+    data = _load_json_file(_pending_file(session_id))
+    turn_key, session_key = _pending_keys(session_id, turn_id)
+    entry = data.pop(turn_key, None) or data.get(session_key) or {}
+    data.pop(session_key, None)
+    _write_json_file(_pending_file(session_id), data)
+    if not isinstance(entry, dict):
+        return {"prompt": "", "context": ""}
+    return {
+        "prompt": str(entry.get("prompt") or ""),
+        "context": str(entry.get("context") or ""),
+    }
+
+
+def _auto_improve_threshold() -> int:
+    raw = os.environ.get("COGNEE_AUTO_IMPROVE_EVERY", "")
+    if raw.isdigit() and int(raw) > 0:
+        return int(raw)
+    return AUTO_IMPROVE_EVERY_DEFAULT
+
+
+def bump_turn_counter(session_id: str) -> tuple[int, bool]:
+    """Increment the per-session tool-call counter.
+
+    Returns (new_count, should_improve). ``should_improve`` is True when
+    the count crossed a multiple of the configured threshold — the
+    caller is expected to fire ``improve()`` and proceed.
+
+    Counter survives across hook invocations via a tiny JSON file.
+    Concurrent writes: we accept rare off-by-one drift under heavy
+    parallel tool use — this is a heartbeat, not a ledger.
+    """
+    if not session_id:
+        return 0, False
+
+    threshold = _auto_improve_threshold()
+
+    data: dict = {}
+    if _COUNTER_FILE.exists():
+        try:
+            data = json.loads(_COUNTER_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            data = {}
+
+    count = int(data.get(session_id, 0)) + 1
+    data[session_id] = count
+
+    try:
+        _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        _COUNTER_FILE.write_text(json.dumps(data), encoding="utf-8")
+    except Exception as exc:
+        hook_log("turn_counter_write_failed", {"path": str(_COUNTER_FILE), "error": str(exc)[:200]})
+
+    should_improve = threshold > 0 and count % threshold == 0
+    return count, should_improve
+
+
+def touch_activity() -> None:
+    """Update the last-activity timestamp for the idle watcher."""
+    try:
+        _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        _ACTIVITY_FILE.write_text(str(datetime.now(timezone.utc).timestamp()), encoding="utf-8")
+    except Exception as exc:
+        hook_log("activity_touch_failed", {"path": str(_ACTIVITY_FILE), "error": str(exc)[:200]})
+
+
+@contextmanager
+def improve_session_lock(session_id: str, owner: str):
+    """Admit exactly one in-flight improve per session, machine-wide.
+
+    Three paths bridge the same session — the idle watcher, ``store-to-session``,
+    and the SessionEnd sync — and the outer ``sync_lock`` is bypassed in API mode
+    (``nullcontext(True) if api_mode``), so in HTTP/cloud mode nothing stopped two
+    of them submitting the same session concurrently. The server's own per-session
+    lock then answered the loser with ``{}`` (busy), which drove a 15s retry loop
+    for up to ten minutes; concurrent writers also collide on the single-writer
+    graph/vector store ("Could not set lock on file"), leaving pipeline runs stuck
+    and the graph unwritten.
+
+    So claim locally BEFORE submitting: the loser skips entirely rather than
+    waiting, because the winner is already bridging the very same session — the
+    work is not lost, it is in flight. Yields True when claimed, False when
+    another process owns it.
+
+    Mirrors ``sync_lock``'s stale handling (dead pid or older than
+    ``SYNC_LOCK_STALE_SECONDS``) so a crashed worker cannot wedge a session, and
+    fails OPEN on unexpected errors — a lock we cannot manage must never be the
+    reason a session goes unsynced.
+    """
+    if not session_id:
+        yield True
+        return
+
+    digest = hashlib.sha1(str(session_id).encode("utf-8")).hexdigest()
+    lock_path = _IMPROVE_LOCK_DIR / f"{digest}.lock"
+    acquired = False
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        now = datetime.now(timezone.utc).timestamp()
+        if lock_path.exists():
+            try:
+                current = json.loads(lock_path.read_text(encoding="utf-8"))
+                created_at = float(current.get("created_at", 0))
+                pid = int(current.get("pid", 0))
+            except Exception:
+                created_at, pid = 0.0, 0
+            if not (pid > 0 and _proc.pid_alive(pid)) or now - created_at > SYNC_LOCK_STALE_SECONDS:
+                try:
+                    lock_path.unlink()
+                    hook_log(
+                        "improve_lock_stale_cleared",
+                        {"session": session_id, "owner": owner, "stale_pid": pid},
+                    )
+                except FileNotFoundError:
+                    pass  # another process cleared the same stale lock
+                except Exception as exc:
+                    hook_log("improve_lock_unlink_failed", {"error": str(exc)[:200]})
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump({"owner": owner, "pid": os.getpid(), "created_at": now}, fh)
+            acquired = True
+            yield True
+        except FileExistsError:
+            hook_log("improve_skipped_concurrent", {"session": session_id, "owner": owner})
+            yield False
+    except Exception as exc:
+        # Fail open: never let lock bookkeeping cost a session its sync.
+        hook_log("improve_lock_failed_open", {"session": session_id, "error": str(exc)[:200]})
+        yield True
+    finally:
+        if acquired:
+            try:
+                lock_path.unlink()
+            except Exception as exc:
+                hook_log("improve_lock_release_failed", {"error": str(exc)[:200]})
+
+
+@contextmanager
+def sync_lock(owner: str):
+    """Best-effort cross-hook lock for graph sync/improve work."""
+    acquired = False
+    try:
+        _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        now = datetime.now(timezone.utc).timestamp()
+        if _SYNC_LOCK.exists():
+            try:
+                current = json.loads(_SYNC_LOCK.read_text(encoding="utf-8"))
+                created_at = float(current.get("created_at", 0))
+                pid = int(current.get("pid", 0))
+            except Exception as exc:
+                hook_log("sync_lock_read_failed", {"owner": owner, "error": str(exc)[:200]})
+                created_at = 0
+                pid = 0
+            pid_alive = False
+            if pid > 0:
+                pid_alive = _proc.pid_alive(pid)
+            if not pid_alive or now - created_at > SYNC_LOCK_STALE_SECONDS:
+                try:
+                    _SYNC_LOCK.unlink()
+                except Exception as exc:
+                    hook_log("sync_lock_unlink_failed", {"owner": owner, "error": str(exc)[:200]})
+        try:
+            fd = os.open(str(_SYNC_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump({"owner": owner, "pid": os.getpid(), "created_at": now}, fh)
+            acquired = True
+            yield True
+        except FileExistsError:
+            hook_log("sync_lock_busy", {"owner": owner})
+            yield False
+    finally:
+        if acquired:
+            try:
+                _SYNC_LOCK.unlink()
+            except Exception as exc:
+                hook_log("sync_lock_release_failed", {"owner": owner, "error": str(exc)[:200]})
+
+
+def _local_api_url_with_source() -> tuple[str, str]:
+    """Resolve the runtime endpoint without assuming hook env propagation."""
+    local_env = str(os.environ.get("COGNEE_LOCAL_API_URL", "") or "").strip()
+    if local_env:
+        return local_env, "env_local_api_url"
+    service_env = str(os.environ.get("COGNEE_BASE_URL", "") or "").strip()
+    if service_env:
+        return service_env, "env_service_url"
+
+    # SessionStart and hot hooks run in separate processes. SessionStart can
+    # resolve config.json and set its own environment, but those mutations do
+    # not propagate back to later hook processes. Read the shared config as the
+    # documented fallback, while leaving API-key resolution in _api_key().
+    try:
+        from config import load_config  # type: ignore
+
+        configured = str(load_config().get("base_url") or "").strip()
+        if configured:
+            return configured, "config_base_url"
+    except Exception:
+        # load_config already logs malformed files; endpoint resolution must
+        # remain fail-safe on the hot path.
+        pass
+
+    return _DEFAULT_LOCAL_SERVICE_URL, "default_local"
+
+
+def _local_api_url() -> str:
+    return _local_api_url_with_source()[0]
+
+
+def _normalize_service_url(value: str) -> str:
+    return str(value or "").strip().rstrip("/")
+
+
+def load_cached_api_key(service_url: str = "") -> str:
+    """Return the single cached principal key (matching service_url if recorded)."""
+    data = _load_json_file(_API_KEY_CACHE)
+    if not isinstance(data, dict):
+        return ""
+    key = str(data.get("api_key") or "").strip()
+    if not key:
+        return ""
+    cached_url = _normalize_service_url(str(data.get("base_url") or ""))
+    wanted = _normalize_service_url(service_url)
+    if wanted and cached_url and cached_url != wanted:
+        return ""
+    return key
+
+
+def save_cached_api_key(service_url: str, key: str) -> None:
+    """Persist the single principal key (env key takes precedence at read time)."""
+    if not str(key or "").strip():
+        return
+    _write_json_file(
+        _API_KEY_CACHE,
+        {
+            "base_url": _normalize_service_url(service_url),
+            "api_key": str(key).strip(),
+            "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        },
+    )
+
+
+def _api_key() -> str:
+    """Resolve the single principal API key.
+
+    Single-principal model: one key for everything. Order:
+      1. ``COGNEE_API_KEY`` env (user-provided, or set in-process after minting).
+      2. The single cached key (``api_key.json``), minted once from the default
+         user by SessionStart when no key was provided.
+    No per-agent keys, no agent-name keying.
+    """
+    env_key = str(os.environ.get("COGNEE_API_KEY", "") or "").strip()
+    if env_key:
+        return env_key
+
+    service_url = _normalize_service_url(_local_api_url())
+    cached = load_cached_api_key(service_url)
+    if cached:
+        os.environ["COGNEE_API_KEY"] = cached
+        return cached
+
+    return ""
+
+
+def resolved_http_endpoint_auth() -> tuple[str, str]:
+    """Return (service_url, api_key) for runtime HTTP calls.
+
+    Service URL falls back through plugin config before localhost. API key is
+    the single principal key: env first, then the single cached key.
+    """
+    service_url = _normalize_service_url(_local_api_url())
+    api_key = _api_key().strip()
+    if service_url:
+        os.environ["COGNEE_BASE_URL"] = service_url
+    if api_key:
+        os.environ["COGNEE_API_KEY"] = api_key
+    return service_url, api_key
+
+
+def http_api_ready() -> bool:
+    service_url, api_key = resolved_http_endpoint_auth()
+    return bool(service_url and api_key)
+
+
+def probe_health(service_url: str = "", timeout: float = 1.0) -> str:
+    """Classified GET {service_url}/health probe.
+
+    Returns:
+      "ready"   — 200 (the server runs migrations in its FastAPI lifespan
+                  *before* it serves, so this reliably means migrations are
+                  done and the DBs are reachable)
+      "down"    — connection refused / DNS / unroutable: positively absent
+      "slow"    — timed out: NO verdict (a busy server times out; a dead one
+                  refuses in milliseconds). Callers must keep prior state.
+      "unknown" — non-200 status, SSL trouble, resets, or no URL: no verdict
+    """
+    base = _normalize_service_url(service_url or _local_api_url())
+    if not base:
+        return UNKNOWN
+    try:
+        with urllib.request.urlopen(
+            f"{base}/health", timeout=timeout, context=_https_context()
+        ) as resp:
+            return "ready" if resp.status == 200 else UNKNOWN
+    except Exception as exc:
+        verdict = classify_transport_exception(exc)
+        return verdict if verdict in (DOWN, SLOW) else UNKNOWN
+
+
+def server_health_ok(service_url: str = "", timeout: float = 1.0) -> bool:
+    """Return True iff /health responds 200. Boolean face of ``probe_health``.
+
+    Callers that must react to *failures* should use ``probe_health`` instead:
+    this bool cannot distinguish "down" (write a failure state) from "slow"
+    (no verdict — keep prior state).
+    """
+    return probe_health(service_url, timeout=timeout) == "ready"
+
+
+# --- Server presence (boot-point evidence) -------------------------------------
+# probe_health cannot tell a BUSY server from an ABSENT one: both miss the HTTP
+# deadline, but only one of them may be installed/booted over. A server that is
+# busy (event loop saturated by a pipeline) misses a 2s probe exactly like a
+# dead one — and treating that as absence lets a boot point upgrade the venv
+# and run migrations UNDER a live server that still holds the graph store's
+# file lock. Presence is therefore judged from three evidence sources:
+#
+#   * HTTP probe    — probe_health; only a 200 is a self-sufficient verdict.
+#   * TCP listener  — a busy server still completes the TCP handshake in
+#     microseconds even when it cannot serve HTTP; a dead one refuses the
+#     connection. This is the busy-vs-dead discriminator.
+#   * server pidfile — written at uvicorn spawn; covers the window between
+#     spawn and port bind, when neither probe nor listener sees the server.
+#
+# The asymmetry is deliberate: extra evidence only ever ADDS presence (vetoing
+# a boot), and absence is only concluded from a positively refused port with no
+# live server pid — never from a timeout. A wrong "busy" delays a boot until
+# the next boot point; a wrong "absent" corrupts databases.
+
+PRESENCE_READY = "ready"  # HTTP 200: serving (lifespan migrations are done)
+PRESENCE_BUSY = "busy"  # evidence of a live server that is not serving
+PRESENCE_ABSENT = "absent"  # positively absent — the only install/boot license
+PRESENCE_UNKNOWN = "unknown"  # conflicting/insufficient evidence: treat as busy
+
+# Second-chance probe budget when confirming absence (see server_presence).
+_PRESENCE_REPROBE_TIMEOUT_SECONDS = 5.0
+
+
+def _presence_reprobe_delay() -> float:
+    """Pause before the absence-confirming re-probe. Read per call so tests
+    (and unusual deployments) can shrink it without re-importing the module."""
+    try:
+        return float(os.environ.get("COGNEE_PRESENCE_REPROBE_DELAY", "") or 3.0)
+    except ValueError:
+        return 3.0
+
+
+def _server_pidfile(port: int) -> Path:
+    # Shared root, not the per-integration dir: the server itself is
+    # machine-wide (one per port), whichever integration's boot point spawned it.
+    return _SHARED_PLUGIN_ROOT / f"server-{int(port)}.pid"
+
+
+def write_server_pidfile(port: int, pid: int, version: str = "") -> None:
+    """Record the uvicorn server spawned on ``port`` (presence evidence)."""
+    try:
+        _write_json_file(
+            _server_pidfile(port),
+            {
+                "pid": int(pid),
+                "port": int(port),
+                "version": version,
+                "created_at": datetime.now(timezone.utc).timestamp(),
+            },
+        )
+    except Exception as exc:
+        hook_log("server_pidfile_write_failed", {"error": str(exc)[:200]})
+
+
+def clear_server_pidfile(port: int) -> None:
+    try:
+        _server_pidfile(port).unlink()
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        hook_log("server_pidfile_clear_failed", {"error": str(exc)[:200]})
+
+
+def _pid_looks_like_server(pid: int) -> bool:
+    """Best-effort check that ``pid``'s command line still looks like the
+    cognee server (guards against OS pid reuse). When the command line cannot
+    be inspected (no ``ps``, permission trouble) err toward presence: pidfile
+    evidence is veto-only, so the cost of a wrong True is a delayed boot, and
+    it self-heals when the reused pid exits (``pid_alive`` gates before this)."""
+    try:
+        out = subprocess.run(
+            ["ps", "-p", str(int(pid)), "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        command = (out.stdout or "").strip().lower()
+        if not command:
+            return False
+        return "uvicorn" in command or "cognee" in command
+    except Exception:
+        return True
+
+
+def _live_server_pid(port: int) -> int:
+    """PID from the port's pidfile iff that process is alive and still looks
+    like the server; 0 otherwise. Stale records (dead or reused pid) are
+    reaped here so they can never veto boots forever."""
+    path = _server_pidfile(port)
+    try:
+        pid = int(json.loads(path.read_text(encoding="utf-8")).get("pid", 0) or 0)
+    except FileNotFoundError:
+        return 0
+    except Exception:
+        pid = 0
+    if pid > 0 and _proc.pid_alive(pid) and _pid_looks_like_server(pid):
+        return pid
+    try:
+        path.unlink()
+    except Exception:
+        pass
+    return 0
+
+
+def tcp_probe(host: str, port: int, timeout: float = 0.5) -> str:
+    """Classify the bare TCP handshake: 'listening' | 'refused' | 'no_verdict'.
+
+    'refused' is a positive signal from the OS that nothing holds the port —
+    the only transport answer that may contribute to an absence verdict.
+    Timeouts and filtered/odd socket states give no verdict, same as the HTTP
+    probe's rules.
+    """
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return "listening"
+    except ConnectionRefusedError:
+        return "refused"
+    except OSError as exc:
+        if getattr(exc, "errno", None) == errno.ECONNREFUSED:
+            return "refused"
+        return "no_verdict"
+    except Exception:
+        return "no_verdict"
+
+
+def _is_loopback_host(host: str) -> bool:
+    host = (host or "").lower()
+    return host in ("localhost", "::1") or host.startswith("127.")
+
+
+def server_presence(
+    service_url: str = "",
+    probe_timeout: float = 2.0,
+    confirm_absent: bool = True,
+) -> tuple[str, dict]:
+    """Classify whether a server exists at ``service_url`` from all local
+    evidence. Returns ``(verdict, evidence)``; the evidence dict is shaped for
+    hook_log so every boot decision records WHY it was made.
+
+    Only PRESENCE_ABSENT licenses installing or booting. ``confirm_absent``
+    adds one delayed, longer-budget re-probe before concluding absence — for
+    boot points about to install; pass False where a rigorous check follows
+    later anyway (e.g. mode selection, whose boot path re-verifies).
+
+    Local evidence (TCP, pidfile) only applies to loopback hosts: for remote
+    URLs the HTTP probe is all there is, and a non-ready remote is UNKNOWN —
+    never absent (nothing can boot a remote host anyway).
+    """
+    base = _normalize_service_url(service_url or _local_api_url())
+    evidence: dict = {"base_url": base}
+    if not base:
+        return PRESENCE_UNKNOWN, evidence
+    if "://" not in base:
+        base = f"http://{base}"
+
+    http_verdict = probe_health(base, timeout=probe_timeout)
+    evidence["http"] = http_verdict
+    if http_verdict == "ready":
+        return PRESENCE_READY, evidence
+
+    parsed = urllib.parse.urlsplit(base)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    if not _is_loopback_host(host):
+        return PRESENCE_UNKNOWN, evidence
+
+    tcp_verdict = tcp_probe(host, port)
+    evidence["tcp"] = tcp_verdict
+    if tcp_verdict == "listening":
+        # Alive but not serving HTTP within budget (busy, wedged, or answering
+        # non-200): a server exists. Never boot over it.
+        return PRESENCE_BUSY, evidence
+
+    pid = _live_server_pid(port)
+    if pid:
+        # Spawned but not (yet) bound to the port — starting up or tearing
+        # down. Either way a server process exists right now.
+        evidence["pid"] = pid
+        return PRESENCE_BUSY, evidence
+
+    if tcp_verdict != "refused":
+        return PRESENCE_UNKNOWN, evidence
+
+    if confirm_absent:
+        # Positively refused with no live pid. Give a recovering/just-starting
+        # server one more chance before licensing an install: the original
+        # incident had 37s between "live" and the probe that booted over it.
+        time.sleep(_presence_reprobe_delay())
+        retry_verdict = probe_health(base, timeout=_PRESENCE_REPROBE_TIMEOUT_SECONDS)
+        evidence["http_retry"] = retry_verdict
+        if retry_verdict == "ready":
+            return PRESENCE_READY, evidence
+        retry_tcp = tcp_probe(host, port)
+        if retry_tcp == "listening":
+            evidence["tcp_retry"] = retry_tcp
+            return PRESENCE_BUSY, evidence
+    return PRESENCE_ABSENT, evidence
+
+
+# Connection states recorded in the (shared) server-ready marker. "ready" means
+# the server is up AND authenticated; the failure states carry the reason shown
+# in the status line as "✕ (<state>)". Any non-"ready" state makes
+# server_ready_hint return False so recall does not attempt against a bad backend.
+# "unreachable" is reserved for POSITIVE absence (connection refused / DNS /
+# unroutable). "not_responding" is deliberately distinct: the server exists
+# (connections are not refused) but has not answered within budget for N
+# consecutive prompts — written only by the slow-streak escalation (see
+# record_slow_probe), never by a lone timeout.
+CONNECTION_STATES = ("ready", "auth_failed", "unreachable", "server_error", "not_responding")
+
+
+# Per-session copies of the status markers. The shared files above are
+# COORDINATION state (is the server up, should recall run) and are deliberately
+# machine-wide; these are DISPLAY state, answering "what did THIS terminal
+# experience". They have to be separate: two terminals can legitimately disagree
+# — one exported LLM_API_KEY and the other didn't, or they hold different
+# COGNEE_API_KEYs — and with a single file the last writer decided what every
+# other bar showed (a keyless launch's "not_set" greying out a healthy session,
+# or a healthy one's "ok" hiding a genuinely missing key).
+_LLM_STATE_DIR = _PLUGIN_DIR / "llm-state"
+_CONN_STATE_DIR = _PLUGIN_DIR / "conn-state"
+
+
+def _session_key_path_safe(key: str) -> bool:
+    """True when `key` is safe to use as a single filename component.
+
+    Excludes every path separator (`/`, `\\`) and drive/stream punctuation (`:`), so a
+    key can only ever name a file INSIDE the target directory — `..` becomes the
+    literal filename `...json`, not a parent-directory hop. The status-line renderer
+    keeps its own copy of this predicate (`_path_safe`) on purpose: it is standalone
+    by design and must not import this module.
+    """
+    return bool(key) and all(c.isalnum() or c in "._-" for c in key)
+
+
+def _write_session_marker(directory: Path, payload: dict) -> None:
+    """Mirror a status payload into ``<directory>/<session_key>.json``.
+
+    No-op when this process has no session key (e.g. an early bootstrap write):
+    the shared marker still gets written, and readers treat an unattributed
+    record as "could be mine" so nothing is lost. Best-effort, never raises.
+    """
+    key = get_session_key()
+    if not _session_key_path_safe(key):
+        return
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        tmp = directory / f".{os.getpid()}.json.tmp"
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp, directory / f"{key}.json")
+    except Exception as exc:
+        hook_log("session_marker_write_failed", {"dir": directory.name, "error": str(exc)[:200]})
+
+
+def write_connection_state(
+    state: str, service_url: str = "", *, detail: str = "", version: str = ""
+) -> None:
+    """Record the last connection outcome in the shared server-ready marker.
+
+    Global (not namespaced) because Claude and Qwen share one server on the
+    same port. Read by hot-path hooks via ``server_ready_hint`` (recall gate) and
+    by the status-line renderer (which reads the file directly). ``state`` is one
+    of ``CONNECTION_STATES``; unknown values are coerced to "unreachable".
+    """
+    if state not in CONNECTION_STATES:
+        state = "unreachable"
+    try:
+        _SERVER_READY_MARKER.parent.mkdir(parents=True, exist_ok=True)
+        now = datetime.now(timezone.utc).timestamp()
+        payload = {
+            "state": state,
+            "base_url": _normalize_service_url(service_url),
+            "checked_at": now,
+            # ready_at kept for backward-compat with any un-upgraded reader; only
+            # advanced on a successful (ready) check.
+            "ready_at": now if state == "ready" else 0,
+            "version": str(version or ""),
+            "detail": str(detail or "")[:200],
+            # Which terminal observed this. Two sessions can hold different
+            # COGNEE_API_KEYs against the same base_url, so "auth_failed" is not
+            # necessarily everyone's truth.
+            "session_key": get_session_key(),
+        }
+        tmp = _SERVER_READY_MARKER.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp, _SERVER_READY_MARKER)
+        _write_session_marker(_CONN_STATE_DIR, payload)
+    except Exception as exc:
+        hook_log("connection_state_write_failed", {"state": state, "error": str(exc)[:200]})
+
+
+def mark_server_ready(service_url: str, version: str = "") -> None:
+    """Back-compat shim: record a healthy, authenticated connection ("ready")."""
+    write_connection_state("ready", service_url, version=version)
+
+
+# Slow-server hysteresis. A single timeout is "no verdict" and must not touch
+# the connection marker — but N consecutive timeout-only prompts with no
+# success in between are a pattern (wedged server, packet-dropping network),
+# not a blip. This counter, keyed by base_url, is how a lone blip stays
+# invisible while a persistent stall still escalates to a visible "slow" state
+# (and recall backoff) instead of leaving the bar green forever.
+_SLOW_STREAK_FILE = _PLUGIN_DIR / "slow-streak.json"
+
+
+def slow_streak_threshold() -> int:
+    """Consecutive timeout-only prompts before escalating to state "slow"."""
+    try:
+        return max(1, int(os.environ.get("COGNEE_SLOW_STREAK_THRESHOLD", "3") or 3))
+    except (TypeError, ValueError):
+        return 3
+
+
+def _slow_streak_window_seconds() -> float:
+    """Ticks further apart than this don't chain — a streak must be recent."""
+    try:
+        return float(os.environ.get("COGNEE_SLOW_STREAK_WINDOW", "600") or 600)
+    except (TypeError, ValueError):
+        return 600.0
+
+
+def _read_slow_streaks() -> dict:
+    try:
+        raw = json.loads(_SLOW_STREAK_FILE.read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except Exception:
+        return {}
+
+
+def _write_slow_streaks(state: dict) -> None:
+    try:
+        _SLOW_STREAK_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _SLOW_STREAK_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(state), encoding="utf-8")
+        os.replace(tmp, _SLOW_STREAK_FILE)
+    except Exception:
+        pass
+
+
+def record_slow_probe(service_url: str) -> int:
+    """Count a consecutive no-verdict (timeout) observation; return the streak.
+
+    The streak resets itself when the previous tick is older than the window —
+    two timeouts hours apart are noise, not a pattern. The caller escalates to
+    ``write_connection_state("not_responding", ...)`` once the return value
+    reaches ``slow_streak_threshold()``.
+    """
+    url = _normalize_service_url(service_url)
+    now = datetime.now(timezone.utc).timestamp()
+    state = _read_slow_streaks()
+    entry = state.get(url) if isinstance(state.get(url), dict) else {}
+    try:
+        last_at = float(entry.get("last_at") or 0)
+        count = int(entry.get("count") or 0)
+    except (TypeError, ValueError):
+        last_at, count = 0.0, 0
+    if now - last_at > _slow_streak_window_seconds():
+        count = 0
+    count += 1
+    state[url] = {"count": count, "last_at": now}
+    _write_slow_streaks(state)
+    return count
+
+
+def clear_slow_streak(service_url: str) -> None:
+    """A definitive observation (success OR hard failure) ends the streak."""
+    url = _normalize_service_url(service_url)
+    state = _read_slow_streaks()
+    if url in state:
+        state.pop(url, None)
+        _write_slow_streaks(state)
+
+
+def same_connection_target(service_url: str, prior_url: str) -> bool:
+    """True unless the two URLs are *provably* different servers.
+
+    Deliberately permissive: when either side is unknown we treat a prior record as
+    being about this target. That direction is chosen on purpose — the caller uses
+    this to decide whether a failed probe means "the server we were talking to just
+    died" (report it) or "a server we know nothing about is still warming up" (stay
+    quiet). Flipping it to require both URLs would swallow a genuine death whenever a
+    URL is missing, which is the case this branch exists to catch.
+
+    The status-line renderer holds the mirror image of this predicate
+    (``_url_mismatch``), and the two MUST stay equivalent:
+    ``same_connection_target(a, b) == (not _url_mismatch(a, b))``. A hook that records
+    a state the renderer then ignores — or vice versa — leaves the user looking at a
+    stale glyph. The renderer cannot import this module (it is standalone by design),
+    so ``tests/test_connection_target_match.py`` pins the equivalence instead.
+    """
+    active = _normalize_service_url(service_url)
+    marked = _normalize_service_url(prior_url)
+    return not (active and marked and active != marked)
+
+
+def read_connection_state() -> dict:
+    """Return the connection marker dict (with 'state'), or {} — for hook use.
+
+    The status-line renderer does NOT use this (it stays import-free of
+    ``_plugin_common`` and reads the file directly); this is for network hooks
+    that need to know the prior state (e.g. warming-vs-died).
+    """
+    try:
+        raw = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    if "state" not in raw and raw.get("ready_at"):
+        raw["state"] = "ready"
+    return raw
+
+
+def authed_liveness(service_url: str = "", api_key: str = "", timeout: float = 1.5) -> str:
+    """Classify the connection via an AUTHENTICATED probe (GET /api/v1/datasets).
+
+    Unlike ``server_health_ok`` (which hits the unauthenticated ``/health`` and so
+    can't tell a bad key from a good one), this sends ``X-Api-Key`` to an endpoint
+    that requires auth, so it distinguishes:
+      "ready"        — 2xx (server up and the key is accepted)
+      "auth_failed"  — 401/403 (server up, key rejected)
+      "server_error" — 5xx
+      "unreachable"  — connection refused / DNS / unroutable (positively absent)
+      "slow"         — timed out: NO verdict, the server may simply be busy.
+                       Callers must keep their prior state, not record a failure.
+      "unknown"      — endpoint absent (404/405), no key to send, or an
+                       unclassifiable transport error; caller should fall back
+                       to ``probe_health`` rather than trust this
+    Returns a string in ``CONNECTION_STATES``, "slow", or "unknown" — "slow"
+    is a probe verdict only, never a recorded marker state. Never raises.
+    """
+    base = _normalize_service_url(service_url or _local_api_url())
+    if not base:
+        return "unknown"
+    key = str(api_key or _api_key() or "").strip()
+    if not key:
+        # No key to authenticate with — can't classify auth; let the caller
+        # fall back to an unauthenticated reachability check.
+        return "unknown"
+    req = urllib.request.Request(f"{base}/api/v1/datasets", method="GET")
+    req.add_header("X-Api-Key", key)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=_https_context()) as resp:
+            status = resp.status
+            if 200 <= status < 300:
+                return "ready"
+            if status >= 500:
+                return "server_error"
+            return "unknown"
+    except urllib.error.HTTPError as exc:
+        if exc.code in (401, 403):
+            return "auth_failed"
+        if exc.code >= 500:
+            return "server_error"
+        return "unknown"
+    except Exception as exc:
+        verdict = classify_transport_exception(exc)
+        if verdict == DOWN:
+            return "unreachable"
+        return "slow" if verdict == SLOW else "unknown"
+
+
+# LLM-key health surfaced in the status line — LOCAL mode only, since LLM_API_KEY
+# is unused when talking to a remote server. Kept in its OWN marker (not
+# server-ready.json) so a plain overwrite suffices — no read-modify-write merge, no
+# race with the server marker. SINGLE WRITER: the idle watcher's _check_llm_key,
+# which resolves the key exactly as the server does (cognee's get_llm_config) and
+# validates it against the provider. Hooks deliberately do NOT write a verdict from
+# their own env: a session launched without the export would flag "not_set" into
+# this machine-wide marker and put a false ✕ on every other session's status line.
+# States:
+#   "not_set"     — no LLM key configured anywhere the server would look
+#   "auth_failed" — key present but rejected by the provider (401/403)
+#   "ok"          — key accepted (renders nothing)
+# Readers apply a TTL (see the renderer's _LLM_STATE_STALE_SECONDS), so a verdict
+# left behind by a dead session stops accusing a key the user has since fixed.
+_LLM_STATE_MARKER = _PLUGIN_DIR / "llm-state.json"
+LLM_STATES = ("ok", "not_set", "auth_failed")
+
+
+def write_llm_state(state: str, detail: str = "") -> None:
+    """Record LLM-key health (local mode). Plain atomic overwrite; never raises.
+
+    Stamped with the writing session's host key: the key is resolved from the
+    writer's OWN environment, so a session launched from a shell without the
+    export legitimately sees no key — without this stamp its "not_set" would
+    land in the machine-wide marker and put a false ✕ on every other session's
+    status line (observed: one keyless launch clobbering a validated "ok").
+    Readers show a verdict only when it is theirs, or unattributable.
+    """
+    if state not in LLM_STATES:
+        state = "ok"
+    try:
+        _LLM_STATE_MARKER.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "llm_state": state,
+            "checked_at": datetime.now(timezone.utc).timestamp(),
+            "session_key": get_session_key(),
+            "detail": str(detail or "")[:200],
+        }
+        tmp = _LLM_STATE_MARKER.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp, _LLM_STATE_MARKER)
+        _write_session_marker(_LLM_STATE_DIR, payload)
+    except Exception as exc:
+        hook_log("llm_state_write_failed", {"state": state, "error": str(exc)[:200]})
+
+
+def read_llm_state() -> dict:
+    """Return this session's LLM-state record, else the shared one, else {}.
+
+    Prefers the per-session copy so the watcher's throttle and the status line both
+    reason about THIS terminal's verdict rather than whichever session wrote last.
+    """
+    key = get_session_key()
+    if _session_key_path_safe(key):
+        try:
+            raw = json.loads((_LLM_STATE_DIR / f"{key}.json").read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                return raw
+        except Exception:
+            pass
+    try:
+        raw = json.loads(_LLM_STATE_MARKER.read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except Exception:
+        return {}
+
+
+def clear_llm_state() -> None:
+    """Remove the LLM-state marker (e.g. a key is present and will be validated)."""
+    try:
+        _LLM_STATE_MARKER.unlink()
+    except FileNotFoundError:
+        return
+    except Exception as exc:
+        hook_log("llm_state_clear_failed", {"error": str(exc)[:200]})
+
+
+def clear_server_ready() -> None:
+    """Drop the readiness marker (e.g. after a failed health re-probe)."""
+    try:
+        _SERVER_READY_MARKER.unlink()
+    except FileNotFoundError:
+        return
+    except Exception as exc:
+        hook_log("server_ready_clear_failed", {"error": str(exc)[:200]})
+
+
+def server_ready_hint(service_url: str = "") -> bool:
+    """Zero-network readiness check for the hot path.
+
+    True iff a readiness marker exists, is within TTL, and (if given) matches
+    the service URL. A stale/missing marker returns False so recall fast-skips
+    while the server is still warming.
+    """
+    try:
+        raw = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return False
+    except Exception:
+        return False
+    # Only a "ready" state counts as ready. A recorded failure (auth_failed /
+    # unreachable / server_error) makes the gate skip so recall never hammers a
+    # bad backend. Legacy markers (no 'state', have ready_at) are treated ready.
+    state = str(raw.get("state") or ("ready" if raw.get("ready_at") else ""))
+    if state != "ready":
+        return False
+    checked_at = float(raw.get("checked_at", 0) or raw.get("ready_at", 0) or 0)
+    if datetime.now(timezone.utc).timestamp() - checked_at > _SERVER_READY_TTL_SECONDS:
+        return False
+    if service_url:
+        marked = _normalize_service_url(raw.get("base_url", ""))
+        if marked and marked != _normalize_service_url(service_url):
+            return False
+    return True
+
+
+# A failed usability probe is memoized here so a genuinely-down server costs
+# one probe per backoff window across all hooks, not one per tool call.
+_PROBE_FAIL_MEMO = _PLUGIN_DIR / "probe-fail.json"
+_PROBE_FAIL_BACKOFF_SECONDS = 10.0
+
+
+def server_usable(service_url: str = "", probe_timeout: float = 1.0) -> bool:
+    """Ready hint, refreshed by a cheap /health probe when stale.
+
+    ``server_ready_hint`` alone conflates "marker TTL expired" with "server
+    down": the marker is only refreshed on the prompt path, so during a long
+    agent turn it goes stale while the server is healthy — and every write
+    hook then buffers to the warmup spillway for no reason, leaving a backlog
+    that some later hook has to drain (#298). On a stale hint this probes once
+    (bounded by ``probe_timeout``) and re-marks ready on success, so the write
+    hooks keep the marker fresh for the whole turn and the buffer only fills
+    when the server is actually unreachable.
+    """
+    if server_ready_hint(service_url):
+        return True
+    now = datetime.now(timezone.utc).timestamp()
+    try:
+        memo = json.loads(_PROBE_FAIL_MEMO.read_text(encoding="utf-8"))
+        if now - float(memo.get("failed_at", 0) or 0) < _PROBE_FAIL_BACKOFF_SECONDS:
+            return False
+    except Exception:
+        pass
+    if server_health_ok(service_url, timeout=probe_timeout):
+        mark_server_ready(service_url)
+        try:
+            _PROBE_FAIL_MEMO.unlink()
+        except Exception:
+            pass
+        return True
+    try:
+        _PROBE_FAIL_MEMO.parent.mkdir(parents=True, exist_ok=True)
+        _PROBE_FAIL_MEMO.write_text(
+            json.dumps({"failed_at": now, "base_url": service_url}), encoding="utf-8"
+        )
+    except Exception:
+        pass
+    return False
+
+
+# --- Credits marker (status-line budget display, SDK-355) ---------------------
+# The status-line renderer is pure-local by contract, so the credits balance it
+# shows comes from this marker, written by hooks/watchers that are already
+# allowed to touch the network. Cloud-only: a local server has no credit
+# concept, so the fetch is gated on a non-loopback base URL (the renderer
+# independently gates on its mode label).
+_CREDITS_MARKER = _PLUGIN_DIR / "credits.json"
+_PLATFORM_API_URL_DEFAULT = "https://api.aws.cognee.ai"
+
+
+def _platform_api_url() -> str:
+    """The cloud control-plane API host (billing/account routes).
+
+    Distinct from the memory data plane: cloud sessions talk to a per-tenant
+    host (``tenant-<id>.aws.cognee.ai``), which serves recall/remember/improve
+    but has NO billing routes — asking it for the credits overview 404s. The
+    billing routes live only on the platform API, which accepts the same
+    tenant ``COGNEE_API_KEY``. Overridable for other cloud deployments.
+    """
+    return (
+        str(os.environ.get("COGNEE_PLATFORM_API_URL", "") or _PLATFORM_API_URL_DEFAULT)
+        .strip()
+        .rstrip("/")
+    )
+
+
+# The marker is a MAP keyed by tenant id: several concurrent Claude sessions
+# on one machine can be connected to DIFFERENT cloud tenants, and a flat
+# last-writer-wins record made them clobber each other's balance. Each entry
+# carries the service base_url it was observed under — that binding is how
+# readers with only a URL in hand (the renderer, the Stop hook) find their
+# tenant's entry.
+_CREDITS_LOCK = _PLUGIN_DIR / "credits.lock"
+_CREDITS_LOCK_STALE_SECONDS = 30.0
+_CREDITS_ENTRY_MAX_AGE_SECONDS = 7 * 24 * 3600.0
+
+
+def read_credits_marker() -> dict:
+    """Return the tenant-keyed credits map, or {} — never raises."""
+    try:
+        raw = json.loads(_CREDITS_MARKER.read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except Exception:
+        return {}
+
+
+def _credits_entry_for_url(marker: dict, service_url: str) -> tuple[str, dict]:
+    """Find the (tenant_id, entry) bound to ``service_url``, or ("", {})."""
+    want = _normalize_service_url(service_url)
+    for key, entry in marker.items():
+        if (
+            isinstance(entry, dict)
+            and _normalize_service_url(str(entry.get("base_url") or "")) == want
+        ):
+            return str(key), entry
+    return "", {}
+
+
+def _try_acquire_credits_lock() -> bool:
+    """Guard the marker's read-modify-write; concurrent writers on different
+    tenants would otherwise each write back a map missing the other's entry.
+    Fail-open like the drain lock: a rare lost update beats a wedged marker."""
+    try:
+        _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        if _CREDITS_LOCK.exists():
+            try:
+                if time.time() - _CREDITS_LOCK.stat().st_mtime > _CREDITS_LOCK_STALE_SECONDS:
+                    _CREDITS_LOCK.unlink()
+            except FileNotFoundError:
+                pass
+        fd = os.open(str(_CREDITS_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.close(fd)
+        return True
+    except FileExistsError:
+        return False
+    except Exception:
+        return True
+
+
+def _release_credits_lock() -> None:
+    try:
+        _CREDITS_LOCK.unlink()
+    except Exception:
+        pass
+
+
+def _select_tenant_budget(overview: dict, tenant_id: str) -> dict | None:
+    """Return the budget record of OUR tenant from the credits overview, or None.
+
+    Exact match only, on purpose: the display answers "what does the tenant I
+    am connected to have left?", and no other number is a valid answer. The
+    overview's account-wide ``budget`` aggregates every workspace the user
+    owns, and its ``tenants`` list may contain workspaces other than the one
+    this session talks to (e.g. your personal workspace while connected to a
+    shared tenant someone else owns) — showing either would be wrong, so with
+    no exact match the caller shows nothing at all.
+    """
+    tenants = overview.get("tenants")
+    tenants = [t for t in tenants if isinstance(t, dict)] if isinstance(tenants, list) else []
+    for t in tenants:
+        if str(t.get("tenantId") or "").strip() == tenant_id:
+            return {
+                "remaining_usd": t.get("remainingUsd"),
+                "spent_usd": t.get("spentUsd"),
+                "total_usd": t.get("maxBudgetUsd"),
+            }
+    return None
+
+
+def refresh_credits(op_label: str = "", *, tenant_id: str = "", timeout: float = 3.0) -> dict:
+    """Fetch the cloud credits overview and update this tenant's marker entry.
+
+    Best-effort by contract: any failure returns {} and leaves the existing
+    marker untouched — the renderer's staleness TTL handles an aging balance,
+    and a fetch problem must never propagate into the calling hook.
+
+    ``tenant_id`` comes from ``load_resolved()`` (the connections/me lookup)
+    when the caller has it; otherwise the tenant is recovered from the marker
+    entry already bound to this service URL (established by the prompt-time
+    refresh). Strictly the CONNECTED tenant's budget or nothing: when the
+    tenant cannot be determined, or is not in the overview, no entry is
+    written and the segment simply does not render.
+
+    ``op_label`` ("turn" / "remember" / "improve") attributes the spend
+    recorded since the previous reading OF THIS TENANT to the operation that
+    just ran. Approximate by design — the cloud aggregates spend
+    asynchronously and concurrent operations overlap, so the delta reads as
+    "~cost", not an invoice. A non-positive delta (aggregation lag, or a
+    top-up between readings) refreshes the balance but records no last_op:
+    a negative "cost" is meaningless, and the prior last_op is kept so the
+    display doesn't flicker away on every idle refresh.
+    """
+    service_url = _local_api_url()
+    if service_url_is_local(service_url):
+        return {}
+    platform_url = _platform_api_url()
+    try:
+        marker = read_credits_marker()
+        tenant_id = str(tenant_id or "").strip()
+        if not tenant_id:
+            tenant_id, _ = _credits_entry_for_url(marker, service_url)
+        if not tenant_id:
+            # Connected tenant unknown (no id from the caller, no prior URL
+            # binding): show nothing rather than someone's other workspace or
+            # the all-tenants aggregate. Skipped BEFORE the fetch — a doomed
+            # lookup is not worth a network call.
+            hook_log("credits_refresh_skipped_no_tenant", {"base_url": service_url})
+            return {}
+        overview = _json_http_request(
+            "/api/v1/billing/credits/overview",
+            None,
+            method="GET",
+            timeout=timeout,
+            base_url=platform_url,
+        )
+        budget = _select_tenant_budget(overview or {}, tenant_id)
+        if budget is None:
+            hook_log(
+                "credits_tenant_not_in_overview",
+                {"tenant_id": tenant_id, "platform_url": platform_url},
+            )
+            return {}
+        remaining = budget.get("remaining_usd")
+        spent = budget.get("spent_usd")
+        if remaining is None and spent is None:
+            hook_log(
+                "credits_fetch_empty",
+                {"platform_url": platform_url, "tenant_id": tenant_id},
+            )
+            return {}
+        now_ts = datetime.now(timezone.utc).timestamp()
+        entry_key = tenant_id
+        entry = {
+            "remaining_usd": remaining,
+            "spent_usd": spent,
+            "total_usd": budget.get("total_usd"),
+            # The service URL this tenant was observed under: the renderer and
+            # tenantless callers look their entry up by it.
+            "base_url": service_url,
+            "platform_url": platform_url,
+            "tenant_id": tenant_id,
+            "checked_at": now_ts,
+        }
+        acquired = _try_acquire_credits_lock()
+        try:
+            # Re-read under the lock: another tenant's refresh may have
+            # updated the map since the pre-fetch read.
+            marker = read_credits_marker()
+            prior = marker.get(entry_key)
+            prior = prior if isinstance(prior, dict) else {}
+            last_op = prior.get("last_op")
+            if op_label:
+                delta = None
+                try:
+                    # Prefer the spend counter; fall back to the remaining-
+                    # balance drop when the API reports only one of the two.
+                    if spent is not None and prior.get("spent_usd") is not None:
+                        delta = float(spent) - float(prior["spent_usd"])
+                    elif remaining is not None and prior.get("remaining_usd") is not None:
+                        delta = float(prior["remaining_usd"]) - float(remaining)
+                except (TypeError, ValueError):
+                    delta = None
+                if delta is not None and delta > 0:
+                    last_op = {
+                        "label": str(op_label)[:24],
+                        "cost_usd": round(delta, 4),
+                        "at": now_ts,
+                    }
+            if isinstance(last_op, dict):
+                entry["last_op"] = last_op
+            marker[entry_key] = entry
+            # Prune long-dead tenants so one-off connections don't accumulate.
+            for key in [
+                k
+                for k, v in marker.items()
+                if k != entry_key
+                and (
+                    not isinstance(v, dict)
+                    or now_ts - float(v.get("checked_at", 0) or 0) > _CREDITS_ENTRY_MAX_AGE_SECONDS
+                )
+            ]:
+                marker.pop(key, None)
+            _CREDITS_MARKER.parent.mkdir(parents=True, exist_ok=True)
+            # Per-pid tmp: a shared staging name let one writer truncate the
+            # file another was about to os.replace into place, and the
+            # renderer briefly saw a torn marker (the "credits disappear
+            # mid-search" flicker).
+            tmp = _CREDITS_MARKER.with_name(f"{_CREDITS_MARKER.name}.{os.getpid()}.tmp")
+            try:
+                tmp.write_text(json.dumps(marker), encoding="utf-8")
+                os.replace(tmp, _CREDITS_MARKER)
+            finally:
+                try:
+                    tmp.unlink()
+                except FileNotFoundError:
+                    pass
+        finally:
+            if acquired:
+                _release_credits_lock()
+        return entry
+    except Exception as exc:
+        # platform_url in the detail: a 404 here once cost a PID-correlation
+        # hunt to discover WHICH host was being asked.
+        hook_log(
+            "credits_fetch_failed",
+            {"error": str(exc)[:200], "platform_url": platform_url},
+        )
+        return {}
+
+
+# --- Plugin update check (Phase 2) -------------------------------------------
+# Background, hourly-guarded check comparing the installed plugin version against the
+# version published on the tracked git ref. The network call runs only here (in
+# the background idle watcher); the hot path (in-context status via
+# render_status_for_host, SessionStart nudge) merely READS the marker this
+# writes. Qwen tracks the repository's git ref (main) rather than a version
+# pin, so the nudge compares the published qwen-extension.json
+# version to the installed one. Talks only to raw.githubusercontent over the
+# shared certifi TLS context. Opt out with COGNEE_UPDATE_CHECK=off.
+_UPDATE_CHECK_FILE = _PLUGIN_DIR / "update-check.json"
+_UPDATE_CHECK_INTERVAL_DEFAULT = 3600.0
+_UPDATE_DEFAULT_REPO = "topoteretes/cognee-integrations"
+_UPDATE_DEFAULT_REF = "main"
+_UPDATE_MANIFEST_PATH = "integrations/qwen/qwen-extension.json"
+
+
+def _update_check_enabled() -> bool:
+    return os.environ.get("COGNEE_UPDATE_CHECK", "").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+def _parse_semver(value: str):
+    """Parse the numeric X.Y.Z core (ignoring any -pre/+build suffix); None if not X.Y.Z."""
+    core = str(value or "").strip().lstrip("vV").split("-", 1)[0].split("+", 1)[0]
+    parts = core.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        return tuple(int(p) for p in parts)
+    except ValueError:
+        return None
+
+
+def _semver_gt(a: str, b: str) -> bool:
+    pa, pb = _parse_semver(a), _parse_semver(b)
+    return bool(pa and pb and pa > pb)
+
+
+def _installed_plugin_version() -> str:
+    candidates = []
+    for variable in ("CLAUDE_PLUGIN_ROOT", "PLUGIN_ROOT"):
+        root = os.environ.get(variable, "").strip()
+        if root:
+            candidates.extend(
+                (Path(root) / "qwen-extension.json", Path(root) / "gemini-extension.json")
+            )
+    extension_root = Path(__file__).resolve().parent.parent
+    candidates.extend(
+        (extension_root / "qwen-extension.json", extension_root / "gemini-extension.json")
+    )
+    for path in candidates:
+        try:
+            version = str(json.loads(path.read_text(encoding="utf-8")).get("version") or "").strip()
+            if version:
+                return version
+        except Exception:
+            continue
+    return ""
+
+
+def _update_source() -> Optional[tuple]:
+    """(repo, ref) to read the published version from.
+
+    Qwen tracks the ref rather than a version pin, so we read the published
+    version from the default repo/ref. The nudge is purely a version comparison,
+    so a local checkout only nags when it is behind the published version.
+    """
+    return _UPDATE_DEFAULT_REPO, _UPDATE_DEFAULT_REF
+
+
+def _fetch_published_version(repo: str, ref: str, etag: str) -> tuple:
+    """GET the raw qwen-extension.json and read its version.
+
+    Returns (version, new_etag, error). version is '' on 304/missing/error so the
+    caller keeps the previously-known latest.
+    """
+    url = f"https://raw.githubusercontent.com/{repo}/{ref}/{_UPDATE_MANIFEST_PATH}"
+    req = urllib.request.Request(url, method="GET")
+    if etag:
+        req.add_header("If-None-Match", etag)
+    try:
+        with urllib.request.urlopen(req, timeout=5.0, context=_https_context()) as resp:
+            body = resp.read().decode("utf-8")
+            new_etag = resp.headers.get("ETag", "") or etag
+            data = json.loads(body)
+            version = str(data.get("version") or "") if isinstance(data, dict) else ""
+            return version, new_etag, ("" if version else "version_missing")
+    except urllib.error.HTTPError as exc:
+        if exc.code == 304:
+            return "", etag, ""  # unchanged since last check
+        return "", etag, f"http_{exc.code}"
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
+        return "", etag, str(exc)[:120]
+
+
+def maybe_check_for_update() -> None:
+    """Background, ≤hourly update check. Writes the marker. Never raises.
+
+    Call from a background process (the idle watcher) — never a synchronous hook,
+    since it may make a network call (bounded to 5s, ≤ once per interval).
+    """
+    try:
+        if not _update_check_enabled():
+            return
+        marker = _load_json_file(_UPDATE_CHECK_FILE)
+        interval = _improve_float_env(
+            "COGNEE_UPDATE_CHECK_INTERVAL", _UPDATE_CHECK_INTERVAL_DEFAULT
+        )
+        now = datetime.now(timezone.utc).timestamp()
+        if now - float(marker.get("last_checked_at", 0) or 0) < interval:
+            return  # checked recently
+        source = _update_source()
+        if source is None:
+            return
+        repo, ref = source
+        installed = _installed_plugin_version()
+        latest, etag, error = _fetch_published_version(repo, ref, str(marker.get("etag") or ""))
+        if not latest:
+            latest = str(marker.get("latest_version") or "")  # 304/error: keep prior
+        update_available = bool(installed and latest and _semver_gt(latest, installed))
+        _write_json_file(
+            _UPDATE_CHECK_FILE,
+            {
+                "last_checked_at": now,
+                "installed_version": installed,
+                "latest_version": latest,
+                "update_available": update_available,
+                "etag": etag,
+                "source": f"{repo}@{ref}",
+                "error": error,
+                "notified_version": str(marker.get("notified_version") or ""),
+            },
+        )
+        hook_log(
+            "update_check",
+            {
+                "installed": installed,
+                "latest": latest,
+                "available": update_available,
+                "error": error,
+            },
+        )
+    except Exception as exc:
+        hook_log("update_check_failed", {"error": str(exc)[:200]})
+
+
+def read_update_status() -> dict:
+    """Zero-network read of the update marker; {} when disabled/absent/current.
+
+    The marker is a snapshot from the last background check, so it goes stale the
+    moment the plugin is updated — it would keep claiming an update is available
+    until the next check (≤ an hour later). Guard against that here, at read time:
+    the snapshot is only trustworthy while its ``installed_version`` is still the
+    version actually running. A mismatch means the update already landed, so the
+    nudge is suppressed immediately rather than after the next network check.
+    Note this compares against the RUNNING version, not the newest on disk — an
+    auto-update that a session has not reloaded yet correctly keeps nudging.
+    """
+    if not _update_check_enabled():
+        return {}
+    marker = _load_json_file(_UPDATE_CHECK_FILE)
+    if not (
+        isinstance(marker, dict)
+        and marker.get("update_available")
+        and marker.get("installed_version")
+        and marker.get("latest_version")
+    ):
+        return {}
+    # An undeterminable running version falls back to trusting the marker, so a
+    # missing/unreadable plugin.json degrades to the previous behaviour.
+    running = _installed_plugin_version()
+    if running and running != marker.get("installed_version"):
+        return {}
+    return marker
+
+
+def mark_update_notified(version: str) -> None:
+    """Record that the one-time SessionStart nudge for `version` has been shown."""
+    try:
+        marker = _load_json_file(_UPDATE_CHECK_FILE)
+        if not marker:
+            return
+        marker["notified_version"] = str(version or "")
+        _write_json_file(_UPDATE_CHECK_FILE, marker)
+    except Exception as exc:
+        hook_log("update_notified_write_failed", {"error": str(exc)[:200]})
+
+
+def resolve_runtime_mode() -> dict:
+    """Resolve hook runtime mode from effective endpoint auth."""
+    service_url, api_key = resolved_http_endpoint_auth()
+    # A configured service URL alone selects HTTP mode; an API key is no longer
+    # required to decide whether to talk to a server (it's still sent when present).
+    mode = "http" if service_url else "local_sdk"
+    return {
+        "mode": mode,
+        "base_url": service_url,
+        "api_key_present": bool(api_key),
+    }
+
+
+def set_agent_registration(registered: bool, session_key: str = "") -> None:
+    # No local resolved cache to patch.
+    _ = (registered, session_key)
+
+
+def _json_http_request(
+    path: str,
+    payload: dict | None = None,
+    *,
+    method: str = "POST",
+    timeout: float = 30.0,
+    base_url: str | None = None,
+):
+    # base_url overrides the resolved service URL for calls that target a
+    # different host than the memory data plane (e.g. the cloud platform API's
+    # billing routes); the same principal X-Api-Key is attached either way.
+    base_url = (base_url or _local_api_url()).rstrip("/")
+    api_key = _api_key()
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["X-Api-Key"] = api_key
+
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+
+    req = urllib.request.Request(
+        f"{base_url}{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+    with urllib.request.urlopen(req, timeout=timeout, context=_https_context()) as resp:
+        body = resp.read().decode("utf-8")
+        if not body:
+            return None
+        return json.loads(body)
+
+
+def _float_env(name: str, default: float) -> float:
+    """Read a float from the environment, falling back to default on absence/parse error."""
+    try:
+        raw = os.environ.get(name, "").strip()
+        return float(raw) if raw else default
+    except (TypeError, ValueError):
+        return default
+
+
+def elapsed_ms(start: float) -> int:
+    """Whole milliseconds elapsed since a ``time.monotonic()`` start marker.
+
+    Monotonic-based so it is immune to wall-clock jumps / NTP drift, and rounded to
+    an int so the ``elapsed_ms`` fields in hook.log stay compact and easy to query.
+    """
+    return round((time.monotonic() - start) * 1000)
+
+
+def wait_for_cognify(
+    dataset_id: str,
+    *,
+    deadline_seconds: float,
+    interval_seconds: float = 3.0,
+    pipeline: str = "cognify_pipeline",
+    request_timeout: float = 10.0,
+) -> str:
+    """Poll GET /api/v1/datasets/status until the cognify pipeline is terminal or the deadline.
+
+    Returns one of:
+      "completed" — DATASET_PROCESSING_COMPLETED (graph queryable; safe to mark written)
+      "errored"   — DATASET_PROCESSING_ERRORED (do NOT mark; a later attempt should retry)
+      "timeout"   — deadline elapsed while still processing (do NOT mark; retry)
+      "unknown"   — cannot poll: no dataset_id, or the status route is absent (older server)
+
+    A background remember returns immediately with a dataset_id; this confirms the
+    server-side cognify actually finished instead of fire-and-forgetting, so the bridge
+    never holds one synchronous request open past the cloud's request ceiling.
+    """
+    if not dataset_id:
+        return "unknown"
+    path = (
+        f"/api/v1/datasets/status?dataset={urllib.parse.quote(str(dataset_id))}"
+        f"&pipeline={urllib.parse.quote(pipeline)}"
+    )
+    deadline = time.monotonic() + max(0.0, deadline_seconds)
+    while True:
+        try:
+            result = _json_http_request(path, None, method="GET", timeout=request_timeout)
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                # Older server without the status route — can't confirm, don't loop.
+                return "unknown"
+            hook_log(
+                "cognify_poll_transient",
+                {"dataset_id": dataset_id, "error": f"HTTP {exc.code}"},
+            )
+            result = None
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            hook_log("cognify_poll_transient", {"dataset_id": dataset_id, "error": str(exc)[:120]})
+            result = None
+
+        status = ""
+        if isinstance(result, dict) and result:
+            raw = result.get(str(dataset_id))
+            if raw is None and len(result) == 1:
+                raw = next(iter(result.values()))
+            # A multi-pipeline response nests {pipeline: status}; unwrap if needed.
+            if isinstance(raw, dict):
+                raw = raw.get(pipeline)
+            status = str(raw or "").upper()
+
+        if status.endswith("COMPLETED"):
+            return "completed"
+        if status.endswith("ERRORED"):
+            return "errored"
+
+        if time.monotonic() >= deadline:
+            return "timeout"
+        time.sleep(max(0.1, interval_seconds))  # floor avoids a tight spin if misconfigured to 0
+
+
+def remember_entry_via_http(
+    dataset: str,
+    session_id: str,
+    entry: dict,
+    *,
+    timeout: float = 30.0,
+) -> dict | None:
+    """Store a typed QA/trace entry through the backend API.
+
+    API-mode hooks use this instead of importing Cognee's Python client,
+    so they don't initialize local databases while talking to a backend.
+    """
+    if not dataset or not session_id:
+        return None
+    entry = _sanitize_value(entry)
+    return _json_http_request(
+        "/api/v1/remember/entry",
+        {
+            "entry": entry,
+            "dataset_name": dataset,
+            "session_id": session_id,
+        },
+        timeout=timeout,
+    )
+
+
+def get_session_detail_via_http(session_id: str, *, timeout: float = 8.0) -> dict | None:
+    """Fetch the server's view of a session: recent QA and trace tails.
+
+    GET /api/v1/sessions/{id} returns the session row plus the last ~20 QA and
+    trace entries. The drain's verify-before-replay pass uses it to check
+    whether an ambiguous write (timed out / gateway error after the request
+    was sent) actually committed. Returns None on any failure — callers must
+    fail open (replay anyway) rather than block the drain on a read.
+    """
+    if not session_id:
+        return None
+    try:
+        result = _json_http_request(
+            f"/api/v1/sessions/{urllib.parse.quote(session_id, safe='')}",
+            None,
+            method="GET",
+            timeout=timeout,
+        )
+        return result if isinstance(result, dict) else None
+    except Exception as exc:
+        hook_log("session_detail_error", {"error": str(exc)[:200]})
+        return None
+
+
+def write_outcome_ambiguous(exc: Exception) -> bool:
+    """True if a failed /remember/entry write may still have been committed.
+
+    The server has no idempotency on the entry path — every accepted write
+    creates and embeds a fresh entry — so replaying a write that actually
+    landed duplicates session content and inflates the next improve. Only
+    failures where the request provably never reached the application are
+    unambiguous:
+      - connection refused / DNS failure: nothing was sent;
+      - HTTP 503: the endpoint returns it before touching the cache
+        ("session cache unavailable"), and a proxy 503 means it never routed.
+    Everything else — timeouts, resets, SSL errors mid-exchange, 500/502/504 —
+    may have committed server-side, so the buffered copy must be verified
+    against the server before replay.
+    """
+    if isinstance(exc, urllib.error.HTTPError):
+        return exc.code != 503
+    reason = exc.reason if isinstance(exc, urllib.error.URLError) else exc
+    if isinstance(reason, (socket.gaierror, ConnectionRefusedError)):
+        return False
+    if isinstance(reason, OSError) and getattr(reason, "errno", None) in (
+        errno.ECONNREFUSED,
+        errno.EHOSTUNREACH,
+        errno.ENETUNREACH,
+    ):
+        return False
+    return True
+
+
+def register_agent_via_http(
+    *,
+    agent_session_name: str,
+    session_id: str = "",
+    dataset_names: list[str] | None = None,
+    timeout: float = 15.0,
+) -> tuple[bool, dict]:
+    payload = {
+        "agent_session_name": agent_session_name,
+        "type": "api",
+        "memory_mode": "hybrid",
+        "source": "api",
+    }
+    if session_id:
+        payload["session_id"] = session_id
+    if dataset_names:
+        payload["dataset_names"] = [str(name) for name in dataset_names if str(name).strip()]
+
+    try:
+        result = _json_http_request(
+            "/api/v1/agents/register", payload, method="POST", timeout=timeout
+        )
+        if isinstance(result, dict):
+            return True, result
+        return True, {}
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            hook_log("agent_register_unsupported", {"status": exc.code})
+            return True, {"lifecycle_supported": False}
+        hook_log("agent_register_failed", {"error": str(exc)[:200]})
+        return False, {}
+    except Exception as exc:
+        hook_log("agent_register_failed", {"error": str(exc)[:200]})
+        return False, {}
+
+
+def unregister_agent_via_http(
+    *, agent_session_name: str, timeout: float = 15.0
+) -> tuple[bool, int]:
+    try:
+        result = _json_http_request(
+            "/api/v1/agents/unregister",
+            {"agent_session_name": agent_session_name},
+            method="POST",
+            timeout=timeout,
+        )
+        if isinstance(result, dict):
+            count = int(result.get("activeAgents", 0) or result.get("active_agents", 0) or 0)
+            return True, count
+        return True, 0
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            hook_log("agent_unregister_unsupported", {"status": exc.code})
+            return True, 0
+        hook_log("agent_unregister_failed", {"error": str(exc)[:200]})
+        return False, 0
+    except Exception as exc:
+        hook_log("agent_unregister_failed", {"error": str(exc)[:200]})
+        return False, 0
+
+
+def recall_via_http(
+    query: str,
+    *,
+    session_id: str,
+    top_k: int,
+    scope: list[str],
+    only_context: bool = True,
+    search_type: str | None = None,
+    context_profile: str | None = None,
+    dataset: str = "",
+    timeout: float = 10.0,
+) -> list:
+    payload = {
+        "query": query,
+        "session_id": session_id,
+        "top_k": top_k,
+        "scope": scope,
+        "only_context": only_context,
+    }
+    # Always scope to the plugin's dataset. Without it the server resolves EVERY
+    # readable dataset and then reconciles against the session's binding, so the
+    # graph scope depends on that binding existing: an unbound session with more
+    # than one readable dataset is rejected as ambiguous rather than searched.
+    # The value must be the dataset the session's entries were written under — a
+    # different one is a binding mismatch server-side, a real error worth surfacing.
+    if dataset:
+        payload["datasets"] = [dataset]
+    if search_type:
+        payload["search_type"] = search_type
+    if context_profile:
+        payload["context_profile"] = context_profile
+    result = _json_http_request("/api/v1/recall", payload, timeout=timeout)
+    return result if isinstance(result, list) else []
+
+
+def _backend_reachable(base_url: str, timeout: float = 1.5) -> bool:
+    try:
+        with urllib.request.urlopen(
+            f"{base_url.rstrip('/')}/health", timeout=timeout, context=_https_context()
+        ) as resp:
+            return 200 <= resp.status < 500
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return False
+
+
+def _multipart_body(
+    fields: dict[str, str], files: list[tuple[str, str, bytes]]
+) -> tuple[bytes, str]:
+    boundary = f"----cogneePlugin{uuid.uuid4().hex}"
+    chunks: list[bytes] = []
+    for name, value in fields.items():
+        chunks.append(f"--{boundary}\r\n".encode("utf-8"))
+        chunks.append(f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode("utf-8"))
+        chunks.append(str(value).encode("utf-8"))
+        chunks.append(b"\r\n")
+    for field_name, filename, content in files:
+        chunks.append(f"--{boundary}\r\n".encode("utf-8"))
+        chunks.append(
+            (
+                f'Content-Disposition: form-data; name="{field_name}"; filename="{filename}"\r\n'
+                "Content-Type: text/plain; charset=utf-8\r\n\r\n"
+            ).encode("utf-8")
+        )
+        chunks.append(content)
+        chunks.append(b"\r\n")
+    chunks.append(f"--{boundary}--\r\n".encode("utf-8"))
+    return b"".join(chunks), boundary
+
+
+def _format_cached_bridge_document(dataset: str, session_id: str) -> tuple[str, str]:
+    cache = _load_json_file(_bridge_file(session_id))
+    key = _bridge_cache_key(dataset, session_id)
+    session_cache = cache.get(key, {})
+
+    qa_lines: list[str] = []
+    for entry in session_cache.get("qa", []) or []:
+        question = str(entry.get("question") or "").strip()
+        answer = str(entry.get("answer") or "").strip()
+        if question:
+            qa_lines.append(f"Question: {question}")
+        if answer:
+            qa_lines.append(f"Answer: {answer}")
+        if question or answer:
+            qa_lines.append("")
+
+    trace_lines = [str(value).strip() for value in session_cache.get("trace", []) or []]
+    trace_lines = [value for value in trace_lines if value]
+
+    qa_doc = "\n".join(qa_lines).strip()
+    trace_doc = "\n\n".join(trace_lines).strip()
+    if qa_doc:
+        qa_doc = f"Session ID: {session_id}\n\n{qa_doc}"
+    if trace_doc:
+        trace_doc = f"Session ID: {session_id}\n\n{trace_doc}"
+    return qa_doc, trace_doc
+
+
+def _post_remember_document(
+    base_url: str,
+    api_key: str,
+    dataset: str,
+    document: str,
+    node_set: str,
+    timeout: float,
+) -> dict:
+    """Submit a document to /api/v1/remember in the BACKGROUND.
+
+    Background avoids holding one synchronous request open for the full cognify,
+    which a large graph build can push past the cloud's request ceiling (the POST
+    is abandoned mid-flight even though the server finishes). Returns the enqueue
+    handle so the caller can poll completion:
+      {"ok": True, "dataset_id": <uuid|"">, "pipeline_run_id": <uuid|"">}
+    On any HTTP/network error returns {"ok": False, ...} (never raises), so the caller
+    skips just this document and keeps syncing the rest; the unmarked digest retries.
+    """
+    body, boundary = _multipart_body(
+        {
+            "datasetName": dataset,
+            "node_set": node_set,
+            "run_in_background": "true",
+        },
+        [("data", f"{node_set}.txt", document.encode("utf-8"))],
+    )
+    req = urllib.request.Request(
+        f"{base_url.rstrip('/')}/api/v1/remember",
+        data=body,
+        headers={
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+            "X-Api-Key": api_key,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=_https_context()) as resp:
+            status_code = resp.status
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        # urlopen raises on non-2xx. Surface it as a graceful failure (not an
+        # exception) so the caller skips this one document and keeps syncing the
+        # others; the unmarked digest lets a later detached attempt retry.
+        # Uniform shape: every failure carries both `status` and `error`.
+        return {
+            "ok": False,
+            "dataset_id": "",
+            "pipeline_run_id": "",
+            "status": exc.code,
+            "error": f"HTTP {exc.code}: {exc.reason}",
+        }
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        # A transient network/timeout error must also skip just this document,
+        # not propagate to the outer handler and abort the whole sync. status=0
+        # signals a network-level (non-HTTP) failure.
+        return {
+            "ok": False,
+            "dataset_id": "",
+            "pipeline_run_id": "",
+            "status": 0,
+            "error": str(exc)[:200],
+        }
+    result = {"ok": True, "dataset_id": "", "pipeline_run_id": ""}
+    try:
+        parsed = json.loads(raw) if raw else {}
+    except (ValueError, TypeError) as exc:
+        # A 2xx with an unparseable body (e.g. a proxy/nginx error page) is NOT a
+        # trustworthy success — flag it (with the uniform status/error shape) so the
+        # caller retries instead of marking done.
+        parsed = {}
+        result["parse_error"] = True
+        result["status"] = status_code
+        result["error"] = f"unparseable 2xx body: {str(exc)[:80]}"
+    if isinstance(parsed, dict):
+        result["dataset_id"] = str(parsed.get("dataset_id") or "")
+        result["pipeline_run_id"] = str(parsed.get("pipeline_run_id") or "")
+    return result
+
+
+def persist_session_cache_to_graph_via_http(
+    dataset: str,
+    session_id: str,
+    timeout: float = 600.0,
+) -> bool:
+    """API-mode equivalent of the local SDK session-cache bridge.
+
+    Local mode reads Cognee's in-process session cache and calls
+    ``cognee.remember(..., self_improvement=False)``. API mode cannot
+    read the server cache directly, so the hooks maintain a small local
+    shadow and this function posts that text to the backend remember
+    endpoint as permanent graph data.
+    """
+    base_url = _local_api_url()
+    if not _backend_reachable(base_url):
+        return False
+    api_key = _api_key()
+    if not api_key:
+        hook_log("http_bridge_skipped_no_api_key", {"dataset": dataset, "session": session_id})
+        return False
+
+    qa_doc, trace_doc = _format_cached_bridge_document(dataset, session_id)
+    if not qa_doc and not trace_doc:
+        hook_log("http_bridge_skipped_empty_cache", {"dataset": dataset, "session": session_id})
+        return False
+
+    # `timeout` is reinterpreted as the overall poll deadline (it used to be the
+    # synchronous read timeout). The POST itself is now fast (it only enqueues), so
+    # it gets a short submit budget; the wait happens by polling the status route.
+    poll_deadline = _float_env("COGNEE_BRIDGE_POLL_DEADLINE", timeout)
+    submit_timeout = _float_env("COGNEE_BRIDGE_SUBMIT_TIMEOUT", 30.0)
+    poll_interval = _float_env("COGNEE_COGNIFY_POLL_INTERVAL", 3.0)
+    status_timeout = _float_env("COGNEE_STATUS_REQUEST_TIMEOUT", 10.0)
+
+    bridge_path = _bridge_file(session_id)
+    bridge_cache = _load_json_file(bridge_path)
+    state = bridge_cache.get("_state", {}) if isinstance(bridge_cache, dict) else {}
+    wrote = False
+    overall_start = time.monotonic()
+    try:
+        for kind, node_set, document in (
+            ("qa", "user_sessions_from_cache", qa_doc),
+            ("trace", "agent_trace_feedbacks", trace_doc),
+        ):
+            if not document:
+                continue
+            state_key = f"{_bridge_cache_key(dataset, session_id)}:{kind}"
+            digest = hashlib.sha256(document.encode("utf-8")).hexdigest()
+            if state.get(state_key) == digest:
+                continue
+            # poll_deadline is an OVERALL budget across all documents, not per-document,
+            # so two documents can't compound to 2x the configured wait.
+            if time.monotonic() - overall_start >= poll_deadline:
+                hook_log("http_bridge_deadline_exceeded", {"dataset": dataset, "kind": kind})
+                break
+            # Time the POST + wait_for_cognify poll together so http_bridge_poll
+            # reports the full latency the caller waited on (submit + confirm).
+            doc_start = time.monotonic()
+            submitted = _post_remember_document(
+                base_url, api_key, dataset, document, node_set, submit_timeout
+            )
+            if not submitted.get("ok"):
+                # Skip this document (digest stays unmarked → retried later) but keep
+                # syncing the others; one bad/transient document must not abort the sync.
+                # Emit elapsed_ms on the failure path too, so slow-failing submits
+                # (e.g. a POST that times out) are still visible in latency logs.
+                hook_log(
+                    "http_bridge_post_failed",
+                    {
+                        "dataset": dataset,
+                        "kind": kind,
+                        "status": submitted.get("status"),
+                        "elapsed_ms": elapsed_ms(doc_start),
+                    },
+                )
+                continue
+            dataset_id = submitted.get("dataset_id") or ""
+            if not dataset_id:
+                if submitted.get("parse_error"):
+                    # 2xx but an unparseable body (e.g. a proxy/nginx error page): we
+                    # can't trust the write landed, so leave the digest unmarked to retry.
+                    hook_log(
+                        "http_bridge_parse_error",
+                        {"dataset": dataset, "kind": kind, "elapsed_ms": elapsed_ms(doc_start)},
+                    )
+                    continue
+                # Valid response with no handle to poll. Mark written so we don't
+                # resubmit and duplicate the cognify on every future sync.
+                state[state_key] = digest
+                wrote = True
+                hook_log(
+                    "http_bridge_no_dataset_id",
+                    {"dataset": dataset, "kind": kind, "elapsed_ms": elapsed_ms(doc_start)},
+                )
+                continue
+            remaining = poll_deadline - (time.monotonic() - overall_start)
+            if remaining <= 0:
+                # The POST consumed the remaining budget — don't start a poll. Time it
+                # like the sibling post-POST logs so a submit slow enough to blow the
+                # whole bridge budget stays visible, not just silently deadline-broken.
+                # The digest stays unmarked ON PURPOSE even though the submit was
+                # enqueued: marking an unconfirmed write would silently lose the
+                # document if that cognify errors. The detached retry's re-submit can
+                # therefore duplicate a cognify of identical content — the same
+                # bounded, accepted cost as the errored/timeout poll outcomes below
+                # (retry-over-loss, never loss-over-duplicate).
+                hook_log(
+                    "http_bridge_deadline_exceeded",
+                    {"dataset": dataset, "kind": kind, "elapsed_ms": elapsed_ms(doc_start)},
+                )
+                break
+            outcome = wait_for_cognify(
+                dataset_id,
+                deadline_seconds=remaining,
+                interval_seconds=poll_interval,
+                request_timeout=status_timeout,
+            )
+            # Only mark written once the graph is confirmed queryable (completed) or we
+            # genuinely cannot poll (older server). errored/timeout stay unmarked so the
+            # detached retry (COGNEE_SYNC_RETRIES) re-submits.
+            if outcome in ("completed", "unknown"):
+                state[state_key] = digest
+                wrote = True
+            hook_log(
+                "http_bridge_poll",
+                {
+                    "dataset": dataset,
+                    "kind": kind,
+                    "outcome": outcome,
+                    "dataset_id": dataset_id,
+                    "elapsed_ms": elapsed_ms(doc_start),
+                },
+            )
+        if isinstance(bridge_cache, dict):
+            bridge_cache["_state"] = state
+            _write_json_file(bridge_path, bridge_cache)
+        hook_log(
+            "http_bridge_done",
+            {"dataset": dataset, "session": session_id, "wrote": wrote},
+        )
+        return wrote
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        hook_log(
+            "http_bridge_failed",
+            {"error": str(exc)[:200], "dataset": dataset, "session": session_id},
+        )
+        return False
+
+
+# --- Session improve (server-side session->graph bridge) ----------------------
+# The hooks write every turn into the SERVER session cache via /remember/entry,
+# so the server can bridge a session itself: POST /api/v1/improve runs feedback
+# weights, QA persist, trace-feedback persist, distillation, and enrichment over
+# that cache. This replaces the legacy full-document bridge above, which re-sent
+# the whole accumulated session text (raw tool outputs included) for a full
+# re-cognify on every sync. The legacy path is kept only as a fallback for
+# servers without session-aware improve.
+_IMPROVE_UNSUPPORTED_MARKER = _SHARED_PLUGIN_ROOT / "improve-unsupported.json"
+_IMPROVE_UNSUPPORTED_TTL_SECONDS = 24 * 3600
+
+
+def _improve_float_env(name: str, default: float) -> float:
+    try:
+        raw = os.environ.get(name, "").strip()
+        return float(raw) if raw else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _improve_submit_timeout() -> float:
+    return _improve_float_env("COGNEE_IMPROVE_SUBMIT_TIMEOUT", 180.0)
+
+
+def mark_improve_unsupported(base_url: str) -> None:
+    """Record that this server lacks the session-aware improve endpoint."""
+    _write_json_file(
+        _IMPROVE_UNSUPPORTED_MARKER,
+        {
+            "base_url": _normalize_service_url(base_url),
+            "marked_at": datetime.now(timezone.utc).timestamp(),
+        },
+    )
+
+
+def improve_unsupported(base_url: str) -> bool:
+    """True if this server recently rejected the improve endpoint (TTL-bounded)."""
+    data = _load_json_file(_IMPROVE_UNSUPPORTED_MARKER)
+    if not data:
+        return False
+    marked_url = _normalize_service_url(str(data.get("base_url") or ""))
+    if marked_url and marked_url != _normalize_service_url(base_url):
+        return False
+    marked_at = float(data.get("marked_at", 0) or 0)
+    return datetime.now(timezone.utc).timestamp() - marked_at < _IMPROVE_UNSUPPORTED_TTL_SECONDS
+
+
+# Buffer-internal marker on a pending entry whose original send may have
+# committed server-side (see write_outcome_ambiguous). Stripped before replay;
+# never sent, never read outside this module.
+_AMBIGUOUS_KEY = "_replay_ambiguous"
+
+
+def append_warmup_entry(
+    dataset: str, session_id: str, entry: dict, *, ambiguous: bool = False
+) -> None:
+    """Buffer a typed QA/trace entry while the server is still warming.
+
+    Per-turn stores go to the server session cache via /remember/entry; before
+    the server serves, those writes would be lost — and improve() bridges only
+    what the server cache holds. Buffered entries are replayed in order by
+    ``drain_warmup_entries`` once the server is ready.
+
+    ``ambiguous=True`` marks an entry whose original send may have committed
+    (a timeout or gateway error after the request went out). The server has no
+    idempotency on /remember/entry, so the drain verifies such entries against
+    the server's session detail before replaying — a blind replay of a
+    committed write stores, embeds, and improve()-processes the text twice.
+    """
+    if not dataset or not session_id or not isinstance(entry, dict):
+        return
+    entry = _sanitize_value(entry)
+    if ambiguous:
+        entry = dict(entry)
+        entry[_AMBIGUOUS_KEY] = True
+    with _buffer_lock():
+        cache = _load_json_file(_bridge_file(session_id))
+        key = _bridge_cache_key(dataset, session_id)
+        session_cache = cache.setdefault(key, {"qa": [], "trace": []})
+        session_cache.setdefault("pending_entries", []).append(entry)
+        _write_json_file(_bridge_file(session_id), cache)
+
+
+def _entry_fingerprint(entry: dict) -> tuple | None:
+    """Content identity of a QA/trace entry, as the server would echo it back.
+
+    Built from the fields the server stores verbatim and returns through
+    GET /api/v1/sessions/{id} (server-generated fields — ids, time,
+    session_feedback — are deliberately excluded). None for entry types the
+    session detail does not expose (feedback, skill_run): those cannot be
+    verified and are replayed unconditionally.
+    """
+    try:
+        etype = str(entry.get("type") or "")
+        if etype == "trace":
+            return (
+                "trace",
+                str(entry.get("origin_function") or ""),
+                str(entry.get("status") or ""),
+                json.dumps(entry.get("method_params") or {}, sort_keys=True, default=str),
+                json.dumps(entry.get("method_return_value"), sort_keys=True, default=str),
+                str(entry.get("error_message") or ""),
+            )
+        if etype == "qa":
+            return (
+                "qa",
+                str(entry.get("question") or ""),
+                str(entry.get("answer") or ""),
+                str(entry.get("context") or ""),
+            )
+    except Exception:
+        return None
+    return None
+
+
+def _server_session_fingerprints(detail: dict) -> set:
+    """Fingerprints of every QA/trace entry in a session-detail response."""
+    prints: set = set()
+    for row in detail.get("traces") or []:
+        if isinstance(row, dict):
+            fp = _entry_fingerprint({**row, "type": "trace"})
+            if fp:
+                prints.add(fp)
+    for row in detail.get("qas") or []:
+        if isinstance(row, dict):
+            fp = _entry_fingerprint({**row, "type": "qa"})
+            if fp:
+                prints.add(fp)
+    return prints
+
+
+_DRAIN_LOCK = _PLUGIN_DIR / "drain.lock"
+_DRAIN_LOCK_STALE_SECONDS = 60.0
+# Pause before the one in-place drain retry in run_session_improve: long enough
+# for a momentary server blip to pass, short enough not to hold up a sync.
+_DRAIN_RETRY_PAUSE_SECONDS = 2.0
+
+
+def _try_acquire_drain_lock() -> bool:
+    """Single-drainer guard: concurrent drains would double-replay entries into
+    the server cache and clobber each other's buffer write-backs."""
+    try:
+        _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        if _DRAIN_LOCK.exists():
+            try:
+                if time.time() - _DRAIN_LOCK.stat().st_mtime > _DRAIN_LOCK_STALE_SECONDS:
+                    _DRAIN_LOCK.unlink()
+            except FileNotFoundError:
+                pass
+        fd = os.open(str(_DRAIN_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.close(fd)
+        return True
+    except FileExistsError:
+        return False
+    except Exception as exc:
+        # Fail open: lock bookkeeping must never be why a buffer can't drain.
+        # The cost is real — /remember/entry has NO server-side idempotency,
+        # so a concurrent double replay stores duplicates — but it needs two
+        # drains inside the same window on a broken lock, and losing the
+        # buffer forever is worse.
+        hook_log("drain_lock_error", {"error": str(exc)[:200]})
+        return True
+
+
+def _release_drain_lock() -> None:
+    try:
+        _DRAIN_LOCK.unlink()
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        hook_log("drain_lock_release_failed", {"error": str(exc)[:200]})
+
+
+# Drain hardening (#298): a session whose replay keeps failing with an HTTP
+# status (a poisoned entry, broken auth, a server-side 503 loop) must not be
+# retried on every trigger forever — one real incident ground a SessionEnd
+# worker against a 503-ing session for 6.5 hours. Consecutive HTTP-status
+# failures back the session's drain off exponentially (doubling from the base,
+# capped). Network errors deliberately do NOT count: the server_usable /
+# ready-marker gates already cover a down server, and backing off on them
+# would delay recovery after a restart.
+_DRAIN_BACKOFF_BASE_SECONDS = 60.0
+_DRAIN_BACKOFF_CAP_SECONDS = 3600.0
+
+
+def _drain_budget_default() -> float:
+    try:
+        return float(os.environ.get("COGNEE_DRAIN_BUDGET", "") or 20.0)
+    except (TypeError, ValueError):
+        return 20.0
+
+
+def drain_warmup_entries(
+    dataset: str, session_id: str, budget_seconds: float | None = None
+) -> tuple:
+    """Replay warmup-buffered entries into the server session cache, in order.
+
+    Returns ``(drained, remaining)``. Stops at the first replay failure so the
+    unreplayed tail stays buffered (order preserved). Guarded by a single-drainer
+    lock, and the buffer trim is computed against a FRESH re-read of the file so
+    entries appended while the replay was in flight are never lost — the replay
+    is N sequential HTTP calls, a wide window for concurrent async hooks.
+
+    Time-boxed (#298): the whole replay stops once ``budget_seconds`` is spent
+    (default ``COGNEE_DRAIN_BUDGET``, 20s), and each entry's socket timeout is
+    clamped to the remaining budget so one hung call cannot eat it all. A
+    session whose replay failed with an HTTP status recently is skipped
+    entirely until its backoff window passes (see ``_DRAIN_BACKOFF_*``).
+
+    Verify-before-replay: entries buffered from an ambiguous send (marked by
+    ``append_warmup_entry(..., ambiguous=True)``) may already exist server-side
+    — /remember/entry has no idempotency, so replaying one blind would store
+    and embed the content twice and feed the duplicate to the next improve.
+    When any are pending, one GET of the session detail supplies the server's
+    recent entries; an ambiguous entry whose content is already there is
+    consumed without being re-sent (logged in ``warmup_drained`` as
+    ``deduped``). If the detail read fails, everything replays as before: a
+    rare duplicate beats a lost turn.
+    """
+    if not dataset or not session_id:
+        return 0, 0
+    path = _bridge_file(session_id)
+    key = _bridge_cache_key(dataset, session_id)
+    state = _load_json_file(path).get(key) or {}
+    snapshot = list(state.get("pending_entries") or [])
+    if not snapshot:
+        return 0, 0
+    fail_count = int(state.get("drain_fail_count") or 0)
+    if fail_count > 0:
+        wait = min(
+            _DRAIN_BACKOFF_CAP_SECONDS,
+            _DRAIN_BACKOFF_BASE_SECONDS * (2 ** (fail_count - 1)),
+        )
+        elapsed = time.time() - float(state.get("drain_fail_at") or 0)
+        if elapsed < wait:
+            hook_log(
+                "warmup_drain_backoff",
+                {
+                    "session": session_id,
+                    "fail_count": fail_count,
+                    "retry_in": round(wait - elapsed, 1),
+                    "pending": len(snapshot),
+                },
+            )
+            return 0, len(snapshot)
+    if not _try_acquire_drain_lock():
+        hook_log("warmup_drain_skipped_locked", {"session": session_id, "pending": len(snapshot)})
+        return 0, len(snapshot)
+    try:
+        if budget_seconds is None:
+            budget_seconds = _drain_budget_default()
+        deadline = time.monotonic() + max(0.0, float(budget_seconds))
+        # One session-detail read serves the whole drain, and only when an
+        # ambiguous entry is actually pending. A failed read degrades to the
+        # pre-verify behavior (replay everything), never to a blocked drain.
+        server_prints: set = set()
+        verified = False
+        if any(isinstance(e, dict) and e.get(_AMBIGUOUS_KEY) for e in snapshot):
+            budget_left = deadline - time.monotonic()
+            detail = get_session_detail_via_http(
+                session_id, timeout=min(8.0, max(1.0, budget_left))
+            )
+            if detail is not None:
+                server_prints = _server_session_fingerprints(detail)
+                verified = True
+            else:
+                hook_log("warmup_verify_unavailable", {"session": session_id})
+        drained = 0
+        deduped = 0
+        http_failure = False
+        for entry in snapshot:
+            budget_left = deadline - time.monotonic()
+            if budget_left <= 0:
+                hook_log(
+                    "warmup_drain_budget_exceeded",
+                    {
+                        "session": session_id,
+                        "drained": drained,
+                        "left": len(snapshot) - drained - deduped,
+                    },
+                )
+                break
+            send_entry = entry
+            ambiguous = False
+            if isinstance(entry, dict) and _AMBIGUOUS_KEY in entry:
+                send_entry = {k: v for k, v in entry.items() if k != _AMBIGUOUS_KEY}
+                ambiguous = True
+            if ambiguous and verified and _entry_fingerprint(send_entry) in server_prints:
+                # The original send committed after all — consume the buffered
+                # copy without re-sending it.
+                deduped += 1
+                continue
+            try:
+                remember_entry_via_http(
+                    dataset,
+                    session_id,
+                    send_entry,
+                    timeout=min(30.0, max(1.0, budget_left)),
+                )
+                drained += 1
+            except urllib.error.HTTPError as exc:
+                http_failure = True
+                hook_log(
+                    "warmup_drain_error",
+                    {"error": str(exc)[:200], "drained": drained, "status": exc.code},
+                )
+                break
+            except Exception as exc:
+                hook_log("warmup_drain_error", {"error": str(exc)[:200], "drained": drained})
+                break
+        # Both sent and dedup-consumed entries leave the buffer; they form a
+        # contiguous head prefix because the loop only ever breaks.
+        drained += deduped
+        remaining = len(snapshot) - drained
+        if drained:
+            # Re-read before trimming, under the buffer mutex: hooks may append
+            # new pending entries (or qa/trace mirror text) during the replay,
+            # and writing back a stale snapshot would silently delete them.
+            with _buffer_lock():
+                cache = _load_json_file(path)
+                session_cache = cache.get(key) or {}
+                fresh = list(session_cache.get("pending_entries") or [])
+                if fresh[:drained] == snapshot[:drained]:
+                    fresh = fresh[drained:]
+                else:
+                    # Unexpected interleaving — remove the replayed entries by value.
+                    for entry in snapshot[:drained]:
+                        try:
+                            fresh.remove(entry)
+                        except ValueError:
+                            pass
+                session_cache["pending_entries"] = fresh
+                cache[key] = session_cache
+                _write_json_file(path, cache)
+            remaining = len(fresh)
+            hook_log(
+                "warmup_drained",
+                {
+                    "session": session_id,
+                    "count": drained,
+                    "deduped": deduped,
+                    "left": remaining,
+                },
+            )
+        # Backoff bookkeeping. An HTTP-status failure arms (or re-arms) the
+        # backoff; any progress first resets it — the entry now at the head is
+        # a different one, so its failure streak starts over. Non-HTTP errors
+        # leave the state untouched: they say nothing about this session.
+        if http_failure or (drained and fail_count):
+            try:
+                with _buffer_lock():
+                    cache = _load_json_file(path)
+                    session_cache = cache.get(key) or {}
+                    if http_failure:
+                        session_cache["drain_fail_count"] = (
+                            1 if drained else int(session_cache.get("drain_fail_count") or 0) + 1
+                        )
+                        session_cache["drain_fail_at"] = time.time()
+                    else:
+                        session_cache.pop("drain_fail_count", None)
+                        session_cache.pop("drain_fail_at", None)
+                    cache[key] = session_cache
+                    _write_json_file(path, cache)
+            except Exception as exc:
+                hook_log("drain_backoff_write_failed", {"error": str(exc)[:200]})
+        return drained, remaining
+    finally:
+        _release_drain_lock()
+
+
+def improve_session_via_http(dataset: str, session_id: str, *, timeout: float = None) -> dict:
+    """Bridge one session into the graph via POST /api/v1/improve.
+
+    The server reads its own session cache (feedback weights, QA persist,
+    trace-feedback persist, distillation, enrichment), so no session text is
+    sent. ``run_in_background=true`` backgrounds the cognify-heavy pipelines,
+    but the agent-context and distillation stages still run inside the request,
+    so the submit timeout must stay generous — this must only ever be called
+    from detached workers/async hooks, never a synchronous hook window.
+
+    A 2xx submit counts as success: improve is idempotent (unchanged session
+    content dedups server-side by content hash, and a per-session improve lock
+    makes a concurrent run a no-op).
+    """
+    if not dataset or not session_id:
+        return {"ok": False, "error": "missing dataset/session"}
+    submit_timeout = timeout if timeout is not None else _improve_submit_timeout()
+    try:
+        result = _json_http_request(
+            "/api/v1/improve",
+            {
+                "dataset_name": dataset,
+                "session_ids": [session_id],
+                "run_in_background": True,
+            },
+            timeout=submit_timeout,
+        )
+    except urllib.error.HTTPError as exc:
+        if exc.code in (404, 405, 422):
+            # Older server without session-aware improve: remember it (TTL'd)
+            # so callers fall back to the legacy document bridge.
+            mark_improve_unsupported(_local_api_url())
+            return {"ok": False, "unsupported": True, "status": exc.code}
+        return {"ok": False, "status": exc.code, "error": f"HTTP {exc.code}: {exc.reason}"}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {"ok": False, "status": 0, "error": str(exc)[:200]}
+
+    if isinstance(result, dict) and not result:
+        # The server's per-session improve lock skipped this run ({} response):
+        # another improve is in flight. That run may have extracted the session
+        # cache BEFORE the latest turns landed, so a skip is NOT success — the
+        # caller must retry once the lock frees.
+        return {"ok": False, "busy": True}
+
+    outcome = {"ok": True, "result": result if isinstance(result, dict) else {}}
+    # Best-effort observability: the submit already succeeded, so a poll that
+    # times out or errors must never turn that into a failure. Reporting the
+    # pipeline states is what lets a caller (and the tests) distinguish "the
+    # bridge was accepted" from "the graph actually finished building" — without
+    # it, improve returns ok while the graph is still empty, which reads as a
+    # silent data-loss bug from the outside.
+    #
+    # Parity with claude-code, which gained this in the background-remember
+    # refactor; the rest of that work was ported here but the improve path was
+    # missed, so qwen reported no cognify_status at all.
+    poll_deadline = _float_env("COGNEE_IMPROVE_POLL_DEADLINE", 600.0)
+    dataset_id = ""
+    if isinstance(result, dict):
+        dataset_id = str(result.get("dataset_id") or "")
+    if dataset_id and poll_deadline > 0:
+        half = poll_deadline / 2
+        outcome["cognify_status"] = wait_for_cognify(dataset_id, deadline_seconds=half)
+        outcome["memify_status"] = wait_for_cognify(
+            dataset_id, deadline_seconds=half, pipeline="memify_pipeline"
+        )
+    return outcome
+
+
+def ensure_dataset_via_http(dataset: str) -> None:
+    """Best-effort create/authorize the dataset before an improve.
+
+    improve() resolves *existing* authorized datasets and fails NON-FATALLY
+    (returning 2xx) when there are none — unlike the legacy /remember bridge,
+    whose add() implicitly created the dataset. Creating here (idempotent
+    POST) means one skipped SessionStart ensure can never silently strand a
+    whole session's sync. Failures are logged and never block the improve —
+    if the dataset truly cannot be created, the improve outcome reports it.
+    """
+    if not dataset:
+        return
+    try:
+        _json_http_request("/api/v1/datasets", {"name": dataset}, timeout=15.0)
+        hook_log("dataset_ensured", {"dataset": dataset})
+        return
+    except urllib.error.HTTPError as exc:
+        # Some deployments route the collection at /datasets/ and answer the
+        # non-slash path with a 307/308, which urllib refuses to follow for a
+        # POST body. Re-issue the POST at the (same-origin) redirect target.
+        if exc.code in (301, 302, 307, 308):
+            base_url = _local_api_url().rstrip("/")
+            target = urllib.parse.urljoin(
+                f"{base_url}/api/v1/datasets", str(exc.headers.get("Location") or "")
+            )
+            if urllib.parse.urlparse(target).netloc == urllib.parse.urlparse(base_url).netloc:
+                headers = {"Content-Type": "application/json"}
+                api_key = _api_key()
+                if api_key:
+                    headers["X-Api-Key"] = api_key
+                req = urllib.request.Request(
+                    target,
+                    data=json.dumps({"name": dataset}).encode("utf-8"),
+                    headers=headers,
+                    method="POST",
+                )
+                try:
+                    with urllib.request.urlopen(
+                        req, timeout=15.0, context=_https_context()
+                    ) as resp:
+                        resp.read()
+                    hook_log("dataset_ensured", {"dataset": dataset, "via": "redirect"})
+                    return
+                except Exception as exc2:
+                    hook_log(
+                        "dataset_ensure_redirect_failed",
+                        {"dataset": dataset, "target": target[:120], "error": str(exc2)[:200]},
+                    )
+                    return
+        # An already-existing dataset may come back 4xx on some servers; log
+        # and proceed rather than blocking the sync on a pre-flight.
+        hook_log("dataset_ensure_http_status", {"dataset": dataset, "status": exc.code})
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        hook_log("dataset_ensure_failed", {"dataset": dataset, "error": str(exc)[:200]})
+
+
+def run_session_improve(dataset: str, session_id: str) -> bool:
+    """API-mode session->graph sync: drain warmup entries, then improve.
+
+    Falls back to the legacy full-document bridge when the server does not
+    support session-aware improve. Returns True when a sync ran successfully.
+
+    Serialized per session by ``improve_session_lock``. The guard lives here
+    rather than at the three call sites (idle watcher, store hook, SessionEnd
+    sync) so every path is covered by construction and a future fourth caller
+    cannot reintroduce the double-submit.
+    """
+    with improve_session_lock(session_id, "run_session_improve") as claimed:
+        if not claimed:
+            # Another process is already bridging this exact session. Report
+            # not-synced so the caller's own retry/reporting path is unchanged;
+            # the work itself is in flight, not dropped.
+            return False
+        return _run_session_improve_locked(dataset, session_id)
+
+
+def _run_session_improve_locked(dataset: str, session_id: str) -> bool:
+    """Body of run_session_improve; assumes the per-session claim is held."""
+    base_url = _local_api_url()
+    if not _backend_reachable(base_url):
+        return False
+    # Detached/idle context: nothing user-visible waits on this, so the drain
+    # gets a far larger budget than the per-prompt hook's default.
+    final_budget = _improve_float_env("COGNEE_DRAIN_BUDGET_FINAL", 120.0)
+    _, remaining = drain_warmup_entries(dataset, session_id, budget_seconds=final_budget)
+    if remaining:
+        # One bounded retry after a short pause: the tail usually failed on a
+        # momentary blip, and improve reads only what reached the server cache.
+        time.sleep(_DRAIN_RETRY_PAUSE_SECONDS)
+        _, remaining = drain_warmup_entries(dataset, session_id, budget_seconds=final_budget)
+    if improve_unsupported(base_url):
+        return persist_session_cache_to_graph_via_http(dataset, session_id)
+    ensure_dataset_via_http(dataset)
+    outcome = improve_session_via_http(dataset, session_id)
+    if outcome.get("unsupported"):
+        hook_log("improve_unsupported_fallback", {"dataset": dataset, "session": session_id})
+        return persist_session_cache_to_graph_via_http(dataset, session_id)
+    # Busy = another improve holds the session lock (e.g. an idle-watcher run
+    # racing the SessionEnd sync). That run's snapshot may predate the latest
+    # turns, so wait for the lock to free and re-submit; the retried improve
+    # dedups unchanged content server-side, so this never double-processes.
+    busy_deadline = time.monotonic() + _improve_float_env("COGNEE_IMPROVE_BUSY_DEADLINE", 600.0)
+    busy_interval = max(0.1, _improve_float_env("COGNEE_IMPROVE_BUSY_RETRY_INTERVAL", 15.0))
+    while outcome.get("busy") and time.monotonic() < busy_deadline:
+        hook_log("improve_busy_retry", {"dataset": dataset, "session": session_id})
+        time.sleep(busy_interval)
+        outcome = improve_session_via_http(dataset, session_id)
+    hook_log(
+        "improve_fired",
+        {
+            "dataset": dataset,
+            "session": session_id,
+            "ok": bool(outcome.get("ok")),
+            "busy": bool(outcome.get("busy")),
+            "error": str(outcome.get("error") or "")[:120],
+        },
+    )
+    if outcome.get("ok"):
+        # Status-line credits: attribute the spend recorded since the previous
+        # reading to this improve. Approximate on purpose — the submit is
+        # run_in_background, so part of this run's cognify cost lands in later
+        # unlabeled refreshes. refresh_credits never raises and no-ops locally.
+        refresh_credits("improve")
+    if remaining:
+        # Buffered entries never reached the server cache, so the improve above
+        # persisted an incomplete session. Partial persist beats none (hence the
+        # improve still ran), but report not-synced so the caller's retry loop
+        # re-drives the whole drain+improve — the drained head is already
+        # trimmed from the buffer, so the re-run replays only the tail.
+        hook_log(
+            "improve_incomplete_drain",
+            {
+                "dataset": dataset,
+                "session": session_id,
+                "remaining": remaining,
+                "improve_ok": bool(outcome.get("ok")),
+            },
+        )
+        return False
+    return bool(outcome.get("ok"))

--- a/integrations/qwen/scripts/_proc.py
+++ b/integrations/qwen/scripts/_proc.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Cross-platform process helpers for the cognee-memory plugin scripts.
+
+Kept stdlib-only so the detached watchers can import it without pulling in the
+rest of the plugin. The plugin decides a session has ended by polling the host
+(Claude/Qwen) PID; the POSIX ``os.kill(pid, 0)`` liveness probe is unsupported
+on Windows, where signal 0 raises ``OSError`` (``WinError 87``), so the check
+needs a native Windows path.
+"""
+
+import os
+import sys
+
+_IS_WINDOWS = sys.platform == "win32"
+
+
+def pid_alive(pid: int) -> bool:
+    """Return ``True`` if a process with ``pid`` is currently running.
+
+    Non-destructive on every platform: it never signals or terminates the
+    target. PIDs <= 1 (unknown / init / kernel) are reported not-alive so the
+    watchers never bind to them.
+    """
+    if pid <= 1:
+        return False
+    if _IS_WINDOWS:
+        return _pid_alive_windows(pid)
+    return _pid_alive_posix(pid)
+
+
+def _pid_alive_posix(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists, owned by another user — still alive from our point of view.
+        return True
+    except Exception:
+        # Any other failure (e.g. an out-of-range PID from a corrupt pidfile)
+        # counts as not-alive — a liveness probe must never raise into a hook.
+        return False
+    return True
+
+
+def _pid_alive_windows(pid: int) -> bool:
+    if pid > 0xFFFFFFFF:
+        # A Windows PID is a DWORD; a larger value (e.g. from a corrupt pidfile)
+        # is not a real process and would otherwise truncate into DWORD range.
+        return False
+    # ``os.kill(pid, 0)`` raises WinError 87 here (signal 0 is unsupported), so
+    # probe via a process handle instead. OpenProcess fails with
+    # ERROR_ACCESS_DENIED for a live process we may not synchronise on (e.g. a
+    # system process); an open handle is non-signalled (WAIT_TIMEOUT) while an
+    # exited process signals immediately.
+    import ctypes
+    from ctypes import wintypes
+
+    SYNCHRONIZE = 0x00100000
+    WAIT_TIMEOUT = 0x00000102
+    ERROR_ACCESS_DENIED = 5
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+
+    handle = kernel32.OpenProcess(SYNCHRONIZE, False, pid)
+    if not handle:
+        return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+    try:
+        return kernel32.WaitForSingleObject(handle, 0) == WAIT_TIMEOUT
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def find_host_ancestor_windows(start_pid: int, host_stem: str) -> int:
+    """Nearest ancestor of ``start_pid`` whose executable base name is ``host_stem``
+    (e.g. "claude" / "qwen"), found by walking the Windows process tree.
+
+    Returns ``start_pid`` unchanged when the process table cannot be read or no
+    matching ancestor is found, so the caller keeps its existing fallback. Used
+    where POSIX shells out to ``ps``, which does not exist on Windows.
+    """
+    return _walk_ancestors(_process_table_windows(), start_pid, host_stem)
+
+
+def _matches_host_exe(exe: str, host_stem: str) -> bool:
+    base = os.path.splitext(exe)[0].casefold()
+    stem = host_stem.casefold()
+    return base == stem or base.startswith(stem + "-")
+
+
+def _walk_ancestors(table: dict[int, tuple[int, str]], start_pid: int, host_stem: str) -> int:
+    pid = start_pid
+    seen: set[int] = set()
+    while pid > 1 and pid not in seen:
+        seen.add(pid)
+        ppid, exe = table.get(pid, (0, ""))
+        if exe and _matches_host_exe(exe, host_stem):
+            return pid
+        pid = ppid
+    return start_pid
+
+
+def _process_table_windows() -> dict[int, tuple[int, str]]:
+    """``{pid: (ppid, exe_basename)}`` for every process via Toolhelp; ``{}`` on failure."""
+    import ctypes
+    from ctypes import wintypes
+
+    TH32CS_SNAPPROCESS = 0x00000002
+    INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+    MAX_PATH = 260
+
+    class PROCESSENTRY32W(ctypes.Structure):
+        # ``th32DefaultHeapID`` is a pointer-sized ULONG_PTR: it must stay
+        # pointer-wide so the fields after it keep the right offsets on 64-bit.
+        _fields_ = (
+            ("dwSize", wintypes.DWORD),
+            ("cntUsage", wintypes.DWORD),
+            ("th32ProcessID", wintypes.DWORD),
+            ("th32DefaultHeapID", ctypes.c_void_p),
+            ("th32ModuleID", wintypes.DWORD),
+            ("cntThreads", wintypes.DWORD),
+            ("th32ParentProcessID", wintypes.DWORD),
+            ("pcPriClassBase", ctypes.c_long),
+            ("dwFlags", wintypes.DWORD),
+            ("szExeFile", ctypes.c_wchar * MAX_PATH),
+        )
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+    kernel32.CreateToolhelp32Snapshot.argtypes = (wintypes.DWORD, wintypes.DWORD)
+    kernel32.Process32FirstW.argtypes = (wintypes.HANDLE, ctypes.POINTER(PROCESSENTRY32W))
+    kernel32.Process32NextW.argtypes = (wintypes.HANDLE, ctypes.POINTER(PROCESSENTRY32W))
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+
+    snapshot = kernel32.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+    if not snapshot or snapshot == INVALID_HANDLE_VALUE:
+        return {}
+
+    table: dict[int, tuple[int, str]] = {}
+    try:
+        entry = PROCESSENTRY32W()
+        entry.dwSize = ctypes.sizeof(PROCESSENTRY32W)
+        ok = kernel32.Process32FirstW(snapshot, ctypes.byref(entry))
+        while ok:
+            table[int(entry.th32ProcessID)] = (int(entry.th32ParentProcessID), entry.szExeFile)
+            ok = kernel32.Process32NextW(snapshot, ctypes.byref(entry))
+    finally:
+        kernel32.CloseHandle(snapshot)
+    return table

--- a/integrations/qwen/scripts/_recall_http.py
+++ b/integrations/qwen/scripts/_recall_http.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Server-first recall against Cognee's ``/api/v1/recall``.
+
+Standalone, stdlib-only, so it runs under the system ``python3`` without the
+plugin venv (the same constraint ``cognee-search.sh`` already works under).
+
+Contract — what gets printed to stdout:
+  * a JSON **list** on a 2xx response. An **empty list is authoritative**:
+    the server searched and found nothing.
+  * the sentinel ``UNREACHABLE`` ONLY when the server is positively absent
+    (connection refused, DNS failure, unroutable host). The caller may then
+    fall back to the local CLI as a degraded path. A **timeout is NOT
+    unreachable**: a dead server refuses in milliseconds, a busy one times
+    out — so timeouts return a *transient* error envelope instead (see below),
+    and the caller keeps its prior view of the server rather than declaring
+    it down.
+  * a JSON **error object** ``{"error", "status", "authoritative": false}`` on
+    any HTTP error (5xx, 4xx, and especially **401/403** auth rejections) or an
+    error-shaped 2xx body. The caller MUST NOT fall back to the local CLI here:
+    the server was reachable and rejected/failed the request, so falling back to
+    a (possibly different / local) backend would return wrong data or bypass the
+    server-side authorization boundary. It is reported as an error, never as
+    "no results".
+
+Diagnostics also go to stderr so the caller can surface them.
+"""
+
+import errno
+import json
+import os
+import socket
+import ssl
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+UNREACHABLE = "UNREACHABLE"
+
+# Transport-exception verdicts (classify_transport_exception). Only DOWN is
+# evidence the server is absent; SLOW means it exists but did not answer in
+# time, and UNKNOWN is anything we cannot classify. The distinction matters:
+# a dead local server refuses connections in milliseconds, while a busy one
+# times out — conflating the two is what painted false "unreachable" states.
+DOWN = "down"
+SLOW = "slow"
+UNKNOWN = "unknown"
+
+# Errnos that positively identify an absent/unroutable server.
+_DOWN_ERRNOS = {errno.ECONNREFUSED, errno.EHOSTUNREACH, errno.ENETUNREACH}
+
+
+def classify_transport_exception(exc) -> str:
+    """Classify a transport failure as DOWN, SLOW, or UNKNOWN.
+
+    Unwraps ``urllib.error.URLError`` (the real cause lives in ``.reason``, and
+    can be an exception *or* a plain string). Order matters below:
+    ``TimeoutError`` and ``ConnectionRefusedError`` are OSError subclasses, and
+    ``ssl.SSLError`` is too, so the generic errno check must come last.
+    """
+    if isinstance(exc, urllib.error.HTTPError):
+        # The server answered; HTTP statuses are the caller's business.
+        return UNKNOWN
+    if isinstance(exc, urllib.error.URLError):
+        exc = exc.reason
+    if isinstance(exc, str):
+        return SLOW if "timed out" in exc else UNKNOWN
+    if isinstance(exc, (TimeoutError, socket.timeout)):
+        return SLOW
+    if isinstance(exc, socket.gaierror):
+        return DOWN
+    if isinstance(exc, ConnectionRefusedError):
+        return DOWN
+    if isinstance(exc, ssl.SSLError):
+        return UNKNOWN
+    if isinstance(exc, OSError) and getattr(exc, "errno", None) in _DOWN_ERRNOS:
+        return DOWN
+    return UNKNOWN
+
+
+# macOS Python installations often lack root CA certs in the default bundle.
+# Build one opener for all HTTPS calls: try certifi opportunistically (if
+# importable), then walk system cert file locations until one loads cleanly.
+def _build_https_opener():
+    try:
+        import certifi
+
+        ctx = ssl.create_default_context(cafile=certifi.where())
+    except ImportError:
+        ctx = ssl.create_default_context()
+        _cert_loaded = False
+        for path in filter(
+            None,
+            [
+                os.environ.get("SSL_CERT_FILE"),
+                "/etc/ssl/cert.pem",
+                "/etc/ssl/certs/ca-certificates.crt",
+            ],
+        ):
+            if os.path.exists(path):
+                try:
+                    ctx.load_verify_locations(path)
+                    _cert_loaded = True
+                    break  # only stop once a path loaded successfully
+                except Exception:
+                    pass
+        if not _cert_loaded:
+            sys.stderr.write(
+                "[cognee-search] SSL: no system cert bundle loaded; HTTPS may fail"
+                " — set SSL_CERT_FILE or install certifi\n"
+            )
+    return urllib.request.build_opener(urllib.request.HTTPSHandler(context=ctx))
+
+
+_HTTPS_OPENER = _build_https_opener()
+
+
+def coerce_top_k(value, default=5):
+    """Best-effort positive int; never raises (a bad value must not look like a server failure)."""
+    try:
+        n = int(str(value).strip())
+    except (TypeError, ValueError, AttributeError):
+        return default
+    return n if n > 0 else default
+
+
+def coerce_scope(value, default="auto"):
+    """Parse the JSON scope arg; fall back to "auto" on anything malformed."""
+    if not value:
+        return default
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _error(status, message, *, transient=False):
+    """An error envelope — the request failed, but the server is NOT known dead.
+
+    Distinct from UNREACHABLE so the caller does NOT fall back to the local CLI.
+    ``transient=True`` marks a no-verdict failure (timeout / unclassifiable
+    transport error): the breaker must count it as neither success nor failure,
+    and no connection state should be rewritten because of it.
+    """
+    envelope = {"error": message, "status": status, "authoritative": False}
+    if transient:
+        envelope["transient"] = True
+    return envelope
+
+
+def do_recall(
+    service_url,
+    api_key,
+    query,
+    session_id,
+    scope,
+    top_k,
+    dataset="",
+    context_profile="",
+    *,
+    opener=None,
+    timeout=120.0,
+):
+    """Query the server. Return results (list), an error envelope (dict), or ``UNREACHABLE``."""
+    url = service_url.rstrip("/") + "/api/v1/recall"
+    body = {
+        "query": query,
+        "top_k": coerce_top_k(top_k),
+        "only_context": True,
+        "scope": coerce_scope(scope),
+    }
+    if session_id:
+        body["session_id"] = session_id
+    # Scope the search to the caller's plugin dataset (resolved by the shell from
+    # COGNEE_PLUGIN_DATASET → default). All plugin writes target
+    # that single dataset, so searching elsewhere only adds noise from unrelated
+    # sessions or SDK calls (e.g. client.py defaulting to 'default_dataset').
+    # Server-side RBAC is still enforced: the named dataset must be owned by the
+    # authenticated user or the server returns DatasetNotFoundError.
+    # When dataset is empty (standalone invocation without shell), fall back to
+    # the original search-all behaviour to avoid breaking direct callers.
+    if dataset:
+        body["datasets"] = [dataset]
+    if context_profile:
+        body["context_profile"] = context_profile
+    headers = {"Content-Type": "application/json"}
+    # Always attach the key when present: cognee >=1.2.2 enforces auth on its
+    # API routes even on localhost (the local key is auto-minted at bootstrap),
+    # and a server running with auth disabled simply ignores the header.
+    if api_key:
+        headers["X-Api-Key"] = api_key
+
+    req = urllib.request.Request(
+        url, data=json.dumps(body).encode("utf-8"), headers=headers, method="POST"
+    )
+    _open = opener if opener is not None else _HTTPS_OPENER.open
+    try:
+        with _open(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        # Reachable but rejected/failed. NOT an authoritative empty, and NOT a
+        # reason to query a different backend via the CLI — report the error.
+        if e.code in (401, 403):
+            msg = "unauthorized (HTTP %s) — check COGNEE_API_KEY / credentials" % e.code
+        else:
+            msg = "server returned HTTP %s for /api/v1/recall" % e.code
+        sys.stderr.write("[cognee-search] %s — NOT falling back to local CLI\n" % msg)
+        return _error(e.code, msg)
+    except Exception as e:
+        verdict = classify_transport_exception(e)
+        if verdict == DOWN:  # refused / DNS / unroutable → positively absent
+            sys.stderr.write(
+                "[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+            )
+            return UNREACHABLE
+        # SLOW (timed out — alive but busy) or UNKNOWN (SSL / reset / a bug in
+        # our own request building): no verdict on the server. Not UNREACHABLE
+        # (no CLI fallback, no "down" marker) and flagged transient so the
+        # breaker counts it as neither success nor failure.
+        sys.stderr.write(
+            "[cognee-search] no verdict (%s) from %s: %s\n" % (verdict, service_url, str(e)[:160])
+        )
+        return _error(0, "recall %s: %s" % (verdict, str(e)[:160]), transient=True)
+
+    # The server responded. A body we can't parse is a SERVER-side bug, not an
+    # unreachable server — report it as an error (do NOT trigger the CLI fallback).
+    try:
+        data = json.loads(raw or "[]")
+    except (json.JSONDecodeError, ValueError) as e:
+        sys.stderr.write("[cognee-search] malformed JSON from /api/v1/recall: %s\n" % str(e)[:160])
+        return _error(200, "malformed JSON response from /api/v1/recall")
+
+    # An error-shaped 2xx body is also not a real result set.
+    if isinstance(data, dict) and data.get("error"):
+        msg = str(data.get("error"))[:200]
+        sys.stderr.write("[cognee-search] server returned error: %s\n" % msg)
+        return _error(200, msg)
+    if isinstance(data, list):
+        return data
+    return [data]
+
+
+def main(argv):
+    # argv: service_url, api_key, query, session_id, scope, top_k[, dataset[, context_profile]]
+    a = list(argv) + [""] * 8
+    result = do_recall(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7])
+    # UNREACHABLE → caller falls back to CLI; a list (results) or an error
+    # object → caller prints as-is and does NOT fall back.
+    print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/integrations/qwen/scripts/_remember_http.py
+++ b/integrations/qwen/scripts/_remember_http.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Server-first remember against Cognee's ``/api/v1/remember``.
+
+Standalone, stdlib-only, so it runs under the system ``python3`` without the
+plugin venv (the same constraint ``cognee-search.sh`` already works under).
+
+Contract — what gets printed to stdout:
+  * ``{"ok": true}`` on a 2xx response.
+  * the sentinel ``UNREACHABLE`` ONLY when the server cannot be reached
+    (connection refused, timeout, DNS). The caller may then fall back to the
+    local CLI as a degraded path.
+  * a JSON **error object** ``{"error", "status", "authoritative": false}`` on
+    any HTTP error (5xx, 4xx, and especially **401/403** auth rejections). The
+    caller MUST NOT fall back to the local CLI here: the server was reachable and
+    rejected/failed the request, so falling back could bypass auth boundaries
+    or silently double-write to a different backend.
+
+Diagnostics also go to stderr so the caller can surface them.
+"""
+
+import json
+import os
+import socket
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+
+UNREACHABLE = "UNREACHABLE"
+
+
+def _multipart_body(fields, files):
+    boundary = f"----cogneeRemember{uuid.uuid4().hex}"
+    chunks = []
+    for name, value in fields.items():
+        chunks.append(f"--{boundary}\r\n".encode("utf-8"))
+        chunks.append(f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode("utf-8"))
+        chunks.append(str(value).encode("utf-8"))
+        chunks.append(b"\r\n")
+    for field_name, filename, content in files:
+        chunks.append(f"--{boundary}\r\n".encode("utf-8"))
+        chunks.append(
+            (
+                f'Content-Disposition: form-data; name="{field_name}"; filename="{filename}"\r\n'
+                "Content-Type: text/plain; charset=utf-8\r\n\r\n"
+            ).encode("utf-8")
+        )
+        chunks.append(content if isinstance(content, bytes) else content.encode("utf-8"))
+        chunks.append(b"\r\n")
+    chunks.append(f"--{boundary}--\r\n".encode("utf-8"))
+    return b"".join(chunks), boundary
+
+
+def _error(status, message):
+    """An error envelope — reachable server, but the request was rejected/failed.
+
+    Distinct from UNREACHABLE so the caller does NOT fall back to the local CLI.
+    """
+    return {"error": message, "status": status, "authoritative": False}
+
+
+def _background_flag():
+    """Whether the server should cognify in the background (default: yes).
+
+    A synchronous cognify (run_in_background=false) can take tens of seconds: it
+    blocks the agent's turn and risks the client read-timeout that gets misread as
+    "server unreachable" (then a CLI fallback that can double-write). Background lets
+    the POST return as soon as the work is enqueued. Set COGNEE_REMEMBER_BACKGROUND=false
+    for a synchronous, immediately-queryable write.
+    """
+    val = os.environ.get("COGNEE_REMEMBER_BACKGROUND", "").strip().lower()
+    return "false" if val in {"0", "false", "no", "off"} else "true"
+
+
+def _timeout_result(timeout):
+    """A write timeout is NOT 'unreachable': the request likely reached the server and
+    the write may have landed. Returning UNREACHABLE would make the caller re-write via
+    the CLI and risk a duplicate, so surface a non-fatal note instead — the caller
+    prints it and does NOT fall back. Background writes make this path rare.
+    """
+    sys.stderr.write(
+        "[cognee-remember] timed out after %ss waiting for confirmation; the write may "
+        "have succeeded — NOT falling back to local CLI\n" % timeout
+    )
+    return _error(0, "remember submitted; timed out after %ss waiting for confirmation" % timeout)
+
+
+def _float_env(name, default):
+    try:
+        raw = os.environ.get(name, "").strip()
+        return float(raw) if raw else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _explicit_wait_seconds():
+    """Seconds the explicit "remember this" waits for the cognify to become queryable.
+
+    Default 8s: a background submit returns immediately, so without a short wait an
+    immediate recall sees the not-yet-cognified graph. 0 disables (fire-and-forget).
+    """
+    return _float_env("COGNEE_REMEMBER_WAIT_SECONDS", 8.0)
+
+
+def _poll_status(
+    service_url,
+    api_key,
+    dataset_id,
+    deadline_seconds,
+    *,
+    opener=urllib.request.urlopen,
+    interval_seconds=3.0,
+    request_timeout=10.0,
+):
+    """Poll /api/v1/datasets/status (cognify_pipeline) until terminal or the deadline.
+
+    Returns "completed" | "errored" | "timeout" | "unknown". Deliberately mirrors
+    _plugin_common.wait_for_cognify but stays stdlib-only and opener-injectable so this
+    module keeps running under bare python3 (no plugin venv) and remains test-mockable.
+    """
+    if not dataset_id:
+        return "unknown"
+    url = (
+        service_url.rstrip("/")
+        + "/api/v1/datasets/status?dataset="
+        + urllib.parse.quote(str(dataset_id))
+        + "&pipeline=cognify_pipeline"
+    )
+    headers = {}
+    # Always attach the key when present: cognee >=1.2.2 enforces auth even on
+    # localhost; a server with auth disabled ignores the header.
+    if api_key:
+        headers["X-Api-Key"] = api_key
+    deadline = time.monotonic() + max(0.0, deadline_seconds)
+    while True:
+        status = ""
+        try:
+            req = urllib.request.Request(url, headers=headers, method="GET")
+            with opener(req, timeout=request_timeout) as resp:
+                raw = resp.read().decode("utf-8")
+            parsed = json.loads(raw or "{}")
+            if isinstance(parsed, dict) and parsed:
+                val = parsed.get(str(dataset_id))
+                if val is None and len(parsed) == 1:
+                    val = next(iter(parsed.values()))
+                if isinstance(val, dict):
+                    val = val.get("cognify_pipeline")
+                status = str(val or "").upper()
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return "unknown"  # older server without the status route
+            # transient — fall through to the deadline check
+        except Exception:
+            pass  # transient (URLError/timeout/parse) — keep polling until deadline
+        if status.endswith("COMPLETED"):
+            return "completed"
+        if status.endswith("ERRORED"):
+            return "errored"
+        if time.monotonic() >= deadline:
+            return "timeout"
+        time.sleep(max(0.1, interval_seconds))  # floor avoids a tight spin if misconfigured to 0
+
+
+def do_remember(
+    service_url,
+    api_key,
+    content,
+    dataset,
+    node_set,
+    *,
+    opener=urllib.request.urlopen,
+    timeout=120.0,
+):
+    """POST content to the server. Return {"ok": true}, an error envelope, or UNREACHABLE."""
+    url = service_url.rstrip("/") + "/api/v1/remember"
+    filename = f"{node_set or 'content'}.txt"
+    body, boundary = _multipart_body(
+        {
+            "datasetName": dataset,
+            "node_set": node_set,
+            "run_in_background": _background_flag(),
+        },
+        [("data", filename, content.encode("utf-8") if isinstance(content, str) else content)],
+    )
+    headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
+    # Always attach the key when present: cognee >=1.2.2 enforces auth on its
+    # API routes even on localhost (the local key is auto-minted at bootstrap),
+    # and a server running with auth disabled simply ignores the header.
+    if api_key:
+        headers["X-Api-Key"] = api_key
+
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with opener(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        if e.code in (401, 403):
+            msg = "unauthorized (HTTP %s) — check COGNEE_API_KEY / credentials" % e.code
+        else:
+            msg = "server returned HTTP %s for /api/v1/remember" % e.code
+        sys.stderr.write("[cognee-remember] %s — NOT falling back to local CLI\n" % msg)
+        return _error(e.code, msg)
+    except (TimeoutError, socket.timeout):
+        return _timeout_result(timeout)
+    except urllib.error.URLError as e:
+        # A read timeout arrives wrapped in URLError on some platforms — treat it as
+        # a timeout, not "unreachable" (the request likely reached the server).
+        if isinstance(getattr(e, "reason", None), (TimeoutError, socket.timeout)):
+            return _timeout_result(timeout)
+        sys.stderr.write(
+            "[cognee-remember] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+        )
+        return UNREACHABLE
+    except Exception as e:
+        sys.stderr.write(
+            "[cognee-remember] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+        )
+        return UNREACHABLE
+
+    # The server responded with 2xx. A body we can't parse is fine —
+    # the important thing is the server accepted the request.
+    try:
+        data = json.loads(raw or "{}")
+    except (json.JSONDecodeError, ValueError):
+        return {"ok": True}
+
+    if isinstance(data, dict) and data.get("error"):
+        msg = str(data.get("error"))[:200]
+        sys.stderr.write("[cognee-remember] server returned error: %s\n" % msg)
+        return _error(200, msg)
+
+    result = {"ok": True}
+    if isinstance(data, dict):
+        if data.get("dataset_id"):
+            result["dataset_id"] = str(data["dataset_id"])
+        if data.get("pipeline_run_id"):
+            result["pipeline_run_id"] = str(data["pipeline_run_id"])
+        if data.get("status"):
+            result["status"] = str(data["status"])
+
+    # A background submit returns as soon as the cognify is enqueued, so the graph
+    # isn't queryable yet. Optionally wait (bounded) and report whether it landed,
+    # so an immediate recall isn't stale. Synchronous writes already completed.
+    wait_seconds = _explicit_wait_seconds()
+    if wait_seconds > 0 and result.get("dataset_id") and _background_flag() == "true":
+        outcome = _poll_status(
+            service_url,
+            api_key,
+            result["dataset_id"],
+            wait_seconds,
+            opener=opener,
+            interval_seconds=_float_env("COGNEE_COGNIFY_POLL_INTERVAL", 3.0),
+            request_timeout=_float_env("COGNEE_STATUS_REQUEST_TIMEOUT", 10.0),
+        )
+        result["wait_outcome"] = outcome
+        result["queryable"] = outcome == "completed"
+        if outcome == "errored":
+            sys.stderr.write(
+                "[cognee-remember] cognify ERRORED for dataset %s\n" % result["dataset_id"]
+            )
+    return result
+
+
+def main(argv):
+    # argv: service_url, api_key, content, dataset, node_set
+    a = list(argv) + [""] * 5
+    result = do_remember(a[0], a[1], a[2], a[3], a[4])
+    print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
+    if result != UNREACHABLE:
+        # Refresh the status-line credits marker, attributing the spend delta
+        # to this remember (cloud-only; the fetch itself no-ops on a local
+        # server). Lazy, guarded import: this module is standalone by design,
+        # and the opt-out env stops _plugin_common's venv re-exec — an execv
+        # here would re-run main() and double-submit the remember.
+        try:
+            os.environ.setdefault("COGNEE_PLUGIN_IN_VENV", "1")
+            sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+            from _plugin_common import refresh_credits
+
+            refresh_credits("remember")
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/integrations/qwen/scripts/cognee-cli.sh
+++ b/integrations/qwen/scripts/cognee-cli.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Doctor subcommand: a self-contained, read-only diagnostic that does not need
+# the Cognee repo, so dispatch it before the repo-root gate below (you often
+# run the doctor from wherever you are when something looks off).
+if [[ "${1:-}" == "doctor" ]]; then
+  shift
+  SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+  exec python3 "${SELF_DIR}/doctor.py" "$@"
+fi
+
+if [[ -n "${COGNEE_REPO_ROOT:-}" ]]; then
+  cd "$COGNEE_REPO_ROOT"
+elif [[ -f pyproject.toml ]] && grep -q '^name = "cognee"$' pyproject.toml; then
+  :
+else
+  echo "Run this from the Cognee repository root or set COGNEE_REPO_ROOT." >&2
+  exit 64
+fi
+
+exec uv run cognee-cli "$@"

--- a/integrations/qwen/scripts/cognee-plugin
+++ b/integrations/qwen/scripts/cognee-plugin
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+# Add script directory to Python path to import cognee_plugin
+sys.path.insert(0, str(Path(__file__).parent))
+
+import cognee_plugin
+
+if __name__ == "__main__":
+    sys.exit(cognee_plugin.main())

--- a/integrations/qwen/scripts/cognee-remember.sh
+++ b/integrations/qwen/scripts/cognee-remember.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Store text in Cognee's permanent knowledge graph.
+#
+# Usage:
+#   cognee-remember.sh <content> [--node-set <node_set>] [--dataset <dataset>]
+#
+# --node-set: node set for categorization (default: user_context)
+#             user_context | project_docs | agent_actions
+# --dataset:  dataset name (default: COGNEE_PLUGIN_DATASET or agent_sessions)
+#
+# Configuration:
+#   Resolves auth from env/api_key.json.
+#   Dataset is env-driven: COGNEE_PLUGIN_DATASET, then agent_sessions.
+#   Falls back to cognee-cli only if the server is unreachable.
+
+set -euo pipefail
+
+PLUGIN_DIR="${HOME}/.cognee-plugin/qwen"
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+runtime_json="$(python3 - <<'PY' "${PLUGIN_DIR}" "${SELF_DIR}" 2>/dev/null || true
+import json
+import pathlib
+import sys
+
+plugin_dir = pathlib.Path(sys.argv[1])
+import os
+# One-time config from ~/.cognee/.env (shell exports still win).
+sys.path.insert(0, sys.argv[2])
+try:
+    from _env_file import load_env_file
+    load_env_file()
+except Exception:
+    pass
+service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
+api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
+
+if not api_key:
+    cache_path = plugin_dir.parent / "api_key.json"
+    if cache_path.exists():
+        try:
+            cache = json.loads(cache_path.read_text())
+            if isinstance(cache, dict):
+                key = str(cache.get("api_key") or "").strip()
+                cached_url = str(cache.get("base_url") or "").strip().rstrip("/")
+                if key and (not cached_url or cached_url == service_url.rstrip("/")):
+                    api_key = key
+        except Exception:
+            pass
+
+dataset = (os.environ.get("COGNEE_PLUGIN_DATASET") or "").strip()
+
+print(json.dumps({"service_url": service_url, "api_key": api_key, "dataset": dataset}))
+PY
+)"
+
+SERVICE_URL="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("service_url") or "").strip())
+except Exception:
+    pass
+PY
+)"
+API_KEY="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("api_key") or "").strip())
+except Exception:
+    pass
+PY
+)"
+DATASET="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("dataset") or "").strip())
+except Exception:
+    pass
+PY
+)"
+
+[ -z "$SERVICE_URL" ] && SERVICE_URL="${COGNEE_BASE_URL:-${COGNEE_LOCAL_API_URL:-http://localhost:8011}}"
+[ -z "$API_KEY" ] && API_KEY="${COGNEE_API_KEY:-}"
+[ -z "$DATASET" ] && DATASET="${COGNEE_PLUGIN_DATASET:-agent_sessions}"
+
+# Parse arguments: content is first positional; flags follow
+CONTENT="${1:-}"
+NODE_SET="user_context"
+
+shift || true
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --node-set)
+            shift
+            NODE_SET="${1:-user_context}"
+            ;;
+        --dataset|-d)
+            shift
+            DATASET="${1:-$DATASET}"
+            ;;
+        *)
+            ;;
+    esac
+    shift || true
+done
+
+if [ -z "$CONTENT" ]; then
+    echo "Error: no content provided" >&2
+    exit 1
+fi
+
+# Server-first: POST to /api/v1/remember via _remember_http.py.
+# UNREACHABLE → fall back to cognee-cli and warn.
+# Any other result (ok or error) → authoritative; do not fall back.
+RESULT="$(python3 "${SELF_DIR}/_remember_http.py" "$SERVICE_URL" "$API_KEY" "$CONTENT" "$DATASET" "$NODE_SET" || true)"
+
+if [ -n "$RESULT" ] && [ "$RESULT" != "UNREACHABLE" ]; then
+    printf '%s\n' "$RESULT"
+else
+    echo "[cognee-remember] falling back to cognee-cli (degraded — server unreachable; verify the store succeeded once the server is back)" >&2
+    uv run cognee-cli remember "$CONTENT" -d "$DATASET" --node-set "$NODE_SET" 2>/dev/null || true
+fi

--- a/integrations/qwen/scripts/cognee-search.sh
+++ b/integrations/qwen/scripts/cognee-search.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Search Cognee's memory (session or permanent graph).
+#
+# Usage:
+#   cognee-search.sh <query> [top_k] [--session | --graph]
+#
+# --session: search session cache only
+# --graph:   search permanent knowledge graph only
+# No flag:   search session first, then graph if empty
+#
+# Configuration:
+#   Resolves session ID from Cognee endpoints using API auth.
+#   Dataset is env-driven: COGNEE_PLUGIN_DATASET, then agent_sessions.
+
+set -euo pipefail
+
+PLUGIN_DIR="${HOME}/.cognee-plugin/qwen"
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+runtime_json="$(python3 - <<'PY' "${PLUGIN_DIR}" "${SELF_DIR}" 2>/dev/null || true
+import json
+import pathlib
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+plugin_dir = pathlib.Path(sys.argv[1])
+import os
+# One-time config from ~/.cognee/.env (shell exports still win).
+sys.path.insert(0, sys.argv[2])
+try:
+    from _env_file import load_env_file
+    load_env_file()
+except Exception:
+    pass
+service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
+api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
+if not api_key:
+    cache_path = plugin_dir.parent / "api_key.json"
+    if cache_path.exists():
+        try:
+            cache = json.loads(cache_path.read_text())
+            if isinstance(cache, dict):
+                key = str(cache.get("api_key") or "").strip()
+                cached_url = str(cache.get("base_url") or "").strip().rstrip("/")
+                if key and (not cached_url or cached_url == service_url.rstrip("/")):
+                    api_key = key
+        except Exception:
+            pass
+
+session_id = ""
+dataset = (os.environ.get("COGNEE_PLUGIN_DATASET") or "").strip()
+if service_url and api_key:
+    try:
+        import ssl
+        try:
+            import certifi
+            _ssl_ctx = ssl.create_default_context(cafile=certifi.where())
+        except ImportError:
+            # macOS host python often lacks root CAs; fall back like the recall path.
+            _ssl_ctx = ssl.create_default_context()
+            for _p in filter(None, [os.environ.get("SSL_CERT_FILE"), "/etc/ssl/cert.pem", "/etc/ssl/certs/ca-certificates.crt"]):
+                if os.path.exists(_p):
+                    try:
+                        _ssl_ctx.load_verify_locations(_p)
+                        break
+                    except Exception:
+                        pass
+        query = ""
+        session_key = (os.environ.get("COGNEE_SESSION_KEY") or "").strip()
+        if session_key:
+            query = "?agent_session_name=" + urllib.parse.quote(session_key, safe="")
+        req = urllib.request.Request(
+            service_url.rstrip("/") + "/api/v1/agents/connections/me" + query,
+            headers={"X-Api-Key": api_key},
+        )
+        with urllib.request.urlopen(req, timeout=3.0, context=_ssl_ctx) as resp:
+            payload = json.loads(resp.read().decode("utf-8") or "{}")
+        if isinstance(payload, dict):
+            agent = payload.get("agent") if isinstance(payload.get("agent"), dict) else {}
+            if isinstance(agent, dict):
+                session_id = str(agent.get("session_id") or "").strip()
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError, json.JSONDecodeError):
+        pass
+
+print(json.dumps({"session_id": session_id, "dataset": dataset, "service_url": service_url, "api_key": api_key}))
+PY
+)"
+
+DATASET="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("dataset") or "").strip())
+except Exception:
+    pass
+PY
+)"
+SESSION_ID="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("session_id") or "").strip())
+except Exception:
+    pass
+PY
+)"
+SERVICE_URL="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("service_url") or "").strip())
+except Exception:
+    pass
+PY
+)"
+API_KEY="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("api_key") or "").strip())
+except Exception:
+    pass
+PY
+)"
+[ -z "$DATASET" ] && DATASET="${COGNEE_PLUGIN_DATASET:-agent_sessions}"
+[ -z "$SESSION_ID" ] && SESSION_ID="${COGNEE_SESSION_ID:-qwen_session}"
+[ -z "$SERVICE_URL" ] && SERVICE_URL="${COGNEE_BASE_URL:-${COGNEE_LOCAL_API_URL:-http://localhost:8011}}"
+[ -z "$API_KEY" ] && API_KEY="${COGNEE_API_KEY:-}"
+
+QUERY="${1:-}"
+TOP_K="${2:-5}"
+MODE="auto"
+
+# Parse flags from any position
+for arg in "$@"; do
+    case "$arg" in
+        --session) MODE="session" ;;
+        --graph)   MODE="graph" ;;
+    esac
+done
+
+if [ -z "$QUERY" ]; then
+    echo "Error: no query provided" >&2
+    exit 1
+fi
+
+# Search scope from MODE
+case "$MODE" in
+    session) SCOPE='["session"]' ;;
+    graph)   SCOPE='["graph"]' ;;
+    *)       SCOPE='["session", "graph"]' ;;
+esac
+
+# Server-first: the running server (/api/v1/recall) is the source of truth.
+# Only a 2xx response is authoritative (an empty list = genuinely no hits).
+# Any non-2xx / error / unreachable returns the UNREACHABLE sentinel so we fall
+# back to cognee-cli and warn — never reporting a server failure as "not found".
+# $DATASET is resolved above (COGNEE_PLUGIN_DATASET → default)
+# and scopes the search to the plugin's dataset so unrelated datasets don't bleed in.
+# Logic lives in _recall_http.py (stdlib-only, unit-tested); stderr is surfaced.
+export COGNEE_PLUGIN_STATE_DIR="$PLUGIN_DIR"
+RECALL_JSON="$(python3 "${SELF_DIR}/_cognee_client.py" "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$SCOPE" "$TOP_K" "$DATASET" || true)"
+
+if [ -n "$RECALL_JSON" ] && [ "$RECALL_JSON" != "UNREACHABLE" ]; then
+    # Server answered — authoritative, even if the result is empty.
+    printf '%s\n' "$RECALL_JSON"
+else
+    echo "[cognee-search] falling back to cognee-cli (degraded — empty CLI output is NOT proof of absence; ground-truth via: curl -X POST \"\$COGNEE_BASE_URL/api/v1/recall\")" >&2
+    if [ "$MODE" = "graph" ]; then
+        cognee-cli recall "$QUERY" -d "$DATASET" -k "$TOP_K" -f json 2>/dev/null || true
+    elif [ "$MODE" = "session" ]; then
+        cognee-cli recall "$QUERY" -s "$SESSION_ID" -k "$TOP_K" -f json 2>/dev/null || true
+    else
+        RESULT=$(cognee-cli recall "$QUERY" -s "$SESSION_ID" -k "$TOP_K" -f json 2>/dev/null || true)
+        if [ -n "$RESULT" ] && [ "$RESULT" != "[]" ]; then
+            echo "$RESULT"
+        else
+            cognee-cli recall "$QUERY" -d "$DATASET" -k "$TOP_K" -f json 2>/dev/null || true
+        fi
+    fi
+fi

--- a/integrations/qwen/scripts/cognee-statusline.sh
+++ b/integrations/qwen/scripts/cognee-statusline.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Cognee status line entrypoint (Qwen).
+#
+# The host pipes the statusline JSON context (including session_id) on stdin.
+# We `exec` into the standalone Python renderer so it inherits that same stdin —
+# the renderer is pure-local (reads only ~/.cognee-plugin/qwen JSON files),
+# never imports the plugin runtime, and makes no network call, so it stays
+# instant.
+exec python3 "$(dirname "$0")/cognee_statusline_render.py"

--- a/integrations/qwen/scripts/cognee_plugin.py
+++ b/integrations/qwen/scripts/cognee_plugin.py
@@ -1,0 +1,264 @@
+"""cognee-plugin - offline usage-metrics CLI for the cognee Qwen plugin.
+
+Usage:
+    cognee-plugin metrics [--json]
+
+Computes a usage rollup purely from this plugin's local state files - no
+network, no import of the cognee package:
+    ~/.cognee-plugin/qwen/hook.log
+    ~/.cognee-plugin/qwen/save_counter.json
+    ~/.cognee-plugin/qwen/last_recall.json
+    ~/.cognee-plugin/qwen/recall-audit.log
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# State this plugin's hooks write (mirrors _plugin_common._PLUGIN_DIR). The
+# claude-code copy of this file points at ".../claude-code"; each copy reads
+# its own dir.
+_PLUGIN_DIR = Path.home() / ".cognee-plugin" / "qwen"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_jsonl(path: Path) -> list:
+    """Read a JSON-Lines file; skip malformed lines silently."""
+    if not path.exists():
+        return []
+    lines = []
+    try:
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                obj = json.loads(raw)
+                if isinstance(obj, dict):
+                    lines.append(obj)
+            except json.JSONDecodeError:
+                pass
+    except OSError:
+        pass
+    return lines
+
+
+def _read_json_file(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return data
+    except (OSError, json.JSONDecodeError):
+        pass
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Metric computation
+# ---------------------------------------------------------------------------
+
+
+def _compute_metrics(plugin_dir: Path) -> dict:
+    hook_log_path = plugin_dir / "hook.log"
+    save_counter_path = plugin_dir / "save_counter.json"
+    last_recall_path = plugin_dir / "last_recall.json"
+    recall_audit_path = plugin_dir / "recall-audit.log"
+
+    # -----------------------------------------------------------------------
+    # 1. hook.log - sessions, mode split, breaker events, save events
+    # -----------------------------------------------------------------------
+    hook_lines = _parse_jsonl(hook_log_path)
+
+    unique_sessions: set = set()
+    local_decisions = 0
+    cloud_decisions = 0
+    breaker_open_events = 0
+    saves_from_log = {"prompt": 0, "trace": 0, "answer": 0}
+
+    for line in hook_lines:
+        ev = line.get("event", "")
+        detail = line.get("detail") or {}
+
+        # Some diagnostic events carry a session id in their detail payload.
+        for key in ("session_id", "session"):
+            sid = detail.get(key)
+            if isinstance(sid, str) and sid:
+                unique_sessions.add(sid)
+
+        # Mode decisions. resolve_runtime_mode() emits "http" (cloud) or
+        # "local_sdk" (local); count any non-http mode as local so the split
+        # stays correct if another local mode name is ever added.
+        if ev == "mode_decision":
+            mode = detail.get("mode", "")
+            if mode == "http":
+                cloud_decisions += 1
+            elif mode:
+                local_decisions += 1
+
+        # recall_breaker_open is logged once per per-prompt recall skipped while
+        # the breaker is open; the 4 local files expose no open/close transition,
+        # so this counts recalls skipped by an open breaker, not distinct trips.
+        if ev == "recall_breaker_open":
+            breaker_open_events += 1
+
+        # Save events recorded in hook.log. Warmup-buffered trace/answer saves
+        # log "store_buffered_warming" (tagged with the originating hook) rather
+        # than trace_stored/stop_stored, so count those too for a full total.
+        if ev == "prompt_pending":
+            saves_from_log["prompt"] += 1
+        elif ev == "trace_stored":
+            saves_from_log["trace"] += 1
+        elif ev == "stop_stored":
+            saves_from_log["answer"] += 1
+        elif ev == "store_buffered_warming":
+            if detail.get("hook") == "tool":
+                saves_from_log["trace"] += 1
+            elif detail.get("hook") == "stop":
+                saves_from_log["answer"] += 1
+
+    # -----------------------------------------------------------------------
+    # 2. save_counter.json - session ids only
+    # -----------------------------------------------------------------------
+    # A per-turn buffer that read_and_reset_save_counter drains on every recall;
+    # each save it records is also written to hook.log, so adding it to the
+    # totals would double-count. Read it only to recover session ids.
+    save_data = _read_json_file(save_counter_path)
+    for _sid in save_data:
+        if isinstance(_sid, str):
+            unique_sessions.add(_sid)
+
+    total_saves = dict(saves_from_log)
+
+    # -----------------------------------------------------------------------
+    # 3. last_recall.json - session id only
+    # -----------------------------------------------------------------------
+    lr_session = _read_json_file(last_recall_path).get("session_id")
+    if isinstance(lr_session, str) and lr_session:
+        unique_sessions.add(lr_session)
+
+    # -----------------------------------------------------------------------
+    # 4. recall-audit.log - total recalls + hit rate
+    # -----------------------------------------------------------------------
+    audit_lines = _parse_jsonl(recall_audit_path)
+    total_recalls = len(audit_lines)
+    recall_hits = 0
+    for entry in audit_lines:
+        hits = entry.get("hits") or {}
+        total_hit_count = sum(int(v) for v in hits.values() if isinstance(v, (int, float)))
+        if total_hit_count > 0:
+            recall_hits += 1
+        sid = entry.get("session_id")
+        if isinstance(sid, str) and sid:
+            unique_sessions.add(sid)
+
+    hit_rate_pct = round(100.0 * recall_hits / total_recalls, 1) if total_recalls > 0 else 0.0
+
+    total_sessions = len(unique_sessions)
+    total_decisions = local_decisions + cloud_decisions
+    local_pct = round(100.0 * local_decisions / total_decisions, 1) if total_decisions > 0 else 0.0
+    cloud_pct = round(100.0 * cloud_decisions / total_decisions, 1) if total_decisions > 0 else 0.0
+
+    return {
+        "sessions": total_sessions,
+        "recalls": {
+            "total": total_recalls,
+            "hits": recall_hits,
+            "hit_rate_pct": hit_rate_pct,
+        },
+        "saves": total_saves,
+        "mode_split": {
+            "local_pct": local_pct,
+            "cloud_pct": cloud_pct,
+            "local_count": local_decisions,
+            "cloud_count": cloud_decisions,
+        },
+        "breaker_open_events": breaker_open_events,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+
+def _print_rollup(metrics: dict, plugin: str) -> None:
+    r = metrics["recalls"]
+    s = metrics["saves"]
+    ms = metrics["mode_split"]
+
+    print(f"cognee-plugin metrics  [{plugin}]")
+    print("=" * 46)
+    print(f"  Sessions            : {metrics['sessions']}")
+    print()
+    print(f"  Recalls             : {r['total']}")
+    print(f"  Recall hits         : {r['hits']}")
+    print(f"  Hit rate            : {r['hit_rate_pct']}%")
+    print()
+    print(f"  Saves (prompt)      : {s['prompt']}")
+    print(f"  Saves (trace)       : {s['trace']}")
+    print(f"  Saves (answer)      : {s['answer']}")
+    print(f"  Saves (total)       : {sum(s.values())}")
+    print()
+    print(f"  Mode - local        : {ms['local_pct']}%  ({ms['local_count']} decisions)")
+    print(f"  Mode - cloud        : {ms['cloud_pct']}%  ({ms['cloud_count']} decisions)")
+    print()
+    print(f"  Breaker open events : {metrics['breaker_open_events']}")
+    print("=" * 46)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cognee-plugin",
+        description="Cognee plugin CLI utilities",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    metrics_p = sub.add_parser(
+        "metrics",
+        help="Print a usage rollup derived purely from local plugin files (no network).",
+    )
+    metrics_p.add_argument(
+        "--json",
+        dest="as_json",
+        action="store_true",
+        help="Output metrics as a JSON object instead of a human-readable rollup.",
+    )
+    return parser
+
+
+def main(argv=None):
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help(sys.stderr)
+        return 1
+
+    if args.command == "metrics":
+        metrics = _compute_metrics(_PLUGIN_DIR)
+        if args.as_json:
+            print(json.dumps(metrics, indent=2))
+        else:
+            _print_rollup(metrics, _PLUGIN_DIR.name)
+        return 0
+
+    parser.print_help(sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/qwen/scripts/cognee_statusline_render.py
+++ b/integrations/qwen/scripts/cognee_statusline_render.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+"""Render the Cognee status line (Qwen).
+
+Invoked via ``cognee-statusline.sh``, which pipes a JSON context on stdin.
+Deliberately standalone and pure-local: reads only env vars and
+``~/.cognee-plugin/config.json`` — no network calls, no ``_plugin_common``
+import.
+
+Output: ``cognee: <dataset-name> · local`` or ``cognee: <dataset-name> · cloud``
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse
+
+from _env_file import forced_backend, load_env_file
+
+# ~/.cognee/.env is pure-local too, so loading it here keeps the renderer's
+# no-network/no-_plugin_common contract while honoring one-time config.
+# load_env_file also applies the COGNEE_BACKEND switch (forced local scrubs the
+# cloud connection vars), so the mode shown below matches what the hooks use.
+load_env_file()
+
+_SHARED_ROOT = Path.home() / ".cognee-plugin"
+_CONFIG_PATH = _SHARED_ROOT / "config.json"
+_SERVER_READY_PATH = _SHARED_ROOT / "server-ready.json"
+_BREAKER_PATH = _SHARED_ROOT / "recall-breaker.json"
+# Written by the external pipeline-health sweep (see the claude-code renderer's
+# `_pipeline_health_glyph` and docs/KB/pipeline-monitor-notify-policy.md in the
+# total_recall/thessary repo). Machine-wide and integration-neutral — deliberately
+# in the shared root, NOT under qwen/ — so both integrations read the same file.
+_PIPELINE_HEALTH_PATH = _SHARED_ROOT / "pipeline-health.json"
+_UPDATE_CHECK_PATH = _SHARED_ROOT / "qwen" / "update-check.json"
+_LLM_STATE_PATH = _SHARED_ROOT / "qwen" / "llm-state.json"
+# Per-session copies (see _plugin_common._write_session_marker): the shared files
+# above are coordination state, these are what THIS terminal observed.
+_LLM_STATE_DIR = _SHARED_ROOT / "qwen" / "llm-state"
+_CONN_STATE_DIR = _SHARED_ROOT / "qwen" / "conn-state"
+
+# TTL for an LLM-key verdict. The marker is machine-wide and refreshed only when an
+# idle watcher LAUNCHES (session start, or a prompt that finds no live watcher) —
+# there is no periodic re-check — so a verdict this old came from a session that is
+# gone. Treat it as unknown rather than keep flagging a key the user may have fixed.
+_LLM_STATE_STALE_SECONDS = 30 * 60
+_CREDITS_PATH = _SHARED_ROOT / "qwen" / "credits.json"
+
+# TTL for the credits balance. Written per turn (prompt + Stop hooks) and by
+# the idle watcher every ~5 minutes — older than this means every writer has
+# stopped (session over, watcher dead); hide the balance rather than show a
+# number that no longer reflects spend.
+_CREDITS_STALE_SECONDS = 15 * 60
+
+# TTL for the pipeline-health sweep's finding, matching the claude-code renderer.
+# The sweep runs every 2-5 minutes, so anything older means the sweep itself has
+# stopped — its own separate (unmonitored-by-this-glyph) problem, not something
+# to imply here; treat the file as stale/unknown rather than showing a possibly-
+# outdated warning.
+_PIPELINE_HEALTH_STALE_SECONDS = 30 * 60
+_DEFAULT_DATASET = "agent_sessions"
+# Must match _plugin_common._DEFAULT_LOCAL_SERVICE_URL: the hooks stamp this URL into
+# the markers this renderer compares against.
+_DEFAULT_LOCAL_BASE_URL = "http://localhost:8011"
+
+
+def _active_dataset() -> str:
+    # 1. env var (inherited from the shell that launched Qwen)
+    v = os.environ.get("COGNEE_PLUGIN_DATASET", "").strip()
+    if v:
+        return v
+    # 2. default
+    return _DEFAULT_DATASET
+
+
+_LOOPBACK = {"localhost", "127.0.0.1", "::1", ""}
+
+
+def _active_mode() -> str:
+    # 0. explicit backend switch: forced local always reads local (the env
+    # scrub in load_env_file guarantees it, this is just the direct answer);
+    # forced cloud with no URL to inspect reads cloud — the misconfig glyph
+    # (see _forced_cloud_unconfigured) reports what is missing.
+    forced = forced_backend()
+    if forced == "local":
+        return "local"
+    # 1. env var
+    url = os.environ.get("COGNEE_BASE_URL", "").strip()
+    # 2. config file
+    if not url:
+        try:
+            data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                url = str(data.get("base_url") or "").strip()
+        except Exception:
+            pass
+    if not url:
+        return "cloud" if forced == "cloud" else "local"
+    return "local" if (urlparse(url).hostname or "") in _LOOPBACK else "cloud"
+
+
+_FAIL_STATES = ("auth_failed", "unreachable", "server_error", "not_responding")
+# Of those, the ones that are a property of the SERVER rather than of the credential
+# the observing session happened to use. Only these may cross session boundaries: if
+# one terminal can't reach the server, neither can the others — but one terminal's
+# rejected API key says nothing about anyone else's. Letting auth_failed cross put a
+# red ✕ (incorrect_cognee_api_key) on a healthy local terminal for a few seconds
+# whenever a keyless cloud terminal started up.
+# "not_responding" (N consecutive recall timeouts) is server-wide too: a server
+# that isn't answering one terminal isn't answering the others either.
+_SERVER_WIDE_FAIL_STATES = ("unreachable", "server_error", "not_responding")
+
+# A failure verdict is only worth a ✕ while it is FRESH. The hooks refresh a
+# genuine outage on every prompt (probe or recall attempt), so a failure marker
+# older than this means no session has re-confirmed it — ambiguous, and ambiguity
+# renders no glyph (same as the warming case) rather than a stale accusation.
+_FAIL_STATE_STALE_SECONDS = 30 * 60
+
+
+def _active_base_url() -> str:
+    """The server URL this session is actually talking to — never empty.
+
+    Mirrors the hooks' resolution (``_plugin_common._local_api_url_with_source``)
+    exactly, including the ``COGNEE_LOCAL_API_URL`` precedence and the localhost
+    default, because the value is compared against the ``base_url`` those hooks stamp
+    into the markers. It used to return "" when nothing was configured — the common
+    local setup — which made the mismatch guard below toothless: with no URL of our
+    own to compare, a marker written for someone else's *cloud* tenant was accepted by
+    a *local* session. Defaulting here is what gives that guard teeth.
+    """
+    for var in ("COGNEE_LOCAL_API_URL", "COGNEE_BASE_URL"):
+        url = os.environ.get(var, "").strip()
+        if url:
+            return url.rstrip("/")
+    try:
+        data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            url = str(data.get("base_url") or "").strip()
+            if url:
+                return url.rstrip("/")
+    except Exception:
+        pass
+    return _DEFAULT_LOCAL_BASE_URL
+
+
+def _read_json(path: Path) -> dict:
+    """Parse a marker file into a dict; {} on anything unreadable. Never raises."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _path_safe(session_id: str) -> bool:
+    """The id comes from the host over stdin — never build a path from it unchecked."""
+    return bool(session_id) and all(c.isalnum() or c in "._-" for c in session_id)
+
+
+def _checked_at(marker: dict) -> float:
+    try:
+        return float(marker.get("checked_at") or marker.get("ready_at") or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _connection_marker(session_id: str) -> dict:
+    """This terminal's own connection record, or the best available substitute.
+
+    Sessions can genuinely disagree (different COGNEE_API_KEY against the same
+    base_url), so a record another session wrote says nothing about this one.
+    Resolution:
+      1. our own per-session record, EXCEPT when the shared marker carries a fresher
+         SERVER-WIDE failure (`unreachable` / `server_error`) — the server is shared,
+         so a just-observed outage applies to everyone and beats our older "ready".
+         `auth_failed` is deliberately excluded: it describes the credential the other
+         session used, not the server, so it must not turn our bar red;
+      2. no record of our own → the shared marker, but only when it is
+         unattributed (pre-upgrade writer, or a write before the session key was
+         known); an attributed record belonging to someone else is ignored;
+      3. nothing usable → {} (renders no glyph, same as a warming server).
+    """
+    shared = _read_json(_SERVER_READY_PATH)
+    mine = _read_json(_CONN_STATE_DIR / f"{session_id}.json") if _path_safe(session_id) else {}
+    if not mine:
+        marked = str(shared.get("session_key") or "")
+        if session_id and marked and marked != session_id:
+            return {}
+        return shared
+    if str(shared.get("state") or "") in _SERVER_WIDE_FAIL_STATES and _checked_at(
+        shared
+    ) > _checked_at(mine):
+        return shared
+    return mine
+
+
+# What the user sees in place of the internal state name — the marker keeps its own
+# vocabulary (`auth_failed`, `not_set`) for logs; the status names the thing to go fix.
+# Both LLM verdicts collapse to one label: the fix is the same either way, and
+# `llm-state.json` still records which of the two it was.
+_COGNEE_KEY_REASON = "incorrect_cognee_api_key"
+_LLM_KEY_REASON = "incorrect_llm_api_key"
+_MISSING_URL_REASON = "missing_cognee_base_url"
+_REASON_LABELS = {"auth_failed": _COGNEE_KEY_REASON}
+
+
+def _url_mismatch(active_url: str, marked_url: str) -> bool:
+    """True only when the marker is PROVABLY about a different server.
+
+    Mirror image of ``_plugin_common.same_connection_target`` (which the hooks use to
+    decide whether to record a failure). The two must stay equivalent, or a hook and
+    this renderer would disagree about whether a marker applies. Kept as its own copy
+    because this module is deliberately standalone — no ``_plugin_common`` import.
+    """
+    return bool(active_url and marked_url and active_url != marked_url)
+
+
+def _breaker_glyph(active_url: str) -> str:
+    """ "✕ (<trip reason>) " when THIS server's breaker is open, else "".
+
+    The breaker file is keyed by base_url (SDK-356): an entry for a different
+    server — a cloud tenant while this terminal is local, or Claude Code's
+    target — must not red this bar. A legacy flat file (machine-wide,
+    target-blind) is ignored for the same reason. The reason travels from the
+    trip site, so a breaker opened by 5xx reads ``server_error``, not a false
+    ``unreachable``.
+    """
+    try:
+        raw = json.loads(_BREAKER_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    servers = raw.get("servers") if isinstance(raw, dict) else None
+    if not isinstance(servers, dict):
+        return ""
+    entry = servers.get(active_url.rstrip("/"))
+    if not isinstance(entry, dict):
+        return ""
+    try:
+        if float(entry.get("cooldown_until", 0) or 0) <= time.time():
+            return ""
+    except (TypeError, ValueError):
+        return ""
+    reason = str(entry.get("reason") or "unreachable")
+    return f"✕ ({_REASON_LABELS.get(reason, reason)}) "
+
+
+def _health_prefix(session_id: str = "") -> str:
+    """Server-connection glyph for THIS session, from local markers (no network).
+
+    Precedence — the ✕ is reserved for CONFIRMED, FRESH, DEFINITIVE failures:
+      1. a fresh recorded failure state in the marker → ``✕ (<reason>)``
+         (older than _FAIL_STATE_STALE_SECONDS → ambiguous → no glyph)
+      2. an open recall breaker for THIS base_url → ``✕ (<trip reason>)``
+      3. a "ready" marker → ``● ``
+      4. otherwise (no marker / warming / stale / different target) → no glyph
+    The marker (``server-ready.json``) carries {state, base_url, ...}; a state is
+    trusted only when its base_url matches this session's, so a local-ready marker
+    never greens a cloud session (or vice versa).
+    """
+    marker = _connection_marker(session_id)
+
+    marked_url = str(marker.get("base_url") or "").rstrip("/")
+    active_url = _active_base_url()
+    url_mismatch = _url_mismatch(active_url, marked_url)
+
+    if marker and not url_mismatch:
+        state = str(marker.get("state") or ("ready" if marker.get("ready_at") else ""))
+        if state in _FAIL_STATES:
+            if time.time() - _checked_at(marker) <= _FAIL_STATE_STALE_SECONDS:
+                return f"✕ ({_REASON_LABELS.get(state, state)}) "
+            # Stale verdict: nobody has re-confirmed the failure — treat as
+            # unknown rather than keep accusing a server that may be fine.
+            return _breaker_glyph(active_url)
+        if state == "ready":
+            return _breaker_glyph(active_url) or "● "
+
+    return _breaker_glyph(active_url)
+
+
+def _update_segment() -> str:
+    """Plain-text 'update available' segment, or '' — read purely from the marker.
+
+    Qwen surfaces status inside the model's context (not a terminal bar), so this
+    stays plain text (no ANSI). The idle watcher's background check writes the
+    marker; this remains network-free and free of any ``_plugin_common`` import.
+    """
+    if os.environ.get("COGNEE_UPDATE_CHECK", "").strip().lower() in ("0", "false", "no", "off"):
+        return ""
+    try:
+        marker = json.loads(_UPDATE_CHECK_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    if not (isinstance(marker, dict) and marker.get("update_available")):
+        return ""
+    installed = str(marker.get("installed_version") or "")
+    latest = str(marker.get("latest_version") or "")
+    if not (installed and latest):
+        return ""
+    # Marker staleness guard, mirroring _plugin_common.read_update_status: the
+    # marker is a snapshot from the last background check, so after an update it
+    # keeps claiming an update is available until the next one runs. Comparing
+    # against the running version clears the segment on the next render instead.
+    running = _running_plugin_version()
+    if running and running != installed:
+        return ""
+    return f"  ⬆ Cognee update available {installed}→{latest}"
+
+
+def _running_plugin_version() -> str:
+    """Version of the plugin copy this renderer belongs to, or '' if unreadable.
+
+    Deliberately does not import ``_plugin_common`` (see module docstring); this
+    file's own location identifies the running copy.
+    """
+    candidates = []
+    for variable in ("CLAUDE_PLUGIN_ROOT", "PLUGIN_ROOT"):
+        root = os.environ.get(variable, "").strip()
+        if root:
+            candidates.extend(
+                (Path(root) / "qwen-extension.json", Path(root) / "gemini-extension.json")
+            )
+    extension_root = Path(__file__).resolve().parent.parent
+    candidates.extend(
+        (extension_root / "qwen-extension.json", extension_root / "gemini-extension.json")
+    )
+    for path in candidates:
+        try:
+            version = str(json.loads(path.read_text(encoding="utf-8")).get("version") or "").strip()
+            if version:
+                return version
+        except Exception:
+            continue
+    return ""
+
+
+def _pipeline_health_glyph() -> str:
+    """ "⚠ N pipeline(s) stuck " / "⚠ server-down " when the pipeline sweep has a
+    fresh, non-stale finding; "" otherwise (no file yet, stale, or everything's
+    clean). Qwen copy of the claude-code renderer's glyph (kept in sync by hand —
+    this module is deliberately standalone); plain text since the status is
+    injected into model context, not a terminal bar. Passive and app-closed-safe:
+    it surfaces a stuck-pipeline finding the instant the user next prompts any
+    Qwen session running the plugin. See docs/KB/pipeline-monitor-notify-policy.md
+    (total_recall/thessary repo) for the full monitoring design this is one small
+    piece of.
+    """
+    try:
+        raw = json.loads(_PIPELINE_HEALTH_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    if not isinstance(raw, dict):
+        return ""
+    try:
+        generated_at = datetime.fromisoformat(str(raw.get("generated_at", "")))
+        age_seconds = (datetime.now(timezone.utc) - generated_at).total_seconds()
+        if age_seconds > _PIPELINE_HEALTH_STALE_SECONDS:
+            return ""
+    except (ValueError, TypeError):
+        return ""
+    # isinstance, not `or {}`: a truthy non-dict ("yes", 5) would flow through
+    # an `or` fallback and raise AttributeError on .get() — and this module must
+    # never raise (see the sum() guard below).
+    server = raw.get("server") if isinstance(raw.get("server"), dict) else {}
+    if server.get("up") is False:
+        return "⚠ server-down "
+    summary = raw.get("summary") if isinstance(raw.get("summary"), dict) else {}
+    worst = str(summary.get("worst_classification") or "ok")
+    # The isinstance guard only vets the container; a non-numeric VALUE
+    # ("many", None, a nested dict) would make sum() raise — and this module
+    # must never raise (a crash here aborts the whole context-injection hook,
+    # silently dropping the turn's recalled memory, not just this glyph).
+    try:
+        flagged = (
+            sum((summary.get("by_classification") or {}).values())
+            if isinstance(summary.get("by_classification"), dict)
+            else 0
+        )
+    except (TypeError, ValueError):
+        flagged = 0
+    if worst in ("alert", "critical") and flagged > 0:
+        return f"⚠ {flagged} pipeline(s) stuck "
+    return ""
+
+
+def _llm_prefix(session_id: str = "") -> str:
+    """Plain-text 'LLM key' failure glyph, or '' — local mode only.
+
+    LLM_API_KEY is only used by the local server, so this is suppressed in cloud
+    mode. Both verdicts come from the background idle watcher, which resolves the
+    key exactly as the server does: `not_set` = no key configured anywhere,
+    `auth_failed` = key rejected by the provider. Distinct reasons from the
+    server-connection ones so the two keys aren't confused. Plain text (no ANSI)
+    since Qwen injects the status into model context, not a terminal bar.
+
+    Per terminal, because the answer genuinely differs per terminal: the key is
+    resolved from the checking session's own environment, so one launch can have it
+    exported and another not. We read THIS session's record
+    (``llm-state/<session_key>.json``) first; the shared marker is consulted only
+    when we have none of our own, and then only if it is unattributed — another
+    terminal's "not_set" must not red a bar whose key is fine, and its "ok" must not
+    green a bar whose key is missing.
+
+    Verdicts expire (`_LLM_STATE_STALE_SECONDS`): the marker is shared by every
+    session, so without a TTL one stale write could keep accusing a key that has
+    since been fixed. The watcher refreshes it when it launches (session start, or
+    a prompt that finds no live watcher), throttled to at most once per
+    COGNEE_LLM_CHECK_INTERVAL — so an active session stays well inside the window,
+    while a session quiet for longer simply drops the glyph until the next check.
+    """
+    if _active_mode() != "local":
+        return ""
+    marker = _read_json(_LLM_STATE_DIR / f"{session_id}.json") if _path_safe(session_id) else {}
+    if not marker:
+        # No verdict of our own yet: the shared marker only speaks for us when it is
+        # unattributed. Another terminal's "ok" must not green a bar whose key is
+        # missing, just as its "not_set" must not red one whose key is fine.
+        marker = _read_json(_LLM_STATE_PATH)
+        marked_key = str(marker.get("session_key") or "")
+        if session_id and marked_key and session_id != marked_key:
+            return ""
+    try:
+        if time.time() - float(marker.get("checked_at") or 0) > _LLM_STATE_STALE_SECONDS:
+            return ""
+    except (TypeError, ValueError):
+        return ""
+    state = str(marker.get("llm_state") or "")
+    if state in ("not_set", "auth_failed"):
+        return f"✕ ({_LLM_KEY_REASON}) "
+    return ""
+
+
+def _forced_cloud_unconfigured() -> bool:
+    """Forced cloud (backend switch) with no URL anywhere: nothing to connect
+    to — a definitive misconfiguration this renderer can see directly from
+    env + config.json, without waiting for a hook to record a failed attempt.
+    """
+    if forced_backend() != "cloud":
+        return False
+    if os.environ.get("COGNEE_BASE_URL", "").strip():
+        return False
+    try:
+        data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+        if isinstance(data, dict) and str(data.get("base_url") or "").strip():
+            return False
+    except Exception:
+        pass
+    return True
+
+
+def _status_prefix(session_id: str = "") -> str:
+    """The single leading glyph slot shared by the server- and LLM-key signals.
+
+    One slot, by precedence — showing a ● next to an ✕ would read as
+    contradictory:
+      0. forced cloud with no URL configured: a misconfiguration this renderer
+         can prove on its own — the precise reason beats any marker-derived one
+      1. a server-connection failure wins: if we can't reach or authenticate
+         against the server, its LLM key is not the actionable problem
+      2. otherwise an LLM-key failure, which *replaces* the ● (the ``llm_*``
+         reason already says the server side itself is fine)
+      3. otherwise whatever the server signal is (``● `` or nothing).
+    """
+    if _forced_cloud_unconfigured():
+        return f"✕ ({_MISSING_URL_REASON}) "
+    server = _health_prefix(session_id)
+    if server.startswith("✕"):
+        return server
+    return _llm_prefix(session_id) or server
+
+
+def _credits_segment() -> str:
+    """Cloud credits balance + approximate cost of the last memory operation.
+
+    Pure-local like everything here: reads only ``credits.json`` — a MAP keyed
+    by tenant id (several terminals can be on different tenants at once), each
+    entry carrying the service base_url it was observed under. Select OUR
+    tenant's entry by that binding. Plain text (the Qwen line carries no ANSI
+    styling). Renders nothing unless ALL of: cloud mode, matching fresh entry
+    with a numeric balance, not opted out (``COGNEE_STATUSLINE_CREDITS=off``).
+    """
+    if os.environ.get("COGNEE_STATUSLINE_CREDITS", "").strip().lower() in (
+        "0",
+        "false",
+        "no",
+        "off",
+    ):
+        return ""
+    if _active_mode() != "cloud":
+        return ""
+    marker = _read_json(_CREDITS_PATH)
+    active = _active_base_url().rstrip("/")
+    entry = None
+    for candidate in marker.values():
+        if (
+            isinstance(candidate, dict)
+            and str(candidate.get("base_url") or "").rstrip("/") == active
+        ):
+            entry = candidate
+            break
+    if entry is None:
+        return ""
+    remaining = entry.get("remaining_usd")
+    if not isinstance(remaining, (int, float)) or isinstance(remaining, bool):
+        return ""
+    try:
+        checked_at = float(entry.get("checked_at", 0) or 0)
+    except (TypeError, ValueError):
+        return ""
+    if time.time() - checked_at > _CREDITS_STALE_SECONDS:
+        return ""
+    sign = "-" if remaining < 0 else ""
+    seg = f" · credits: {sign}${abs(remaining):,.2f}"
+    last_op = entry.get("last_op")
+    if isinstance(last_op, dict):
+        label = str(last_op.get("label") or "").strip()
+        cost = last_op.get("cost_usd")
+        if label and isinstance(cost, (int, float)) and not isinstance(cost, bool):
+            seg += f" · last {label} ~${cost:,.2f}"
+    return seg
+
+
+def render_status_for_host(host_id: str) -> str:
+    """Return the status string. ``host_id`` is this session's key, used to show only
+    LLM-key verdicts written by this session (the marker is machine-wide)."""
+    return (
+        f"{_pipeline_health_glyph()}{_status_prefix(str(host_id or ''))}"
+        f"cognee: {_active_dataset()} · {_active_mode()}"
+        f"{_credits_segment()}{_update_segment()}"
+    )
+
+
+def main() -> None:
+    # Windows defaults stdio to the locale code page (e.g. cp1252), which cannot
+    # encode the status glyphs (●, ✕, ⬆); writing one raises UnicodeEncodeError
+    # and exits non-zero. Force UTF-8 on both streams so this renderer stays
+    # crash-free when invoked directly via cognee-statusline.sh. Kept inside
+    # main() (not at module scope) because session-start.py and
+    # session-context-lookup.py import render_status_for_host — a module-level
+    # reconfigure would hijack the importer's stdout. Best-effort: a stream that
+    # can't be reconfigured (e.g. a captured stdout under test) is left as-is.
+    for _stream in (sys.stdin, sys.stdout):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except Exception:
+            pass
+
+    try:
+        json.load(sys.stdin)  # consume stdin as required by the host
+    except Exception:
+        pass
+    sys.stdout.write(
+        f"{_pipeline_health_glyph()}{_status_prefix()}"
+        f"cognee: {_active_dataset()} · {_active_mode()}"
+        f"{_credits_segment()}{_update_segment()}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/qwen/scripts/config.py
+++ b/integrations/qwen/scripts/config.py
@@ -1,0 +1,637 @@
+"""Shared configuration for the Cognee Qwen plugin.
+
+Loads settings from (in priority order):
+  1. Environment variables (runtime overrides)
+  2. Env file (~/.cognee/.env — one-time setup, injected into os.environ
+     with setdefault, so it sits just below real shell exports)
+  3. Config file (~/.cognee-plugin/config.json)
+  4. Defaults
+
+The env file may hold both modes' variables at once; cloud wins when both are
+configured. `export COGNEE_BACKEND=local` (or `=cloud`) flips one terminal —
+COGNEE_QWEN_BACKEND does the same for this plugin only, beating the shared
+name. A forced mode is pinned: forced local scrubs the cloud connection vars
+from the process environment (see _env_file), and forced cloud keeps
+is_cloud_mode() true even when connection vars are missing, so the plugin
+attempts the cloud connection and the status line reports what is wrong
+instead of silently falling back to local.
+
+Config file is created on first SessionStart if it doesn't exist.
+
+Supports three modes:
+  - Local: Cognee runs in-process (SQLite + LanceDB + Kuzu)
+  - Cloud: Connect to Cognee Cloud via cognee.serve()
+  - Server: Legacy — direct base_url (kept for backward compat)
+"""
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+from _env_file import load_env_file
+
+# Must run before the _ENV_MAP scan in load_config() and before any importer's
+# module-level os.environ reads.
+load_env_file()
+
+_CONFIG_DIR = Path.home() / ".cognee-plugin"
+_STATE_DIR = _CONFIG_DIR / "qwen"
+_CONFIG_FILE = _CONFIG_DIR / "config.json"
+_BRIDGE_STATE_FILE = _STATE_DIR / "bridge_state.json"
+_HOOK_LOG = _STATE_DIR / "hook.log"
+
+_DEFAULTS = {
+    "dataset": "agent_sessions",
+    "agent_name": "qwen-agent",
+    "session_strategy": "per-directory",  # per-directory | git-branch | static
+    "session_prefix": "qwen",
+    "top_k": 3,
+    "backend": "auto",
+    "user_email": "default_user@example.com",
+    "user_password": "default_password",
+    # Cloud / remote
+    "base_url": "",
+    "api_key": "",
+    # Local mode
+    "llm_api_key": "",
+    "llm_model": "",
+}
+
+
+def _config_log(event: str, detail: dict | None = None) -> None:
+    try:
+        from datetime import datetime, timezone
+
+        _HOOK_LOG.parent.mkdir(parents=True, exist_ok=True)
+        line = {
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "pid": os.getpid(),
+            "event": event,
+        }
+        if detail:
+            line["detail"] = detail
+        with _HOOK_LOG.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(line, default=str) + "\n")
+    except Exception:
+        pass
+
+
+# Env var overrides (env var name → config key)
+_ENV_MAP = {
+    # Backend switch: the shared name is scanned first so the plugin-specific
+    # one, applied later, wins when both are exported. COGNEE_CLAUDE_BACKEND is
+    # deliberately absent — an export targeting the Claude Code plugin must not
+    # flip this one.
+    "COGNEE_BACKEND": "backend",
+    "COGNEE_QWEN_BACKEND": "backend",
+    "COGNEE_AGENT_NAME": "agent_name",
+    "COGNEE_PLUGIN_DATASET": "dataset",
+    "COGNEE_SESSION_STRATEGY": "session_strategy",
+    "COGNEE_SESSION_PREFIX": "session_prefix",
+    "COGNEE_BASE_URL": "base_url",
+    "COGNEE_API_KEY": "api_key",
+    "COGNEE_USER_EMAIL": "user_email",
+    "COGNEE_USER_PASSWORD": "user_password",
+    "LLM_API_KEY": "llm_api_key",
+    "LLM_MODEL": "llm_model",
+    # Background remember + cognify polling (read at the call sites via _float_env;
+    # registered here for config-file support and discoverability).
+    "COGNEE_COGNIFY_POLL_INTERVAL": "cognify_poll_interval",
+    "COGNEE_BRIDGE_POLL_DEADLINE": "bridge_poll_deadline",
+    "COGNEE_BRIDGE_SUBMIT_TIMEOUT": "bridge_submit_timeout",
+    "COGNEE_REMEMBER_WAIT_SECONDS": "remember_wait_seconds",
+    "COGNEE_STATUS_REQUEST_TIMEOUT": "status_request_timeout",
+    # Legacy compat
+    "COGNEE_SESSION_ID": "_static_session_id",
+}
+
+
+def load_config() -> dict:
+    """Load merged config: defaults → file → env vars."""
+    config = dict(_DEFAULTS)
+
+    # Layer 2: config file
+    # dataset is intentionally excluded here: it is always driven by the default
+    # or by COGNEE_PLUGIN_DATASET (env var, layer 3). Reading it from the file
+    # would create confusing precedence when users open a terminal without the
+    # env var set. The value is still written to the file for human visibility.
+    _file_excluded = {"dataset"}
+    if _CONFIG_FILE.exists():
+        try:
+            file_cfg = json.loads(_CONFIG_FILE.read_text(encoding="utf-8"))
+            config.update(
+                {
+                    k: v
+                    for k, v in file_cfg.items()
+                    if v is not None and v != "" and k not in _file_excluded
+                }
+            )
+        except Exception as exc:
+            _config_log(
+                "config_file_load_failed", {"path": str(_CONFIG_FILE), "error": str(exc)[:200]}
+            )
+
+    # Layer 3: env vars (highest priority)
+    for env_key, config_key in _ENV_MAP.items():
+        val = os.environ.get(env_key, "")
+        if val:
+            config[config_key] = val
+
+    backend = str(config.get("backend") or "auto").lower()
+    if backend in ("native", "local", "sdk"):
+        config["base_url"] = ""
+        config["api_key"] = ""
+        config["_forced_backend"] = "local"
+    elif backend in ("http", "api", "cloud", "server"):
+        # Forced cloud is pinned even when connection vars are missing:
+        # is_cloud_mode() honors this flag, so the plugin attempts the cloud
+        # connection (and the status line reports the failure) instead of
+        # silently falling back to local.
+        config["_forced_backend"] = "cloud"
+    else:
+        # The service URL is the sole router: a URL alone is a complete
+        # instruction (connect to it, or boot it if local; auth falls back to
+        # the default user when no key is given). A key with no URL has nothing
+        # to point at, so drop it and fall back to the local default.
+        if not str(config.get("base_url") or "").strip():
+            config["api_key"] = ""
+            config["base_url"] = ""
+
+    return config
+
+
+def save_config(config: dict) -> None:
+    """Write config to disk. Creates directory if needed."""
+    _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    # Only save non-secret, non-default values.
+    # dataset is always written even when it equals the default so that users
+    # who open the file can see which dataset the plugin is using.
+    transient_keys = {"api_key", "llm_api_key", "base_url", "backend"}
+    _always_include = {"dataset"}
+    to_save = {
+        k: v
+        for k, v in config.items()
+        if k not in transient_keys
+        and not k.startswith("_")
+        and v
+        and (k in _always_include or v != _DEFAULTS.get(k))
+    }
+    _CONFIG_FILE.write_text(json.dumps(to_save, indent=2), encoding="utf-8")
+
+
+def get_session_id(config: dict, cwd: Optional[str] = None) -> str:
+    """Resolve the Cognee session id for this launch.
+
+    Single-session model: the Cognee session id is minted fresh per launch and
+    kept stable across the launch's separate hook processes via the host-keyed
+    map (see ``resolve_cognee_session_id``). It is the single scoping key for all
+    saves/recalls. The host (Qwen) session id is read from the in-process
+    ``COGNEE_SESSION_KEY`` purely as the local correlation key.
+
+    Hooks call this after setting the host session key from their payload, so the
+    resolver finds the launch's id in the map. An explicit ``COGNEE_SESSION_ID``
+    env (or ``.cognee/session-config.json`` picker) overrides.
+    """
+    from _plugin_common import get_session_key, resolve_cognee_session_id
+
+    if cwd is None:
+        cwd = os.environ.get("QWEN_CWD", os.getcwd())
+    return resolve_cognee_session_id(get_session_key(), cwd)
+
+
+def get_dataset(config: dict) -> str:
+    """Get the dataset name from config."""
+    return config.get("dataset", "agent_sessions")
+
+
+def is_cloud_mode(config: dict) -> bool:
+    """Check if cloud/remote mode is configured (or forced by the backend switch)."""
+    return bool(config.get("base_url")) or config.get("_forced_backend") == "cloud"
+
+
+def is_local_mode(config: dict) -> bool:
+    """Check if local mode (has LLM key, no cloud URL)."""
+    return bool(config.get("llm_api_key")) and not is_cloud_mode(config)
+
+
+async def ensure_identity(config: dict):
+    """Resolve the single Cognee principal for this session.
+
+    Single-principal model: there are no per-agent users and no per-agent API
+    keys. Authentication is the user-provided ``COGNEE_API_KEY`` (or a key minted
+    once from the default user — handled in session-start's registration path).
+
+    In cloud/server mode the API key already lives in the environment/cache, so
+    here we only resolve the principal's user id (best-effort) for dataset
+    readiness and watchers. In local SDK mode we resolve the default user.
+
+    Returns (user_id, api_key) tuple. api_key may be empty in local mode.
+    """
+    service_url = config.get("base_url", "")
+
+    if service_url:
+        from _plugin_common import _api_key
+
+        api_key = _api_key()
+        user_id = await _user_id_via_api(service_url, api_key) if api_key else ""
+        return user_id, api_key
+    else:
+        user_id = await _ensure_identity_via_sdk()
+        return user_id, ""
+
+
+def _cloud_http_request(
+    url: str,
+    *,
+    method: str = "GET",
+    api_key: str = "",
+    json_body: dict | None = None,
+    form_body: dict | None = None,
+    cookies: dict | None = None,
+    timeout: float = 10.0,
+) -> tuple[int, str]:
+    """Blocking stdlib-urllib HTTP for the cloud/remote setup path.
+
+    Cloud mode is a thin REST client that must run without the plugin venv
+    (which is only ever built in local mode), so these setup calls use urllib —
+    like the runtime hot path in ``_plugin_common`` — instead of aiohttp, which
+    would otherwise force the venv onto the cloud path just to be importable.
+
+    Returns ``(status_code, body_text)``. An HTTP error status is captured as
+    ``(code, body)`` rather than raised, so callers branch on the status exactly
+    as they did with aiohttp; network-level errors (URLError/timeout) still
+    raise, matching the aiohttp behavior the callers already guard against.
+    """
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    from _plugin_common import _https_context
+
+    headers: dict[str, str] = {}
+    data: bytes | None = None
+    if json_body is not None:
+        data = json.dumps(json_body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    elif form_body is not None:
+        data = urllib.parse.urlencode(form_body).encode("utf-8")
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+    if api_key:
+        headers["X-Api-Key"] = str(api_key).strip()
+    if cookies:
+        headers["Cookie"] = "; ".join(f"{k}={v}" for k, v in cookies.items())
+
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=_https_context()) as resp:
+            return resp.status, resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        try:
+            body = exc.read().decode("utf-8")
+        except Exception:
+            body = ""
+        return exc.code, body
+
+
+async def _user_id_via_api(service_url: str, api_key: str) -> str:
+    """Best-effort resolve the principal's user id from an API key."""
+    if not service_url or not str(api_key or "").strip():
+        return ""
+
+    base = service_url.rstrip("/")
+    try:
+        status, body = _cloud_http_request(f"{base}/api/v1/users/me", api_key=api_key, timeout=10.0)
+        if status == 200:
+            data = json.loads(body) if body else {}
+            return str(data.get("id", "") or "")
+    except Exception as exc:
+        _config_log("users_me_lookup_failed", {"error": str(exc)[:200]})
+    return ""
+
+
+async def ensure_dataset_ready_via_api(service_url: str, api_key: str, dataset: str) -> None:
+    """Ensure the remote backend has the dataset for the authenticated agent.
+
+    This mirrors local SDK mode's ``ensure_dataset_ready(dataset, user)``:
+    the backend creates or returns the dataset and grants permissions to
+    the API-key user.
+    """
+    if not service_url or not api_key or not dataset:
+        return
+
+    base = service_url.rstrip("/")
+    status, text = _cloud_http_request(
+        f"{base}/api/v1/datasets",
+        method="POST",
+        api_key=api_key,
+        json_body={"name": dataset},
+        timeout=30.0,
+    )
+    if status in (200, 201):
+        return
+    raise RuntimeError(f"remote dataset ensure failed ({status}: {text[:200]})")
+
+
+async def _ensure_identity_via_sdk() -> str:
+    """Resolve the default user via the SDK (local mode, no backend).
+
+    Single-principal model: no agent user is created — the default user is the
+    one principal that owns all sessions/data in local mode.
+    """
+    from cognee.modules.users.methods import get_default_user
+
+    try:
+        user = await get_default_user()
+        if user:
+            return str(user.id)
+    except Exception as exc:
+        _config_log("default_user_resolve_failed", {"error": str(exc)[:200]})
+    return ""
+
+
+_LOCAL_SETUP_DONE = False
+
+
+async def _ensure_local_databases() -> None:
+    """Create Cognee's local relational/vector stores for SDK mode."""
+    global _LOCAL_SETUP_DONE
+    if _LOCAL_SETUP_DONE:
+        return
+
+    from cognee.modules.engine.operations.setup import setup
+
+    await setup()
+    _LOCAL_SETUP_DONE = True
+
+
+async def ensure_cognee_ready(config: dict) -> None:
+    """Configure cognee for the active mode (cloud or local).
+
+    In local SDK mode, also runs Cognee's setup() so a fresh machine or
+    fresh virtualenv has its databases/tables before identity, recall, or
+    session writes touch them.
+    """
+    if is_cloud_mode(config):
+        url = config["base_url"]
+        status, text = _cloud_http_request(f"{url.rstrip('/')}/health", timeout=10.0)
+        if status >= 400:
+            raise RuntimeError(f"backend health check failed ({status}: {text[:200]})")
+        print(f"cognee-plugin: connected to {url}", file=sys.stderr)
+        return
+
+    import cognee
+
+    if config.get("llm_api_key"):
+        cognee.config.set_llm_api_key(config["llm_api_key"])
+    if config.get("llm_model"):
+        cognee.config.set_llm_model(config["llm_model"])
+
+    await _ensure_local_databases()
+    print("cognee-plugin: local databases ready", file=sys.stderr)
+
+
+async def ensure_dataset_ready(dataset: str, user) -> None:
+    """Ensure the user can write to the dataset before session bridging.
+
+    On a fresh local install, session bridging can run before the dataset
+    has been created, causing persistence to no-op with permission
+    errors. Use Cognee's own pipeline resolver so dataset creation and
+    ACL grants follow the SDK's normal path.
+
+    Cognee 1.0.8's session/trace persistence pipelines call memify()
+    without forwarding their user argument. In local plugin processes,
+    make the resolved agent the process-local default user too, so those
+    nested calls resolve the same write permissions.
+    """
+    from cognee.base_config import get_base_config
+    from cognee.modules.pipelines.layers.resolve_authorized_user_datasets import (
+        resolve_authorized_user_datasets,
+    )
+
+    email = getattr(user, "email", "")
+    if email:
+        get_base_config().default_user_email = email
+
+    await resolve_authorized_user_datasets(dataset, user=user)
+
+
+async def sync_graph_context_to_session(dataset: str, session_id: str, user) -> dict:
+    """Sync permanent graph context into one session without full improve().
+
+    ``cognee.improve(session_ids=[...])`` also persists session cache
+    entries. The integration already does that explicitly via
+    ``persist_session_cache_to_graph()``, so call only Cognee's final
+    graph-context sync step to keep recall working without duplicating
+    session documents or holding the DB lock for the full improve path.
+    """
+    if not session_id or not user:
+        return {"synced": 0}
+
+    from cognee.modules.pipelines.layers.resolve_authorized_user_datasets import (
+        resolve_authorized_user_datasets,
+    )
+    from cognee.tasks.memify.sync_graph_to_session import sync_graph_to_session
+
+    _, authorized_datasets = await resolve_authorized_user_datasets(dataset, user=user)
+    if not authorized_datasets:
+        return {"synced": 0}
+
+    return await sync_graph_to_session(
+        user_id=str(user.id),
+        session_id=session_id,
+        dataset_id=authorized_datasets[0].id,
+        dataset_name=dataset,
+    )
+
+
+async def improve_session_local(dataset: str, session_id: str, user) -> dict:
+    """Bridge one session into the graph via the SDK's session-aware improve.
+
+    ``cognee.improve(session_ids=[...])`` reads the session cache itself and
+    runs feedback weights, QA persist, trace-feedback persist (the compact
+    per-step feedback lines — not raw tool output), distillation, enrichment,
+    and (in foreground mode) the graph→session sync — so the explicit
+    persist+sync pair below is only kept as a fallback for older cognee
+    versions without session-aware improve.
+
+    Serialized per session by ``improve_session_lock``, matching the HTTP path in
+    ``run_session_improve``. ``store-to-session``'s background fire takes no outer
+    ``sync_lock``, so without this the local path could double-submit one session
+    and have two writers contend for the single-writer graph store.
+    """
+    if not session_id or not user:
+        return {"ok": False, "error": "missing session/user"}
+
+    import cognee
+    from _plugin_common import improve_session_lock
+
+    with improve_session_lock(session_id, "improve_session_local") as claimed:
+        if not claimed:
+            # Winner is already bridging this session; not dropped, just in flight.
+            return {"ok": False, "skipped": "concurrent"}
+        try:
+            result = await cognee.improve(
+                dataset,
+                session_ids=[session_id],
+                user=user,
+                run_in_background=False,
+            )
+            return {"ok": True, "result": result}
+        except TypeError as exc:
+            # Older cognee without session-aware improve: legacy persist + sync.
+            _config_log("improve_local_unsupported", {"error": str(exc)[:200]})
+            wrote = await persist_session_cache_to_graph(dataset, session_id, user)
+            graph_result = await sync_graph_context_to_session(dataset, session_id, user)
+            return {"ok": wrote, "legacy": True, "graph_synced": graph_result.get("synced", 0)}
+
+
+def _read_field(entry, field: str) -> str:
+    if isinstance(entry, dict):
+        return str(entry.get(field) or "")
+    return str(getattr(entry, field, "") or "")
+
+
+def _load_bridge_state() -> dict:
+    try:
+        return json.loads(_BRIDGE_STATE_FILE.read_text(encoding="utf-8"))
+    except Exception as exc:
+        _config_log(
+            "bridge_state_load_failed", {"path": str(_BRIDGE_STATE_FILE), "error": str(exc)[:200]}
+        )
+        return {}
+
+
+def _save_bridge_state(state: dict) -> None:
+    try:
+        _BRIDGE_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _BRIDGE_STATE_FILE.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+    except Exception as exc:
+        _config_log(
+            "bridge_state_save_failed", {"path": str(_BRIDGE_STATE_FILE), "error": str(exc)[:200]}
+        )
+
+
+def _bridge_state_key(dataset: str, session_id: str, user_id: str, kind: str) -> str:
+    return hashlib.sha256(f"{user_id}:{dataset}:{session_id}:{kind}".encode()).hexdigest()
+
+
+def _content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+async def persist_session_cache_to_graph(dataset: str, session_id: str, user) -> bool:
+    """Persist cached session QA/trace text to the permanent graph.
+
+    This is a local-mode compatibility bridge for Cognee 1.0.8. The SDK's
+    built-in session persistence can complete without extracting entries
+    from the file-system cache in the plugin setup. Reading the same
+    cache directly here keeps the integration useful while still using
+    cognee.remember() for the actual add+cognify pipeline.
+    """
+    if not session_id or not user:
+        return False
+
+    import cognee
+    from cognee.infrastructure.session.get_session_manager import get_session_manager
+
+    await ensure_dataset_ready(dataset, user)
+
+    user_id = str(user.id)
+    session_manager = get_session_manager()
+    if not session_manager.is_available:
+        return False
+
+    wrote = False
+    bridge_state = _load_bridge_state()
+    state_changed = False
+
+    qa_entries = await session_manager.get_session(
+        user_id=user_id,
+        session_id=session_id,
+        formatted=False,
+    )
+    qa_lines: list[str] = []
+    for entry in qa_entries or []:
+        question = _read_field(entry, "question").strip()
+        answer = _read_field(entry, "answer").strip()
+        if question:
+            qa_lines.append(f"Question: {question}")
+        if answer:
+            qa_lines.append(f"Answer: {answer}")
+        if question or answer:
+            qa_lines.append("")
+    qa_text = "\n".join(qa_lines).strip()
+    if qa_text:
+        qa_document = f"Session ID: {session_id}\n\n{qa_text}"
+        qa_key = _bridge_state_key(dataset, session_id, user_id, "qa")
+        qa_hash = _content_hash(qa_document)
+        if bridge_state.get(qa_key) == qa_hash:
+            qa_text = ""
+        else:
+            bridge_state[qa_key] = qa_hash
+            state_changed = True
+
+    if qa_text:
+        await cognee.remember(
+            qa_document,
+            dataset_name=dataset,
+            node_set=["user_sessions_from_cache"],
+            self_improvement=False,
+            run_in_background=False,
+            user=user,
+        )
+        wrote = True
+
+    trace_values = await session_manager.get_agent_trace_feedback(
+        user_id=user_id,
+        session_id=session_id,
+    )
+    trace_text = "\n".join(str(value).strip() for value in trace_values or [] if str(value).strip())
+    if trace_text:
+        trace_document = f"Session ID: {session_id}\n\n{trace_text}"
+        trace_key = _bridge_state_key(dataset, session_id, user_id, "trace")
+        trace_hash = _content_hash(trace_document)
+        if bridge_state.get(trace_key) == trace_hash:
+            trace_text = ""
+        else:
+            bridge_state[trace_key] = trace_hash
+            state_changed = True
+
+    if trace_text:
+        await cognee.remember(
+            trace_document,
+            dataset_name=dataset,
+            node_set=["agent_trace_feedbacks"],
+            self_improvement=False,
+            run_in_background=False,
+            user=user,
+        )
+        wrote = True
+
+    if state_changed:
+        _save_bridge_state(bridge_state)
+
+    return wrote
+
+
+def _get_git_branch(cwd: str) -> str:
+    """Get current git branch, or empty string if not a git repo."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        if result.returncode == 0:
+            branch = result.stdout.strip()
+            # Sanitize for use in session IDs
+            return branch.replace("/", "-").replace(" ", "-")[:40]
+    except Exception as exc:
+        _config_log("git_branch_lookup_failed", {"cwd": cwd, "error": str(exc)[:200]})
+    return ""

--- a/integrations/qwen/scripts/credits-refresh.py
+++ b/integrations/qwen/scripts/credits-refresh.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Refresh the status-line credits marker when a turn finishes (SDK-355).
+
+Registered on ``Stop``: the user should see what the finished turn cost as
+soon as the response completes — not one prompt later. Qwen does not support
+async command hooks yet (an ``async: true`` hook is skipped entirely), so this
+runs synchronously with a tight timeout; Qwen launches matching hooks
+concurrently, so the QA store on the same event does not wait on it.
+
+The spend delta since the previous reading (normally the unlabeled
+prompt-time refresh in store-user-prompt) is attributed to the turn and
+rendered as ``last turn ~$X.XX``. ``refresh_credits`` never raises and no-ops
+entirely on a local server, so this hook is safe to fire unconditionally.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from _plugin_common import hook_log, quiet_hook_output, refresh_credits
+
+
+def main():
+    sys.stdin.read()  # consume the hook payload as the host requires
+    try:
+        with quiet_hook_output("credits-refresh"):
+            marker = refresh_credits("turn")
+        if marker:
+            hook_log(
+                "credits_turn_refresh",
+                {"remaining_usd": marker.get("remaining_usd")},
+            )
+    except Exception as exc:
+        hook_log("credits_refresh_error", {"error": str(exc)[:200]})
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/qwen/scripts/doctor.py
+++ b/integrations/qwen/scripts/doctor.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Cognee Doctor — unified diagnostics for the Qwen plugin.
+
+Read-only command that aggregates configuration, connectivity, and
+circuit-breaker state into a single diagnostic report.
+
+Usage:
+    python doctor.py           # human-readable table
+    python doctor.py --json    # machine-readable JSON
+
+Never modifies configuration, initialises databases, registers
+resources, writes files, or mutates state.
+"""
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+# Ensure the scripts directory is on sys.path so sibling modules resolve.
+_SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+
+def _resolve_local_cognee_version() -> str:
+    """Cognee version installed in the plugin's managed venv.
+
+    The plugin installs cognee into ~/.cognee-plugin/venv at session start;
+    probe that interpreter directly. Returns "Not installed" when the venv is
+    absent and "Unknown" if the probe fails.
+    """
+    from _plugin_common import _VENV_PYTHON
+
+    if not _VENV_PYTHON.exists():
+        return "Not installed"
+    try:
+        probe = "import importlib.metadata as m; print(m.version('cognee'))"
+        out = subprocess.run(
+            [str(_VENV_PYTHON), "-c", probe],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            return out.stdout.strip()
+    except Exception:
+        pass
+    return "Unknown"
+
+
+def _resolve_mode() -> str:
+    """Return the resolved operating mode: Local, Local Managed, or Cloud.
+
+    - No base_url configured → Local (or Cloud when the backend switch forces
+      cloud — the mode is pinned even though there is nothing to connect to)
+    - base_url pointing to localhost / 127.0.0.1 / ::1 → Local Managed
+    - Remote base_url → Cloud
+    """
+    import urllib.parse
+
+    from config import load_config
+
+    cfg = load_config()
+    base_url = str(cfg.get("base_url") or "").strip()
+
+    if not base_url:
+        return "Cloud" if cfg.get("_forced_backend") == "cloud" else "Local"
+
+    hostname = urllib.parse.urlparse(base_url).hostname or ""
+    if hostname in ("localhost", "127.0.0.1", "::1"):
+        return "Local Managed"
+
+    return "Cloud"
+
+
+def _mode_annotation() -> str:
+    """Suffix for the mode row when the backend switch forced the decision."""
+    from _env_file import forced_backend_with_source
+    from config import load_config
+
+    forced, var = forced_backend_with_source()
+    if not forced:
+        return ""
+    note = f" — forced by {var}={forced}"
+    if forced == "cloud" and not str(load_config().get("base_url") or "").strip():
+        note += " (missing COGNEE_BASE_URL — nothing to connect to)"
+    return note
+
+
+def _resolve_server_url() -> tuple:
+    """Return (display_url, raw_url).
+
+    In local mode the display value is "-", while the raw URL remains
+    available for the health probe. Forced cloud with no URL configured has
+    nothing to probe at all.
+    """
+    from _plugin_common import _local_api_url_with_source
+    from config import load_config
+
+    mode = _resolve_mode()
+    if mode == "Cloud" and not str(load_config().get("base_url") or "").strip():
+        return "-", ""
+    raw_url, _source = _local_api_url_with_source()
+    display = "-" if mode == "Local" else raw_url
+    return display, raw_url
+
+
+_SHARED_PLUGIN_ROOT = pathlib.Path.home() / ".cognee-plugin"
+_API_KEY_CACHE = _SHARED_PLUGIN_ROOT / "api_key.json"
+
+
+def _resolve_api_key_source() -> str:
+    """Return a human-friendly label for where the API key came from.
+
+    Qwen's _plugin_common._api_key does not return the source, so we
+    inline the same precedence logic here without modifying the module.
+    """
+    env_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
+    if env_key:
+        # The env layer is fed by both real exports and ~/.cognee/.env
+        # (setdefault); tell them apart for debuggability.
+        from _env_file import env_file_path, parse_env_file
+
+        file_key = parse_env_file(env_file_path()).get("COGNEE_API_KEY", "")
+        if file_key and file_key == env_key:
+            return "Env file"
+        return "ENV"
+
+    # Check the single cached key file.
+    try:
+        if _API_KEY_CACHE.exists():
+            data = json.loads(_API_KEY_CACHE.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and (data.get("api_key") or "").strip():
+                return "Config"
+    except Exception:
+        pass
+
+    return "Default"
+
+
+def _check_health(server_url: str, timeout: float = 5.0) -> dict:
+    """Probe GET /health and return reachability + latency.
+
+    Returns a dict with keys: reachable (bool), latency_ms (float|None),
+    and raw_body (dict|None) for downstream consumers.
+    """
+    base = server_url.rstrip("/") if server_url else ""
+    if not base:
+        return {"reachable": False, "latency_ms": None, "raw_body": None}
+    from _plugin_common import _https_context
+
+    try:
+        t0 = time.monotonic()
+        with urllib.request.urlopen(
+            f"{base}/health", timeout=timeout, context=_https_context()
+        ) as resp:
+            latency = (time.monotonic() - t0) * 1000  # ms
+            body_text = resp.read().decode("utf-8", errors="replace")
+            try:
+                body = json.loads(body_text)
+            except (json.JSONDecodeError, ValueError):
+                body = None
+            if resp.status == 200:
+                return {"reachable": True, "latency_ms": round(latency, 1), "raw_body": body}
+        return {"reachable": False, "latency_ms": None, "raw_body": None}
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return {"reachable": False, "latency_ms": None, "raw_body": None}
+
+
+def _resolve_server_version(health_body: dict | None) -> str:
+    """Extract a server version from the health response, if present."""
+    if isinstance(health_body, dict):
+        version = health_body.get("version")
+        if version and str(version).strip():
+            return str(version).strip()
+    return "Unknown"
+
+
+def _resolve_circuit_breaker() -> str:
+    """Return a human description of the circuit breaker state."""
+    from _cognee_client import breaker_open
+
+    is_open, retry = breaker_open()
+    if is_open:
+        return f"Open (retry in ~{retry}s)"
+    return "Closed"
+
+
+def _resolve_embedding() -> tuple[str, str]:
+    """Embedding model + dimensions from the environment cognee reads.
+
+    cognee resolves embeddings from EMBEDDING_MODEL / EMBEDDING_DIMENSIONS; no
+    HTTP endpoint exposes them, so we surface what the local environment sets
+    (the values that govern local mode). "Default" means unset — cognee falls
+    back to its built-in default.
+    """
+    model = (os.environ.get("EMBEDDING_MODEL") or "").strip() or "Default"
+    dims = (os.environ.get("EMBEDDING_DIMENSIONS") or "").strip() or "Default"
+    return model, dims
+
+
+def _resolve_env_file() -> str:
+    """One-time config file (~/.cognee/.env): presence, key names, overrides.
+
+    Values are never shown — only which keys the file defines, and which of
+    them are shadowed by a real shell export (exports win over the file).
+    """
+    from _env_file import env_file_status
+
+    status = env_file_status()
+    path = status.get("path", "")
+    if not status.get("exists"):
+        return f"Not found ({path})"
+    keys = status.get("keys") or []
+    desc = f"{path} ({len(keys)} key{'s' if len(keys) != 1 else ''}: {', '.join(keys)})"
+    overridden = status.get("overridden") or []
+    if overridden:
+        desc += f" — overridden by shell env: {', '.join(overridden)}"
+    return desc
+
+
+def collect_report() -> dict:
+    """Gather all diagnostic fields into an ordered dict."""
+    mode = _resolve_mode()
+    display_url, raw_url = _resolve_server_url()
+    api_key_source = _resolve_api_key_source()
+    health = _check_health(raw_url)
+    cognee_server = _resolve_server_version(health["raw_body"])
+    cognee_local = _resolve_local_cognee_version()
+    circuit_breaker = _resolve_circuit_breaker()
+    embedding_model, embedding_dimensions = _resolve_embedding()
+
+    return {
+        "mode": mode + _mode_annotation(),
+        "env_file": _resolve_env_file(),
+        "server_url": display_url if display_url != "-" else None,
+        "api_key_source": api_key_source,
+        "reachable": health["reachable"],
+        "latency_ms": health["latency_ms"],
+        "cognee_local": cognee_local,
+        "cognee_server": cognee_server,
+        "embedding_model": embedding_model,
+        "embedding_dimensions": embedding_dimensions,
+        "circuit_breaker": circuit_breaker,
+    }
+
+
+_DISPLAY_ORDER = [
+    ("Mode", "mode"),
+    ("Env File", "env_file"),
+    ("Server URL", "server_url"),
+    ("API Key Source", "api_key_source"),
+    ("Reachable", "reachable"),
+    ("Latency", "latency_ms"),
+    ("Cognee (local)", "cognee_local"),
+    ("Cognee (server)", "cognee_server"),
+    ("Embedding Model", "embedding_model"),
+    ("Embedding Dims", "embedding_dimensions"),
+    ("Circuit Breaker", "circuit_breaker"),
+]
+
+
+def _format_value(key: str, value) -> str:
+    """Format a single report value for human display."""
+    if key == "server_url":
+        return str(value) if value else "-"
+    if key == "reachable":
+        return "Yes" if value else "No"
+    if key == "latency_ms":
+        if value is None:
+            return "N/A"
+        return f"{value} ms"
+    if value is None:
+        return "N/A"
+    return str(value)
+
+
+def format_human(report: dict) -> str:
+    """Render the report as a human-readable table."""
+    lines = ["", "Cognee Doctor", ""]
+    for label, key in _DISPLAY_ORDER:
+        value = _format_value(key, report.get(key))
+        lines.append(f"{label + ':':<21}{value}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_json(report: dict) -> str:
+    """Render the report as pretty-printed JSON."""
+    return json.dumps(report, indent=2)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = argv if argv is not None else sys.argv[1:]
+    use_json = "--json" in args
+
+    report = collect_report()
+
+    if use_json:
+        print(format_json(report))
+    else:
+        print(format_human(report))
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/qwen/scripts/exit-watcher.py
+++ b/integrations/qwen/scripts/exit-watcher.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Run Cognee graph sync after the owning Qwen process exits.
+
+Qwen CLI currently may not invoke plugin SessionEnd on normal shutdown.
+SessionStart launches this watcher with the hook parent PID. The watcher
+does nothing while Qwen is alive; once that PID disappears, it starts the
+normal detached graph sync worker and exits.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+from _proc import pid_alive as _pid_alive
+
+_PLUGIN_DIR = Path.home() / ".cognee-plugin" / "qwen"
+_EXIT_WATCHERS_DIR = _PLUGIN_DIR / "exit-watchers"
+_PIDFILE = _PLUGIN_DIR / "exit-watcher.pid"
+_LOGFILE = _PLUGIN_DIR / "exit-watcher.log"
+_SYNC_SCRIPT = Path(__file__).with_name("sync-session-to-graph.py")
+_DETACHED_SYNC_ARG = "--detached-final"
+_POLL_SECONDS = 2.0
+_SYNC_START_DELAY = 2.0
+
+
+def _log(event: str, **detail) -> None:
+    try:
+        _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        line = {"ts": time.time(), "pid": os.getpid(), "event": event}
+        if detail:
+            line["detail"] = detail
+        with _LOGFILE.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(line, default=str) + "\n")
+    except Exception:
+        pass
+
+
+def _owns_pidfile(pidfile: Path) -> bool:
+    try:
+        return int(pidfile.read_text(encoding="utf-8").strip()) == os.getpid()
+    except Exception as exc:
+        _log("pidfile_read_failed", pidfile=str(pidfile), error=str(exc)[:200])
+        return False
+
+
+def _spawn_sync(
+    session_id: str,
+    dataset: str,
+    *,
+    session_key: str = "",
+    agent_session_name: str = "",
+    api_key: str = "",
+    service_url: str = "",
+) -> None:
+    try:
+        env = os.environ.copy()
+        env.setdefault("COGNEE_SYNC_START_DELAY", str(_SYNC_START_DELAY))
+        env["COGNEE_UNREGISTER_ON_FINISH"] = "1"
+        if session_id:
+            env["COGNEE_SYNC_SESSION_ID"] = session_id
+        if dataset:
+            env["COGNEE_SYNC_DATASET"] = dataset
+        if session_key:
+            env["COGNEE_SESSION_KEY"] = session_key
+        if agent_session_name:
+            env["COGNEE_AGENT_SESSION_NAME"] = agent_session_name
+        if api_key:
+            env["COGNEE_API_KEY"] = api_key
+        if service_url:
+            env["COGNEE_BASE_URL"] = service_url
+        subprocess.Popen(
+            [sys.executable, str(_SYNC_SCRIPT), _DETACHED_SYNC_ARG],
+            cwd=os.getcwd(),
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        _log("exit_sync_deferred", session=session_id, dataset=dataset)
+    except Exception as exc:
+        _log("exit_sync_detach_failed", error=str(exc)[:300])
+
+
+def _refresh_credits_marker(service_url: str) -> None:
+    """Keep the status-line credits marker fresh for the WHOLE session.
+
+    This is the only plugin process whose lifetime matches the host session —
+    the idle watcher exits at ``bridge_complete``, minutes after the last
+    activity, so a credits poll there dies with it and the segment ages out
+    of its 15-minute TTL during any longer idle stretch. Cloud only,
+    throttled against our tenant's own entry, best-effort by contract.
+    """
+    try:
+        from _plugin_common import (
+            _credits_entry_for_url,
+            _local_api_url,
+            read_credits_marker,
+            refresh_credits,
+            service_url_is_local,
+        )
+
+        base_url = str(service_url or "") or _local_api_url()
+        if service_url_is_local(base_url):
+            return  # local server: no credits concept
+        interval = float(os.environ.get("COGNEE_CREDITS_CHECK_INTERVAL", "") or 300.0)
+        _tid, prior = _credits_entry_for_url(read_credits_marker(), base_url)
+        if time.time() - float(prior.get("checked_at", 0) or 0) < interval:
+            return
+        refresh_credits()
+    except Exception as exc:
+        _log("credits_check_error", error=str(exc)[:200])
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        _log("fatal_missing_args")
+        return
+    try:
+        bootstrap = json.loads(sys.argv[1])
+    except Exception as exc:
+        _log("fatal_bad_args", error=str(exc)[:200])
+        return
+
+    parent_pid = int(bootstrap.get("parent_pid") or 0)
+    session_id = str(bootstrap.get("session_id") or "")
+    dataset = str(bootstrap.get("dataset") or "agent_sessions")
+    session_key = str(bootstrap.get("session_key") or "")
+    agent_session_name = str(bootstrap.get("agent_session_name") or "")
+    api_key = str(bootstrap.get("api_key") or "")
+    service_url = str(bootstrap.get("base_url") or "")
+    pidfile_raw = str(bootstrap.get("pidfile") or "").strip()
+    pidfile = Path(pidfile_raw) if pidfile_raw else _PIDFILE
+    if not parent_pid:
+        _log("fatal_no_parent_pid", session=session_id, dataset=dataset)
+        return
+
+    try:
+        _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        _EXIT_WATCHERS_DIR.mkdir(parents=True, exist_ok=True)
+
+        if pidfile.exists():
+            try:
+                existing = int(pidfile.read_text(encoding="utf-8").strip())
+                if _pid_alive(existing):
+                    _log(
+                        "already_running_for_parent",
+                        parent_pid=parent_pid,
+                        session=session_id,
+                        dataset=dataset,
+                        pidfile=str(pidfile),
+                        existing_pid=existing,
+                    )
+                    return
+            except Exception:
+                pass
+
+        pidfile.write_text(str(os.getpid()), encoding="utf-8")
+    except Exception as exc:
+        _log("pidfile_write_failed", pidfile=str(pidfile), error=str(exc)[:200])
+        return
+
+    _log(
+        "started",
+        parent_pid=parent_pid,
+        session=session_id,
+        dataset=dataset,
+        pidfile=str(pidfile),
+    )
+    while _owns_pidfile(pidfile) and _pid_alive(parent_pid):
+        # Session-long steady-state credits refresh (throttled internally).
+        _refresh_credits_marker(service_url)
+        time.sleep(_POLL_SECONDS)
+
+    if not _owns_pidfile(pidfile):
+        _log("pidfile_replaced", parent_pid=parent_pid, pidfile=str(pidfile))
+        return
+
+    _log("parent_exited", parent_pid=parent_pid, session=session_id, dataset=dataset)
+    _spawn_sync(
+        session_id,
+        dataset,
+        session_key=session_key,
+        agent_session_name=agent_session_name,
+        api_key=api_key,
+        service_url=service_url,
+    )
+
+    try:
+        if _owns_pidfile(pidfile):
+            pidfile.unlink()
+    except Exception as exc:
+        _log("pidfile_unlink_failed", pidfile=str(pidfile), error=str(exc)[:200])
+    _log("exiting", parent_pid=parent_pid, pidfile=str(pidfile))
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/qwen/scripts/idle-watcher.py
+++ b/integrations/qwen/scripts/idle-watcher.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Idle watcher daemon - persists quiet Qwen sessions into Cognee.
+
+Launched detached from ``session-start.py``. Polls
+``~/.cognee-plugin/qwen/activity.ts`` every ``POLL_SECONDS``. When the last
+activity is older than ``IDLE_SECONDS`` and we haven't bridged since
+that point, persists the session cache and refreshes graph context.
+
+Stops cleanly on:
+  * ``~/.cognee-plugin/qwen/watcher.stop`` sentinel file.
+  * Receiving SIGTERM (from SessionEnd hook or manual kill).
+  * The pidfile being overwritten by a newer watcher (restart case).
+
+Survives Qwen crashes better than foreground hooks.
+"""
+
+import asyncio
+import json
+import os
+import signal
+import sys
+import time
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Optional
+
+# Tunable via env. Defaults chosen to avoid thrashing the LLM: 60s idle
+# threshold means you have to actively pause a full minute, and the 10-minute
+# improve cooldown prevents back-to-back improve runs when activity is sporadic.
+POLL_SECONDS = float(os.environ.get("COGNEE_IDLE_POLL", "10"))
+IDLE_SECONDS = float(os.environ.get("COGNEE_IDLE_THRESHOLD", "60"))
+IMPROVE_COOLDOWN = float(os.environ.get("COGNEE_IMPROVE_COOLDOWN", "600"))
+
+_PLUGIN_DIR = Path.home() / ".cognee-plugin" / "qwen"
+_ACTIVITY = _PLUGIN_DIR / "activity.ts"
+_PIDFILE = _PLUGIN_DIR / "watcher.pid"
+_STOPFILE = _PLUGIN_DIR / "watcher.stop"
+_LOGFILE = _PLUGIN_DIR / "watcher.log"
+
+# Script-local stop flag flipped by SIGTERM handler.
+_should_stop = False
+
+
+def _log(event: str, **detail) -> None:
+    try:
+        _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        line = {"ts": time.time(), "pid": os.getpid(), "event": event}
+        if detail:
+            line["detail"] = detail
+        with _LOGFILE.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(line, default=str) + "\n")
+    except Exception:
+        pass
+
+
+def _read_activity_ts() -> Optional[float]:
+    if not _ACTIVITY.exists():
+        return None
+    try:
+        return float(_ACTIVITY.read_text(encoding="utf-8").strip())
+    except Exception as exc:
+        _log("activity_read_failed", error=str(exc)[:200])
+        return None
+
+
+def _owns_pidfile() -> bool:
+    """Return True if the pidfile still points at us."""
+    try:
+        return int(_PIDFILE.read_text(encoding="utf-8").strip()) == os.getpid()
+    except Exception as exc:
+        _log("pidfile_read_failed", error=str(exc)[:200])
+        return False
+
+
+def _install_signal_handlers() -> None:
+    def _handler(signum, _frame):
+        global _should_stop
+        _should_stop = True
+        _log("signal_received", signum=signum)
+
+    signal.signal(signal.SIGTERM, _handler)
+    signal.signal(signal.SIGINT, _handler)
+
+
+async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
+    """Fire one session improve cycle. Returns True on success."""
+    sys.path.insert(0, os.path.dirname(__file__))
+    try:
+        from _plugin_common import (  # type: ignore
+            http_api_ready,
+            load_resolved,
+            resolve_user,
+            run_session_improve,
+            set_session_key,
+            sync_lock,
+        )
+
+        session_key = str(config.get("session_key") or "").strip()
+        if session_key:
+            set_session_key(session_key)
+        api_mode = http_api_ready()
+        # Server-side improve has its own per-session lock; only local SDK
+        # mode needs the cross-hook file lock.
+        lock = nullcontext(True) if api_mode else sync_lock("idle-watcher")
+    except Exception as exc:
+        _log("sync_lock_import_error", error=str(exc)[:200])
+        api_mode = False
+        lock = nullcontext(True)
+
+    with lock as acquired:
+        if not acquired:
+            _log("bridge_skipped_lock_busy", session=session_id, dataset=dataset)
+            return False
+
+        try:
+            from config import (  # type: ignore
+                ensure_cognee_ready,
+                ensure_dataset_ready,
+                ensure_identity,
+                improve_session_local,
+            )
+
+            if api_mode:
+                wrote = run_session_improve(dataset, session_id)
+                _log(
+                    "session_bridge_done",
+                    session=session_id,
+                    dataset=dataset,
+                    via="http_improve",
+                    wrote=wrote,
+                )
+                return True
+
+            await ensure_cognee_ready(config)
+            user_id = str(config.get("user_id") or load_resolved().get("user_id") or "")
+            if not user_id:
+                user_id, _ = await ensure_identity(config)
+
+            user = await resolve_user(user_id) if user_id else None
+            if user:
+                await ensure_dataset_ready(dataset, user)
+                result = await improve_session_local(dataset, session_id, user)
+                _log(
+                    "session_bridge_done",
+                    session=session_id,
+                    dataset=dataset,
+                    user_id=str(user.id),
+                    via="local_improve",
+                    ok=bool(result.get("ok")),
+                )
+            return True
+        except Exception as exc:
+            _log("bridge_error", error=str(exc)[:300])
+            return False
+
+
+def _run_update_check() -> None:
+    """Fire the background, interval-guarded plugin update check (best-effort)."""
+    try:
+        sys.path.insert(0, os.path.dirname(__file__))
+        from _plugin_common import maybe_check_for_update  # type: ignore
+
+        maybe_check_for_update()
+    except Exception as exc:
+        _log("update_check_error", error=str(exc)[:200])
+
+
+def _check_llm_key(config: dict) -> None:
+    """Provider-agnostic LLM-key validation for the status line (local mode).
+
+    Runs in this BACKGROUND watcher — never a hot-path hook — because it imports
+    cognee/litellm (heavy) and makes one tiny real LLM call. That real call is the
+    only way to validate a key that works across ALL providers: litellm normalizes
+    every provider's rejection into ``AuthenticationError``, so we don't hardcode
+    any provider's endpoint/auth. (recall can't be used — the plugin passes
+    only_context=True, which skips the LLM entirely.)
+
+    ``max_tokens=1`` is a floor on cost, not a guarantee: providers differ on whether
+    it caps reasoning tokens or only content, so a reasoning model may bill more than
+    one token (or reject the request outright — see the classifier below). That is
+    acceptable here because the call is infrequent, off the hot path, bounded by a
+    15s timeout, and its response is discarded unread.
+
+    Writes the shared llm-state marker: ``ok`` / ``auth_failed`` / ``not_set``.
+    Local mode only (LLM_API_KEY is unused against a remote server). Throttled via
+    the marker's ``checked_at``. Honors COGNEE_LLM_KEY_CHECK=off.
+    """
+    try:
+        if os.environ.get("COGNEE_LLM_KEY_CHECK", "").strip().lower() in (
+            "0",
+            "false",
+            "no",
+            "off",
+        ):
+            return
+        sys.path.insert(0, os.path.dirname(__file__))
+        from _plugin_common import (
+            get_session_key,
+            read_llm_state,
+            service_url_is_local,
+            write_llm_state,
+        )
+
+        base_url = str(config.get("base_url") or "")
+        if base_url and not service_url_is_local(base_url):
+            return  # cloud: the remote server owns its own LLM key
+
+        # Throttle against OUR OWN last verdict only. The marker is machine-wide, so
+        # honouring another session's timestamp would let a keyless launch's verdict
+        # stand in for ours and leave this session permanently unvalidated.
+        interval = float(os.environ.get("COGNEE_LLM_CHECK_INTERVAL", "") or 300.0)
+        prior = read_llm_state()
+        if str(prior.get("session_key") or "") == get_session_key() and (
+            time.time() - float(prior.get("checked_at", 0) or 0) < interval
+        ):
+            return
+
+        from cognee.infrastructure.llm.config import get_llm_config
+
+        cfg = get_llm_config()
+        key = str(getattr(cfg, "llm_api_key", "") or "").strip()
+        if not key:
+            # Logged, not silent: this write is what puts ✕ (incorrect_llm_api_key) on the bar,
+            # and tracking down an unexplained one cost real time.
+            write_llm_state("not_set")
+            _log("llm_key_not_set")
+            return
+
+        import litellm
+
+        try:
+            litellm.completion(
+                model=cfg.llm_model,
+                messages=[{"role": "user", "content": "ping"}],
+                max_tokens=1,
+                api_key=cfg.llm_api_key,
+                api_base=getattr(cfg, "llm_endpoint", None) or None,
+                custom_llm_provider=(getattr(cfg, "llm_provider", None) or None),
+                timeout=15,
+            )
+            write_llm_state("ok")
+            _log("llm_key_ok")
+        except Exception as exc:
+            # Classify by the provider's HTTP status, NOT by "did a completion
+            # succeed": `max_tokens=1` legitimately 400s on reasoning models (the
+            # single token goes to reasoning, leaving no room for content), so
+            # demanding a clean 200 leaves a good key permanently unverified and an
+            # earlier "not_set" unclearable. Providers authenticate BEFORE they
+            # validate anything else, so any status other than 401/403 already
+            # proves the key was accepted.
+            status = getattr(exc, "status_code", None)
+            try:
+                status = int(status) if status is not None else None
+            except (TypeError, ValueError):
+                status = None
+            if exc.__class__.__name__ == "AuthenticationError" or status in (401, 403):
+                write_llm_state("auth_failed", detail=str(exc)[:200])
+                _log("llm_key_auth_failed")
+            elif status is not None:
+                # Reached the provider and got a non-auth rejection (400 output
+                # limit, 404 unknown model, 429, 5xx): the key itself works.
+                write_llm_state("ok")
+                _log("llm_key_ok", status=status)
+            else:
+                # No HTTP status → local/transport failure (timeout, DNS, bad
+                # api_base): not a key verdict either way, so leave the marker
+                # untouched rather than falsely accuse or falsely clear.
+                _log("llm_key_check_inconclusive", error=str(exc)[:200])
+    except Exception as exc:
+        _log("llm_key_check_error", error=str(exc)[:200])
+
+
+async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
+    _log(
+        "started",
+        session=session_id,
+        dataset=dataset,
+        user_id=config.get("user_id", ""),
+        poll=POLL_SECONDS,
+        idle=IDLE_SECONDS,
+    )
+    # Runs once per watcher launch (≈ once per session); the check itself is
+    # internally rate-limited to ≤ once per COGNEE_UPDATE_CHECK_INTERVAL.
+    _run_update_check()
+    # Validate the LLM key once at session start (background, provider-agnostic).
+    _check_llm_key(config)
+    last_improved_at = 0.0
+    exit_reason = "loop_complete"
+    bridge_disabled = False
+
+    while not _should_stop:
+        if _STOPFILE.exists():
+            _log("stop_sentinel_seen")
+            exit_reason = "stop_sentinel"
+            break
+        if not _owns_pidfile():
+            _log("pidfile_replaced")
+            exit_reason = "pidfile_replaced"
+            break
+
+        now = time.time()
+        ts = _read_activity_ts()
+        if ts is None:
+            await asyncio.sleep(POLL_SECONDS)
+            continue
+
+        idle_for = now - ts
+        time_since_improve = now - last_improved_at
+        if (
+            not bridge_disabled
+            and idle_for >= IDLE_SECONDS
+            and time_since_improve >= IMPROVE_COOLDOWN
+        ):
+            _log("idle_trigger", idle_for=round(idle_for, 1))
+            ok = await _improve_once(session_id, dataset, config)
+            if ok:
+                last_improved_at = time.time()
+                _log("bridge_done")
+                exit_reason = "bridge_complete"
+                break
+            bridge_disabled = True
+            _log("bridge_disabled_after_failure")
+
+        await asyncio.sleep(POLL_SECONDS)
+
+    if _should_stop:
+        exit_reason = "signal"
+
+    ts = _read_activity_ts()
+    if (
+        not bridge_disabled
+        and exit_reason in {"signal", "stop_sentinel"}
+        and ts
+        and ts > last_improved_at
+    ):
+        _log("shutdown_trigger", reason=exit_reason, activity_age=round(time.time() - ts, 1))
+        ok = await _improve_once(session_id, dataset, config)
+        if ok:
+            last_improved_at = time.time()
+            _log("shutdown_bridge_done")
+        else:
+            _log("shutdown_bridge_failed")
+
+    _log("exiting", reason=exit_reason)
+    try:
+        if _owns_pidfile():
+            _PIDFILE.unlink()
+    except Exception as exc:
+        _log("pidfile_unlink_failed", error=str(exc)[:200])
+
+
+def main():
+    _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Config passed as a single JSON arg to avoid shell-quoting hazards.
+    if len(sys.argv) < 2:
+        _log("fatal_missing_args")
+        sys.exit(1)
+    try:
+        bootstrap = json.loads(sys.argv[1])
+    except Exception as exc:
+        _log("fatal_bad_args", error=str(exc)[:200])
+        sys.exit(1)
+
+    session_id = bootstrap.get("session_id", "")
+    dataset = bootstrap.get("dataset", "agent_sessions")
+    user_id = bootstrap.get("user_id", "")
+    session_key = str(bootstrap.get("session_key", "") or "").strip()
+    try:
+        from config import load_config  # type: ignore
+
+        config = load_config()
+        config.update({k: v for k, v in bootstrap.get("config", {}).items() if v})
+    except Exception as exc:
+        _log("config_load_failed", error=str(exc)[:200])
+        config = bootstrap.get("config", {})
+    if not session_id:
+        _log("fatal_no_session_id")
+        sys.exit(1)
+    if user_id:
+        config["user_id"] = user_id
+        os.environ["COGNEE_USER_ID"] = user_id
+    if session_key:
+        config["session_key"] = session_key
+        os.environ["COGNEE_SESSION_KEY"] = session_key
+
+    try:
+        _PIDFILE.write_text(str(os.getpid()), encoding="utf-8")
+    except Exception as exc:
+        _log("pidfile_write_failed", error=str(exc)[:200])
+        sys.exit(1)
+
+    # Make sure a stale stop sentinel from a prior run doesn't kill us
+    # the moment we start.
+    try:
+        if _STOPFILE.exists():
+            _STOPFILE.unlink()
+    except Exception as exc:
+        _log("stopfile_unlink_failed", error=str(exc)[:200])
+
+    _install_signal_handlers()
+
+    try:
+        asyncio.run(_main_loop(session_id, dataset, config))
+    except Exception as exc:
+        _log("fatal_loop_error", error=str(exc)[:300])
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/qwen/scripts/pre-compact.py
+++ b/integrations/qwen/scripts/pre-compact.py
@@ -294,7 +294,16 @@ def main():
     except Exception as exc:
         hook_log("precompact_run_exception", {"error": str(exc)[:200]})
     if anchor:
-        print(anchor)
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreCompact",
+                        "additionalContext": anchor,
+                    }
+                }
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/integrations/qwen/scripts/pre-compact.py
+++ b/integrations/qwen/scripts/pre-compact.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Build a memory anchor before context-window compaction.
+
+Runs on the PreCompact hook. Pulls a compact summary from already-stored
+session-cache layers — recent QAs and per-step trace feedback — and emits a
+markdown block the compactor preserves.
+
+PreCompact intentionally does not run live graph search: there is no real user
+query at compact time, and deriving one from recalled/compacted context can feed
+synthetic text back into Cognee as if it were a user question.
+"""
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Add scripts dir to path for helper imports
+sys.path.insert(0, os.path.dirname(__file__))
+from _plugin_common import (
+    get_session_key,
+    hook_log,
+    load_resolved,
+    quiet_hook_output,
+    recall_via_http,
+    resolve_session_key_from_payload,
+    resolve_user,
+    set_session_key,
+)
+from config import (
+    ensure_cognee_ready,
+    ensure_dataset_ready,
+    get_dataset,
+    get_session_id,
+    is_cloud_mode,
+    load_config,
+)
+
+_SESSION_TOP_K = 5
+_TRACE_TOP_K = 8
+_SYNC_SCRIPT = Path(__file__).with_name("sync-session-to-graph.py")
+_DETACHED_SYNC_ARG = "--detached-final"
+_SYNC_START_DELAY_SECONDS = "2"
+
+
+def _load_resolved_fields() -> tuple[str, str, str]:
+    """Return (session_id, dataset, user_id) from runtime endpoint state or config."""
+    if not get_session_key():
+        hook_log("precompact_missing_session_key")
+        return "", "", ""
+    resolved = load_resolved()
+    session_id = resolved.get("session_id", "")
+    dataset = resolved.get("dataset", "")
+    user_id = resolved.get("user_id", "")
+    if not session_id or not dataset:
+        config = load_config()
+        session_id = session_id or get_session_id(config)
+        dataset = dataset or get_dataset(config)
+    return session_id, dataset, user_id
+
+
+def _as_dict(entry):
+    if hasattr(entry, "model_dump"):
+        try:
+            return entry.model_dump()
+        except Exception as exc:
+            hook_log("precompact_model_dump_failed", {"error": str(exc)[:200]})
+    if hasattr(entry, "dict"):
+        try:
+            return entry.dict()
+        except Exception as exc:
+            hook_log("precompact_dict_dump_failed", {"error": str(exc)[:200]})
+    if hasattr(entry, "__dict__"):
+        return dict(entry.__dict__)
+    return entry
+
+
+def _spawn_background_sync(session_id: str, dataset: str, user_id: str) -> None:
+    """Kick off session-to-graph sync without blocking the PreCompact hook."""
+    try:
+        env = os.environ.copy()
+        env.setdefault("COGNEE_SYNC_START_DELAY", _SYNC_START_DELAY_SECONDS)
+        subprocess.Popen(
+            [sys.executable, str(_SYNC_SCRIPT), _DETACHED_SYNC_ARG],
+            cwd=os.getcwd(),
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        hook_log(
+            "precompact_sync_deferred",
+            {"session": session_id, "dataset": dataset, "user_id": user_id},
+        )
+    except Exception as exc:
+        hook_log(
+            "precompact_sync_defer_failed",
+            {"session": session_id, "dataset": dataset, "error": str(exc)[:300]},
+        )
+
+
+async def _recall(
+    session_id: str,
+    dataset: str,
+    query: str,
+    scope: list[str],
+    top_k: int,
+    config: dict,
+    user=None,
+) -> list:
+    """Thin wrapper around cognee.recall; tolerates empty/failed recalls."""
+    try:
+        if is_cloud_mode(config):
+            qtype = "GRAPH_COMPLETION" if "graph" in scope else None
+            results = recall_via_http(
+                query,
+                session_id=session_id,
+                top_k=top_k,
+                scope=scope,
+                only_context=True,
+                search_type=qtype,
+                dataset=get_dataset(config),
+            )
+        else:
+            import cognee
+            from cognee.modules.search.types import SearchType
+
+            query_type = SearchType.GRAPH_COMPLETION if "graph" in scope else None
+            results = await cognee.recall(
+                query,
+                session_id=session_id,
+                datasets=[dataset] if "graph" in scope else None,
+                top_k=top_k,
+                scope=scope,
+                query_type=query_type,
+                user=user,
+            )
+        return list(results) if results else []
+    except Exception as exc:
+        hook_log("precompact_recall_error", {"scope": scope, "error": str(exc)[:200]})
+        return []
+
+
+def _format_session_section(entries: list) -> str:
+    lines = ["### Session Memory (recent turns)"]
+    for entry in entries:
+        entry = _as_dict(entry)
+        if not isinstance(entry, dict):
+            continue
+        q = str(entry.get("question") or "").strip()
+        a = str(entry.get("answer") or "").strip()
+        if not (q or a):
+            continue
+        short = (q or a)[:300]
+        if len(q or a) > 300:
+            short += "..."
+        prefix = "Q: " if q else "A: "
+        lines.append(f"- {prefix}{short}")
+    return "\n".join(lines) if len(lines) > 1 else ""
+
+
+def _format_trace_section(entries: list) -> str:
+    lines = ["### Agent Trace (tool calls & feedback)"]
+    for entry in entries:
+        entry = _as_dict(entry)
+        if not isinstance(entry, dict):
+            continue
+        origin = entry.get("origin_function", "?")
+        status = entry.get("status", "")
+        feedback = str(entry.get("session_feedback") or "").strip()
+        if feedback:
+            lines.append(f"- {origin} [{status}]: {feedback[:200]}")
+        else:
+            lines.append(f"- {origin} [{status}]")
+    return "\n".join(lines) if len(lines) > 1 else ""
+
+
+async def _run():
+    session_id, dataset, user_id = _load_resolved_fields()
+    if not session_id:
+        hook_log("no_session_id", {"event": "precompact"})
+        return ""
+    hook_log("precompact_start", {"session": session_id, "dataset": dataset, "user_id": user_id})
+
+    config = load_config()
+    await ensure_cognee_ready(config)
+    user = None
+    if not is_cloud_mode(config):
+        user = await resolve_user(user_id)
+        await ensure_dataset_ready(dataset, user)
+
+    # Short queries: use the session's recent activity as the seed
+    # since we don't have a specific user question at compact time.
+    # First pull session+trace so we can derive a query from them.
+    seed_results = await _recall(
+        session_id,
+        dataset,
+        query="",
+        scope=["session", "trace"],
+        top_k=_TRACE_TOP_K,
+        config=config,
+        user=user,
+    )
+    normalized_seed = [_as_dict(r) for r in seed_results]
+    session_entries = [
+        r
+        for r in normalized_seed
+        if isinstance(r, dict) and (r.get("source") or r.get("_source")) == "session"
+    ]
+    trace_entries = [
+        r
+        for r in normalized_seed
+        if isinstance(r, dict) and (r.get("source") or r.get("_source")) == "trace"
+    ]
+
+    # Fall back: if recall returned nothing (keyword-miss on empty query),
+    # pull entries directly. This keeps the anchor useful mid-session
+    # before any user prompts have landed in the cache.
+    if not session_entries and not trace_entries:
+        try:
+            from cognee.infrastructure.session.get_session_manager import get_session_manager
+
+            resolved = load_resolved()
+            user_id = resolved.get("user_id", "")
+            if user_id:
+                sm = get_session_manager()
+                if sm.is_available:
+                    raw_qa = await sm.get_session(
+                        user_id=user_id, session_id=session_id, formatted=False
+                    )
+                    session_entries = list(raw_qa)[-_SESSION_TOP_K:] if raw_qa else []
+                    raw_trace = await sm.get_agent_trace_session(
+                        user_id=user_id, session_id=session_id
+                    )
+                    trace_entries = list(raw_trace)[-_TRACE_TOP_K:] if raw_trace else []
+        except Exception as exc:
+            hook_log("precompact_direct_fetch_error", {"error": str(exc)[:200]})
+
+    session_entries = session_entries[-_SESSION_TOP_K:]
+    trace_entries = trace_entries[-_TRACE_TOP_K:]
+
+    sections = []
+    if session_entries:
+        s = _format_session_section(session_entries)
+        if s:
+            sections.append(s)
+    if trace_entries:
+        s = _format_trace_section(trace_entries)
+        if s:
+            sections.append(s)
+
+    if not sections:
+        hook_log("precompact_empty")
+        _spawn_background_sync(session_id, dataset, user_id)
+        return ""
+
+    header = (
+        "## Cognee Memory Anchor\n"
+        "Preserved context from session, agent trace, and knowledge graph:\n"
+    )
+    anchor = header + "\n\n".join(sections)
+
+    hook_log(
+        "precompact_anchor",
+        {
+            "session_entries": len(session_entries),
+            "trace_entries": len(trace_entries),
+        },
+    )
+    _spawn_background_sync(session_id, dataset, user_id)
+    return anchor
+
+
+def main():
+    # Read the PreCompact payload to recover the host session id, which lets the
+    # session resolver map back to this launch's Cognee session id (the body is
+    # otherwise unused — PreCompact is just a trigger).
+    payload_raw = sys.stdin.read()
+    try:
+        payload = json.loads(payload_raw) if payload_raw.strip() else {}
+    except json.JSONDecodeError:
+        payload = {}
+    session_key_candidate, _ = resolve_session_key_from_payload(payload)
+    if session_key_candidate:
+        set_session_key(session_key_candidate)
+
+    anchor = ""
+    try:
+        with quiet_hook_output("pre-compact"):
+            anchor = asyncio.run(_run())
+    except Exception as exc:
+        hook_log("precompact_run_exception", {"error": str(exc)[:200]})
+    if anchor:
+        print(anchor)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/qwen/scripts/session-context-lookup.py
+++ b/integrations/qwen/scripts/session-context-lookup.py
@@ -649,8 +649,11 @@ def main():
         hook_log("context_lookup_missing_session_key")
         return
 
-    prompt = payload.get("prompt", "")
-    if not prompt or len(prompt) < 5:
+    # Qwen fires this event for internal ToolResult/Hook sends as well. The
+    # pre-expansion provenance field exists only for an actual interactive
+    # user submission, and keeps recalled context out of tool continuations.
+    prompt = payload.get("submitted_prompt")
+    if not isinstance(prompt, str) or len(prompt.strip()) < 5:
         return
 
     output = None

--- a/integrations/qwen/scripts/session-context-lookup.py
+++ b/integrations/qwen/scripts/session-context-lookup.py
@@ -1,0 +1,676 @@
+#!/usr/bin/env python3
+"""Search session + trace + agent guidance + graph for context relevant to the user's prompt.
+
+Runs on the Qwen UserPromptSubmit hook. Calls ``cognee.recall`` once per
+scope (``session``, ``trace``, ``session_context``, ``graph``) so every
+layer the SessionManager holds (QA entries, agent trace steps, standing
+agent guidance, and the graph knowledge built by ``improve()``) flows back
+into Qwen's context.
+
+Configuration:
+    Resolves session state via Cognee HTTP endpoints.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import time
+
+# Add scripts dir to path for helper imports
+sys.path.insert(0, os.path.dirname(__file__))
+from _plugin_common import (
+    authed_liveness,
+    bounded_dim_mismatch_hint,
+    clear_slow_streak,
+    get_session_key,
+    hook_log,
+    load_resolved,
+    mark_server_ready,
+    notify,
+    probe_health,
+    quiet_hook_output,
+    read_and_reset_save_counter,
+    read_connection_state,
+    recall_via_http,
+    record_slow_probe,
+    resolve_runtime_mode,
+    resolve_session_key_from_payload,
+    resolve_user,
+    same_connection_target,
+    server_ready_hint,
+    service_url_is_local,
+    set_session_key,
+    slow_streak_threshold,
+    write_connection_state,
+)
+from _recall_http import DOWN, SLOW, classify_transport_exception
+from cognee_statusline_render import render_status_for_host
+from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, "") or default)
+    except (TypeError, ValueError):
+        return default
+
+
+TOP_K = 5
+TRUNCATE_ANSWER = 500
+TRUNCATE_RETURN = 400
+TRUNCATE_GRAPH_CTX = 1500
+RECENT_TRACE_FALLBACK_TOP_K = 5
+# Smallest per-scope timeout worth dispatching; with less budget than this
+# left, remaining scopes are skipped rather than fired with a doomed deadline.
+MIN_SCOPE_TIMEOUT = 0.2
+
+
+def _load_session_id() -> str:
+    resolved = load_resolved()
+    session_id = resolved.get("session_id", "")
+    if not session_id:
+        config = load_config()
+        session_id = get_session_id(config)
+    return session_id
+
+
+def _load_user_id() -> str:
+    return load_resolved().get("user_id", "")
+
+
+def _format_entry(entry: dict) -> str:
+    """Format a single recall result according to its _source tag."""
+    source = entry.get("source", "")
+
+    if source == "graph_context":
+        # graph_context entries carry `content`; graph_completion results
+        # (folded in from scope=graph) carry `text`. Try both.
+        content = str(entry.get("content", "") or entry.get("text", ""))[:TRUNCATE_GRAPH_CTX]
+        return f"[graph-snapshot]\n{content}"
+
+    if source == "session_context":
+        content = str(entry.get("content", "") or entry.get("text", ""))[:TRUNCATE_GRAPH_CTX]
+        return f"[agent-guidance]\n{content}"
+
+    if source == "trace":
+        origin = entry.get("origin_function", "?")
+        status = entry.get("status", "")
+        feedback = entry.get("session_feedback", "")
+        mrv = entry.get("method_return_value", "")
+        if isinstance(mrv, (dict, list)):
+            mrv = json.dumps(mrv, default=str)
+        mrv = str(mrv)[:TRUNCATE_RETURN]
+        parts = [f"[trace] {origin} — {status}"]
+        if feedback:
+            parts.append(f"  feedback: {feedback}")
+        if mrv:
+            parts.append(f"  output: {mrv}")
+        return "\n".join(parts)
+
+    # session (QA) or generic
+    q = entry.get("question", "")
+    a = entry.get("answer", "")
+    t = entry.get("time", "")
+    lines = []
+    if q:
+        lines.append(f"[{t}] Q: {q}")
+    if a:
+        a_short = a[:TRUNCATE_ANSWER] + "..." if len(a) > TRUNCATE_ANSWER else a
+        lines.append(f"A: {a_short}")
+    return "\n".join(lines)
+
+
+def _has_entry_content(entry: dict) -> bool:
+    """Return True when a recall entry has useful content to inject."""
+    source = entry.get("source", "")
+    if source == "graph_context":
+        return bool(str(entry.get("content", "") or entry.get("text", "")).strip())
+    if source == "session_context":
+        return bool(str(entry.get("content", "") or entry.get("text", "")).strip())
+    if source == "trace":
+        fields = ("origin_function", "status", "session_feedback", "method_return_value")
+    else:
+        fields = ("question", "answer")
+    return any(str(entry.get(field, "") or "").strip() for field in fields)
+
+
+async def _recent_trace_fallback(session_id: str, user_id: str, top_k: int) -> list[dict]:
+    """Return recent trace rows directly when semantic trace recall misses.
+
+    Tool calls are chronological session context, not only semantic context. A
+    casual next prompt often will not match the words in a tool output, but the
+    agent still needs to see the recent tool calls it just made.
+    """
+    try:
+        from cognee.infrastructure.session.get_session_manager import get_session_manager
+
+        sm = get_session_manager()
+        if not sm.is_available or not user_id:
+            return []
+        raw_trace = await sm.get_agent_trace_session(user_id=user_id, session_id=session_id)
+        entries = list(raw_trace or [])[-top_k:]
+    except Exception as exc:
+        hook_log("trace_fallback_error", {"error": str(exc)[:200]})
+        return []
+
+    normalized: list[dict] = []
+    for entry in entries:
+        if hasattr(entry, "model_dump"):
+            entry = entry.model_dump()
+        elif hasattr(entry, "dict"):
+            entry = entry.dict()
+        elif hasattr(entry, "__dict__"):
+            entry = dict(entry.__dict__)
+        if not isinstance(entry, dict):
+            continue
+        entry["source"] = "trace"
+        if _has_entry_content(entry):
+            normalized.append(entry)
+    return normalized
+
+
+async def _run(prompt: str) -> dict | None:
+    config = load_config()
+    runtime = resolve_runtime_mode()
+    cloud_mode = runtime["mode"] == "http"
+    # Readiness gate, redesigned (SDK-356): the recall attempt itself is the
+    # probe. A fresh "ready" marker or a merely-stale/unknown state goes
+    # STRAIGHT to recall — a successful scope call is an authenticated,
+    # real-workload confirmation that beats any synthetic /health check, and
+    # the recall budget already bounds the worst case. Probing survives only
+    # as a cheap re-entry gate while the marker holds a KNOWN failure state,
+    # so a confirmed-bad backend costs one bounded probe per prompt instead of
+    # the full budget.
+    service_url = runtime.get("base_url", "")
+    probe_timeout = _float_env("COGNEE_READY_PROBE_TIMEOUT", 1.0)
+    prior = read_connection_state()
+    # Permissive on purpose: "same target" unless the two URLs provably differ,
+    # so a recorded state still applies when a URL is unknown. Mirrors the
+    # renderer's _url_mismatch (equivalence pinned by
+    # tests/test_connection_target_match.py).
+    prior_same_target = same_connection_target(service_url, str(prior.get("base_url") or ""))
+    prior_state = str(prior.get("state") or ("ready" if prior.get("ready_at") else ""))
+    known_bad = prior_same_target and prior_state in (
+        "auth_failed",
+        "unreachable",
+        "server_error",
+        "not_responding",
+    )
+    if known_bad:
+        # Prefer an AUTHENTICATED probe so a bad/expired key is classified as
+        # auth_failed instead of being masked as "ready" by an unauthenticated
+        # /health 200. Fall back to /health only when the authed probe can't
+        # classify (no key, or the endpoint is absent on an older server).
+        state = authed_liveness(service_url, timeout=probe_timeout)
+        if state == "unknown":
+            health = probe_health(service_url, timeout=probe_timeout)
+            state = {"ready": "ready", "down": "unreachable"}.get(health, health)
+        if state == "ready":
+            mark_server_ready(service_url)
+            clear_slow_streak(service_url)
+            # fall through to recall below
+        else:
+            if state in ("auth_failed", "unreachable", "server_error"):
+                # A definitive verdict: refresh/replace the recorded failure.
+                write_connection_state(state, service_url, detail="authed liveness probe")
+                clear_slow_streak(service_url)
+            # "slow"/"unknown" from the probe is NO verdict — keep the recorded
+            # state untouched rather than promote a timeout to a failure.
+            hook_log("recall_skipped_not_ready", {"base_url": service_url, "state": state})
+            return None
+
+    if not cloud_mode:
+        await ensure_cognee_ready(config)
+
+    session_id = _load_session_id()
+    if not session_id:
+        hook_log("no_session_id", {"event": "context_lookup"})
+        return None
+
+    # NOTE: the warmup-buffer drain deliberately does NOT run here. This hook
+    # is synchronous on the keystroke->answer path, and replaying N buffered
+    # entries (~1s of server work each) stalled the prompt for 10-30s after any
+    # long turn (#298). The sibling hook on this same event
+    # (store-user-prompt.py) drains instead; improve/SessionEnd re-drain too.
+    saves_last_turn = read_and_reset_save_counter(session_id)
+
+    # Run scopes independently: a failure in one (e.g. graph search hitting an
+    # empty/locked Ladybug DB) must not discard hits already collected from the
+    # others. cognee.recall loops over scopes and re-raises on the first failure,
+    # so we call it once per scope and collect whatever succeeds.
+    results: list = []
+    # Cheap scopes first (tens of ms each), the graph search last: it is the
+    # only call that can consume a full per-call timeout, and running it
+    # earlier starved session_context out of the budget entirely. A single
+    # graph scope on purpose: the server (cognee >= 1.4) aliases the old
+    # graph_context scope to graph, so a graph_context + graph pair ran the
+    # same full graph retrieval twice per prompt. HYBRID_COMPLETION combines
+    # BM25 + vector + graph retrieval (with only_context=True the LLM
+    # completion is skipped server-side either way).
+    scope_specs = [
+        (["session"], None, None),
+        (["trace"], None, None),
+        (["session_context"], None, "agent"),
+        (["graph"], "HYBRID_COMPLETION", None),
+    ]
+    if not cloud_mode:
+        import cognee
+        from cognee.modules.search.types import SearchType
+
+        user = await resolve_user(_load_user_id())
+
+    # Per-scope instrumentation (WS7 observability): capture {hits, elapsed_ms}
+    # for every scope, keyed by its stable label. Pre-seed all scopes as
+    # skipped, in canonical order and before the breaker-open branch below can
+    # blank scope_specs, so the event always carries the full set; the loop
+    # overwrites each scope that actually runs. Purely additive: it must not
+    # touch recall results, ordering, or control flow, and must never raise into
+    # the keystroke->answer path.
+    per_scope: dict[str, dict] = {
+        scope_list[0]: {"hits": 0, "elapsed_ms": 0, "skipped": True}
+        for scope_list, _qtype, _profile in scope_specs
+    }
+
+    # Hard time-box: this hook is on the keystroke->answer path, so recall must
+    # never be the long pole. Each scope gets a short per-call timeout, and the
+    # whole loop stops once the overall budget is spent. Partial results are fine.
+    recall_timeout = _float_env("COGNEE_RECALL_TIMEOUT", 2.5)
+    budget_deadline = time.monotonic() + _float_env("COGNEE_RECALL_BUDGET", 4.0)
+    # Respect the shared circuit breaker: when the server has been failing (tripped
+    # by the explicit recall path), skip this per-prompt recall rather than hammering
+    # a down backend on every keystroke. HTTP/cloud mode only.
+    if cloud_mode:
+        try:
+            from _cognee_client import breaker_open
+
+            _bopen, _bretry = breaker_open(service_url)
+        except Exception:
+            _bopen, _bretry = False, 0
+        if _bopen:
+            hook_log("recall_breaker_open", {"retry_in": _bretry})
+            scope_specs = []
+    # Health accounting for this prompt's recall attempts (the attempt IS the
+    # probe): a scope that returns is proof of life; a refused connection is
+    # proof of death; timeouts alone are no verdict and only feed the streak.
+    scopes_ok = 0  # calls that returned (even empty — the server answered)
+    scopes_answered_err = 0  # HTTP-level errors: reachable, but not healthy
+    scope_timeouts = 0
+    server_down = False
+    auth_rejected = False  # 401/403: the server answered and rejected OUR key
+    server_errors = 0  # 5xx answers: reachable but failing
+    for scope_list, qtype, context_profile in scope_specs:
+        # Clamp each call to what is left of the budget so a single scope can
+        # never overshoot the deadline (previously a scope dispatched just
+        # before the deadline could run a full recall_timeout past it). Below
+        # the floor a call cannot return anything useful, so skip the
+        # remaining scopes instead of firing a doomed request.
+        remaining = budget_deadline - time.monotonic()
+        if remaining < MIN_SCOPE_TIMEOUT:
+            hook_log("recall_budget_exceeded", {"collected": len(results)})
+            break
+        scope_timeout = min(recall_timeout, remaining)
+        part = None
+        t0 = time.monotonic()
+        try:
+            if cloud_mode:
+                part = recall_via_http(
+                    prompt,
+                    session_id=session_id,
+                    top_k=TOP_K,
+                    scope=scope_list,
+                    only_context=True,
+                    search_type=qtype,
+                    context_profile=context_profile,
+                    dataset=get_dataset(config),
+                    timeout=scope_timeout,
+                )
+            else:
+                query_type = getattr(SearchType, qtype, None) if qtype else None
+                part = await asyncio.wait_for(
+                    cognee.recall(
+                        prompt,
+                        session_id=session_id,
+                        top_k=TOP_K,
+                        scope=scope_list,
+                        only_context=True,
+                        query_type=query_type,
+                        user=user,
+                        **({"context_profile": context_profile} if context_profile else {}),
+                    ),
+                    timeout=scope_timeout,
+                )
+            if part:
+                results.extend(part)
+            scopes_ok += 1
+        except Exception as exc:
+            import urllib.error as _urlerr
+
+            if isinstance(exc, asyncio.TimeoutError):
+                verdict = SLOW  # pre-3.11 asyncio.TimeoutError isn't TimeoutError
+            else:
+                verdict = classify_transport_exception(exc)
+            if isinstance(exc, _urlerr.HTTPError):
+                scopes_answered_err += 1
+                if exc.code in (401, 403):
+                    auth_rejected = True
+                elif exc.code >= 500:
+                    server_errors += 1
+            elif verdict == SLOW:
+                scope_timeouts += 1
+            elif verdict == DOWN:
+                server_down = True
+            hook_log(
+                "recall_error",
+                {"scope": scope_list, "error": str(exc)[:200], "verdict": verdict},
+            )
+        finally:
+            # hits = raw count from this scope's call (pre-bucketing/filtering);
+            # elapsed_ms measured around the call, recorded even when it errored.
+            per_scope[scope_list[0]] = {
+                "hits": len(part or []),
+                "elapsed_ms": round((time.monotonic() - t0) * 1000, 1),
+            }
+        if server_down:
+            # Positively absent (refused/DNS): the remaining scopes would fail
+            # the same way in milliseconds each — stop here.
+            hook_log("recall_server_down", {"base_url": service_url})
+            break
+        if auth_rejected:
+            # Every scope shares the same API key, so the remaining scopes are
+            # doomed to the same 401/403 — don't spend the budget on them.
+            hook_log("recall_auth_rejected", {"base_url": service_url})
+            break
+
+    # Fold this prompt's recall outcomes back into the shared health state.
+    # Best-effort: accounting must never break the keystroke->answer path.
+    try:
+        if server_down:
+            # Suppress the write during a genuine cold-start warm-up: a refused
+            # connection with no prior ready marker for this URL is likely the
+            # server still launching/migrating — stay quiet rather than flash a
+            # false red (and don't feed the breaker with warm-up refusals).
+            warming = not (prior_state == "ready" and prior_same_target)
+            if not warming:
+                write_connection_state(
+                    "unreachable", service_url, detail="connection refused during recall"
+                )
+                clear_slow_streak(service_url)
+                if cloud_mode:
+                    try:
+                        from _cognee_client import record_failure as _breaker_failure
+
+                        _breaker_failure(
+                            "connection refused",
+                            service_url=service_url,
+                            reason="unreachable",
+                        )
+                    except Exception:
+                        pass
+        elif auth_rejected and not scopes_ok:
+            # The server answered and rejected the key — definitive, and the
+            # same signal the pre-recall authed probe used to provide, now from
+            # a real request. The re-entry gate's authed probe lifts the state
+            # once the key is fixed.
+            write_connection_state("auth_failed", service_url, detail="401/403 during recall")
+            clear_slow_streak(service_url)
+        elif scopes_ok:
+            # The server answered — an authenticated, real-workload proof of
+            # life. Refresh the marker only when it isn't already fresh-ready,
+            # so steady-state prompts don't rewrite the file every keystroke.
+            clear_slow_streak(service_url)
+            if not server_ready_hint(service_url):
+                mark_server_ready(service_url)
+            if cloud_mode:
+                try:
+                    from _cognee_client import record_success as _breaker_success
+
+                    _breaker_success(service_url)
+                except Exception:
+                    pass
+        elif server_errors:
+            # Reachable but failing (5xx on every answered scope, none ok):
+            # record the state and, mirroring the explicit-search path, one
+            # breaker failure for the prompt.
+            write_connection_state("server_error", service_url, detail="5xx during recall")
+            clear_slow_streak(service_url)
+            if cloud_mode:
+                try:
+                    from _cognee_client import record_failure as _breaker_failure
+
+                    _breaker_failure("http 5xx", service_url=service_url, reason="server_error")
+                except Exception:
+                    pass
+        elif scope_timeouts and not scopes_answered_err:
+            # Every attempted scope timed out and none got an HTTP answer: no
+            # verdict on its own, but N consecutive such prompts are a pattern.
+            # Escalate to "not_responding" — deliberately distinct from
+            # "unreachable" (positively absent: refused/DNS): the server exists
+            # but is not answering. A lone timeout never writes anything.
+            streak = record_slow_probe(service_url)
+            if streak >= slow_streak_threshold():
+                write_connection_state(
+                    "not_responding",
+                    service_url,
+                    detail="%d consecutive timeout-only prompts" % streak,
+                )
+                hook_log("slow_streak_escalated", {"base_url": service_url, "streak": streak})
+    except Exception as exc:
+        hook_log("recall_health_accounting_failed", {"error": str(exc)[:200]})
+
+    # Bucket results by _source for human-readable output.
+    # Local SDK mode returns Pydantic models (ResponseQAEntry, etc.); cloud
+    # mode returns plain dicts via HTTP. Normalize to dicts here.
+    by_source: dict[str, list] = {
+        "session": [],
+        "trace": [],
+        "graph_context": [],
+        "session_context": [],
+    }
+    for r in results or []:
+        if hasattr(r, "model_dump"):
+            r = r.model_dump()
+        if not isinstance(r, dict):
+            continue
+        src = r.get("source", "session")
+        # The graph scope tags results source=graph; keep the historical
+        # graph_context bucket name so the status line, last_recall.json
+        # consumers and the `g` counter stay stable.
+        if src == "graph":
+            r["source"] = "graph_context"
+            src = "graph_context"
+        if not _has_entry_content(r):
+            continue
+        by_source.setdefault(src, []).append(r)
+
+    if not cloud_mode and not by_source.get("trace"):
+        fallback_traces = await _recent_trace_fallback(
+            session_id,
+            _load_user_id(),
+            RECENT_TRACE_FALLBACK_TOP_K,
+        )
+        if fallback_traces:
+            by_source["trace"].extend(fallback_traces)
+            hook_log("trace_fallback_hit", {"count": len(fallback_traces)})
+
+    counts = {k: len(v) for k, v in by_source.items()}
+    total = sum(counts.values())
+
+    # Write last-turn counts so the status line script can render them.
+    # Best-effort; failure here must not break the hook output.
+    try:
+        from pathlib import Path as _Path
+
+        _state = _Path.home() / ".cognee-plugin" / "qwen" / "last_recall.json"
+        _state.parent.mkdir(parents=True, exist_ok=True)
+        _state.write_text(
+            json.dumps(
+                {
+                    "session_id": session_id,
+                    "ts": __import__("datetime")
+                    .datetime.now(__import__("datetime").timezone.utc)
+                    .isoformat(timespec="seconds"),
+                    "hits": counts,
+                    "per_scope": per_scope,
+                    "saves_last_turn": saves_last_turn,
+                }
+            ),
+            encoding="utf-8",
+        )
+    except Exception as exc:
+        hook_log("last_recall_write_failed", {"error": str(exc)[:200]})
+
+    # Build a visibility header so the user (via the assistant's
+    # context) can tell that memory fired on this turn — both what it
+    # recalled right now and what the previous turn persisted.
+    status_line = render_status_for_host(get_session_key())
+    header = (
+        f"{status_line}\n"
+        "Cognee memory: recall "
+        f"{counts['session']} session / {counts['trace']} trace / "
+        f"{counts['graph_context']} graph / {counts['session_context']} agent; saved last turn "
+        f"{saves_last_turn['prompt']} prompt / {saves_last_turn['trace']} trace / "
+        f"{saves_last_turn['answer']} answer"
+    )
+
+    section_lines = []
+    if by_source.get("session_context"):
+        section_lines.append("=== Active agent guidance ===")
+        for e in by_source["session_context"]:
+            section_lines.append(_format_entry(e))
+            section_lines.append("")
+    if by_source.get("graph_context"):
+        section_lines.append("=== Knowledge graph snapshot ===")
+        for e in by_source["graph_context"]:
+            section_lines.append(_format_entry(e))
+            section_lines.append("")
+    if by_source.get("trace"):
+        section_lines.append("=== Prior agent trace ===")
+        for e in by_source["trace"]:
+            section_lines.append(_format_entry(e))
+            section_lines.append("")
+    if by_source.get("session"):
+        section_lines.append("=== Prior session turns ===")
+        for e in by_source["session"]:
+            section_lines.append(_format_entry(e))
+            section_lines.append("")
+
+    if total > 0:
+        full_context = (
+            f"{header}\n\nRelevant context from this session's memory:\n\n"
+            + "\n".join(section_lines).strip()
+        )
+        hook_log(
+            "context_lookup_hit",
+            {"counts": counts, "per_scope": per_scope, "saves_last_turn": saves_last_turn},
+        )
+        notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
+    else:
+        # Zero results can mean a genuine miss OR that the embedding model changed
+        # since indexing (stored vs query vectors differ in size, so nothing can
+        # match). Only the local store is introspectable here; surface a one-line
+        # actionable error when a mismatch is positively confirmed, else fall back
+        # to the normal "no matches" line.
+        dim_message = None
+        if service_url_is_local(service_url):
+            try:
+                dim_message = await bounded_dim_mismatch_hint(timeout=2.0)
+            except Exception as exc:
+                hook_log("dim_check_error", {"error": str(exc)[:200]})
+        if dim_message:
+            full_context = f"{header}\n\n{dim_message}"
+            hook_log("context_lookup_dim_mismatch", {"message": dim_message})
+            notify(dim_message)
+        else:
+            full_context = f"{header}\n\n(no memory matches for this prompt)"
+            hook_log(
+                "context_lookup_empty",
+                {"per_scope": per_scope, "saves_last_turn": saves_last_turn},
+            )
+            notify(f"no recall matches; saves last turn {saves_last_turn}")
+
+    # Audit log: persist full recall details per turn for debugging.
+    try:
+        from datetime import datetime as _dt
+        from datetime import timezone as _tz
+        from pathlib import Path as _Path
+
+        _audit = _Path.home() / ".cognee-plugin" / "qwen" / "recall-audit.log"
+        _audit.parent.mkdir(parents=True, exist_ok=True)
+        with _audit.open("a", encoding="utf-8") as fh:
+            fh.write(
+                json.dumps(
+                    {
+                        "ts": _dt.now(_tz.utc).isoformat(timespec="seconds"),
+                        "session_id": session_id,
+                        "prompt": prompt,
+                        "hits": counts,
+                        "per_scope": per_scope,
+                        "context": full_context,
+                    }
+                )
+                + "\n"
+            )
+    except Exception as exc:
+        hook_log("recall_audit_write_failed", {"error": str(exc)[:200]})
+
+    # additionalContext is the MODEL injection channel and must carry the full
+    # recalled content — trimming it to the status line would silently disable
+    # memory for the model. systemMessage carries the short status for the
+    # terminal (mirrors the claude-code integration); hosts that render
+    # additionalContext directly will still show the full block.
+    output = {
+        "systemMessage": header,
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": full_context,
+        },
+    }
+    return output
+
+
+def main():
+    payload_raw = sys.stdin.read()
+    if not payload_raw.strip():
+        return
+
+    try:
+        payload = json.loads(payload_raw)
+    except json.JSONDecodeError:
+        return
+
+    session_key_candidate, session_key_source = resolve_session_key_from_payload(payload)
+    if session_key_candidate:
+        set_session_key(session_key_candidate)
+    hook_log(
+        "context_lookup_session_key", {"source": session_key_source, "value": session_key_candidate}
+    )
+    if not get_session_key():
+        hook_log("context_lookup_missing_session_key")
+        return
+
+    prompt = payload.get("prompt", "")
+    if not prompt or len(prompt) < 5:
+        return
+
+    output = None
+    try:
+        with quiet_hook_output("session-context-lookup"):
+            output = asyncio.run(_run(prompt))
+    except Exception as exc:
+        hook_log("context_lookup_exception", {"error": str(exc)[:200]})
+    return output
+
+
+if __name__ == "__main__":
+    print(
+        json.dumps(
+            main()
+            or {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": "",
+                }
+            }
+        )
+    )

--- a/integrations/qwen/scripts/session-start.py
+++ b/integrations/qwen/scripts/session-start.py
@@ -1,0 +1,1446 @@
+#!/usr/bin/env python3
+"""Initialize Cognee memory at session start.
+
+Runs on the SessionStart hook. Responsibilities:
+  1. Load config (file + env vars)
+  2. Compute per-directory session ID
+  3. Connect to Cognee Cloud if configured
+  4. Configure local LLM if local mode
+  5. Register the current Qwen thread as an active agent connection
+"""
+
+import asyncio
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from contextlib import contextmanager
+from pathlib import Path
+
+# Add scripts dir to path for config import
+sys.path.insert(0, os.path.dirname(__file__))
+from _plugin_common import (
+    _COGNEE_CACHE_DIR,
+    _COGNEE_DATA_DIR,
+    _COGNEE_SYSTEM_DIR,
+    _VENV_DIR,
+    _VENV_PYTHON,
+    _VENV_READY_MARKER,
+    PRESENCE_ABSENT,
+    PRESENCE_READY,
+    _https_context,
+    _reexec_into_venv,
+    apply_cognee_env,
+    clear_server_pidfile,
+    ensure_launch_record,
+    hook_log,
+    probe_health,
+    quiet_hook_output,
+    resolve_session_key_from_payload,
+    server_presence,
+    set_session_key,
+    touch_activity,
+    write_connection_state,
+    write_server_pidfile,
+)
+from _proc import find_host_ancestor_windows
+from _proc import pid_alive as _pid_alive
+from cognee_statusline_render import render_status_for_host
+from config import (
+    _cloud_http_request,
+    _user_id_via_api,
+    ensure_cognee_ready,
+    ensure_dataset_ready,
+    ensure_dataset_ready_via_api,
+    ensure_identity,
+    get_dataset,
+    is_cloud_mode,
+    load_config,
+    save_config,
+)
+
+_STATE_DIR = Path.home() / ".cognee-plugin" / "qwen"
+_GLOBAL_STATE_DIR = Path.home() / ".cognee-plugin"
+_WATCHER_PID = _STATE_DIR / "watcher.pid"
+_WATCHER_STOP = _STATE_DIR / "watcher.stop"
+_WATCHER_SCRIPT = Path(__file__).with_name("idle-watcher.py")
+_EXIT_WATCHER_SCRIPT = Path(__file__).with_name("exit-watcher.py")
+_EXIT_WATCHERS_DIR = _STATE_DIR / "exit-watchers"
+_LOCAL_SERVICE_URL = "http://localhost:8011"
+_HEALTH_URL = f"{_LOCAL_SERVICE_URL}/health"
+_HEALTH_TIMEOUT_SECONDS = 30
+_HEALTH_POLL_SECONDS = 1.0
+_SERVER_BOOT_LOCK = _GLOBAL_STATE_DIR / "server-bootstrap.lock"
+_SERVER_BOOT_LOCK_STALE_SECONDS = 2 * _HEALTH_TIMEOUT_SECONDS
+_SERVER_BOOT_LOCK_WAIT_SECONDS = _HEALTH_TIMEOUT_SECONDS + 5.0
+_SERVER_BOOT_LOCK_POLL_SECONDS = 0.2
+
+# Lazy bootstrap: defer server boot + registration to a detached worker so the
+# SessionStart hook returns fast and migrations never time out the 15s budget.
+_BOOTSTRAP_ARG = "--bootstrap"
+_BOOTSTRAP_LOCK = _GLOBAL_STATE_DIR / "server-bootstrap-worker.lock"
+_SERVER_BOOT_DEADLINE_SECONDS = float(os.environ.get("COGNEE_SERVER_BOOT_DEADLINE", "") or 600.0)
+_BOOTSTRAP_LOCK_STALE_SECONDS = _SERVER_BOOT_DEADLINE_SECONDS + 60.0
+_LAZY_BOOTSTRAP = os.environ.get("COGNEE_LAZY_BOOTSTRAP", "1").strip().lower() not in (
+    "0",
+    "false",
+    "no",
+)
+
+# --- Self-managed cognee install (SHARED with the Claude Code plugin) --------
+# uv + a uv-managed Python guarantee a cognee-compatible runtime (3.10-3.14)
+# regardless of what's on the machine. All paths sit under the shared
+# ~/.cognee-plugin root so the two plugins install once and reuse one venv.
+_UV_DIR = _GLOBAL_STATE_DIR / "uv"
+_UV_BIN = _UV_DIR / ("uv.exe" if os.name == "nt" else "uv")
+_UV_PYTHON_DIR = _GLOBAL_STATE_DIR / "python"
+_UV_INSTALL_URL = "https://astral.sh/uv/install.sh"
+_PINNED_PYTHON = os.environ.get("COGNEE_PLUGIN_PYTHON", "") or "3.12"
+_PINNED_COGNEE_VERSION = "1.5.0"
+_INSTALL_TIMEOUT_SECONDS = float(os.environ.get("COGNEE_INSTALL_TIMEOUT", "") or 600.0)
+
+# Install single-flight. Distinct from the server boot lock (which is short): a
+# cold cognee install can take minutes, so concurrent sessions — across BOTH
+# plugins, since the lock path is shared — must NOT install into the venv at once.
+_VENV_INSTALL_LOCK = _GLOBAL_STATE_DIR / "venv-install.lock"
+_VENV_INSTALL_LOCK_STALE_SECONDS = _INSTALL_TIMEOUT_SECONDS + 60.0
+_VENV_INSTALL_WAIT_SECONDS = _INSTALL_TIMEOUT_SECONDS + 60.0
+_VENV_INSTALL_POLL_SECONDS = 0.5
+
+
+def _find_uv() -> str:
+    """Locate uv: prefer our self-managed copy, then anything on PATH."""
+    if _UV_BIN.exists():
+        return str(_UV_BIN)
+    found = shutil.which("uv")
+    return found or ""
+
+
+def _install_uv() -> str:
+    """Install the standalone uv binary into ~/.cognee-plugin/uv (no PATH edits)."""
+    try:
+        _UV_DIR.mkdir(parents=True, exist_ok=True)
+        env = os.environ.copy()
+        # UV_UNMANAGED_INSTALL drops the binary in the given dir without editing
+        # shell profiles or managing updates — exactly what we want.
+        env["UV_UNMANAGED_INSTALL"] = str(_UV_DIR)
+        subprocess.run(
+            ["sh", "-c", f"curl -LsSf {_UV_INSTALL_URL} | sh"],
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if _UV_BIN.exists():
+            return str(_UV_BIN)
+    except Exception as exc:
+        hook_log("uv_install_failed", {"error": str(exc)[:300]})
+    return ""
+
+
+def _venv_cognee_version() -> str:
+    """Installed cognee version inside the plugin venv, or '' if unimportable."""
+    if not _VENV_PYTHON.exists():
+        return ""
+    try:
+        out = subprocess.run(
+            [
+                str(_VENV_PYTHON),
+                "-c",
+                "import importlib.metadata as m; print(m.version('cognee'))",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if out.returncode == 0:
+            return out.stdout.strip()
+    except Exception as exc:
+        hook_log("cognee_version_probe_failed", {"error": str(exc)[:200]})
+    return ""
+
+
+def _write_venv_ready(version: str) -> None:
+    try:
+        payload = {
+            "cognee_version": version,
+            "python": str(_VENV_PYTHON),
+            "updated_at": time.time(),
+        }
+        tmp = _VENV_READY_MARKER.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp, _VENV_READY_MARKER)
+    except Exception as exc:
+        hook_log("venv_ready_write_failed", {"error": str(exc)[:200]})
+
+
+def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
+    """Ensure the shared plugin venv exists and holds the pinned cognee version.
+
+    Called from the server-boot critical section (so it is already
+    single-flighted) and only at boot points where the server is POSITIVELY
+    absent (see server_presence) — a merely unresponsive server may be busy and
+    still holding the graph store's file lock, and upgrading the venv under it
+    corrupts the databases. Always installs the exact pinned version
+    (_PINNED_COGNEE_VERSION) so the server's FastAPI lifespan migrations run on
+    a known-good release.
+
+    Fails soft: if the install can't run (e.g. offline) but a usable cognee is
+    already present, returns True with whatever version is there. Returns False
+    only when no importable cognee venv exists afterwards.
+    """
+    apply_cognee_env()
+    for directory in (_COGNEE_SYSTEM_DIR, _COGNEE_DATA_DIR, _COGNEE_CACHE_DIR):
+        try:
+            directory.mkdir(parents=True, exist_ok=True)
+        except Exception as exc:
+            hook_log(
+                "cognee_data_dir_mkdir_failed", {"dir": str(directory), "error": str(exc)[:200]}
+            )
+
+    owner = f"install:{os.getpid()}"
+    acquired = False
+    deadline = time.monotonic() + _VENV_INSTALL_WAIT_SECONDS
+    try:
+        _VENV_INSTALL_LOCK.parent.mkdir(parents=True, exist_ok=True)
+        while True:
+            now = time.time()
+            if _VENV_INSTALL_LOCK.exists():
+                stale = False
+                try:
+                    raw = json.loads(_VENV_INSTALL_LOCK.read_text(encoding="utf-8"))
+                    pid = int(raw.get("pid", 0) or 0)
+                    created_at = float(raw.get("created_at", 0) or 0)
+                    stale = (not _pid_alive(pid)) or (
+                        now - created_at > _VENV_INSTALL_LOCK_STALE_SECONDS
+                    )
+                except Exception:
+                    stale = True
+                if stale:
+                    try:
+                        _VENV_INSTALL_LOCK.unlink()
+                    except Exception as exc:
+                        hook_log("venv_install_lock_unlink_failed", {"error": str(exc)[:200]})
+
+            try:
+                fd = os.open(str(_VENV_INSTALL_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    json.dump({"owner": owner, "pid": os.getpid(), "created_at": now}, fh)
+                acquired = True
+                break
+            except FileExistsError:
+                # Another process owns the install. Don't install concurrently —
+                # wait for it to produce a usable venv, then reuse it.
+                if _venv_cognee_version() == _PINNED_COGNEE_VERSION:
+                    return True
+                if time.monotonic() >= deadline:
+                    return bool(_venv_cognee_version())
+                time.sleep(_VENV_INSTALL_POLL_SECONDS)
+
+        uv = _find_uv() or _install_uv()
+        venv_present = _VENV_PYTHON.exists()
+
+        if uv:
+            env = os.environ.copy()
+            env.setdefault("UV_PYTHON_INSTALL_DIR", str(_UV_PYTHON_DIR))
+            try:
+                if not venv_present:
+                    subprocess.run(
+                        [uv, "venv", str(_VENV_DIR), "--python", _PINNED_PYTHON],
+                        env=env,
+                        check=True,
+                        capture_output=True,
+                        text=True,
+                        timeout=timeout,
+                    )
+                subprocess.run(
+                    [
+                        uv,
+                        "pip",
+                        "install",
+                        "--upgrade",
+                        "--python",
+                        str(_VENV_PYTHON),
+                        f"cognee=={_PINNED_COGNEE_VERSION}",
+                    ],
+                    env=env,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                )
+            except Exception as exc:
+                hook_log("cognee_install_failed", {"via": "uv", "error": str(exc)[:300]})
+        elif not venv_present:
+            # Last-resort fallback: stdlib venv + pip. Slower, and relies on the
+            # system python3 being a cognee-compatible version (3.10-3.14).
+            try:
+                subprocess.run(
+                    [sys.executable, "-m", "venv", str(_VENV_DIR)],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                )
+                subprocess.run(
+                    [
+                        str(_VENV_PYTHON),
+                        "-m",
+                        "pip",
+                        "install",
+                        "--upgrade",
+                        f"cognee=={_PINNED_COGNEE_VERSION}",
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                )
+            except Exception as exc:
+                hook_log("cognee_install_failed", {"via": "venv_pip", "error": str(exc)[:300]})
+
+        version = _venv_cognee_version()
+        if not version:
+            hook_log("cognee_venv_unusable", {"venv_python": str(_VENV_PYTHON)})
+            return False
+        _write_venv_ready(version)
+        hook_log("cognee_install_ready", {"version": version})
+        return True
+    finally:
+        if acquired:
+            try:
+                _VENV_INSTALL_LOCK.unlink()
+            except Exception as exc:
+                hook_log("venv_install_lock_release_failed", {"error": str(exc)[:200]})
+
+
+def _parse_host_port(url: str) -> tuple[str, int]:
+    parsed = urllib.parse.urlparse(url if "://" in url else f"http://{url}")
+    return (parsed.hostname or "localhost"), (parsed.port or 8011)
+
+
+def _is_local_url(url: str) -> bool:
+    """True if the URL points at this machine (so we may boot a server on it)."""
+    host, _ = _parse_host_port(url)
+    return host in ("localhost", "127.0.0.1", "0.0.0.0", "::1")
+
+
+def _with_scheme(url: str) -> str:
+    """Ensure the URL has a scheme so urllib + downstream HTTP helpers accept it."""
+    url = str(url or "").strip()
+    if url and "://" not in url:
+        url = f"http://{url}"
+    return url.rstrip("/")
+
+
+def _health_url(service_url: str) -> str:
+    return f"{_with_scheme(service_url or _LOCAL_SERVICE_URL)}/health"
+
+
+def _health_ok(url: str = _HEALTH_URL, timeout: float = 2.0) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout, context=_https_context()) as response:
+            return response.status == 200
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return False
+
+
+def _wait_for_health(deadline_seconds: float, health_url: str = _HEALTH_URL) -> bool:
+    """Poll /health until the server is serving or the deadline elapses.
+
+    Used by bootstrap workers that did not win the boot single-flight: they
+    don't spawn uvicorn, they just wait for whichever worker did to finish
+    booting (including migrations) before registering.
+    """
+    deadline = time.monotonic() + deadline_seconds
+    while True:
+        if _health_ok(health_url):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(_HEALTH_POLL_SECONDS)
+
+
+def _ensure_local_server_running(
+    config: dict, health_timeout: float = _HEALTH_TIMEOUT_SECONDS
+) -> None:
+    # Target the configured local URL (any port) or the default; boot uvicorn on
+    # that URL's port if it's not already serving.
+    service_url = _with_scheme(config.get("base_url", "") or _LOCAL_SERVICE_URL)
+    health_url = _health_url(service_url)
+    _, port = _parse_host_port(service_url)
+
+    def _ready() -> None:
+        config["base_url"] = service_url
+        os.environ["COGNEE_BASE_URL"] = service_url
+
+    if _health_ok(health_url):
+        _ready()
+        return
+
+    # A missed probe is NOT absence: a server that is busy (cognifying, event
+    # loop saturated) misses the health deadline exactly like a dead one, but
+    # only a dead one may be installed/booted over — a busy server still holds
+    # the graph store's file lock, and upgrading + migrating under it corrupts
+    # the databases (2026-08-13 incident). Only a positively-absent verdict
+    # from the full-evidence presence check licenses going further.
+    def _require_absent(stage: str) -> bool:
+        """True when the server turned out to be serving (caller returns);
+        raises unless it is positively absent."""
+        verdict, evidence = server_presence(service_url, confirm_absent=(stage == "pre_install"))
+        if verdict == PRESENCE_READY:
+            return True
+        if verdict != PRESENCE_ABSENT:
+            hook_log(
+                "boot_refused_server_present",
+                {"stage": stage, "verdict": verdict, **evidence},
+            )
+            raise RuntimeError(
+                f"server at {service_url} is present but not serving "
+                f"(verdict={verdict}, stage={stage}); refusing to install or boot over it"
+            )
+        return False
+
+    if _require_absent("pre_install"):
+        _ready()
+        return
+
+    # The server is positively absent and we're at a boot point: ensure the
+    # shared venv holds the latest cognee BEFORE booting, so the server's
+    # lifespan migrations run on the upgraded code. Single-flighted on its own
+    # (long) lock, separate from the short boot lock below, since a cold
+    # install can take minutes.
+    if not ensure_cognee_installed():
+        raise RuntimeError("cognee runtime unavailable (install/upgrade failed)")
+
+    # A cold install can take minutes — long enough for the world to change.
+    # Re-verify the premise before proceeding to the boot lock.
+    if _require_absent("post_install"):
+        _ready()
+        return
+
+    owner = f"session-start:{os.getpid()}"
+    acquired = False
+    deadline = time.monotonic() + _SERVER_BOOT_LOCK_WAIT_SECONDS
+    try:
+        _SERVER_BOOT_LOCK.parent.mkdir(parents=True, exist_ok=True)
+        while True:
+            now = time.time()
+            if _SERVER_BOOT_LOCK.exists():
+                stale = False
+                try:
+                    raw = json.loads(_SERVER_BOOT_LOCK.read_text(encoding="utf-8"))
+                    pid = int(raw.get("pid", 0) or 0)
+                    created_at = float(raw.get("created_at", 0) or 0)
+                    stale = (not _pid_alive(pid)) or (
+                        now - created_at > _SERVER_BOOT_LOCK_STALE_SECONDS
+                    )
+                except Exception:
+                    stale = True
+                if stale:
+                    try:
+                        _SERVER_BOOT_LOCK.unlink()
+                        hook_log("server_bootstrap_lock_stale_reaped", {"owner": owner})
+                    except Exception as exc:
+                        hook_log("server_bootstrap_lock_unlink_failed", {"error": str(exc)[:200]})
+
+            try:
+                fd = os.open(str(_SERVER_BOOT_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    json.dump({"owner": owner, "pid": os.getpid(), "created_at": now}, fh)
+                acquired = True
+                hook_log("server_bootstrap_lock_acquired", {"owner": owner})
+                break
+            except FileExistsError:
+                if _health_ok(health_url):
+                    _ready()
+                    return
+                if time.monotonic() >= deadline:
+                    raise RuntimeError("server bootstrap lock timeout")
+                time.sleep(_SERVER_BOOT_LOCK_POLL_SECONDS)
+
+        # Final re-check under the lock: waiting for it may have taken a while,
+        # and only a still-absent server may be spawned over the port.
+        if _require_absent("in_lock"):
+            _ready()
+            return
+
+        server_env = os.environ.copy()
+        # Data-dir pins + CACHING are already in os.environ via apply_cognee_env(),
+        # so the copy carries them to the server process.
+        # We are spawning the server, so run it in agent mode: it tears itself
+        # down once all registered agents disconnect.
+        server_env["COGNEE_AGENT_MODE"] = "true"
+        server_proc = subprocess.Popen(
+            [str(_VENV_PYTHON), "-m", "uvicorn", "cognee.api.client:app", "--port", str(port)],
+            env=server_env,
+            start_new_session=True,
+        )
+        # Presence evidence for future boot points: covers the spawn-to-bind
+        # window where neither the health probe nor the TCP listener sees it.
+        write_server_pidfile(port, server_proc.pid, version=_PINNED_COGNEE_VERSION)
+
+        health_deadline = time.monotonic() + health_timeout
+        while time.monotonic() < health_deadline:
+            if _health_ok(health_url):
+                _ready()
+                return
+            exit_code = server_proc.poll()
+            if exit_code is not None:
+                clear_server_pidfile(port)
+                # An immediate exit is usually a failed port bind — something
+                # claimed the port between our absence check and the spawn. If
+                # that something is serving, connect to it instead of failing.
+                if _health_ok(health_url):
+                    _ready()
+                    return
+                raise RuntimeError(
+                    f"server process exited (rc={exit_code}) before becoming "
+                    f"healthy at {health_url}"
+                )
+            time.sleep(_HEALTH_POLL_SECONDS)
+
+        raise RuntimeError(
+            f"Cognee server did not become healthy at {health_url} within {health_timeout}s"
+        )
+    finally:
+        if acquired:
+            try:
+                _SERVER_BOOT_LOCK.unlink()
+                hook_log("server_bootstrap_lock_released", {"owner": owner})
+            except Exception as exc:
+                hook_log("server_bootstrap_lock_release_failed", {"error": str(exc)[:200]})
+
+
+def _normalize_service_url(service_url: str) -> str:
+    return str(service_url or "").strip().rstrip("/")
+
+
+async def _login_default_user_for_owner_api_key(service_url: str, config: dict) -> str:
+    base = _normalize_service_url(service_url)
+    email = config.get("user_email", "")
+    password = config.get("user_password", "")
+
+    status, body = _cloud_http_request(
+        f"{base}/api/v1/auth/login",
+        method="POST",
+        form_body={"username": email, "password": password},
+        timeout=30.0,
+    )
+    if status != 200:
+        raise RuntimeError(
+            "default-user login failed "
+            f"({status}: {body[:200]}). "
+            "Set COGNEE_USER_EMAIL/COGNEE_USER_PASSWORD correctly."
+        )
+    login_data = json.loads(body) if body else {}
+    jwt = str(login_data.get("access_token", "") or "")
+    if not jwt:
+        raise RuntimeError("default-user login returned no access token")
+
+    status, body = _cloud_http_request(
+        f"{base}/api/v1/auth/api-keys",
+        method="GET",
+        cookies={"auth_token": jwt},
+        timeout=30.0,
+    )
+    if status == 200:
+        keys = json.loads(body) if body else []
+        if isinstance(keys, list) and keys:
+            key = str(keys[0].get("key", "") or "")
+            if key:
+                return key
+
+    status, body = _cloud_http_request(
+        f"{base}/api/v1/auth/api-keys",
+        method="POST",
+        json_body={"name": "qwen-owner-bootstrap"},
+        cookies={"auth_token": jwt},
+        timeout=30.0,
+    )
+    if status != 200:
+        raise RuntimeError(f"default-user API key creation failed ({status}: {body[:200]})")
+    payload = json.loads(body) if body else {}
+    key = str(payload.get("key", "") or "")
+    if not key:
+        raise RuntimeError("default-user API key creation returned empty key")
+    return key
+
+
+def _resolve_agent_name(config: dict, cwd: str) -> str:
+    def _normalize(name: str) -> str:
+        raw = str(name or "").strip()
+        if raw.endswith("@cognee.agent"):
+            raw = raw[: -len("@cognee.agent")]
+        suffix = "_qwen"
+        if raw.endswith(suffix):
+            return raw
+        return f"{raw}{suffix}"
+
+    configured = str(config.get("agent_name", "") or "").strip()
+    if configured:
+        return _normalize(configured)
+    return _normalize(f"qwen-{Path(cwd).name}")
+
+
+async def _resolve_single_principal_key(service_url: str, config: dict) -> str:
+    """Resolve the one API key for this deployment.
+
+    Order: env ``COGNEE_API_KEY`` -> single cached key -> mint once from the
+    default user (and cache it). No per-agent users or keys.
+    """
+    from _plugin_common import load_cached_api_key, save_cached_api_key
+
+    api_key = str(config.get("api_key", "") or os.environ.get("COGNEE_API_KEY", "")).strip()
+    if not api_key:
+        api_key = load_cached_api_key(service_url)
+    if not api_key:
+        api_key = await _login_default_user_for_owner_api_key(service_url, config)
+        if api_key:
+            save_cached_api_key(service_url, api_key)
+    return api_key
+
+
+async def _ensure_agent_credentials_and_register(
+    config: dict, cwd: str, session_id: str, agent_session_name: str, session_key: str
+) -> tuple[str, str, str, bool]:
+    service_url = _normalize_service_url(str(config.get("base_url", "") or ""))
+    if not service_url:
+        return "", "", "", False
+
+    api_key = await _resolve_single_principal_key(service_url, config)
+    if not api_key:
+        return "", "", "", False
+
+    os.environ["COGNEE_API_KEY"] = api_key
+    config["api_key"] = api_key
+
+    # The principal user id (best-effort) — used for dataset readiness + watchers.
+    user_id = await _user_id_via_api(service_url, api_key)
+
+    from _plugin_common import register_agent_via_http
+
+    # Registration is now purely a lifecycle counter + connection registry under
+    # the single principal. The connection handle IS the Cognee session id.
+    registered, registration = register_agent_via_http(
+        agent_session_name=agent_session_name,
+        session_id=session_id,
+        dataset_names=[str(config.get("dataset", "") or "").strip()],
+    )
+    if not registered:
+        raise RuntimeError(f"Failed to register session '{session_id}' on {service_url}.")
+
+    hook_log(
+        "agent_register_result",
+        {
+            "agent_session_name": agent_session_name,
+            "registered": registered,
+            "connection_id": str(registration.get("id", "")),
+            "session_id": session_id,
+            "user_id": user_id,
+        },
+    )
+
+    return user_id, api_key, agent_session_name, registered
+
+
+def _watcher_alive() -> bool:
+    if not _WATCHER_PID.exists():
+        return False
+    try:
+        pid = int(_WATCHER_PID.read_text(encoding="utf-8").strip())
+    except Exception:
+        return False
+    return _pid_alive(pid)
+
+
+def _spawn_idle_watcher(
+    session_id: str, dataset: str, user_id: str, config: dict, session_key: str
+) -> None:
+    """Launch the idle watcher as a detached background process.
+
+    Idempotent: if a watcher is already alive (from an earlier session
+    on the same machine), we kill it so the new one picks up the new
+    session. Launched with its own session via ``start_new_session=True``
+    so it survives the parent shell closing.
+    """
+    if _watcher_alive():
+        try:
+            pid = int(_WATCHER_PID.read_text(encoding="utf-8").strip())
+            os.kill(pid, signal.SIGTERM)
+        except Exception as exc:
+            hook_log("idle_watcher_kill_failed", {"error": str(exc)[:200]})
+
+    # Clear any stale stop sentinel from a previous run.
+    try:
+        if _WATCHER_STOP.exists():
+            _WATCHER_STOP.unlink()
+    except Exception as exc:
+        hook_log("watcher_stop_unlink_failed", {"error": str(exc)[:200]})
+
+    # Only the non-secret surface of config needs to travel — the
+    # watcher re-runs ``ensure_cognee_ready`` on its own.
+    bootstrap = {
+        "session_id": session_id,
+        "dataset": dataset,
+        "user_id": user_id,
+        "session_key": session_key,
+        "config": {
+            "base_url": config.get("base_url", ""),
+            "llm_model": config.get("llm_model", ""),
+            "dataset": dataset,
+        },
+    }
+
+    log_path = _STATE_DIR / "watcher.log"
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_fh = log_path.open("a", encoding="utf-8")
+    except Exception as exc:
+        hook_log("watcher_log_open_failed", {"error": str(exc)[:200]})
+        log_fh = subprocess.DEVNULL
+
+    try:
+        env = os.environ.copy()
+        if session_key:
+            env["COGNEE_SESSION_KEY"] = session_key
+        subprocess.Popen(
+            [sys.executable, str(_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            env=env,
+            start_new_session=True,
+            close_fds=True,
+        )
+        print("cognee-plugin: idle watcher started", file=sys.stderr)
+    except Exception as e:
+        print(f"cognee-plugin: idle watcher launch failed ({e})", file=sys.stderr)
+
+
+def _find_qwen_parent_pid() -> int:
+    """Find the nearest live Qwen ancestor, skipping hook shells."""
+    fallback = os.getppid()
+    if sys.platform == "win32":
+        return find_host_ancestor_windows(fallback, "qwen")
+    try:
+        raw = subprocess.check_output(
+            ["ps", "-axo", "pid=,ppid=,command="],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception as exc:
+        hook_log("find_qwen_parent_failed", {"error": str(exc)[:200]})
+        return fallback
+
+    table: dict[int, tuple[int, str]] = {}
+    for line in raw.splitlines():
+        parts = line.strip().split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        table[pid] = (ppid, parts[2])
+
+    import re
+
+    # Match "qwen" as an executable basename anywhere in the command line,
+    # tolerant of spaces in the executable path (a naive split()[0] mis-tokenizes
+    # paths like "/…/Application Support/…/qwen").
+    host_re = re.compile(r"(?:^|/)qwen(?:-[\w.]+)?(?:\s|$)")
+    pid = fallback
+    seen: set[int] = set()
+    while pid > 1 and pid not in seen:
+        seen.add(pid)
+        ppid, command = table.get(pid, (0, ""))
+        if command and host_re.search(command):
+            return pid
+        pid = ppid
+    return fallback
+
+
+def _spawn_exit_watcher(
+    session_id: str,
+    dataset: str,
+    *,
+    session_key: str = "",
+    agent_session_name: str = "",
+    api_key: str = "",
+    service_url: str = "",
+) -> None:
+    """Launch a detached watcher that syncs only after Qwen exits."""
+
+    # Cleanup stale watcher pidfiles so the directory does not grow forever.
+    try:
+        if _EXIT_WATCHERS_DIR.exists():
+            for pidfile in _EXIT_WATCHERS_DIR.glob("*.pid"):
+                try:
+                    pid = int(pidfile.read_text(encoding="utf-8").strip())
+                    if not _pid_alive(pid):
+                        pidfile.unlink()
+                except Exception:
+                    continue
+    except Exception as exc:
+        hook_log("exit_watcher_prune_failed", {"error": str(exc)[:200]})
+
+    parent_pid = _find_qwen_parent_pid()
+    watcher_pidfile = _EXIT_WATCHERS_DIR / f"{parent_pid}.pid"
+    try:
+        if watcher_pidfile.exists():
+            existing = int(watcher_pidfile.read_text(encoding="utf-8").strip())
+            if _pid_alive(existing):
+                hook_log(
+                    "exit_watcher_already_running",
+                    {"parent_pid": parent_pid, "pidfile": str(watcher_pidfile)},
+                )
+                return
+    except Exception:
+        pass
+
+    bootstrap = {
+        "parent_pid": parent_pid,
+        "session_id": session_id,
+        "dataset": dataset,
+        "session_key": session_key,
+        "agent_session_name": agent_session_name,
+        "api_key": api_key,
+        "base_url": service_url,
+        "pidfile": str(watcher_pidfile),
+    }
+    log_path = _STATE_DIR / "exit-watcher.log"
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        _EXIT_WATCHERS_DIR.mkdir(parents=True, exist_ok=True)
+        log_fh = log_path.open("a", encoding="utf-8")
+    except Exception as exc:
+        hook_log("exit_watcher_log_open_failed", {"error": str(exc)[:200]})
+        log_fh = subprocess.DEVNULL
+
+    try:
+        env = os.environ.copy()
+        if session_key:
+            env["COGNEE_SESSION_KEY"] = session_key
+        subprocess.Popen(
+            [sys.executable, str(_EXIT_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            env=env,
+            start_new_session=True,
+            close_fds=True,
+        )
+        hook_log(
+            "exit_watcher_started",
+            {
+                "parent_pid": parent_pid,
+                "session_id": session_id,
+                "dataset": dataset,
+                "pidfile": str(watcher_pidfile),
+            },
+        )
+    except Exception as e:
+        hook_log("exit_watcher_launch_failed", {"error": str(e)[:300]})
+
+
+def _purge_legacy_resolved_files() -> None:
+    legacy = _STATE_DIR / "resolved.json"
+    scoped_dir = _STATE_DIR / "resolved"
+    try:
+        if legacy.exists():
+            legacy.unlink()
+    except Exception as exc:
+        hook_log("legacy_resolved_unlink_failed", {"error": str(exc)[:200]})
+    try:
+        if scoped_dir.exists():
+            shutil.rmtree(scoped_dir)
+    except Exception as exc:
+        hook_log("legacy_resolved_dir_remove_failed", {"error": str(exc)[:200]})
+
+
+@contextmanager
+def _bootstrap_singleflight():
+    """Allow exactly one detached bootstrap worker at a time (machine-wide).
+
+    The marker is global because Claude and Qwen share one local server, so
+    only one of them should drive the boot + migration at any moment.
+    """
+    acquired = False
+    try:
+        _BOOTSTRAP_LOCK.parent.mkdir(parents=True, exist_ok=True)
+        now = time.time()
+        if _BOOTSTRAP_LOCK.exists():
+            stale = False
+            try:
+                raw = json.loads(_BOOTSTRAP_LOCK.read_text(encoding="utf-8"))
+                pid = int(raw.get("pid", 0) or 0)
+                created_at = float(raw.get("created_at", 0) or 0)
+                stale = (not _pid_alive(pid)) or (now - created_at > _BOOTSTRAP_LOCK_STALE_SECONDS)
+            except Exception:
+                stale = True
+            if stale:
+                try:
+                    _BOOTSTRAP_LOCK.unlink()
+                except Exception as exc:
+                    hook_log("bootstrap_lock_unlink_failed", {"error": str(exc)[:200]})
+        try:
+            fd = os.open(str(_BOOTSTRAP_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump({"pid": os.getpid(), "created_at": now}, fh)
+            acquired = True
+        except FileExistsError:
+            acquired = False
+        yield acquired
+    finally:
+        if acquired:
+            try:
+                _BOOTSTRAP_LOCK.unlink()
+            except Exception as exc:
+                hook_log("bootstrap_lock_release_failed", {"error": str(exc)[:200]})
+
+
+def _spawn_bootstrap(
+    config: dict,
+    cwd: str,
+    session_id: str,
+    agent_session_name: str,
+    session_key: str,
+    dataset: str,
+) -> None:
+    """Launch the detached server-bootstrap worker (this script, --bootstrap)."""
+    bootstrap = {
+        "cwd": cwd,
+        "session_id": session_id,
+        "session_key": session_key,
+        "dataset": dataset,
+        "agent_session_name": agent_session_name,
+        "base_url": str(config.get("base_url", "") or _LOCAL_SERVICE_URL),
+    }
+    log_path = _STATE_DIR / "bootstrap.log"
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_fh = log_path.open("a", encoding="utf-8")
+    except Exception as exc:
+        hook_log("bootstrap_log_open_failed", {"error": str(exc)[:200]})
+        log_fh = subprocess.DEVNULL
+    try:
+        env = os.environ.copy()
+        if session_key:
+            env["COGNEE_SESSION_KEY"] = session_key
+        subprocess.Popen(
+            [sys.executable, str(Path(__file__).resolve()), _BOOTSTRAP_ARG, json.dumps(bootstrap)],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            env=env,
+            start_new_session=True,
+            close_fds=True,
+        )
+        hook_log("bootstrap_spawned", {"session_id": session_id})
+    except Exception as exc:
+        hook_log("bootstrap_spawn_failed", {"error": str(exc)[:300]})
+
+
+def _status_from_error(message: str) -> int:
+    """Extract an HTTP status embedded as ``(<status>: ...)`` in an error string.
+
+    ``ensure_cognee_ready`` and ``ensure_dataset_ready_via_api`` both format their
+    RuntimeError as ``... (<status>: <body>)``; return 0 when none is present
+    (e.g. a connection error carries no HTTP status).
+    """
+    import re
+
+    m = re.search(r"\((\d{3})[:\s)]", str(message or ""))
+    return int(m.group(1)) if m else 0
+
+
+def _classify_conn_status(status: int) -> str:
+    """Map an HTTP status to a connection-failure state."""
+    if status in (401, 403):
+        return "auth_failed"
+    if status >= 500:
+        return "server_error"
+    return "unreachable"
+
+
+async def _run_heavy(
+    config: dict,
+    cwd: str,
+    session_id: str,
+    agent_session_name: str,
+    session_key: str,
+    dataset: str,
+    *,
+    managed_endpoint: bool,
+    boot_timeout: float,
+) -> tuple[str, str, bool]:
+    """Slow session bootstrap shared by the inline (legacy) path and the
+    detached worker: server boot wait, cognee init, agent registration, dataset
+    creation, and the server-ready marker.
+
+    Returns ``(user_id, agent_api_key, ok)``. ``ok`` is False only on a hard
+    cloud-registration failure (mirrors the legacy early-abort).
+    """
+    if not managed_endpoint:
+        try:
+            _ensure_local_server_running(config, health_timeout=boot_timeout)
+        except Exception as exc:
+            hook_log("server_bootstrap_warning", {"error": str(exc)[:200]})
+
+    # On a cold start this worker began under the host python3, so the
+    # _plugin_common import-time guard could not re-exec us. The boot above
+    # (via ensure_cognee_installed) has now built the shared venv, so flip into
+    # it before any cognee/aiohttp import below resolves against the host. No-op
+    # when the venv is absent (connect/managed mode) or already inside it.
+    _reexec_into_venv()
+
+    # Track the cloud connection outcome so the status line can show a precise
+    # "✕ (<reason>)". Stays None in local mode (handled by the health probe at
+    # the tail).
+    _conn_state = None
+    _conn_detail = ""
+
+    # Configure cognee (cloud or local)
+    try:
+        await ensure_cognee_ready(config)
+    except Exception as e:
+        print(f"cognee-plugin: init warning ({e})", file=sys.stderr)
+        if is_cloud_mode(config):
+            status = _status_from_error(e)
+            _conn_state = _classify_conn_status(status) if status else "unreachable"
+            _conn_detail = str(e)[:200]
+
+    # Register agent identity.
+    user_id = ""
+    agent_api_key = ""
+    agent_id = ""
+    agent_name = _resolve_agent_name(config, cwd)
+    os.environ["COGNEE_AGENT_NAME"] = agent_name
+
+    # HTTP path: resolve the single principal key (env / cache / mint from the
+    # default user) and register this session as an agent-mode connection.
+    if is_cloud_mode(config):
+        try:
+            (
+                agent_id,
+                agent_api_key,
+                agent_name,
+                _registered,
+            ) = await _ensure_agent_credentials_and_register(
+                config, cwd, session_id, agent_session_name, session_key
+            )
+            if agent_id:
+                user_id = agent_id
+        except Exception as exc:
+            message = str(exc)[:300]
+            hook_log("agent_lifecycle_error", {"error": message})
+            print(f"cognee-plugin: agent lifecycle failed ({message})", file=sys.stderr)
+            # Classify for the status line. Preserve an earlier health-derived
+            # state; otherwise a reachable server rejecting registration is almost
+            # always auth, while a positively-absent one is a connection failure.
+            # A timed-out probe is NO verdict (busy != down): keep the prior
+            # recorded state rather than stamp a false "unreachable".
+            if _conn_state is None:
+                try:
+                    health = probe_health(
+                        _normalize_service_url(str(config.get("base_url", "") or "")), timeout=1.5
+                    )
+                except Exception:
+                    health = "unknown"
+                if health == "ready":
+                    _conn_state, _conn_detail = "auth_failed", message
+                elif health == "down":
+                    _conn_state, _conn_detail = "unreachable", message
+            if _conn_state:
+                write_connection_state(
+                    _conn_state, str(config.get("base_url", "") or ""), detail=_conn_detail
+                )
+            else:
+                hook_log(
+                    "conn_state_unverified",
+                    {"reason": "probe returned no verdict after registration failure"},
+                )
+            return "", "", False
+    else:
+        # Local SDK fallback path.
+        try:
+            if not user_id:
+                user_id, fallback_key = await ensure_identity(config)
+                if fallback_key and not agent_api_key:
+                    agent_api_key = fallback_key
+        except Exception as e:
+            print(f"cognee-plugin: identity warning ({e})", file=sys.stderr)
+
+    try:
+        # Cloud: the API key IS the identity (the server derives the principal
+        # from X-Api-Key), so dataset creation must NOT be gated on user_id —
+        # servers without /users/me (e.g. cloud tenants) leave user_id empty
+        # while auth works fine. Only the SDK branch below needs a User object.
+        if is_cloud_mode(config):
+            await ensure_dataset_ready_via_api(
+                config.get("base_url", ""),
+                agent_api_key or config.get("api_key", ""),
+                dataset,
+            )
+        elif user_id:
+            from uuid import UUID
+
+            from cognee.modules.users.methods import get_user
+
+            user = await get_user(UUID(user_id))
+            await ensure_dataset_ready(dataset, user)
+    except Exception as e:
+        print(f"cognee-plugin: dataset warning ({e})", file=sys.stderr)
+        if is_cloud_mode(config):
+            status = _status_from_error(e)
+            # An authed 401/403 here is a definitive auth failure — let it win.
+            if status in (401, 403):
+                _conn_state, _conn_detail = "auth_failed", str(e)[:200]
+            elif status >= 500 and _conn_state is None:
+                _conn_state, _conn_detail = "server_error", str(e)[:200]
+    if user_id:
+        os.environ["COGNEE_USER_ID"] = user_id
+
+    # Record the connection outcome so the status line shows "● " (ready) or
+    # "✕ (<reason>)". Cloud: use the classified state gathered above, else confirm
+    # ready. Local/managed: a health probe decides ready-vs-unreachable.
+    service_url = _normalize_service_url(str(config.get("base_url", "") or ""))
+    if not service_url and not managed_endpoint:
+        service_url = _LOCAL_SERVICE_URL
+    if is_cloud_mode(config):
+        if _conn_state and _conn_state != "ready":
+            write_connection_state(
+                _conn_state, str(config.get("base_url", "") or ""), detail=_conn_detail
+            )
+        elif service_url:
+            health = probe_health(service_url, timeout=1.5)
+            if health == "ready":
+                write_connection_state("ready", service_url)
+            elif health == "down":
+                write_connection_state(
+                    "unreachable", str(config.get("base_url", "") or service_url)
+                )
+            else:
+                # "slow"/"unknown": no verdict — keep whatever state is already
+                # recorded instead of branding a busy server unreachable.
+                hook_log("conn_state_unverified", {"base_url": service_url, "health": health})
+    elif service_url and probe_health(service_url, timeout=1.5) == "ready":
+        write_connection_state("ready", service_url)
+
+    return user_id, agent_api_key, True
+
+
+async def _run_bootstrap(bootstrap: dict) -> None:
+    """Detached worker body.
+
+    Two distinct concerns, deliberately decoupled:
+      1. Boot the local server EXACTLY ONCE — single-flighted on _BOOTSTRAP_LOCK
+         so concurrent agents don't each spawn uvicorn. Workers that don't win
+         the lock just wait for /health instead of returning.
+      2. Register THIS agent/session — runs for EVERY agent, regardless of who
+         booted, because registration is per-agent (and concurrency-safe via
+         the agent-keys / agent-lifecycle locks inside _run_heavy).
+    """
+    config = load_config()
+    cwd = str(bootstrap.get("cwd") or os.getcwd())
+    session_id = str(bootstrap.get("session_id", "") or "")
+    session_key = str(bootstrap.get("session_key", "") or "")
+    dataset = str(bootstrap.get("dataset", "") or get_dataset(config))
+    agent_session_name = str(bootstrap.get("agent_session_name", "") or session_id)
+    if session_key:
+        os.environ["COGNEE_SESSION_KEY"] = session_key
+    if session_id:
+        os.environ["COGNEE_SESSION_ID"] = session_id
+    service_url = _with_scheme(bootstrap.get("base_url", "") or _LOCAL_SERVICE_URL)
+    health_url = _health_url(service_url)
+    config["base_url"] = service_url
+    os.environ["COGNEE_BASE_URL"] = service_url
+
+    # 1. Ensure the server is up. Only the single-flight winner spawns uvicorn;
+    #    everyone else waits for /health (the winner may still be migrating).
+    if not _health_ok(health_url):
+        with _bootstrap_singleflight() as acquired:
+            if acquired:
+                try:
+                    _ensure_local_server_running(
+                        config, health_timeout=_SERVER_BOOT_DEADLINE_SECONDS
+                    )
+                except Exception as exc:
+                    hook_log("server_bootstrap_warning", {"error": str(exc)[:200]})
+            else:
+                hook_log("bootstrap_waiting_for_peer", {"session_id": session_id})
+        if not _wait_for_health(_SERVER_BOOT_DEADLINE_SECONDS, health_url):
+            hook_log("bootstrap_server_unhealthy", {"session_id": session_id})
+            return
+
+    # 2. Register this agent/session. Runs for every agent — NOT gated by the
+    #    boot single-flight. _run_heavy's _ensure_local_server_running is a
+    #    no-op now that the server is healthy.
+    try:
+        await _run_heavy(
+            config,
+            cwd,
+            session_id,
+            agent_session_name,
+            session_key,
+            dataset,
+            managed_endpoint=False,
+            boot_timeout=_SERVER_BOOT_DEADLINE_SECONDS,
+        )
+        hook_log("bootstrap_complete", {"session_id": session_id})
+    except Exception as exc:
+        hook_log("bootstrap_failed", {"error": str(exc)[:300]})
+
+
+async def _start(payload: dict | None = None) -> dict:
+    config = load_config()
+    payload = payload or {}
+    cwd = str(payload.get("cwd") or os.environ.get("QWEN_CWD") or os.getcwd())
+    # The service URL is the sole router (api_key is optional auth, with a
+    # default-user fallback in registration). COGNEE_AGENT_MODE is NOT decided
+    # here: it's set only when we actually boot a server (in
+    # _ensure_local_server_running), so connecting to an already-running server
+    # never claims ownership of its teardown.
+    configured_url = _with_scheme(str(config.get("base_url", "") or "").strip())
+    api_key = str(config.get("api_key", "") or "").strip()
+    # Forced cloud (backend switch) with no URL configured: there is nothing to
+    # boot and nothing to fall back to — keep the target empty so no local
+    # server is spawned, let the connection attempt fail, and let the status
+    # line report the missing URL. Everything else keeps the localhost default.
+    forced_cloud_unconfigured = not configured_url and config.get("_forced_backend") == "cloud"
+    target_url = configured_url or ("" if forced_cloud_unconfigured else _LOCAL_SERVICE_URL)
+    config["base_url"] = target_url
+    os.environ["COGNEE_BASE_URL"] = target_url
+    if api_key:
+        os.environ["COGNEE_API_KEY"] = api_key
+
+    # NOTE: the local server's LLM_API_KEY health is deliberately NOT judged here.
+    # A hook-env read (config's llm_api_key / OPENAI_API_KEY) is blind to a key that
+    # lives in cognee's own config or a .env the server loads, so a session launched
+    # from a shell without the export wrote "not_set" into a marker that EVERY
+    # session's status line reads — a false ✕ (incorrect_llm_api_key) for sessions whose key is
+    # fine. The idle watcher is the sole authority instead: it resolves the key the
+    # same way the server does (cognee's get_llm_config) and validates it against
+    # the provider, so the verdict matches reality. It runs at session start, so the
+    # signal still appears within seconds of launch.
+
+    # The host (Qwen) session id is a local correlation key only: it keeps every
+    # hook process of this launch resolving the SAME Cognee session id (via the
+    # host-keyed map). It is never sent to Cognee as an identity.
+    session_candidate, session_source = resolve_session_key_from_payload(payload)
+    session_key = set_session_key(session_candidate)
+    if not session_key:
+        hook_log("missing_payload_session_id", {"cwd": cwd})
+        print(
+            "cognee-plugin: missing payload session_id; refusing to register",
+            file=sys.stderr,
+        )
+        return {
+            "hookSpecificOutput": {"hookEventName": "SessionStart"},
+        }
+    os.environ["COGNEE_SESSION_KEY"] = session_key
+
+    # Resolve (and persist) this launch's record: session_id (data scoping, unique
+    # per launch) + conn_uuid (liveness handle for registration/counting). Written
+    # synchronously here so prompt hooks read back the identical ids before any run.
+    session_id, conn_uuid = ensure_launch_record(session_key, cwd)
+    os.environ["COGNEE_SESSION_ID"] = session_id
+    agent_session_name = conn_uuid
+    hook_log(
+        "session_resolved",
+        {
+            "source": session_source,
+            "session_key": session_key,
+            "session_id": session_id,
+            "conn_uuid": conn_uuid,
+        },
+    )
+    dataset = get_dataset(config)
+
+    # Boot-vs-connect is decided purely by whether the server is already up:
+    #   * up                -> connect (we don't boot, so agent mode is left as-is)
+    #   * down + local URL  -> boot it; agent mode is set at the uvicorn spawn so
+    #                          the server tears down once all agents disconnect
+    #   * down + remote URL -> can't boot a remote host; connect and degrade
+    user_id = ""
+    agent_api_key = ""
+    # An empty target (forced cloud, no URL) must never boot: _is_local_url("")
+    # parses to localhost, so gate on the URL being present at all.
+    # Local endpoints get the full-evidence presence check (quick form — the
+    # boot path re-verifies rigorously before any install), so the recorded
+    # decision distinguishes a busy server from an absent one. Remote endpoints
+    # keep the plain HTTP probe: there is no local evidence for them, and they
+    # are never booted. will_boot means "enter the local bootstrap path" — the
+    # actual install/boot license is enforced inside _ensure_local_server_running,
+    # so a busy server still gets a worker that waits for it instead of a boot.
+    presence_verdict, presence_evidence = "", {}
+    if target_url and _is_local_url(target_url):
+        presence_verdict, presence_evidence = server_presence(target_url, confirm_absent=False)
+        server_live = presence_verdict == PRESENCE_READY
+    else:
+        server_live = bool(target_url) and _health_ok(_health_url(target_url))
+    will_boot = (not server_live) and bool(target_url) and _is_local_url(target_url)
+    hook_log(
+        "endpoint_mode_selected",
+        {
+            "base_url": target_url,
+            "server_live": server_live,
+            "will_boot": will_boot,
+            **(
+                {"presence": presence_verdict, "evidence": presence_evidence}
+                if presence_verdict
+                else {}
+            ),
+        },
+    )
+    if will_boot and _LAZY_BOOTSTRAP:
+        _spawn_bootstrap(config, cwd, session_id, agent_session_name, session_key, dataset)
+        user_id = os.environ.get("COGNEE_USER_ID", "")
+    else:
+        user_id, agent_api_key, ok = await _run_heavy(
+            config,
+            cwd,
+            session_id,
+            agent_session_name,
+            session_key,
+            dataset,
+            managed_endpoint=not will_boot,
+            boot_timeout=_HEALTH_TIMEOUT_SECONDS,
+        )
+        if not ok:
+            if _LAZY_BOOTSTRAP and target_url and _is_local_url(target_url):
+                # Inline attempt failed; retry the heavy path out of band.
+                _spawn_bootstrap(config, cwd, session_id, agent_session_name, session_key, dataset)
+            else:
+                return {}
+
+    # Remove legacy resolved cache files. Runtime state now comes from HTTP endpoints.
+    _purge_legacy_resolved_files()
+
+    # Create config file on first run if it doesn't exist
+    config_file = Path.home() / ".cognee-plugin" / "config.json"
+    if not config_file.exists():
+        save_config(config)
+
+    # Reset the idle clock for this Qwen process before the watcher
+    # starts, otherwise a stale timestamp from a prior session can cause
+    # an immediate improve on startup.
+    touch_activity()
+
+    # Launch the idle watcher (syncs session memory to graph after the agent
+    # goes idle). Runs in both local-server and cloud modes — the watcher picks
+    # the HTTP or local sync path itself. COGNEE_IDLE_DISABLED opts out.
+    if os.environ.get("COGNEE_IDLE_DISABLED", "").lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        _spawn_idle_watcher(session_id, dataset, user_id, config, session_key)
+
+    _spawn_exit_watcher(
+        session_id,
+        dataset,
+        session_key=session_key,
+        agent_session_name=agent_session_name,
+        api_key=agent_api_key,
+        service_url=str(config.get("base_url", "") or ""),
+    )
+
+    mode = "cloud" if config.get("base_url") else "local"
+    print(
+        f"cognee-plugin: session ready (mode={mode}, "
+        f"session={session_id}, dataset={dataset}, user={user_id[:8]}...)",
+        file=sys.stderr,
+    )
+
+    status_line = render_status_for_host(session_key)
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": status_line + _update_nudge_suffix(),
+        },
+    }
+
+
+def _update_nudge_suffix() -> str:
+    """One-time 'update available' line appended to SessionStart context.
+
+    Reads the marker written by the idle watcher's background check (no network),
+    shown once per newly-detected version (tracked via ``notified_version``). The
+    per-turn in-context status (render_status_for_host) carries the short ambient
+    segment; this is the actionable one-shot nudge with the update command.
+    """
+    try:
+        from _plugin_common import mark_update_notified, read_update_status
+
+        status = read_update_status()
+    except Exception:
+        return ""
+    if not status:
+        return ""
+    installed = str(status.get("installed_version") or "")
+    latest = str(status.get("latest_version") or "")
+    if not (installed and latest) or status.get("notified_version") == latest:
+        return ""
+    try:
+        mark_update_notified(latest)
+    except Exception:
+        pass
+    return (
+        f"\n\nCognee update available {installed} → {latest} — run "
+        "`qwen extensions update cognee` to update."
+    )
+
+
+def main():
+    # First run: leave a commented ~/.cognee/.env template so one-time config
+    # has a documented file to land in. Values (if any) were already loaded
+    # into os.environ when _plugin_common was imported.
+    from _env_file import ensure_env_file_template, env_file_path
+
+    if ensure_env_file_template():
+        hook_log("env_file_template_created", {"path": str(env_file_path())})
+
+    # Detached bootstrap mode: run the slow server boot + registration out of
+    # band so the SessionStart hook itself returns fast.
+    if _BOOTSTRAP_ARG in sys.argv:
+        idx = sys.argv.index(_BOOTSTRAP_ARG)
+        raw = sys.argv[idx + 1] if len(sys.argv) > idx + 1 else ""
+        try:
+            bootstrap = json.loads(raw) if raw.strip() else {}
+        except json.JSONDecodeError:
+            bootstrap = {}
+        try:
+            asyncio.run(_run_bootstrap(bootstrap))
+        except Exception as exc:
+            hook_log("bootstrap_main_exception", {"error": str(exc)[:200]})
+        return
+
+    payload_raw = sys.stdin.read()
+    try:
+        payload = json.loads(payload_raw) if payload_raw.strip() else {}
+    except json.JSONDecodeError:
+        payload = {}
+
+    # Keep SessionStart output as a valid empty hook result. Recall context is
+    # injected on UserPromptSubmit, matching the original Qwen hook contract.
+    output = {}
+    try:
+        with quiet_hook_output("session-start"):
+            output = asyncio.run(_start(payload)) or {}
+    except Exception as exc:
+        hook_log("session_start_exception", {"error": str(exc)[:200]})
+    print(json.dumps(output))
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/qwen/scripts/store-to-session.py
+++ b/integrations/qwen/scripts/store-to-session.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""Store tool calls and assistant responses into the Cognee session cache.
+
+Routes tool calls to the structured ``TraceEntry`` path (new trace-step
+shape with origin_function / method_params / method_return_value /
+status). Routes the final assistant message on Stop to a ``QAEntry``.
+
+Runs async on the PostToolUse / Stop hooks - fire-and-forget, never
+blocks Qwen.
+
+Configuration:
+    Resolves session state via Cognee HTTP endpoints.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import urllib.error
+
+# Add scripts dir to path for helper imports
+sys.path.insert(0, os.path.dirname(__file__))
+from _plugin_common import (
+    append_http_bridge_entry,
+    append_warmup_entry,
+    bump_save_counter,
+    bump_turn_counter,
+    get_session_key,
+    hook_log,
+    http_api_ready,
+    load_resolved,
+    notify,
+    pop_pending_prompt,
+    quiet_hook_output,
+    remember_entry_via_http,
+    resolve_runtime_mode,
+    resolve_session_key_from_payload,
+    resolve_user,
+    run_session_improve,
+    server_usable,
+    set_session_key,
+    touch_activity,
+    write_outcome_ambiguous,
+)
+from config import (
+    ensure_cognee_ready,
+    ensure_dataset_ready,
+    get_dataset,
+    get_session_id,
+    improve_session_local,
+    load_config,
+)
+
+# Hard cap per field to avoid ballooning the cache with massive tool outputs.
+_MAX_PARAMS_BYTES = 4000
+_MAX_RETURN_BYTES = 8000
+_MAX_ASSISTANT_BYTES = 8000
+
+
+async def _fire_improve_background(dataset: str, session_id: str, user, reason: str) -> None:
+    """Fire-and-forget session improve; failures are logged but never raised.
+
+    The server bridges the session itself from its session cache (improve),
+    instead of the old client-side full-document re-post — see run_session_improve.
+    """
+    try:
+        if http_api_ready():
+            wrote = run_session_improve(dataset, session_id)
+            hook_log(
+                "auto_improve_fired",
+                {"reason": reason, "session": session_id, "via": "http_improve", "wrote": wrote},
+            )
+            if wrote:
+                notify(f"session improve submitted ({reason})")
+            return
+
+        await ensure_dataset_ready(dataset, user)
+        result = await improve_session_local(dataset, session_id, user)
+        hook_log(
+            "auto_improve_fired",
+            {
+                "reason": reason,
+                "session": session_id,
+                "via": "local_improve",
+                "ok": bool(result.get("ok")),
+            },
+        )
+        notify(f"session improve completed ({reason})")
+    except Exception as exc:
+        hook_log("auto_improve_error", {"reason": reason, "error": str(exc)[:200]})
+
+
+def _truncate_str(value, cap: int) -> str:
+    """Coerce to string and cap at ``cap`` bytes (utf-8), appending ``...`` if truncated.
+
+    Always round-trips through utf-8 with errors="replace": hook payloads can
+    carry lone surrogates (binary tool output rendered into the transcript),
+    and one stored surrogate 500s the session-detail endpoint and wedges the
+    improve pipeline server-side.
+    """
+    if value is None:
+        return ""
+    text = value if isinstance(value, str) else json.dumps(value, default=str, ensure_ascii=False)
+    encoded = text.encode("utf-8", errors="replace")
+    if len(encoded) <= cap:
+        return encoded.decode("utf-8")
+    return encoded[: cap - 3].decode("utf-8", errors="ignore") + "..."
+
+
+def _infer_status(payload: dict) -> tuple[str, str]:
+    """Return (status, error_message) from a PostToolUse payload."""
+    # Qwen and Claude-style payloads may set tool_response.is_error=True on failures; also
+    # check for an explicit 'error' key at the top level.
+    response = payload.get("tool_response") or payload.get("tool_output") or ""
+    if isinstance(response, dict):
+        if response.get("is_error") or response.get("error"):
+            err = response.get("error") or response.get("message") or "Tool reported an error."
+            return "error", _truncate_str(err, 500)
+    if isinstance(payload.get("error"), str) and payload["error"]:
+        return "error", _truncate_str(payload["error"], 500)
+    return "success", ""
+
+
+def _load_session() -> tuple[str, str, str]:
+    """Load session_id, dataset, user_id from resolved cache with fallbacks."""
+    resolved = load_resolved()
+    session_id = resolved.get("session_id", "")
+    dataset = resolved.get("dataset", "")
+    user_id = resolved.get("user_id", "")
+    if not session_id or not dataset:
+        config = load_config()
+        session_id = session_id or get_session_id(config)
+        dataset = dataset or get_dataset(config)
+    return session_id, dataset, user_id
+
+
+async def _store_tool_call(payload: dict) -> None:
+    """Write a PostToolUse event as a TraceEntry."""
+    tool_name = payload.get("tool_name", "unknown")
+    tool_input = payload.get("tool_input") or {}
+    tool_output = payload.get("tool_output") or payload.get("tool_response") or ""
+
+    # Suppress self-reference: any Bash call that mentions 'cognee' is
+    # likely the plugin/CLI talking to itself and would recurse.
+    if tool_name == "Bash":
+        cmd = ""
+        if isinstance(tool_input, dict):
+            cmd = str(tool_input.get("command", ""))
+        if "cognee" in cmd:
+            hook_log("skip_self_cognee_bash", {"cmd_prefix": cmd[:80]})
+            return
+
+    status, error_message = _infer_status(payload)
+
+    # Normalize method_params: small structured dict is ideal; fall back
+    # to a truncated-string dict if we got something non-JSON-safe.
+    if isinstance(tool_input, dict):
+        params = {}
+        for k, v in tool_input.items():
+            params[k] = _truncate_str(v, _MAX_PARAMS_BYTES)
+    else:
+        params = {"value": _truncate_str(tool_input, _MAX_PARAMS_BYTES)}
+
+    return_value = _truncate_str(tool_output, _MAX_RETURN_BYTES)
+
+    session_id, dataset, user_id = _load_session()
+    if not session_id:
+        hook_log("no_session_id", {"tool": tool_name})
+        return
+
+    config = load_config()
+    runtime = resolve_runtime_mode()
+    use_http = runtime["mode"] == "http"
+    entry = {
+        "type": "trace",
+        "origin_function": tool_name,
+        "status": status,
+        "method_params": params,
+        "method_return_value": return_value,
+        "error_message": error_message,
+        # LLM-backed feedback per step is expensive on a busy session —
+        # fall back to the deterministic one-liner. Users who want the
+        # LLM summary can flip this in a future config.
+        "generate_feedback_with_llm": False,
+    }
+
+    if not server_usable(runtime.get("base_url", "")):
+        # Server unreachable (stale marker AND a failed probe — a stale marker
+        # alone no longer buffers; this hook fires per tool call, so its probe
+        # keeps the ready marker fresh through long turns, #298): don't block
+        # the tool call and don't lose the trace. Buffer the structured entry
+        # for a later /remember/entry replay (improve bridges only what the
+        # server session cache holds), and keep the legacy text mirror for the
+        # document-bridge fallback path.
+        append_warmup_entry(dataset, session_id, entry)
+        trace_text = (
+            f"{tool_name} [{status}]\n"
+            f"Params: {json.dumps(params, ensure_ascii=False)}\n"
+            f"Return: {return_value}"
+        )
+        append_http_bridge_entry(dataset, session_id, trace=trace_text)
+        bump_save_counter(session_id, "trace")
+        hook_log("store_buffered_warming", {"hook": "tool", "tool": tool_name})
+        return
+    if not use_http:
+        await ensure_cognee_ready(config)
+
+    try:
+        if use_http:
+            result = remember_entry_via_http(dataset, session_id, entry)
+            user = None
+        else:
+            import cognee
+            from cognee.memory import TraceEntry
+
+            user = await resolve_user(user_id)
+            result = await cognee.remember(
+                TraceEntry(**entry),
+                dataset_name=dataset,
+                session_id=session_id,
+                self_improvement=False,
+                user=user,
+            )
+    except Exception as exc:
+        # Same reasoning as the Stop path: the server_usable() guard above only
+        # catches an outage already known about, so a server that dies inside the
+        # ready marker's 30s TTL lands here with a real, failed write. Buffer the
+        # retryable cases so the trace survives; drop a 4xx loudly, because the
+        # drain stops at the first entry it cannot send and a permanently
+        # rejected one would block every entry behind it.
+        status_code = exc.code if isinstance(exc, urllib.error.HTTPError) else None
+        retryable = status_code is None or status_code >= 500
+        if retryable:
+            # A timeout or gateway error may have landed server-side; mark the
+            # buffered copy so the drain verifies before re-sending —
+            # /remember/entry has no idempotency, and a blind replay of a
+            # committed write duplicates the trace into the next improve.
+            append_warmup_entry(dataset, session_id, entry, ambiguous=write_outcome_ambiguous(exc))
+            trace_text = (
+                f"{tool_name} [{status}]\n"
+                f"Params: {json.dumps(params, ensure_ascii=False)}\n"
+                f"Return: {return_value}"
+            )
+            append_http_bridge_entry(dataset, session_id, trace=trace_text)
+            bump_save_counter(session_id, "trace")
+            hook_log(
+                "trace_buffered_after_error",
+                {"tool": tool_name, "status": status_code, "error": str(exc)[:200]},
+            )
+            notify(f"trace store failed, buffered for replay ({exc})")
+        else:
+            hook_log(
+                "trace_store_error",
+                {
+                    "tool": tool_name,
+                    "error": str(exc)[:200],
+                    "status": status_code,
+                    "buffered": False,
+                },
+            )
+            notify(f"trace store failed ({exc})")
+        return
+
+    if result:
+        trace_id = (
+            result.get("entry_id")
+            if isinstance(result, dict)
+            else getattr(result, "entry_id", None)
+        )
+        hook_log(
+            "trace_stored",
+            {
+                "tool": tool_name,
+                "status": status,
+                "trace_id": trace_id,
+            },
+        )
+        notify(f"trace stored ({tool_name}, {status})")
+        if use_http:
+            trace_text = (
+                f"{tool_name} [{status}]\n"
+                f"Params: {json.dumps(params, ensure_ascii=False)}\n"
+                f"Return: {return_value}"
+            )
+            append_http_bridge_entry(
+                dataset,
+                session_id,
+                trace=trace_text,
+            )
+        bump_save_counter(session_id, "trace")
+
+        touch_activity()
+        count, should_improve = bump_turn_counter(session_id)
+        if should_improve:
+            await _fire_improve_background(dataset, session_id, user, reason=f"turn_{count}")
+    else:
+        hook_log("trace_store_noresult", {"tool": tool_name})
+
+
+async def _store_assistant_stop(payload: dict) -> None:
+    """Write a Stop-hook payload (final assistant message) as a QAEntry."""
+    msg = str(payload.get("assistant_message") or payload.get("last_assistant_message") or "")
+    if not msg or msg == "null":
+        return
+
+    msg = _truncate_str(msg, _MAX_ASSISTANT_BYTES)
+
+    session_id, dataset, user_id = _load_session()
+    if not session_id:
+        hook_log("no_session_id", {"event": "stop"})
+        return
+
+    config = load_config()
+    runtime = resolve_runtime_mode()
+    use_http = runtime["mode"] == "http"
+    pending = pop_pending_prompt(session_id, turn_id=str(payload.get("turn_id") or ""))
+
+    # Qwen intentionally differs from Claude here: store one paired
+    # prompt/answer row so Cognee's filesystem session cache does not get
+    # separate question-only and answer-only QA entries for the same turn.
+    entry = {
+        "type": "qa",
+        "question": pending.get("prompt", ""),
+        "answer": msg,
+        "context": pending.get("context", ""),
+    }
+
+    if not server_usable(runtime.get("base_url", "")):
+        # Server unreachable (stale marker AND a failed probe): buffer the
+        # structured entry for a later /remember/entry replay (improve bridges
+        # only what the server session cache holds), and keep the legacy text
+        # mirror for the document-bridge fallback path.
+        append_warmup_entry(dataset, session_id, entry)
+        append_http_bridge_entry(
+            dataset,
+            session_id,
+            question=pending.get("prompt", ""),
+            answer=msg,
+        )
+        bump_save_counter(session_id, "answer")
+        hook_log("store_buffered_warming", {"hook": "stop"})
+        return
+    if not use_http:
+        await ensure_cognee_ready(config)
+
+    try:
+        if use_http:
+            result = remember_entry_via_http(dataset, session_id, entry)
+            user = None
+        else:
+            import cognee
+            from cognee.memory import QAEntry
+
+            user = await resolve_user(user_id)
+            result = await cognee.remember(
+                QAEntry(**entry),
+                dataset_name=dataset,
+                session_id=session_id,
+                self_improvement=False,
+                user=user,
+            )
+    except Exception as exc:
+        # A write that FAILED must still be buffered, or the turn is simply lost.
+        # The `server_usable()` guard above only catches an outage the plugin
+        # already knows about: the ready marker has a 30s TTL, so a server that
+        # dies inside that window leaves server_usable() returning True, the write
+        # is attempted for real, and this is where it lands. Logging alone here is
+        # what the warmup spillway exists to prevent.
+        #
+        # Not every failure is worth replaying, though. The drain stops at the
+        # first entry it cannot send and only trims what it drained, so an entry
+        # that can never succeed would sit at the head of the queue and block
+        # everything behind it forever. A 4xx is exactly that: the same bytes will
+        # be rejected the same way next time. Transport failures and 5xx are
+        # retryable, so those are buffered and anything else is dropped loudly.
+        status = exc.code if isinstance(exc, urllib.error.HTTPError) else None
+        retryable = status is None or status >= 500
+        if retryable:
+            # Ambiguous outcomes (timeout / gateway error after the request
+            # went out) are verified against the server before replay — see
+            # write_outcome_ambiguous.
+            append_warmup_entry(dataset, session_id, entry, ambiguous=write_outcome_ambiguous(exc))
+            append_http_bridge_entry(
+                dataset,
+                session_id,
+                question=pending.get("prompt", ""),
+                answer=msg,
+            )
+            bump_save_counter(session_id, "answer")
+            hook_log(
+                "store_buffered_after_error",
+                {"hook": "stop", "status": status, "error": str(exc)[:200]},
+            )
+            notify(f"stop store failed, buffered for replay ({exc})")
+        else:
+            hook_log(
+                "stop_store_error",
+                {"error": str(exc)[:200], "status": status, "buffered": False},
+            )
+            notify(f"stop store failed ({exc})")
+        return
+
+    if result:
+        if use_http:
+            append_http_bridge_entry(
+                dataset,
+                session_id,
+                question=pending.get("prompt", ""),
+                answer=msg,
+            )
+        qa_id = (
+            result.get("entry_id")
+            if isinstance(result, dict)
+            else getattr(result, "entry_id", None)
+        )
+        hook_log("stop_stored", {"chars": len(msg), "qa_id": qa_id})
+        notify(f"assistant message stored ({len(msg)} chars)")
+        bump_save_counter(session_id, "answer")
+
+        touch_activity()
+        count, should_improve = bump_turn_counter(session_id)
+        if should_improve:
+            await _fire_improve_background(dataset, session_id, user, reason=f"turn_{count}")
+
+
+def main():
+    payload_raw = sys.stdin.read()
+    if not payload_raw.strip():
+        return
+
+    try:
+        payload = json.loads(payload_raw)
+    except json.JSONDecodeError:
+        hook_log("invalid_payload_json")
+        return
+
+    session_key_candidate, session_key_source = resolve_session_key_from_payload(payload)
+    if session_key_candidate:
+        set_session_key(session_key_candidate)
+    hook_log("store_session_key", {"source": session_key_source, "value": session_key_candidate})
+    if not get_session_key():
+        hook_log("store_missing_session_key")
+        return
+
+    is_stop = "--stop" in sys.argv
+    try:
+        with quiet_hook_output("store-to-session"):
+            if is_stop:
+                asyncio.run(_store_assistant_stop(payload))
+            else:
+                asyncio.run(_store_tool_call(payload))
+    except Exception as exc:
+        hook_log("run_exception", {"stop": is_stop, "error": str(exc)[:200]})
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/qwen/scripts/store-user-prompt.py
+++ b/integrations/qwen/scripts/store-user-prompt.py
@@ -207,8 +207,12 @@ def main():
         hook_log("prompt_missing_session_key")
         return
 
-    prompt = payload.get("prompt", "")
-    if not prompt or len(prompt) < 5:
+    # Qwen also fires UserPromptSubmit for internal ToolResult/Hook sends. Only
+    # an ordinary interactive user turn carries the pre-expansion provenance
+    # field, so using ``prompt`` here can replace the pending question with a
+    # function-response payload before Stop pairs it with the answer.
+    prompt = payload.get("submitted_prompt")
+    if not isinstance(prompt, str) or len(prompt.strip()) < 5:
         return
 
     try:

--- a/integrations/qwen/scripts/store-user-prompt.py
+++ b/integrations/qwen/scripts/store-user-prompt.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Store the user's prompt until Qwen Stop provides the assistant answer.
+
+Runs async on the UserPromptSubmit hook so it doesn't block the
+parallel context-lookup hook. Unlike the Claude integration, Qwen keeps
+the prompt pending and writes a single paired QAEntry on Stop.
+
+Configuration:
+    Resolves session state via Cognee HTTP endpoints.
+"""
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Add scripts dir to path for helper imports
+sys.path.insert(0, os.path.dirname(__file__))
+from _plugin_common import (
+    bump_save_counter,
+    drain_warmup_entries,
+    get_session_key,
+    hook_log,
+    load_resolved,
+    notify,
+    quiet_hook_output,
+    refresh_credits,
+    remember_pending_prompt,
+    resolve_runtime_mode,
+    resolve_session_key_from_payload,
+    resolve_user,
+    server_ready_hint,
+    server_usable,
+    set_session_key,
+    touch_activity,
+)
+from _proc import pid_alive
+from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
+
+MAX_TEXT = 4000
+_STATE_DIR = Path.home() / ".cognee-plugin" / "qwen"
+_WATCHER_PID = _STATE_DIR / "watcher.pid"
+_WATCHER_STOP = _STATE_DIR / "watcher.stop"
+_WATCHER_SCRIPT = Path(__file__).with_name("idle-watcher.py")
+
+
+def _load_session() -> tuple[str, str, str, str]:
+    resolved = load_resolved()
+    session_id = resolved.get("session_id", "")
+    dataset = resolved.get("dataset", "")
+    user_id = resolved.get("user_id", "")
+    tenant_id = resolved.get("tenant_id", "")
+    if not session_id or not dataset:
+        config = load_config()
+        session_id = session_id or get_session_id(config)
+        dataset = dataset or get_dataset(config)
+    return session_id, dataset, user_id, tenant_id
+
+
+def _watcher_alive() -> bool:
+    if not _WATCHER_PID.exists():
+        return False
+    try:
+        pid = int(_WATCHER_PID.read_text(encoding="utf-8").strip())
+    except Exception as exc:
+        hook_log("prompt_watcher_alive_check_failed", {"error": str(exc)[:200]})
+        return False
+    return pid_alive(pid)
+
+
+def _ensure_idle_watcher(session_id: str, dataset: str, user_id: str, config: dict) -> None:
+    """Start the idle watcher on a new prompt if the prior one exited after bridging."""
+    if os.environ.get("COGNEE_IDLE_DISABLED", "").lower() in ("1", "true", "yes"):
+        return
+    if not session_id or _watcher_alive():
+        return
+
+    try:
+        if _WATCHER_STOP.exists():
+            _WATCHER_STOP.unlink()
+    except Exception as exc:
+        hook_log("prompt_watcher_stop_unlink_failed", {"error": str(exc)[:200]})
+
+    bootstrap = {
+        "session_id": session_id,
+        "dataset": dataset,
+        "user_id": user_id,
+        "session_key": os.environ.get("COGNEE_SESSION_KEY", ""),
+        "config": {
+            "base_url": config.get("base_url", ""),
+            "llm_model": config.get("llm_model", ""),
+            "dataset": dataset,
+        },
+    }
+
+    log_path = _STATE_DIR / "watcher.log"
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_fh = log_path.open("a", encoding="utf-8")
+    except Exception as exc:
+        hook_log("prompt_watcher_log_open_failed", {"error": str(exc)[:200]})
+        log_fh = subprocess.DEVNULL
+
+    try:
+        env = os.environ.copy()
+        subprocess.Popen(
+            [sys.executable, str(_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            env=env,
+            start_new_session=True,
+            close_fds=True,
+        )
+        hook_log("idle_watcher_restarted", {"session": session_id, "dataset": dataset})
+    except Exception as exc:
+        hook_log("idle_watcher_restart_failed", {"error": str(exc)[:200]})
+
+
+def _prompt_context(payload: dict) -> str:
+    context = {
+        "cwd": payload.get("cwd"),
+        "model": payload.get("model"),
+        "turn_id": payload.get("turn_id"),
+        "transcript_path": payload.get("transcript_path"),
+    }
+    return json.dumps({k: v for k, v in context.items() if v}, default=str)
+
+
+async def _store(prompt: str, payload: dict):
+    session_id, dataset, user_id, tenant_id = _load_session()
+    if not session_id:
+        hook_log("no_session_id", {"event": "prompt"})
+        return
+
+    config = load_config()
+    touch_activity()
+    _ensure_idle_watcher(session_id, dataset, user_id, config)
+
+    runtime = resolve_runtime_mode()
+    if runtime["mode"] == "local_sdk" and server_ready_hint(runtime.get("base_url", "")):
+        # Keep Cognee initialization parity with Claude so fresh local
+        # databases, identities, and datasets are ready before Stop writes.
+        # Skipped while the server is still warming so this hook never blocks;
+        # the prompt is still buffered below and flushed once the server is up.
+        try:
+            await ensure_cognee_ready(config)
+            await resolve_user(user_id)
+        except Exception as exc:
+            hook_log("prompt_prepare_warning", {"error": str(exc)[:200]})
+
+    # Round-trip through utf-8 with errors="replace": prompts pasted from
+    # transcripts can carry lone surrogates, and one stored surrogate 500s
+    # the session-detail endpoint and wedges the improve pipeline server-side.
+    safe_prompt = prompt[:MAX_TEXT].encode("utf-8", errors="replace").decode("utf-8")
+    remember_pending_prompt(
+        session_id,
+        safe_prompt,
+        turn_id=str(payload.get("turn_id") or ""),
+        context=_prompt_context(payload),
+    )
+    hook_log("prompt_pending", {"chars": len(prompt), "turn_id": payload.get("turn_id")})
+    notify(f"user prompt pending ({len(prompt)} chars)")
+    bump_save_counter(session_id, "prompt")
+
+    # Replay any warmup-buffered entries. This hook is the sibling of
+    # session-context-lookup on the same UserPromptSubmit event — identical
+    # trigger point, but the prompt's recall does not wait on it, so the drain
+    # (N sequential /remember/entry calls) can no longer starve recall (#298).
+    # It runs LAST so a mid-drain kill cannot cost the fast bookkeeping above;
+    # the drain itself is a cheap no-op on an empty buffer, preserves the
+    # unreplayed tail on failure, and is single-flighted by its own lock
+    # against the improve/SessionEnd paths that also drain.
+    if server_usable(runtime.get("base_url", "")):
+        try:
+            drain_warmup_entries(dataset, session_id)
+        except Exception as exc:
+            hook_log("warmup_drain_failed", {"error": str(exc)[:200]})
+        # Status-line credits: unlabeled refresh at turn START. This reading
+        # is the baseline the Stop-time refresh (credits-refresh.py) diffs
+        # against to attribute the finished turn's cost — labeling it here
+        # would misattribute the PREVIOUS turn's tail as this turn's recall.
+        # tenant_id (from this turn's connections/me lookup) binds the marker
+        # entry to our tenant, so the tenantless Stop-hook refresh can find it
+        # by base_url. Never raises; no-ops on a local server.
+        refresh_credits(tenant_id=tenant_id)
+
+
+def main():
+    payload_raw = sys.stdin.read()
+    if not payload_raw.strip():
+        return
+
+    try:
+        payload = json.loads(payload_raw)
+    except json.JSONDecodeError:
+        hook_log("invalid_payload_json", {"event": "prompt"})
+        return
+
+    session_key_candidate, session_key_source = resolve_session_key_from_payload(payload)
+    if session_key_candidate:
+        set_session_key(session_key_candidate)
+    hook_log("prompt_session_key", {"source": session_key_source, "value": session_key_candidate})
+    if not get_session_key():
+        hook_log("prompt_missing_session_key")
+        return
+
+    prompt = payload.get("prompt", "")
+    if not prompt or len(prompt) < 5:
+        return
+
+    try:
+        with quiet_hook_output("store-user-prompt"):
+            asyncio.run(_store(prompt, payload))
+    except Exception as exc:
+        hook_log("prompt_run_exception", {"error": str(exc)[:200]})
+
+
+if __name__ == "__main__":
+    main()
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": "",
+                }
+            }
+        )
+    )

--- a/integrations/qwen/scripts/sync-session-to-graph.py
+++ b/integrations/qwen/scripts/sync-session-to-graph.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Bridge session cache entries into the permanent knowledge graph on session end.
+
+Runs the integration's explicit session bridge:
+  1. Persist session Q&A/trace cache into the permanent graph
+  2. Sync graph knowledge back into the session cache for recall
+
+Configuration:
+    Resolves session identity from Cognee endpoints via API auth.
+"""
+
+import asyncio
+import hashlib
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from contextlib import nullcontext
+from pathlib import Path
+
+# Add scripts dir to path for config/_plugin_common imports
+sys.path.insert(0, os.path.dirname(__file__))
+from _plugin_common import (
+    get_session_key,
+    hook_log,
+    http_api_ready,
+    load_resolved,
+    resolve_session_key_from_payload,
+    resolve_user,
+    resolved_http_endpoint_auth,
+    run_session_improve,
+    set_session_key,
+    sync_lock,
+    unregister_agent_via_http,
+)
+from config import (
+    ensure_cognee_ready,
+    ensure_dataset_ready,
+    get_dataset,
+    get_session_id,
+    improve_session_local,
+    load_config,
+)
+
+_STATE_DIR = Path.home() / ".cognee-plugin" / "qwen"
+_WATCHER_PID = _STATE_DIR / "watcher.pid"
+_WATCHER_STOP = _STATE_DIR / "watcher.stop"
+_DETACHED_ARG = "--detached-final"
+_SESSION_END_ARG = "--session-end"
+_FINAL_SYNC_ONCE_DIR = _STATE_DIR / "final-sync-once"
+_FINAL_SYNC_ONCE_TTL_SECONDS = 3600
+_DETACHED_RETRIES_DEFAULT = 3
+_DETACHED_RETRY_DELAY_DEFAULT = 10.0
+_SESSION_END_START_DELAY_DEFAULT = 2.0
+
+
+def _stop_idle_watcher() -> None:
+    """Signal the idle watcher to exit and drop its pidfile.
+
+    Uses both a sentinel file (safe, polled by the watcher) and a
+    SIGTERM (fast). Either path is sufficient; both together handle
+    the SIGTERM-blocked-during-improve edge case.
+    """
+    try:
+        _WATCHER_STOP.parent.mkdir(parents=True, exist_ok=True)
+        _WATCHER_STOP.write_text("stop", encoding="utf-8")
+    except Exception as exc:
+        hook_log("watcher_stop_write_failed", {"error": str(exc)[:200]})
+    if _WATCHER_PID.exists():
+        try:
+            pid = int(_WATCHER_PID.read_text(encoding="utf-8").strip())
+            os.kill(pid, signal.SIGTERM)
+        except Exception as exc:
+            hook_log("watcher_sigterm_failed", {"error": str(exc)[:200]})
+
+
+def _spawn_detached_sync() -> bool:
+    """Run the expensive sync outside a short hook window."""
+    try:
+        env = os.environ.copy()
+        env.setdefault("COGNEE_SYNC_START_DELAY", str(_SESSION_END_START_DELAY_DEFAULT))
+        env["COGNEE_UNREGISTER_ON_FINISH"] = "1"
+        subprocess.Popen(
+            [sys.executable, str(Path(__file__).resolve()), _DETACHED_ARG],
+            cwd=os.getcwd(),
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        return True
+    except Exception as exc:
+        hook_log("sync_detach_failed", {"error": str(exc)[:300]})
+        return False
+
+
+def _final_sync_identity() -> tuple[str, str]:
+    """Return a stable per-session token for detached final sync dedupe."""
+    session_key = str(os.environ.get("COGNEE_SESSION_KEY", "") or "").strip()
+    if session_key:
+        return session_key, "COGNEE_SESSION_KEY"
+    session_id = str(os.environ.get("COGNEE_SYNC_SESSION_ID", "") or "").strip()
+    if session_id:
+        return session_id, "COGNEE_SYNC_SESSION_ID"
+    return "", "missing"
+
+
+def _claim_final_sync_once() -> bool:
+    """Allow exactly one detached final sync worker per session."""
+    _prune_final_sync_markers()
+
+    token, source = _final_sync_identity()
+    if not token:
+        # No stable identity available; do not risk skipping final sync.
+        hook_log("final_sync_once_no_token", {"source": source})
+        return True
+
+    digest = hashlib.sha1(token.encode("utf-8")).hexdigest()
+    marker = _FINAL_SYNC_ONCE_DIR / f"{digest}.done"
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(str(marker), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(token)
+        hook_log("final_sync_once_claimed", {"source": source, "marker": str(marker)})
+        return True
+    except FileExistsError:
+        hook_log("final_sync_once_already_claimed", {"source": source, "marker": str(marker)})
+        return False
+    except Exception as exc:
+        # On marker failure, prefer proceeding to avoid data loss.
+        hook_log("final_sync_once_claim_failed", {"source": source, "error": str(exc)[:200]})
+        return True
+
+
+def _prune_final_sync_markers() -> None:
+    """Delete stale detached-sync dedupe markers older than configured TTL."""
+    try:
+        if not _FINAL_SYNC_ONCE_DIR.exists():
+            return
+        now = time.time()
+        removed = 0
+        for path in _FINAL_SYNC_ONCE_DIR.glob("*.done"):
+            try:
+                age = now - path.stat().st_mtime
+                if age > _FINAL_SYNC_ONCE_TTL_SECONDS:
+                    path.unlink()
+                    removed += 1
+            except FileNotFoundError:
+                continue
+            except Exception:
+                continue
+        if removed:
+            hook_log(
+                "final_sync_once_pruned",
+                {"removed": removed, "ttl_seconds": _FINAL_SYNC_ONCE_TTL_SECONDS},
+            )
+    except Exception as exc:
+        hook_log("final_sync_once_prune_failed", {"error": str(exc)[:200]})
+
+
+def _is_session_end_payload(payload_raw: str) -> bool:
+    """Return True only for an actual SessionEnd hook payload."""
+    if not payload_raw.strip():
+        return False
+    try:
+        payload = json.loads(payload_raw)
+    except json.JSONDecodeError:
+        return False
+
+    def _contains_session_end(value) -> bool:
+        if isinstance(value, dict):
+            return any(_contains_session_end(item) for item in value.values())
+        if isinstance(value, list):
+            return any(_contains_session_end(item) for item in value)
+        if isinstance(value, str):
+            return value == "SessionEnd" or value.endswith(".SessionEnd")
+        return False
+
+    event = (
+        payload.get("hook_event_name")
+        or payload.get("hookEventName")
+        or payload.get("event")
+        or payload.get("hook")
+    )
+    return event == "SessionEnd" or _contains_session_end(payload)
+
+
+def _load_resolved() -> tuple:
+    """
+    Load session ID, dataset, user ID,
+    agent session name, registration marker, and API key marker.
+    """
+    session_key = set_session_key(get_session_key())
+    env_session_id = str(os.environ.get("COGNEE_SYNC_SESSION_ID", "") or "").strip()
+    env_dataset = str(os.environ.get("COGNEE_SYNC_DATASET", "") or "").strip()
+    env_agent_session_name = str(os.environ.get("COGNEE_AGENT_SESSION_NAME", "") or "").strip()
+    env_api_key = str(os.environ.get("COGNEE_API_KEY", "") or "").strip()
+    env_service_url = str(os.environ.get("COGNEE_BASE_URL", "") or "").strip()
+    resolved_service_url, resolved_api_key = resolved_http_endpoint_auth()
+    env_api_key = env_api_key or resolved_api_key
+    env_service_url = env_service_url or resolved_service_url
+
+    if not session_key:
+        hook_log("sync_missing_session_key")
+    data = load_resolved(session_key=session_key)
+    if data:
+        service_url = env_service_url or str(data.get("base_url", "") or "").strip()
+        if service_url:
+            os.environ["COGNEE_BASE_URL"] = service_url
+        if data.get("user_id"):
+            os.environ["COGNEE_USER_ID"] = str(data.get("user_id"))
+        return (
+            env_session_id or data.get("session_id", ""),
+            # load_resolved() carries no dataset key, so without the env
+            # override (only the exit watcher sets it) this must fall back to
+            # config, or the SessionEnd worker syncs with an empty dataset.
+            env_dataset or data.get("dataset", "") or get_dataset(load_config()),
+            data.get("user_id", ""),
+            env_agent_session_name or data.get("agent_session_name", ""),
+            bool(data.get("registered", False)),
+            bool(env_api_key or data.get("api_key", "")),
+            session_key,
+        )
+
+    config = load_config()
+    fallback_session_id = get_session_id(config)
+    fallback_agent_session_name = session_key or ""
+    if env_service_url:
+        os.environ["COGNEE_BASE_URL"] = env_service_url
+    return (
+        env_session_id or fallback_session_id,
+        env_dataset or get_dataset(config),
+        "",
+        env_agent_session_name or fallback_agent_session_name,
+        False,
+        bool(env_api_key),
+        session_key,
+    )
+
+
+async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: bool = False):
+    session_id, dataset, user_id, agent_session_name, was_registered, has_api_key, session_key = (
+        _load_resolved()
+    )
+    target_sessions = [session_id] if session_id else []
+    hook_log(
+        "sync_start",
+        {
+            "session": session_id,
+            "targets": target_sessions,
+            "dataset": dataset,
+            "user_id": user_id,
+            "stop_watcher": stop_watcher,
+        },
+    )
+
+    try:
+        if stop_watcher:
+            _stop_idle_watcher()
+            hook_log("sync_stopped_watcher", {"session": session_id, "dataset": dataset})
+
+        config = load_config()
+        api_mode = http_api_ready()
+        lock = nullcontext(True) if api_mode else sync_lock("sync-session-to-graph")
+        with lock as acquired:
+            if not acquired:
+                hook_log("sync_skipped_lock_busy", {"session": session_id, "dataset": dataset})
+                print("cognee-sync: skipped, another sync is running", file=sys.stderr)
+                return
+
+            if not target_sessions:
+                hook_log("sync_no_target_sessions", {"dataset": dataset})
+                return
+
+            incomplete: list[str] = []
+            if api_mode:
+                for sid in target_sessions:
+                    wrote = run_session_improve(dataset, sid)
+                    if not wrote:
+                        incomplete.append(sid)
+                    hook_log(
+                        "sync_bridge_done",
+                        {
+                            "session": sid,
+                            "dataset": dataset,
+                            "via": "http_improve",
+                            "wrote": wrote,
+                        },
+                    )
+                    print(
+                        f"cognee-sync: dataset={dataset} session={sid} "
+                        f"via=http_improve wrote={wrote}",
+                        file=sys.stderr,
+                    )
+                if strict and incomplete:
+                    # The detached final worker retries on exceptions only. This
+                    # is the session's LAST sync — an incomplete one (failed
+                    # improve or undelivered warmup entries) must re-drive the
+                    # whole drain+improve, not silently report success.
+                    raise RuntimeError(
+                        f"final session sync incomplete for: {', '.join(incomplete)}"
+                    )
+                return
+
+            await ensure_cognee_ready(config)
+            user = await resolve_user(user_id)
+            await ensure_dataset_ready(dataset, user)
+            for sid in target_sessions:
+                result = await improve_session_local(dataset, sid, user)
+                if not result.get("ok"):
+                    incomplete.append(sid)
+                hook_log(
+                    "sync_bridge_done",
+                    {
+                        "session": sid,
+                        "dataset": dataset,
+                        "user_id": str(getattr(user, "id", "")),
+                        "via": "local_improve",
+                        "ok": bool(result.get("ok")),
+                    },
+                )
+                print(
+                    f"cognee-sync: dataset={dataset} session={sid} "
+                    f"via=local_improve ok={result.get('ok')}",
+                    file=sys.stderr,
+                )
+            if strict and incomplete:
+                raise RuntimeError(f"final session sync incomplete for: {', '.join(incomplete)}")
+    finally:
+        if unregister_on_finish:
+            if not (was_registered or has_api_key):
+                hook_log(
+                    "agent_unregister_skipped_no_auth",
+                    {"session": session_id, "dataset": dataset},
+                )
+            else:
+                unregister_name = str(agent_session_name or session_key or "").strip()
+                if not unregister_name:
+                    hook_log(
+                        "agent_unregister_skipped_no_session_name",
+                        {"session": session_id, "dataset": dataset},
+                    )
+                else:
+                    ok, active = unregister_agent_via_http(agent_session_name=unregister_name)
+                    hook_log(
+                        "agent_unregister_result",
+                        {
+                            "session": session_id,
+                            "dataset": dataset,
+                            "agent_session_name": unregister_name,
+                            "ok": ok,
+                            "active_agents": active,
+                            "cached_registered": was_registered,
+                        },
+                    )
+
+
+def main():
+    detached_final = _DETACHED_ARG in sys.argv
+    forced_session_end = _SESSION_END_ARG in sys.argv
+    payload_raw = "" if detached_final else sys.stdin.read()
+    if not detached_final and payload_raw.strip():
+        try:
+            payload = json.loads(payload_raw)
+        except json.JSONDecodeError:
+            payload = {}
+        session_key_candidate, session_key_source = resolve_session_key_from_payload(payload)
+        if session_key_candidate:
+            set_session_key(session_key_candidate)
+        hook_log("sync_session_key", {"source": session_key_source, "value": session_key_candidate})
+    is_session_end = forced_session_end or _is_session_end_payload(payload_raw)
+    hook_log(
+        "sync_payload",
+        {
+            "is_session_end": is_session_end,
+            "detached_final": detached_final,
+            "forced_session_end": forced_session_end,
+            "payload_preview": payload_raw[:200],
+        },
+    )
+
+    if detached_final:
+        delay_raw = os.environ.get("COGNEE_SYNC_START_DELAY", "")
+        try:
+            delay = float(delay_raw) if delay_raw else 0.0
+        except ValueError:
+            delay = 0.0
+        if delay > 0:
+            hook_log("sync_start_delayed", {"seconds": delay})
+            time.sleep(delay)
+        if not _claim_final_sync_once():
+            hook_log("sync_detached_skipped_duplicate")
+            return
+
+    unregister_on_finish = detached_final and os.environ.get(
+        "COGNEE_UNREGISTER_ON_FINISH", ""
+    ).lower() in ("1", "true", "yes")
+
+    # Only a true SessionEnd should stop the watcher. Manual syncs and
+    # slash-command invocations happen mid-session, and killing the watcher
+    # there prevents later idle persistence.
+    if is_session_end:
+        _stop_idle_watcher()
+        spawned = _spawn_detached_sync()
+        hook_log("sync_deferred_to_shutdown_worker", {"spawned": spawned})
+        return
+
+    attempts = 1
+    retry_delay = 0.0
+    if detached_final:
+        attempts = int(os.environ.get("COGNEE_SYNC_RETRIES", str(_DETACHED_RETRIES_DEFAULT)))
+        retry_delay = float(
+            os.environ.get("COGNEE_SYNC_RETRY_DELAY", str(_DETACHED_RETRY_DELAY_DEFAULT))
+        )
+
+    for attempt in range(1, max(1, attempts) + 1):
+        try:
+            asyncio.run(
+                _sync(
+                    stop_watcher=False,
+                    unregister_on_finish=unregister_on_finish,
+                    # The detached-final run is the session's last sync: an
+                    # incomplete result raises so this loop retries it.
+                    strict=detached_final,
+                )
+            )
+            return
+        except Exception as exc:
+            # Non-fatal: session sync failure should not crash Qwen.
+            hook_log(
+                "sync_failed",
+                {"attempt": attempt, "attempts": attempts, "error": str(exc)[:300]},
+            )
+            print(f"cognee-sync: failed ({exc})", file=sys.stderr)
+            if attempt < attempts:
+                hook_log("sync_retry_scheduled", {"attempt": attempt + 1, "delay": retry_delay})
+                time.sleep(retry_delay)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/qwen/skills/codebase/SKILL.md
+++ b/integrations/qwen/skills/codebase/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: codebase
+description: Use when ingesting, cognifying, or querying a codebase with Cognee CLI from Qwen.
+---
+
+# Cognee CLI Codebase Workflows
+
+Use this skill when the user asks Qwen to build a Cognee memory of a repository,
+index code, query implementation details, or create a code-aware knowledge graph.
+
+## Rules
+
+- Use `uv run cognee-cli ...`; do not use MCP.
+- Start by defining the codebase scope and dataset name.
+- Never ingest `.env`, private keys, credentials, local database files, virtualenvs, dependency caches, or generated build output.
+- Prefer focused ingestion over sending an entire large repository at once.
+- Use `rg --files` first to inspect candidate paths.
+
+## Scope
+
+Create a dataset name that is stable and readable, such as:
+
+```text
+codebase-cognee
+codebase-frontend
+codebase-api
+```
+
+Inspect candidate files:
+
+```bash
+rg --files
+```
+
+Common exclusions include:
+
+```text
+.git/
+.venv/
+node_modules/
+dist/
+build/
+.next/
+coverage/
+.env
+*.sqlite
+*.db
+*.key
+*.pem
+```
+
+## Ingest
+
+For a focused set of source paths:
+
+```bash
+uv run cognee-cli add <path-1> <path-2> <path-3> -d <dataset-name>
+uv run cognee-cli cognify -d <dataset-name> --background
+```
+
+For small docs or architectural notes:
+
+```bash
+uv run cognee-cli remember <path-or-note> -d <dataset-name>
+```
+
+If command length becomes unwieldy, ingest in batches by directory or feature
+area, then run `cognify` once for the dataset.
+
+## Query
+
+For code-specific questions:
+
+```bash
+uv run cognee-cli search "<implementation question>" -d <dataset-name> -t CODE -k 10 -f pretty
+```
+
+For architecture and reasoning questions:
+
+```bash
+uv run cognee-cli recall "<architecture question>" -d <dataset-name> -t GRAPH_COMPLETION -f pretty
+```
+
+For citation-like output:
+
+```bash
+uv run cognee-cli search "<specific symbol or behavior>" -d <dataset-name> -t CHUNKS -k 10 -f json
+```
+
+Use results as supporting context. Verify important claims against the actual
+files before editing code.
+
+**The server is the source of truth.** `cognee-cli` can print empty stdout even when content exists, so never conclude "not found" from an empty CLI run — confirm against the server directly (authoritative), and omit `-d <dataset>` to search all datasets:
+
+```bash
+curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: ${COGNEE_API_KEY:-}" \
+  -d '{"query": "<question>", "top_k": 10, "only_context": true, "scope": ["graph"]}'
+```

--- a/integrations/qwen/skills/local-ui/SKILL.md
+++ b/integrations/qwen/skills/local-ui/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: local-ui
+description: Use when launching, checking, or reporting on the local Cognee UI/backend through cognee-cli -ui.
+---
+
+# Cognee CLI Local UI
+
+Use this skill when the user asks to launch the local Cognee UI, check whether
+Cognee is running, or report how well the UI/backend work.
+
+## Rules
+
+- Use `uv run cognee-cli -ui` as the primary launcher.
+- Do not use MCP for this plugin.
+- Keep the process running when the user wants the UI available.
+- If ports are already occupied, inspect the running services before starting another copy.
+- Do not kill user processes without explicit approval.
+
+## Launch
+
+From the Cognee repository root:
+
+```bash
+uv run cognee-cli -ui
+```
+
+Expected local surfaces:
+
+```text
+Backend: http://localhost:8000
+Frontend: http://localhost:3000
+```
+
+## Health Checks
+
+Backend:
+
+```bash
+curl -i http://localhost:8000/health
+```
+
+Frontend:
+
+```bash
+curl -i http://localhost:3000/
+```
+
+Useful route checks:
+
+```bash
+curl -i http://localhost:3000/dashboard
+curl -i http://localhost:3000/datasets
+curl -i http://localhost:3000/search
+curl -i http://localhost:3000/knowledge-graph
+```
+
+If authenticated checks are needed, use the repository's documented local test
+credentials only when appropriate and do not expose real user credentials.
+
+## Reporting Status
+
+Report:
+
+- which process or command is running;
+- backend health and any warnings;
+- frontend route availability;
+- working authenticated flows, if checked;
+- broken or suspicious behavior with file references when possible.

--- a/integrations/qwen/skills/memory/SKILL.md
+++ b/integrations/qwen/skills/memory/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: memory
+description: Use when Qwen should remember, recall, search, improve, or forget information using Cognee.
+---
+
+# Cognee Memory
+
+Use this skill when the user asks Qwen to use Cognee as memory, add facts or
+documents, search a knowledge graph, recall prior context, or improve existing
+memory.
+
+## Rules
+
+- Prefer the server-first paths below (HTTP to the running Cognee server).
+- Use `uv run cognee-cli ...` only when the server is genuinely unreachable.
+- Choose a clear dataset name with `-d` or `--dataset-name`; ask only if the dataset boundary is genuinely ambiguous.
+- Do not ingest secrets, credentials, `.env` files, private keys, token dumps, or unrelated generated artifacts.
+- Before destructive commands such as `forget`, `delete`, or `--everything`, get explicit user confirmation.
+
+## Add And Build
+
+**Server-first (one-step ingestion):**
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-remember.sh "<text>" --node-set user_context
+```
+
+Use `--node-set project_docs` for project/code content, `--node-set agent_actions` for agent notes. The script POSTs directly to `/api/v1/remember`. A `{"ok": true}` response means the server accepted the data. An error response means the server rejected or failed the request — check `COGNEE_API_KEY` and server logs; do **not** re-run or conclude the data wasn't stored without confirming against the server.
+
+**Background by default + eventual consistency**: the wrapper submits with `run_in_background=true` (so a large cognify never holds one request open past the cloud's ~10-min request ceiling). The POST returns once the work is **enqueued**, with `dataset_id` and `pipeline_run_id`; `status: "running"` means *submitted, not yet in the permanent graph*. The session cache is searchable immediately, but the graph is queryable only after the cognify pipeline **completes**.
+
+By default the wrapper then waits a short, bounded time (`COGNEE_REMEMBER_WAIT_SECONDS`, default `8`) polling `/api/v1/datasets/status` and adds `"queryable": true|false` + `"wait_outcome"` to the result. `queryable: true` means it's now in the graph and an immediate recall will find it. If `queryable: false`, check `wait_outcome`: `"timeout"` means it's still processing (recall later — not an error), `"errored"` means the cognify failed (check server logs), `"unknown"` means completion couldn't be confirmed (e.g. an older server without the status route). Set `COGNEE_REMEMBER_WAIT_SECONDS=0` to skip the wait, or `COGNEE_REMEMBER_BACKGROUND=false` for a fully synchronous, immediately-queryable write (small content only — large content risks the request ceiling).
+
+**Fallback only — server unreachable:**
+
+```bash
+uv run cognee-cli remember <text-or-path> -d <dataset-name>
+```
+
+For staged work (no HTTP equivalent — CLI only):
+
+```bash
+uv run cognee-cli add <text-or-path> -d <dataset-name>
+uv run cognee-cli cognify -d <dataset-name>
+```
+
+For long processing:
+
+```bash
+uv run cognee-cli remember <text-or-path> -d <dataset-name> --background
+uv run cognee-cli cognify -d <dataset-name> --background
+```
+
+## Recall And Search
+
+**Server-first (authoritative):**
+
+```bash
+curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: ${COGNEE_API_KEY:-}" \
+  -d '{"query": "<question>", "top_k": 10, "only_context": true, "scope": ["graph"]}'
+```
+
+Omit `-H "X-Api-Key: ..."` for a local single-user server (auth is optional). An empty list `[]` from the server is authoritative — the server searched and found nothing.
+
+**Fallback only — server unreachable:**
+
+```bash
+uv run cognee-cli recall "<question>" -d <dataset-name> -f pretty
+```
+
+Search modes (CLI only):
+
+```bash
+uv run cognee-cli search "<question>" -d <dataset-name> -t GRAPH_COMPLETION -f pretty
+uv run cognee-cli search "<exact passage or citation need>" -d <dataset-name> -t CHUNKS -k 10 -f pretty
+uv run cognee-cli search "<code question>" -d <dataset-name> -t CODE -k 10 -f pretty
+```
+
+### The server is the source of truth
+
+`cognee-cli` is a thin client over the running Cognee server and can print **empty stdout even when content exists** (a serialization quirk). So:
+- **Never conclude "not found" from an empty/clean CLI run.** Confirm against the server directly — this is authoritative.
+- **Do not re-run the same CLI search to "retry."** One server answer is authoritative.
+- Omit `-d <dataset>` to search **all** your datasets; restricting to one dataset can miss content that lives in another.
+
+## Improve Memory
+
+**Server-first (session → graph sync):**
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/sync-session-to-graph.py"
+```
+
+**Fallback only — server unreachable:**
+
+```bash
+uv run cognee-cli improve -d <dataset-name>
+```
+
+Bridge session feedback or Q&A into the graph:
+
+```bash
+uv run cognee-cli improve -d <dataset-name> -s <session-id>
+```
+
+For targeted enrichment:
+
+```bash
+uv run cognee-cli improve -d <dataset-name> --node-name <entity-name>
+```
+
+## Forget
+
+Use the narrowest deletion command possible and confirm first:
+
+```bash
+uv run cognee-cli forget --dataset <dataset-name>
+uv run cognee-cli forget --dataset <dataset-name> --data-id <data-uuid>
+```
+
+Avoid `uv run cognee-cli forget --everything` unless the user explicitly asks
+to delete all Cognee data.

--- a/integrations/qwen/skills/memory/SKILL.md
+++ b/integrations/qwen/skills/memory/SKILL.md
@@ -17,12 +17,24 @@ memory.
 - Do not ingest secrets, credentials, `.env` files, private keys, token dumps, or unrelated generated artifacts.
 - Before destructive commands such as `forget`, `delete`, or `--everything`, get explicit user confirmation.
 
+## Extension Script Paths
+
+Qwen injects `Base directory for this skill: <qwen-injected-skill-base>` before
+this skill. That base is `<extension-root>/skills/memory`. For every extension
+script below, resolve the extension root **two levels above** that injected base,
+then append `scripts/<script-name>`:
+
+```bash
+# Replace <qwen-injected-skill-base> with the exact absolute path Qwen injected.
+EXTENSION_ROOT="$(cd "<qwen-injected-skill-base>/../.." && pwd)"
+```
+
 ## Add And Build
 
 **Server-first (one-step ingestion):**
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/cognee-remember.sh "<text>" --node-set user_context
+"$EXTENSION_ROOT/scripts/cognee-remember.sh" "<text>" --node-set user_context
 ```
 
 Use `--node-set project_docs` for project/code content, `--node-set agent_actions` for agent notes. The script POSTs directly to `/api/v1/remember`. A `{"ok": true}` response means the server accepted the data. An error response means the server rejected or failed the request — check `COGNEE_API_KEY` and server logs; do **not** re-run or conclude the data wasn't stored without confirming against the server.
@@ -90,7 +102,7 @@ uv run cognee-cli search "<code question>" -d <dataset-name> -t CODE -k 10 -f pr
 **Server-first (session → graph sync):**
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/sync-session-to-graph.py"
+python3 "$EXTENSION_ROOT/scripts/sync-session-to-graph.py"
 ```
 
 **Fallback only — server unreachable:**

--- a/integrations/qwen/skills/setup/SKILL.md
+++ b/integrations/qwen/skills/setup/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: setup
+description: Use when setting up, checking, or connecting Cognee through the cognee CLI from Qwen.
+---
+
+# Cognee CLI Setup
+
+Use this skill when the user asks to configure Cognee, check whether Cognee is
+ready, connect to a local or cloud Cognee instance, or inspect CLI capability.
+
+## Rules
+
+- Use `uv run cognee-cli ...` as the primary interface.
+- Do not use MCP for this plugin.
+- Work from the Cognee repository root when available.
+- Do not print secret values from `.env`, config files, shell history, or command output.
+- If a command may create, delete, or overwrite durable Cognee state, say what it will affect before running it.
+
+## Checks
+
+Start with the local command surface:
+
+```bash
+uv run cognee-cli --help
+uv run cognee-cli --version
+```
+
+If dependencies are missing, use the repository command:
+
+```bash
+uv sync --dev --all-extras --reinstall
+```
+
+Inspect configuration without exposing values:
+
+```bash
+uv run cognee-cli config list
+```
+
+Use `config get <KEY>` only for non-secret settings. For secret-like keys,
+report whether the key appears configured rather than showing the value.
+
+## Connect
+
+For a local backend:
+
+```bash
+uv run cognee-cli serve --url http://localhost:8000
+```
+
+For a hosted instance with an API key, do not paste the key into the transcript.
+Use an environment variable or an already configured credential.
+
+For the plugin itself, durable configuration (`COGNEE_BASE_URL`,
+`COGNEE_API_KEY`, `LLM_API_KEY`, ...) belongs in `~/.cognee/.env` — a one-time
+setup file shared with the Claude Code plugin, loaded at session start. Shell
+exports still override it per terminal. Guide the user to edit that file
+rather than exporting in every shell; never echo its secret values.
+
+The file may hold both modes' variables at once: with nothing exported, cloud
+wins (`COGNEE_BASE_URL` routes the connection). To pin one terminal to a mode,
+the user exports `COGNEE_BACKEND=local` or `COGNEE_BACKEND=cloud` before
+launching — that beats the URL rule, and `unset COGNEE_BASE_URL` is NOT a way
+to go local (the file re-injects the URL on the next launch).
+
+To disconnect:
+
+```bash
+uv run cognee-cli serve --logout
+```
+
+## Multi-Agent Or API Mode
+
+When the user wants concurrent or multi-agent use, prefer a running Cognee API
+server and pass:
+
+```bash
+uv run cognee-cli --api-url http://localhost:8000 <command>
+```
+
+For isolated session history and permissions, include:
+
+```bash
+uv run cognee-cli --user-id <uuid> <command>
+```

--- a/integrations/tests/README.md
+++ b/integrations/tests/README.md
@@ -1,9 +1,9 @@
-# Shared test infrastructure — Claude Code + Codex
+# Shared test infrastructure — Claude Code + Codex + Qwen
 
-Reusable pytest harness for the two Python hook suites, `claude-code` and
-`codex`, which are the same code differing only in constants. One parametrized
-test set runs against both. openclaw (TypeScript) and hermes-agent (SDK-based)
-are out of scope here.
+Reusable pytest harness for the three Python hook suites, `claude-code`,
+`codex`, and `qwen`. Their memory runtimes differ mainly in host constants,
+so one parametrized test set runs against all three. OpenClaw (TypeScript) and
+Hermes Agent (SDK-based) are out of scope here.
 
 ## Layout
 
@@ -32,36 +32,41 @@ uv run pytest tests/ -v
 ```
 
 CI runs the same via `.github/workflows/ci.yml`; changes under
-`integrations/claude-code/`, `integrations/codex/`, or `integrations/tests/`
-all trigger this suite.
+`integrations/claude-code/`, `integrations/codex/`, `integrations/qwen/`,
+or `integrations/tests/` all trigger this suite.
 
 ## Ground truth (verified against the scripts)
 
-| | `claude-code` | `codex` |
-|---|---|---|
-| Scripts dir | `claude-code/scripts/` | `codex/plugins/cognee/scripts/` |
-| config.json | `~/.cognee-plugin/claude-code/` | `~/.cognee-plugin/` (shared root) |
-| State dir | `~/.cognee-plugin/claude-code/` | `~/.cognee-plugin/codex/` |
-| Default dataset | `agent_sessions` | `agent_sessions` |
-| `agent_name` default | `claude-code-agent` | `codex-agent` |
-| `session_prefix` | `claude` | `codex` |
-| cwd env var | `CLAUDE_CWD` | `CODEX_CWD` |
-| Agent-session suffix | `_claude` | `_codex` |
+| | `claude-code` | `codex` | `qwen` |
+|---|---|---|---|
+| Scripts dir | `claude-code/scripts/` | `codex/plugins/cognee/scripts/` | `qwen/scripts/` |
+| config.json | `~/.cognee-plugin/claude-code/` | `~/.cognee-plugin/` (shared root) | `~/.cognee-plugin/` (shared root) |
+| State dir | `~/.cognee-plugin/claude-code/` | `~/.cognee-plugin/codex/` | `~/.cognee-plugin/qwen/` |
+| Default dataset | `agent_sessions` | `agent_sessions` | `agent_sessions` |
+| `agent_name` default | `claude-code-agent` | `codex-agent` | `qwen-agent` |
+| `session_prefix` | `claude` | `codex` | `qwen` |
+| cwd env var | `CLAUDE_CWD` | `CODEX_CWD` | `QWEN_CWD` |
+| Agent-session suffix | `_claude` | `_codex` | `_qwen` |
 ### Capability flags
 
 Divergences are named by a declared flag on `Suite`, never inferred from
 `suite.name` and never from another flag that happens to correlate:
 
-| Flag | `claude-code` | `codex` | Gates |
-|---|---|---|---|
-| `has_background_remember` | `True` | `True` | background bridge, `{"ok": ...}` envelope, `wait_for_cognify`, bounded `do_remember` wait |
-| `has_improve_pipeline_polling` | `True` | `False` | `improve_session_via_http` reports `cognify_status`/`memify_status` |
-| `has_async_hooks` | `True` | `False` | `async` hook entries + `StopFailure` in `hooks.json` |
-| `has_elapsed_ms_helper` | `True` | `True` | `_plugin_common.elapsed_ms`, and `elapsed_ms` on the bridge events |
-| `has_recall_latency_metric` | `True` | `False` | aggregate `elapsed_ms` on `context_lookup_*` |
-| `has_rich_statusline` | `True` | `False` | health glyphs, recall-counts strip, mode word, install registry |
-| `has_precompact_http` | `False` | `True` | `pre-compact.py` recalls over HTTP — the one place codex is ahead |
-| `host_stem` | `claude` | `codex` | `_proc`'s Windows ancestry match |
+| Flag | `claude-code` | `codex` | `qwen` | Gates |
+|---|---|---|---|---|
+| `has_background_remember` | `True` | `True` | `True` | background bridge, `{"ok": ...}` envelope, `wait_for_cognify`, bounded `do_remember` wait |
+| `has_improve_pipeline_polling` | `True` | `True` | `True` | `improve_session_via_http` reports `cognify_status`/`memify_status` |
+| `has_async_hooks` | `True` | `False` | `False` | `async` hook entries + `StopFailure` in `hooks.json` |
+| `has_elapsed_ms_helper` | `True` | `True` | `True` | `_plugin_common.elapsed_ms`, and `elapsed_ms` on the bridge events |
+| `has_recall_latency_metric` | `True` | `False` | `False` | aggregate `elapsed_ms` on `context_lookup_*` |
+| `has_rich_statusline` | `True` | `False` | `False` | health glyphs, recall-counts strip, mode word, install registry |
+| `has_precompact_http` | `False` | `True` | `True` | `pre-compact.py` recalls over HTTP |
+| `host_stem` | `claude` | `codex` | `qwen` | `_proc`'s Windows ancestry match |
+
+Qwen's runtime matches Codex, but its package seam does not: it has
+`qwen-extension.json` plus `gemini-extension.json`, external hooks at
+`hooks/hooks.json`, `${CLAUDE_PLUGIN_ROOT}` command roots, and millisecond
+timeouts. `test_qwen_gemini_packaging.py` guards those differences.
 
 `has_background_remember` was `False` for codex until the refactor was ported in
 main; **39 codex tests started passing the moment the flag flipped**, with no test
@@ -228,21 +233,19 @@ Failures dump `hook.log`, the recall-related events, `recall-audit.log` and
 |---|---|---|
 | `test_cross_session_recall.py` | the core promise: two turns in session A are recalled by a fresh session B on the same dataset | yes |
 | `test_session_capture.py` | within-session recall of prompts, answers and tool traces, plus the save counters behind the status line | no — the session cache answers directly, so these are the cheap ones |
-| `test_user_surfaces.py` | the three places a user meets memory: the status line (rendering for both, counts for claude-code), the pre-compact anchor (**strict xfail on claude-code only**, see below), and `cognee-search.sh` | no |
+| `test_user_surfaces.py` | the three places a user meets memory: the status line (rendering for every host, counts for claude-code), the pre-compact anchor (**strict xfail on claude-code only**, see below), and `cognee-search.sh` | no |
 | `test_resilience.py` | hooks stay successful when the server dies; a mid-outage write should be buffered (**strict xfail**, see below); buffered turns replay once the server returns; a slow cold query is judged `slow`, not `down`, and never trips the breaker | one |
 | `test_concurrency.py` | two sessions' interleaved turns both reach the graph, and each session claims its own final sync | one |
 | `test_graph_writes.py` | two populated datasets do not leak into each other; a repeated SessionEnd starts exactly one final-sync worker | two |
-| `test_shared_brain.py` | either integration recalls what the other wrote to the shared graph, **in both directions** — only testable live, and cheap now that no CLI is involved | yes |
+| `test_shared_brain.py` | Claude Code and Codex recall what the other wrote to the shared graph, **in both directions** — only testable live, and cheap now that no CLI is involved | yes |
 
-### Both integrations, every scenario
+### Every host integration, every scenario
 
-`live_suite` is parametrized over `ALL_SUITES`, so all 17 scenarios run twice —
-34 suite-parametrized tests plus the 2 shared-brain directions. That doubles
-wall-clock and LLM spend deliberately: the plugins still diverge in ways a mock
-cannot show. The write paths largely converged when the background bridge was
-ported to codex, but the improve path did not travel with it
-(`has_improve_pipeline_polling`), and a real graph is the only place you can see
-whether a write actually arrives by either route.
+`live_suite` is parametrized over `ALL_SUITES`, so every scenario runs once
+for Claude Code, Codex, and Qwen. That increases wall-clock and LLM spend
+deliberately: the hosts still diverge in ways a mock cannot show, and a real
+graph is the only place to prove a write arrives by each route. The dedicated
+shared-brain directions remain Claude↔Codex.
 
 Three fixtures are deliberately **suite-agnostic**, which is what makes the
 cross-suite direction possible:
@@ -255,7 +258,7 @@ cross-suite direction possible:
 - `live_artifacts` — as an **autouse** fixture, depending on `live_suite` would
   force the parametrization onto every test in the directory, including the
   cross-suite ones. It iterates the suites instead, which also means a cross-suite
-  failure dumps both sides.
+  failure dumps every host's artifacts.
 
 Cross-suite tests use `session_for(suite, name)` rather than `started_session`:
 the latter rides the parametrization, so a writer/reader pair built from it would
@@ -315,9 +318,8 @@ Four things worth knowing, each of which would bite:
 else.** That precondition is the entire safety argument; do not point
 `COGNEE_LIVE_BASE_URL` at a tenant with real data.
 
-Whole tier: **32 passed, 1 skipped, 3 xfailed in ~24m30s** (the skip is codex's
-counts segment; the xfails are the gaps below). Roughly 3x the single-suite time
-rather than 2x, because each suite boots its own server per test.
+Each suite boots its own server per test, so the live tier scales roughly with
+the number of hosts. Exact duration and LLM spend depend on the selected backend.
 
 Two behaviours worth knowing before writing more of these, both learned by
 getting them wrong:

--- a/integrations/tests/tests/e2e/live/conftest.py
+++ b/integrations/tests/tests/e2e/live/conftest.py
@@ -150,12 +150,11 @@ def cloud_tenant_is_clean(live_backend: str, live_prereqs: str):
 
 @pytest.fixture(params=ALL_SUITES, ids=lambda s: s.name)
 def live_suite(request) -> Suite:
-    """Every scenario runs against both integrations.
+    """Every scenario runs against every host integration.
 
-    This doubles the tier's wall-clock and LLM spend, which is the point: the two
-    plugins diverge in exactly the places a mock cannot show (codex's bridge is
-    synchronous and has no cognify poll), so a shared graph is the only place that
-    divergence becomes visible.
+    This multiplies the tier's wall-clock and LLM spend, which is the point:
+    host seams can diverge in ways a mock cannot show, so a real graph is the
+    only place those differences become visible.
     """
     return request.param
 

--- a/integrations/tests/tests/e2e/live/test_user_surfaces.py
+++ b/integrations/tests/tests/e2e/live/test_user_surfaces.py
@@ -148,7 +148,13 @@ def test_precompact_produces_an_anchor_carrying_the_session(
     )
     assert run.ok, f"pre-compact failed (rc={run.returncode}): {run.stderr[:600]}"
 
-    anchor = run.stdout.strip()
+    output = run.stdout.strip()
+    if live_suite.name == "qwen":
+        hook_output = json.loads(output)
+        assert hook_output["hookSpecificOutput"]["hookEventName"] == "PreCompact"
+        anchor = hook_output["hookSpecificOutput"]["additionalContext"]
+    else:
+        anchor = output
     assert anchor, "pre-compact produced no anchor at all — nothing would survive compaction"
     assert nonce.lower() in anchor.lower(), (
         f"the anchor does not mention the session's subject ({nonce}):\n{anchor[:1200]}"

--- a/integrations/tests/tests/e2e/live/test_user_surfaces.py
+++ b/integrations/tests/tests/e2e/live/test_user_surfaces.py
@@ -111,7 +111,7 @@ def test_precompact_produces_an_anchor_carrying_the_session(
 ):
     """Compaction drops the transcript; the anchor is what carries memory across it.
 
-    Both suites now recall over HTTP, so both must produce an anchor against a real
+    Every suite now recalls over HTTP, so each must produce an anchor against a real
     server. That was not always true: claude-code's pre-compact was local-SDK only
     — ``cognee.recall`` plus a ``get_session_manager()`` fallback — while in server
     mode the session cache lives on the server. Session and trace entries came back

--- a/integrations/tests/tests/integration/test_qwen_http_backend_compat.py
+++ b/integrations/tests/tests/integration/test_qwen_http_backend_compat.py
@@ -1,0 +1,54 @@
+"""Qwen works with Cognee HTTP servers that expose only the data plane."""
+
+from __future__ import annotations
+
+import pytest
+from utils.suites import QWEN
+
+REGISTER = "/api/v1/agents/register"
+UNREGISTER = "/api/v1/agents/unregister"
+
+
+@pytest.fixture
+def pc(isolated_modules, mock_server, monkeypatch):
+    common = isolated_modules(QWEN, "_plugin_common")
+    monkeypatch.setenv("COGNEE_BASE_URL", mock_server.url)
+    monkeypatch.setattr(common, "hook_log", lambda *a, **kw: None)
+    return common
+
+
+def test_qwen_reachability_uses_health_instead_of_optional_docs(pc, mock_server):
+    mock_server.force_response("GET", "/docs", 404, {"detail": "Not Found"})
+
+    assert pc._backend_reachable(mock_server.url) is True
+    mock_server.assert_called("GET", "/health")
+    mock_server.assert_not_called("GET", "/docs")
+
+
+def _register(pc):
+    return pc.register_agent_via_http(
+        agent_session_name="qwen-compat-test",
+        session_id="session-test",
+        dataset_names=["agent_sessions"],
+    )
+
+
+def test_qwen_treats_missing_agent_registration_as_unsupported(pc, mock_server):
+    mock_server.force_response("POST", REGISTER, 404, {"detail": "Not Found"})
+
+    assert _register(pc) == (True, {"lifecycle_supported": False})
+
+
+def test_qwen_treats_missing_agent_unregistration_as_unsupported(pc, mock_server):
+    mock_server.force_response("POST", UNREGISTER, 404, {"detail": "Not Found"})
+
+    assert pc.unregister_agent_via_http(agent_session_name="qwen-compat-test") == (True, 0)
+
+
+@pytest.mark.parametrize("status", [401, 403, 500])
+def test_qwen_preserves_agent_lifecycle_http_failures(pc, mock_server, status):
+    mock_server.force_response("POST", REGISTER, status, {"detail": "rejected"})
+    mock_server.force_response("POST", UNREGISTER, status, {"detail": "rejected"})
+
+    assert _register(pc) == (False, {})
+    assert pc.unregister_agent_via_http(agent_session_name="qwen-compat-test") == (False, 0)

--- a/integrations/tests/tests/unit/test_backend_switch.py
+++ b/integrations/tests/tests/unit/test_backend_switch.py
@@ -22,8 +22,16 @@ import os
 import pytest
 
 #: Each suite's own switch, and the OTHER plugin's switch — which it must ignore.
-OWN_BACKEND_VAR = {"claude-code": "COGNEE_CLAUDE_BACKEND", "codex": "COGNEE_CODEX_BACKEND"}
-OTHER_BACKEND_VAR = {"claude-code": "COGNEE_CODEX_BACKEND", "codex": "COGNEE_CLAUDE_BACKEND"}
+OWN_BACKEND_VAR = {
+    "claude-code": "COGNEE_CLAUDE_BACKEND",
+    "codex": "COGNEE_CODEX_BACKEND",
+    "qwen": "COGNEE_QWEN_BACKEND",
+}
+OTHER_BACKEND_VAR = {
+    "claude-code": "COGNEE_CODEX_BACKEND",
+    "codex": "COGNEE_CLAUDE_BACKEND",
+    "qwen": "COGNEE_CLAUDE_BACKEND",
+}
 
 CLOUD_URL = "https://tenant.cognee.ai"
 CLOUD_ENV_FILE = "\n".join(

--- a/integrations/tests/tests/unit/test_hooks_contract.py
+++ b/integrations/tests/tests/unit/test_hooks_contract.py
@@ -30,8 +30,8 @@ EXPECTED = [
     ("SessionEnd", "sync-session-to-graph.py", "--session-end"),
 ]
 
-#: ${CLAUDE_PLUGIN_ROOT} / ${PLUGIN_ROOT} / ${extensionPath}, quoted or bare.
-_PLUGIN_ROOT = re.compile(r'"?\$\{(?:(?:CLAUDE_)?PLUGIN_ROOT|extensionPath)\}"?')
+#: ${CLAUDE_PLUGIN_ROOT} / ${PLUGIN_ROOT}, quoted or bare.
+_PLUGIN_ROOT = re.compile(r'"?\$\{(?:CLAUDE_)?PLUGIN_ROOT\}"?')
 
 
 @pytest.fixture

--- a/integrations/tests/tests/unit/test_hooks_contract.py
+++ b/integrations/tests/tests/unit/test_hooks_contract.py
@@ -30,8 +30,8 @@ EXPECTED = [
     ("SessionEnd", "sync-session-to-graph.py", "--session-end"),
 ]
 
-#: ${CLAUDE_PLUGIN_ROOT} / ${PLUGIN_ROOT}, quoted or bare.
-_PLUGIN_ROOT = re.compile(r'"?\$\{(?:CLAUDE_)?PLUGIN_ROOT\}"?')
+#: ${CLAUDE_PLUGIN_ROOT} / ${PLUGIN_ROOT} / ${extensionPath}, quoted or bare.
+_PLUGIN_ROOT = re.compile(r'"?\$\{(?:(?:CLAUDE_)?PLUGIN_ROOT|extensionPath)\}"?')
 
 
 @pytest.fixture

--- a/integrations/tests/tests/unit/test_qwen_gemini_packaging.py
+++ b/integrations/tests/tests/unit/test_qwen_gemini_packaging.py
@@ -127,9 +127,7 @@ def test_commands_expand_qwen_claude_plugin_root():
         command = str(hook.get("command", ""))
         if "python" in command and not _PLUGIN_ROOT.search(command):
             missing.append((event, command[:80]))
-    assert not missing, (
-        f"Qwen hooks must use ${{CLAUDE_PLUGIN_ROOT}}: {missing}"
-    )
+    assert not missing, f"Qwen hooks must use ${{CLAUDE_PLUGIN_ROOT}}: {missing}"
 
 
 def test_qwen_hook_root_contract_rejects_extension_path():

--- a/integrations/tests/tests/unit/test_qwen_gemini_packaging.py
+++ b/integrations/tests/tests/unit/test_qwen_gemini_packaging.py
@@ -1,0 +1,151 @@
+"""Qwen packing: Gemini-style extension manifests and Claude-style hooks."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_INTEGRATIONS = Path(__file__).resolve().parents[3]
+_REPO = _INTEGRATIONS.parent
+QWEN = _INTEGRATIONS / "qwen"
+
+_CLAUDE_EVENTS = (
+    "SessionStart",
+    "UserPromptSubmit",
+    "PostToolUse",
+    "Stop",
+    "PreCompact",
+    "SessionEnd",
+)
+_GEMINI_ONLY_EVENTS = ("BeforeAgent", "AfterAgent", "BeforeTool", "AfterTool", "PreCompress")
+_PLUGIN_ROOT = re.compile(r"\$\{(?:extensionPath|CLAUDE_PLUGIN_ROOT)\}")
+
+
+def _manifest(name: str) -> dict:
+    return json.loads((QWEN / name).read_text(encoding="utf-8"))
+
+
+def _hooks() -> dict:
+    spec = json.loads((QWEN / "hooks" / "hooks.json").read_text(encoding="utf-8"))
+    return spec.get("hooks", spec)
+
+
+def _command_hooks():
+    for event, groups in _hooks().items():
+        if not isinstance(groups, list):
+            continue
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            for hook in group.get("hooks", []):
+                if isinstance(hook, dict) and hook.get("type") == "command":
+                    yield event, hook
+
+
+def test_gemini_extension_manifest_has_required_keys():
+    manifest = _manifest("gemini-extension.json")
+    assert manifest["name"] == "cognee"
+    assert manifest["version"]
+    assert manifest["contextFileName"] in ("GEMINI.md", "QWEN.md", ["GEMINI.md", "QWEN.md"])
+
+
+def test_qwen_extension_manifest_mirrors_name_and_version():
+    gemini = _manifest("gemini-extension.json")
+    qwen = _manifest("qwen-extension.json")
+    assert qwen["name"] == gemini["name"] == "cognee"
+    assert qwen["version"] == gemini["version"]
+
+
+def test_manifests_reference_existing_context_and_hooks_files():
+    for name in ("gemini-extension.json", "qwen-extension.json"):
+        manifest = _manifest(name)
+        context_files = manifest["contextFileName"]
+        if isinstance(context_files, str):
+            context_files = [context_files]
+        assert context_files
+        assert all((QWEN / context_file).is_file() for context_file in context_files)
+        assert manifest["hooks"] == "hooks/hooks.json"
+
+
+def test_qwen_ships_memory_setup_and_codebase_skills():
+    for skill in ("memory", "setup", "codebase"):
+        assert (QWEN / "skills" / skill / "SKILL.md").is_file()
+
+
+def test_hooks_use_qwen_extension_layout():
+    assert (QWEN / "hooks" / "hooks.json").is_file()
+    assert not (QWEN / "hooks.json").exists()
+
+
+def test_claude_event_names_are_wired():
+    hooks = _hooks()
+    for event in _CLAUDE_EVENTS:
+        assert event in hooks, f"Qwen missing event {event}"
+
+
+def test_gemini_only_event_names_are_not_used():
+    hooks = _hooks()
+    for event in _GEMINI_ONLY_EVENTS:
+        assert event not in hooks, f"Qwen must not use Gemini CLI event {event}"
+
+
+def test_command_timeouts_are_milliseconds():
+    too_small = []
+    missing = []
+    for event, hook in _command_hooks():
+        timeout = hook.get("timeout")
+        if timeout is None:
+            missing.append(event)
+        elif int(timeout) < 1000:
+            too_small.append((event, timeout))
+    assert not missing, f"Qwen command hooks need explicit millisecond timeouts: {missing}"
+    assert not too_small, f"Qwen command timeouts must be milliseconds (>=1000): {too_small}"
+
+
+def test_commands_expand_qwen_extension_root():
+    missing = []
+    for event, hook in _command_hooks():
+        command = str(hook.get("command", ""))
+        if "python" in command and not _PLUGIN_ROOT.search(command):
+            missing.append((event, command[:80]))
+    assert not missing, (
+        f"Qwen hooks must use ${{extensionPath}} or ${{CLAUDE_PLUGIN_ROOT}}: {missing}"
+    )
+
+
+def test_python3_commands_fall_back_to_python():
+    missing = []
+    for event, hook in _command_hooks():
+        command = str(hook.get("command", ""))
+        if "python3 " in command and "|| python " not in command:
+            missing.append(event)
+    assert not missing, f"python3-only Qwen hooks: {missing}"
+
+
+def test_state_backend_and_cwd_are_qwen_namespaced():
+    config = (QWEN / "scripts" / "config.py").read_text(encoding="utf-8")
+    env_file = (QWEN / "scripts" / "_env_file.py").read_text(encoding="utf-8")
+    common = (QWEN / "scripts" / "_plugin_common.py").read_text(encoding="utf-8")
+    session_start = (QWEN / "scripts" / "session-start.py").read_text(encoding="utf-8")
+
+    assert "COGNEE_QWEN_BACKEND" in env_file
+    assert "COGNEE_QWEN_BACKEND" in config
+    assert "COGNEE_CODEX_BACKEND" not in env_file
+    assert '.cognee-plugin" / "qwen"' in common
+    assert "qwen-agent" in config
+    assert "QWEN_CWD" in common
+    assert "QWEN_CWD" in session_start
+
+
+def test_linux_ci_routes_qwen_changes_to_the_shared_suite():
+    workflow = (_REPO / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert "claude-code|codex|qwen|tests" in workflow
+
+
+def test_windows_ci_checks_out_and_triggers_on_qwen():
+    workflow = (_REPO / ".github" / "workflows" / "plugin-windows-tests.yml").read_text(
+        encoding="utf-8"
+    )
+    assert workflow.count("integrations/qwen/**") == 2
+    assert "            integrations/qwen" in workflow

--- a/integrations/tests/tests/unit/test_qwen_gemini_packaging.py
+++ b/integrations/tests/tests/unit/test_qwen_gemini_packaging.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 from pathlib import Path
 
 _INTEGRATIONS = Path(__file__).resolve().parents[3]
@@ -19,7 +20,7 @@ _CLAUDE_EVENTS = (
     "SessionEnd",
 )
 _GEMINI_ONLY_EVENTS = ("BeforeAgent", "AfterAgent", "BeforeTool", "AfterTool", "PreCompress")
-_PLUGIN_ROOT = re.compile(r"\$\{(?:extensionPath|CLAUDE_PLUGIN_ROOT)\}")
+_PLUGIN_ROOT = re.compile(r"\$\{CLAUDE_PLUGIN_ROOT\}")
 
 
 def _manifest(name: str) -> dict:
@@ -73,6 +74,23 @@ def test_qwen_ships_memory_setup_and_codebase_skills():
         assert (QWEN / "skills" / skill / "SKILL.md").is_file()
 
 
+def test_installed_memory_skill_resolves_extension_scripts_from_injected_base(tmp_path):
+    """Qwen injects the installed skill base, not a plugin-root environment variable."""
+    installed_extension = tmp_path / "installed-extensions" / "cognee"
+    shutil.copytree(QWEN, installed_extension)
+    installed_skill = installed_extension / "skills" / "memory" / "SKILL.md"
+    skill = installed_skill.read_text(encoding="utf-8")
+
+    assert "${CLAUDE_PLUGIN_ROOT}" not in skill
+    assert "two levels above" in skill
+    assert 'EXTENSION_ROOT="$(cd "<qwen-injected-skill-base>/../.." && pwd)"' in skill
+
+    extension_root = installed_skill.parent.parent.parent
+    scripts = re.findall(r"\$EXTENSION_ROOT/scripts/([\w.-]+)", skill)
+    assert scripts, "memory skill does not name any extension-root script commands"
+    assert not [script for script in scripts if not (extension_root / "scripts" / script).is_file()]
+
+
 def test_hooks_use_qwen_extension_layout():
     assert (QWEN / "hooks" / "hooks.json").is_file()
     assert not (QWEN / "hooks.json").exists()
@@ -103,15 +121,19 @@ def test_command_timeouts_are_milliseconds():
     assert not too_small, f"Qwen command timeouts must be milliseconds (>=1000): {too_small}"
 
 
-def test_commands_expand_qwen_extension_root():
+def test_commands_expand_qwen_claude_plugin_root():
     missing = []
     for event, hook in _command_hooks():
         command = str(hook.get("command", ""))
         if "python" in command and not _PLUGIN_ROOT.search(command):
             missing.append((event, command[:80]))
     assert not missing, (
-        f"Qwen hooks must use ${{extensionPath}} or ${{CLAUDE_PLUGIN_ROOT}}: {missing}"
+        f"Qwen hooks must use ${{CLAUDE_PLUGIN_ROOT}}: {missing}"
     )
+
+
+def test_qwen_hook_root_contract_rejects_extension_path():
+    assert _PLUGIN_ROOT.search("${extensionPath}/scripts/session-start.py") is None
 
 
 def test_python3_commands_fall_back_to_python():

--- a/integrations/tests/tests/unit/test_qwen_host_semantics.py
+++ b/integrations/tests/tests/unit/test_qwen_host_semantics.py
@@ -1,0 +1,140 @@
+"""Qwen-specific hook protocol seams that the shared suite cannot infer."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+from utils.suites import QWEN, state_dir
+
+
+def _set_stdin(monkeypatch, payload: dict) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+
+
+def test_precompact_anchor_uses_qwen_additional_context_envelope(
+    hook_module, monkeypatch, capsys
+):
+    """Qwen ignores raw PreCompact stdout; the anchor must be structured context."""
+    module = hook_module(QWEN, "pre-compact.py")
+    anchor = "## Cognee Memory Anchor\nkeep this context"
+
+    async def return_anchor():
+        return anchor
+
+    monkeypatch.setattr(module, "_run", return_anchor)
+    _set_stdin(
+        monkeypatch,
+        {
+            "hook_event_name": "PreCompact",
+            "session_id": "qwen-session",
+            "trigger": "auto",
+        },
+    )
+
+    module.main()
+
+    assert json.loads(capsys.readouterr().out) == {
+        "hookSpecificOutput": {
+            "hookEventName": "PreCompact",
+            "additionalContext": anchor,
+        }
+    }
+
+
+def test_internal_qwen_continuation_does_not_replace_submitted_prompt(
+    hook_module, monkeypatch, temp_home
+):
+    """ToolResult/Hook sends lack provenance and must not replace the user turn."""
+    module = hook_module(QWEN, "store-user-prompt.py")
+    monkeypatch.setenv("COGNEE_IDLE_DISABLED", "1")
+    monkeypatch.setattr(
+        module,
+        "_load_session",
+        lambda: ("cognee-session", "agent_sessions", "user", "tenant"),
+    )
+    monkeypatch.setattr(module, "load_config", lambda: {})
+    monkeypatch.setattr(
+        module,
+        "resolve_runtime_mode",
+        lambda: {"mode": "http", "base_url": "http://127.0.0.1:9"},
+    )
+    monkeypatch.setattr(module, "server_usable", lambda _url: False)
+
+    _set_stdin(
+        monkeypatch,
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "qwen-host-session",
+            "prompt": "expanded prompt plus injected context",
+            "submitted_prompt": "original user question",
+        },
+    )
+    module.main()
+
+    _set_stdin(
+        monkeypatch,
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "qwen-host-session",
+            "prompt": '{"functionResponse":{"name":"read_file"}}',
+        },
+    )
+    module.main()
+
+    pending_files = list((state_dir(QWEN, temp_home) / "pending").glob("*.json"))
+    assert len(pending_files) == 1
+    pending = json.loads(pending_files[0].read_text(encoding="utf-8"))
+    assert {entry["prompt"] for entry in pending.values()} == {"original user question"}
+
+
+def test_qwen_recall_uses_submitted_prompt_provenance(hook_module, monkeypatch):
+    """Recall must query the user's text, not the model-bound expanded prompt."""
+    module = hook_module(QWEN, "session-context-lookup.py")
+    queries = []
+
+    async def capture_query(prompt):
+        queries.append(prompt)
+        return None
+
+    monkeypatch.setattr(module, "_run", capture_query)
+    _set_stdin(
+        monkeypatch,
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "qwen-host-session",
+            "prompt": "expanded prompt plus injected context",
+            "submitted_prompt": "original user question",
+        },
+    )
+
+    module.main()
+
+    assert queries == ["original user question"]
+
+
+def test_qwen_recall_skips_internal_continuations_without_provenance(
+    hook_module, monkeypatch
+):
+    """ToolResult/Hook sends are not user questions and must not trigger recall."""
+    module = hook_module(QWEN, "session-context-lookup.py")
+    queries = []
+
+    async def capture_query(prompt):
+        queries.append(prompt)
+        return None
+
+    monkeypatch.setattr(module, "_run", capture_query)
+    _set_stdin(
+        monkeypatch,
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "qwen-host-session",
+            "prompt": '{"functionResponse":{"name":"read_file"}}',
+        },
+    )
+
+    module.main()
+
+    assert queries == []

--- a/integrations/tests/tests/unit/test_qwen_host_semantics.py
+++ b/integrations/tests/tests/unit/test_qwen_host_semantics.py
@@ -13,9 +13,7 @@ def _set_stdin(monkeypatch, payload: dict) -> None:
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
 
 
-def test_precompact_anchor_uses_qwen_additional_context_envelope(
-    hook_module, monkeypatch, capsys
-):
+def test_precompact_anchor_uses_qwen_additional_context_envelope(hook_module, monkeypatch, capsys):
     """Qwen ignores raw PreCompact stdout; the anchor must be structured context."""
     module = hook_module(QWEN, "pre-compact.py")
     anchor = "## Cognee Memory Anchor\nkeep this context"
@@ -114,9 +112,7 @@ def test_qwen_recall_uses_submitted_prompt_provenance(hook_module, monkeypatch):
     assert queries == ["original user question"]
 
 
-def test_qwen_recall_skips_internal_continuations_without_provenance(
-    hook_module, monkeypatch
-):
+def test_qwen_recall_skips_internal_continuations_without_provenance(hook_module, monkeypatch):
     """ToolResult/Hook sends are not user questions and must not trigger recall."""
     module = hook_module(QWEN, "session-context-lookup.py")
     queries = []

--- a/integrations/tests/tests/unit/test_statusline_credits.py
+++ b/integrations/tests/tests/unit/test_statusline_credits.py
@@ -260,4 +260,7 @@ def test_hooks_json_wires_credits_refresh_at_turn_end(suite):
     else:
         for hook in entries:
             assert "async" not in hook, f"{suite.name} skips async hooks entirely"
-            assert isinstance(hook.get("timeout"), (int, float)) and hook["timeout"] <= 15
+            timeout = hook.get("timeout")
+            assert isinstance(timeout, (int, float))
+            seconds = timeout / 1000 if suite.name == "qwen" else timeout
+            assert seconds <= 15

--- a/integrations/tests/tests/unit/test_timing_metrics.py
+++ b/integrations/tests/tests/unit/test_timing_metrics.py
@@ -89,8 +89,9 @@ def run_bridge(pc, suite, tmp_path, monkeypatch):
         monkeypatch.setattr(
             pc,
             "_post_remember_document",
-            lambda *a, **k: post_result
-            or {"ok": True, "dataset_id": "d1", "pipeline_run_id": "p1"},
+            lambda *a, **k: (
+                post_result or {"ok": True, "dataset_id": "d1", "pipeline_run_id": "p1"}
+            ),
         )
         monkeypatch.setattr(pc, "wait_for_cognify", lambda *a, **k: outcome)
         monkeypatch.setattr(

--- a/integrations/tests/utils/__init__.py
+++ b/integrations/tests/utils/__init__.py
@@ -1,4 +1,4 @@
-"""Shared test infrastructure for the Claude Code and Codex Cognee integrations.
+"""Shared test infrastructure for the Claude Code, Codex, and Qwen integrations.
 
 Building blocks (see README.md):
   - suites        : Suite descriptors that parametrize tests over claude-code / codex
@@ -16,6 +16,7 @@ from .suites import (
     ALL_SUITES,
     CLAUDE,
     CODEX,
+    QWEN,
     Suite,
     cognee_home,
     config_dir,
@@ -27,6 +28,7 @@ __all__ = [
     "ALL_SUITES",
     "CLAUDE",
     "CODEX",
+    "QWEN",
     "Suite",
     "cognee_home",
     "config_dir",

--- a/integrations/tests/utils/fixtures.py
+++ b/integrations/tests/utils/fixtures.py
@@ -3,7 +3,7 @@
 Registered as a plugin by ``integrations/tests/conftest.py``.
 
 Key fixtures:
-  - ``suite``            : parametrized over claude-code and codex
+  - ``suite``            : parametrized over claude-code, codex, and qwen
   - ``temp_home``        : isolated HOME dir for the test (nothing hits real ~)
   - ``project_dir``      : isolated working dir (the hook ``cwd``)
   - ``mock_server``      : running MockCogneeServer (ephemeral port)
@@ -38,7 +38,7 @@ DEFAULT_TEST_API_KEY = "test-api-key"
 
 @pytest.fixture(params=ALL_SUITES, ids=lambda s: s.name)
 def suite(request) -> Suite:
-    """Run the test once per integration suite (claude-code, codex)."""
+    """Run the test once per integration suite."""
     return request.param
 
 

--- a/integrations/tests/utils/isolation.py
+++ b/integrations/tests/utils/isolation.py
@@ -67,7 +67,7 @@ DETERMINISTIC_ENV = {
 
 #: Env-var prefixes scrubbed from the inherited environment so a developer's
 #: exported COGNEE_*/LLM_* configuration can never leak into a test.
-_SCRUBBED_PREFIXES = ("COGNEE_", "LLM_", "CLAUDE_", "CODEX_")
+_SCRUBBED_PREFIXES = ("COGNEE_", "LLM_", "CLAUDE_", "CODEX_", "QWEN_")
 
 
 def scrub_env_dict(env: dict[str, str]) -> dict[str, str]:
@@ -76,7 +76,7 @@ def scrub_env_dict(env: dict[str, str]) -> dict[str, str]:
 
 
 def scrub_cognee_env(monkeypatch) -> None:
-    """Delete all COGNEE_*/LLM_*/CLAUDE_*/CODEX_* vars for one test (in-process)."""
+    """Delete all Cognee and host-specific vars for one test (in-process)."""
     for key in list(os.environ):
         if key.startswith(_SCRUBBED_PREFIXES):
             monkeypatch.delenv(key, raising=False)

--- a/integrations/tests/utils/live.py
+++ b/integrations/tests/utils/live.py
@@ -207,7 +207,7 @@ def build_live_env(
 ) -> dict[str, str]:
     """The environment a live hook subprocess runs in.
 
-    Inherited COGNEE_*/LLM_*/CLAUDE_*/CODEX_* are scrubbed so a developer's shell
+    Inherited Cognee and host-specific variables are scrubbed so a developer's shell
     (or the parent agent's own session vars) cannot leak in and redirect the run
     at a real server.
 
@@ -218,7 +218,7 @@ def build_live_env(
     env = {
         k: v
         for k, v in os.environ.items()
-        if not k.startswith(("COGNEE_", "LLM_", "CLAUDE", "CODEX"))
+        if not k.startswith(("COGNEE_", "LLM_", "CLAUDE", "CODEX", "QWEN"))
     }
     env.update(
         {

--- a/integrations/tests/utils/payloads.py
+++ b/integrations/tests/utils/payloads.py
@@ -46,6 +46,9 @@ def user_prompt(
         "session_id": session_id,
         "cwd": cwd,
         "prompt": prompt,
+        # Qwen captures this before model-bound expansion and uses its absence
+        # to distinguish ToolResult/Hook continuations from real user turns.
+        "submitted_prompt": prompt,
     }
     if model is not None:
         payload["model"] = model

--- a/integrations/tests/utils/statusline.py
+++ b/integrations/tests/utils/statusline.py
@@ -1,6 +1,6 @@
 """Suite-aware expectations for the status-line renderer.
 
-The two renderers are the same logic with one deliberate difference: claude-code
+The renderers share the same logic with one deliberate difference: claude-code
 styles the bar with ANSI escapes for a terminal, while codex's string is injected
 into the model's context and must stay plain text. Tests that care about *which*
 glyph or segment appears are shared and go through these helpers; tests that care

--- a/integrations/tests/utils/suites.py
+++ b/integrations/tests/utils/suites.py
@@ -1,13 +1,16 @@
-"""Suite descriptors for the two near-identical Python integrations.
+"""Suite descriptors for the near-identical Python hook integrations.
 
-claude-code and codex are the same hook code differing only in constants. A Suite
-captures those differences so one parametrized test set runs against both.
+Claude Code, Codex, and Qwen share the same hook runtime with host-specific
+constants. A Suite captures those differences so one parametrized test set runs
+against all three.
 
 Constants are verified against each suite's ``config.py`` / ``_plugin_common.py``:
   - claude-code: config AND state both live in ``~/.cognee-plugin/claude-code/``
   - codex:       config.json lives at the shared root ``~/.cognee-plugin/``,
                  state nests under ``~/.cognee-plugin/codex/``
-  - both:        default dataset ``agent_sessions``; the shared server-ready
+  - qwen:        config.json lives at the shared root ``~/.cognee-plugin/``,
+                 state nests under ``~/.cognee-plugin/qwen/``
+  - all:         default dataset ``agent_sessions``; the shared server-ready
                  marker sits at the ``~/.cognee-plugin/`` root; local-SDK data
                  dirs live under ``~/.cognee/``
 """
@@ -20,7 +23,7 @@ from pathlib import Path
 # .../integrations/tests/utils/suites.py -> parents[2] == .../integrations
 _INTEGRATIONS = Path(__file__).resolve().parents[2]
 
-#: Name of the shared plugin root under HOME, used by both suites.
+#: Name of the shared plugin root under HOME, used by every suite.
 PLUGIN_DIR_NAME = ".cognee-plugin"
 
 #: Local-SDK home (data/system/cache dirs and the .env file) under HOME.
@@ -29,7 +32,7 @@ COGNEE_HOME_DIR_NAME = ".cognee"
 
 @dataclass(frozen=True)
 class Suite:
-    """A single integration suite (claude-code or codex)."""
+    """A single host integration suite."""
 
     name: str
     scripts_dir: Path
@@ -40,7 +43,7 @@ class Suite:
     default_dataset: str
     agent_name: str
     session_prefix: str
-    #: The suite's hooks.json manifest (claude: <root>/hooks/, codex: plugin root).
+    #: The suite's hooks.json manifest (claude/qwen: <root>/hooks/, codex: plugin root).
     hooks_json: Path
     #: The plugin manifest whose "version" the runtime reports as its own.
     plugin_manifest: Path
@@ -159,7 +162,29 @@ CODEX = Suite(
     has_precompact_http=True,
 )
 
-ALL_SUITES = [CLAUDE, CODEX]
+QWEN = Suite(
+    name="qwen",
+    scripts_dir=_INTEGRATIONS / "qwen" / "scripts",
+    hooks_json=_INTEGRATIONS / "qwen" / "hooks" / "hooks.json",
+    plugin_manifest=_INTEGRATIONS / "qwen" / "gemini-extension.json",
+    config_subdir="",
+    state_subdir="qwen",
+    default_dataset="agent_sessions",
+    agent_name="qwen-agent",
+    session_prefix="qwen",
+    cwd_env="QWEN_CWD",
+    session_suffix="_qwen",
+    host_stem="qwen",
+    has_background_remember=True,
+    has_improve_pipeline_polling=True,
+    has_async_hooks=False,
+    has_elapsed_ms_helper=True,
+    has_recall_latency_metric=False,
+    has_rich_statusline=False,
+    has_precompact_http=True,
+)
+
+ALL_SUITES = [CLAUDE, CODEX, QWEN]
 
 
 def plugin_root(home: Path | str) -> Path:


### PR DESCRIPTION
## Summary

- add a self-contained Qwen Code extension with Gemini-shaped manifests and Qwen's Claude-style hook events
- capture supported interactive prompts, tool traces, assistant responses, PreCompact anchors, and SessionEnd graph sync through the Cognee HTTP backend
- isolate Qwen runtime state and backend selection under `~/.cognee-plugin/qwen/` and `COGNEE_QWEN_BACKEND`
- use Qwen's millisecond timeout units, external-hook root contract, and injected skill-base path semantics
- add shared-suite, packaging, host-semantics, HTTP compatibility, Linux, and Windows coverage
- document the current Qwen prompt-provenance boundary and upstream prerequisite QwenLM/qwen-code#9511

## Host-specific hardening

- `PreCompact` emits `hookSpecificOutput.additionalContext`, which Qwen actually consumes
- prompt capture and recall use `submitted_prompt` so ToolResult/Hook continuations cannot replace the real user question
- installed memory skills resolve extension scripts from Qwen's injected skill base instead of an undeclared Claude variable
- external hook files require `${CLAUDE_PLUGIN_ROOT}`; `${extensionPath}` is rejected for this loader path

Qwen currently omits `submitted_prompt` for ACP, headless, `serve`, SDK, remote-input, restored, and Vim-mode inputs while also omitting send type from command-hook payloads. Those model-bound prompts are intentionally skipped rather than guessed from `prompt`; tool/assistant/PreCompact/session hooks remain active. The additive host field needed to support those modes is tracked at https://github.com/QwenLM/qwen-code/issues/9511.

## Install safety

A fresh Qwen 0.21.10 install into an isolated temporary home:

- installed and listed Cognee v1.4.4 with origin `QwenCode`
- loaded the context file and all four skills
- did not create `~/.qwen/settings.json`
- did not modify the live Qwen extension, live Qwen settings, or Codex config (before/after hashes and metadata were identical)

## Verification

- `cd integrations/tests && uv run pytest tests/ -q` — **1446 passed, 127 skipped, 53 deselected**
- `ruff format --check integrations/` — **308 files already formatted**
- `ruff check integrations/` — **all checks passed**
- Qwen JSON manifests/hooks validated with `jq empty`
- `git diff --check origin/main...HEAD` — clean
- independent full review plus scoped fix re-reviews — no remaining Critical or Important integration findings
- live credit-bearing suite was not run; its Qwen envelope behavior is covered hermetically

Related: #350  
Qwen host prerequisite: https://github.com/QwenLM/qwen-code/issues/9511

Closes #351