### PR TITLE
feat: add opt-in per-project dataset isolation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "author": {
         "name": "Cognee"
       },

--- a/docs/superpowers/plans/2026-08-19-project-dataset-isolation.md
+++ b/docs/superpowers/plans/2026-08-19-project-dataset-isolation.md
@@ -1,0 +1,1170 @@
+# Project Dataset Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (\`- [ ]\`) syntax for tracking.
+
+**Goal:** Add opt-in, deterministic per-project Cognee datasets to the Claude Code and Codex hook integrations while preserving one unique session per host conversation.
+
+**Architecture:** A pure, byte-identical \`_project_dataset.py\` module derives \`project_<slug>_<hash12>\` from a normalized Git origin, shared Git directory, or canonical workspace. Configuration applies the approved precedence, SessionStart pins the chosen dataset in the existing host-keyed launch record, and every recall/write/worker/status surface reads that pinned value. Current upstream does not contain Qwen or Antigravity, so this branch implements Claude Code and Codex; their open PRs receive parity after merge without blocking issue #356.
+
+**Tech Stack:** Python 3.10+, stdlib \`pathlib\`/\`subprocess\`/\`urllib.parse\`/\`hashlib\`, Bash wrappers, pytest shared integration harness, Ruff, GitHub CLI.
+
+---
+
+## File map
+
+- Create \`integrations/claude-code/scripts/_project_dataset.py\`: pure project identity and dataset resolver.
+- Create \`integrations/codex/plugins/cognee/scripts/_project_dataset.py\`: byte-identical independently installable resolver.
+- Create \`integrations/tests/tests/unit/test_project_dataset.py\`: remote normalization, fallback, worktree, timeout, and cross-copy contract.
+- Create \`integrations/tests/tests/unit/test_project_dataset_config.py\`: configuration precedence and non-persistence contract.
+- Create \`integrations/tests/tests/unit/test_project_dataset_session_state.py\`: first-writer dataset pinning in launch records.
+- Create \`integrations/tests/tests/e2e/test_project_dataset_pipeline.py\`: SessionStart-through-recall/write/final-sync agreement.
+- Create \`integrations/tests/tests/integration/test_project_dataset_cli.py\`: direct search/remember wrapper resolution.
+- Modify both \`scripts/config.py\` copies: workspace-aware dataset selection and source metadata.
+- Modify both \`scripts/_plugin_common.py\` copies: store and expose pinned dataset/source in launch records.
+- Modify both \`scripts/session-start.py\` copies: resolve from payload cwd and pin before workers launch.
+- Modify both \`scripts/session-context-lookup.py\` copies: use the pinned dataset for recall.
+- Modify both \`scripts/sync-session-to-graph.py\` copies: prefer pinned runtime state and correct stale comments.
+- Modify both \`scripts/cognee_statusline_render.py\` copies: show the pinned dataset without network access.
+- Modify both \`scripts/cognee-search.sh\` and \`scripts/cognee-remember.sh\` copies: resolve project scope from the invoking cwd.
+- Modify both \`scripts/doctor.py\` copies: report effective dataset and source.
+- Modify \`integrations/tests/utils/isolation.py\`: isolate the new module in shared tests.
+- Modify \`integrations/tests/tests/integration/test_doctor.py\` and status-line tests for the new diagnostics/display.
+- Modify both plugin READMEs, changelogs, manifests, and \`.claude-plugin/marketplace.json\`: document and version the feature.
+
+### Task 1: Build the pure project dataset resolver
+
+**Files:**
+- Create: \`integrations/claude-code/scripts/_project_dataset.py\`
+- Create: \`integrations/codex/plugins/cognee/scripts/_project_dataset.py\`
+- Modify: \`integrations/tests/utils/isolation.py\`
+- Create: \`integrations/tests/tests/unit/test_project_dataset.py\`
+
+- [ ] **Step 1: Register the new module with test isolation**
+
+Add \`"_project_dataset"\` to \`ISOLATED_MODULES\` so imports are reloaded under the temporary HOME:
+
+\`\`\`python
+ISOLATED_MODULES = (
+    "config",
+    "_plugin_common",
+    "_project_dataset",
+    "_cognee_client",
+    "_env_file",
+    "_proc",
+    "_recall_http",
+    "_remember_http",
+    "cognee_plugin",
+    "cognee_statusline_render",
+    "doctor",
+)
+\`\`\`
+
+- [ ] **Step 2: Write failing pure-resolver tests**
+
+Create parametrized tests covering equivalent remotes, credential stripping, ports, malformed/local remotes, slug bounds, worktrees, non-Git workspaces, Git failures, and byte identity:
+
+\`\`\`python
+from __future__ import annotations
+
+import subprocess
+import re
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "remote",
+    [
+        "git@github.com:Topoteretes/Cognee.git",
+        "ssh://git@github.com/Topoteretes/Cognee.git",
+        "ssh://git@github.com:22/Topoteretes/Cognee.git",
+        "https://token:secret@github.com/Topoteretes/Cognee.git",
+    ],
+)
+def test_equivalent_remotes_normalize_identically(suite, isolated_modules, remote):
+    resolver = isolated_modules(suite, "_project_dataset")
+    assert resolver.normalize_git_remote(remote) == "git:github.com/Topoteretes/Cognee"
+
+
+def test_non_default_port_is_part_of_identity(suite, isolated_modules):
+    resolver = isolated_modules(suite, "_project_dataset")
+    assert (
+        resolver.normalize_git_remote("ssh://git@example.com:2222/Org/Repo.git")
+        == "git:example.com:2222/Org/Repo"
+    )
+
+
+def test_dataset_name_is_bounded_and_contains_no_credentials(suite, isolated_modules):
+    resolver = isolated_modules(suite, "_project_dataset")
+    name = resolver.dataset_name(
+        "git:example.com/Org/This Is A Very Long Repository Name With Ünicode",
+        "This Is A Very Long Repository Name With Ünicode",
+    )
+    assert re.fullmatch(r"project_[a-z0-9-]{1,32}_[0-9a-f]{12}", name)
+    assert len(name) <= 53
+    assert "secret" not in name
+
+
+@pytest.mark.parametrize(
+    "remote",
+    ["/tmp/local/repo.git", "file:///tmp/local/repo.git", "not a remote"],
+)
+def test_unsupported_or_malformed_remote_returns_none(suite, isolated_modules, remote):
+    resolver = isolated_modules(suite, "_project_dataset")
+    assert resolver.normalize_git_remote(remote) is None
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def test_remote_linked_worktrees_share_complete_name(suite, isolated_modules, tmp_path):
+    resolver = isolated_modules(suite, "_project_dataset")
+    repo = tmp_path / "primary"
+    linked = tmp_path / "different-worktree-name"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "remote", "add", "origin", "git@github.com:Org/Repo.git")
+    (repo / "seed").write_text("x", encoding="utf-8")
+    _git(repo, "add", "seed")
+    _git(repo, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed")
+    _git(repo, "worktree", "add", str(linked))
+    assert resolver.derive_project_dataset(str(repo)) == resolver.derive_project_dataset(str(linked))
+
+
+def test_remote_less_worktrees_share_complete_name(suite, isolated_modules, tmp_path):
+    resolver = isolated_modules(suite, "_project_dataset")
+    repo = tmp_path / "primary"
+    linked = tmp_path / "linked"
+    repo.mkdir()
+    _git(repo, "init")
+    (repo / "seed").write_text("x", encoding="utf-8")
+    _git(repo, "add", "seed")
+    _git(repo, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed")
+    _git(repo, "worktree", "add", str(linked))
+    assert resolver.derive_project_dataset(str(repo)) == resolver.derive_project_dataset(str(linked))
+
+
+def test_git_failure_falls_back_to_workspace(suite, isolated_modules, tmp_path, monkeypatch):
+    resolver = isolated_modules(suite, "_project_dataset")
+    workspace = tmp_path / "plain"
+    workspace.mkdir()
+    monkeypatch.setattr(resolver.subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()))
+    assert resolver.derive_project_dataset(str(workspace)).startswith("project_plain_")
+
+
+def test_git_timeout_falls_back_to_workspace(suite, isolated_modules, tmp_path, monkeypatch):
+    resolver = isolated_modules(suite, "_project_dataset")
+    workspace = tmp_path / "plain"
+    workspace.mkdir()
+    monkeypatch.setattr(
+        resolver.subprocess,
+        "run",
+        lambda *a, **k: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(cmd=["git"], timeout=1)
+        ),
+    )
+    assert resolver.derive_project_dataset(str(workspace)).startswith("project_plain_")
+
+
+def test_invalid_workspace_returns_none(suite, isolated_modules, tmp_path):
+    resolver = isolated_modules(suite, "_project_dataset")
+    assert resolver.derive_project_dataset(str(tmp_path / "missing")) is None
+
+
+def test_resolver_copies_are_byte_identical():
+    root = Path(__file__).resolve().parents[3]
+    claude = root / "claude-code" / "scripts" / "_project_dataset.py"
+    codex = root / "codex" / "plugins" / "cognee" / "scripts" / "_project_dataset.py"
+    assert claude.read_bytes() == codex.read_bytes()
+\`\`\`
+
+- [ ] **Step 3: Run the resolver tests and confirm RED**
+
+Run:
+
+\`\`\`bash
+cd integrations/tests
+uv run pytest tests/unit/test_project_dataset.py -v
+\`\`\`
+
+Expected: collection/import failures because \`_project_dataset.py\` does not exist.
+
+- [ ] **Step 4: Implement the resolver in both plugin packages**
+
+Implement the same public contract in both files:
+
+\`\`\`python
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+import unicodedata
+from pathlib import Path
+from urllib.parse import urlsplit
+
+GIT_TIMEOUT_SECONDS = 1.0
+_SUPPORTED_SCHEMES = {"git", "http", "https", "ssh"}
+_SCP_REMOTE = re.compile(r"^(?:[^@/\s]+@)?(?P<host>\[[^\]]+\]|[^:/\s]+):(?P<path>.+)$")
+
+
+def _repository_path(value: str) -> str:
+    path = str(value or "").strip().strip("/")
+    if path.lower().endswith(".git"):
+        path = path[:-4]
+    return path.strip("/")
+
+
+def normalize_git_remote(remote: str) -> str | None:
+    value = str(remote or "").strip()
+    if not value:
+        return None
+    if "://" not in value:
+        match = _SCP_REMOTE.fullmatch(value)
+        if not match or (len(match["host"]) == 1 and match["path"].startswith(("\\", "/"))):
+            return None
+        host = match["host"].strip("[]").lower()
+        path = _repository_path(match["path"])
+        return f"git:{host}/{path}" if host and path else None
+    try:
+        parsed = urlsplit(value)
+        scheme = parsed.scheme.lower()
+        if scheme not in _SUPPORTED_SCHEMES or not parsed.hostname:
+            return None
+        host = parsed.hostname.lower()
+        port = parsed.port
+    except (TypeError, ValueError):
+        return None
+    if scheme == "ssh" and port == 22:
+        port = None
+    host_part = f"[{host}]" if ":" in host else host
+    if port is not None:
+        host_part = f"{host_part}:{port}"
+    path = _repository_path(parsed.path)
+    return f"git:{host_part}/{path}" if path else None
+
+
+def _slug(value: str) -> str:
+    ascii_value = (
+        unicodedata.normalize("NFKD", str(value or ""))
+        .encode("ascii", "ignore")
+        .decode("ascii")
+        .lower()
+    )
+    slug = re.sub(r"[^a-z0-9]+", "-", ascii_value).strip("-")[:32].rstrip("-")
+    return slug or "workspace"
+
+
+def dataset_name(identity: str, slug_source: str) -> str:
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:12]
+    return f"project_{_slug(slug_source)}_{digest}"
+
+
+def _run_git(workspace: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(workspace),
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=GIT_TIMEOUT_SECONDS,
+            check=False,
+            shell=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _canonical_dir(value: str | Path, *, relative_to: Path | None = None) -> Path | None:
+    try:
+        path = Path(value).expanduser()
+        if relative_to is not None and not path.is_absolute():
+            path = relative_to / path
+        path = path.resolve(strict=True)
+        return path if path.is_dir() else None
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def derive_project_dataset(workspace: str) -> str | None:
+    root = _canonical_dir(workspace)
+    if root is None:
+        return None
+    top_raw = _run_git(root, "rev-parse", "--show-toplevel")
+    top = _canonical_dir(top_raw) if top_raw else None
+    if top is not None:
+        normalized = normalize_git_remote(_run_git(root, "config", "--get", "remote.origin.url"))
+        if normalized:
+            return dataset_name(normalized, normalized.rsplit("/", 1)[-1])
+        common_raw = _run_git(root, "rev-parse", "--git-common-dir")
+        common = _canonical_dir(common_raw, relative_to=root) if common_raw else None
+        if common is not None:
+            slug_source = common.parent.name if common.name == ".git" else common.name.removesuffix(".git")
+            return dataset_name(f"gitdir:{common}", slug_source)
+    return dataset_name(f"workspace:{root}", root.name)
+\`\`\`
+
+- [ ] **Step 5: Run resolver tests and confirm GREEN**
+
+Run: \`uv run pytest tests/unit/test_project_dataset.py -v\`
+
+Expected: all resolver cases pass on both suites.
+
+- [ ] **Step 6: Commit**
+
+\`\`\`bash
+git add integrations/claude-code/scripts/_project_dataset.py \
+  integrations/codex/plugins/cognee/scripts/_project_dataset.py \
+  integrations/tests/utils/isolation.py \
+  integrations/tests/tests/unit/test_project_dataset.py
+git commit -m "feat: derive stable project datasets"
+\`\`\`
+
+### Task 2: Apply configuration precedence
+
+**Files:**
+- Modify: \`integrations/claude-code/scripts/config.py\`
+- Modify: \`integrations/codex/plugins/cognee/scripts/config.py\`
+- Modify: both \`scripts/_env_file.py\` copies
+- Create: \`integrations/tests/tests/unit/test_project_dataset_config.py\`
+- Modify: \`integrations/tests/tests/unit/test_env_file.py\`
+
+- [ ] **Step 1: Write failing precedence tests**
+
+\`\`\`python
+def test_scope_absent_keeps_default(suite, isolated_modules, project_dir):
+    config = isolated_modules(suite, "config")
+    loaded = config.load_config(str(project_dir))
+    assert loaded["dataset"] == "agent_sessions"
+    assert loaded["_dataset_source"] == "default"
+
+
+def test_unknown_scope_keeps_default(suite, isolated_modules, project_dir, monkeypatch):
+    config = isolated_modules(suite, "config")
+    monkeypatch.setenv("COGNEE_DATASET_SCOPE", "repository")
+    loaded = config.load_config(str(project_dir))
+    assert (loaded["dataset"], loaded["_dataset_source"]) == ("agent_sessions", "default")
+
+
+def test_project_scope_derives_dataset(suite, isolated_modules, project_dir, monkeypatch):
+    config = isolated_modules(suite, "config")
+    monkeypatch.setenv("COGNEE_DATASET_SCOPE", " Project ")
+    monkeypatch.setattr(config, "derive_project_dataset", lambda workspace: "project_repo_abc123def456")
+    loaded = config.load_config(str(project_dir))
+    assert loaded["dataset"] == "project_repo_abc123def456"
+    assert loaded["_dataset_source"] == "project"
+
+
+def test_explicit_dataset_wins_over_project_scope(suite, isolated_modules, project_dir, monkeypatch):
+    config = isolated_modules(suite, "config")
+    monkeypatch.setenv("COGNEE_DATASET_SCOPE", "project")
+    monkeypatch.setenv("COGNEE_PLUGIN_DATASET", "explicit")
+    loaded = config.load_config(str(project_dir))
+    assert (loaded["dataset"], loaded["_dataset_source"]) == ("explicit", "env")
+
+
+def test_picker_marker_wins_over_project_scope(suite, isolated_modules, project_dir, monkeypatch):
+    config = isolated_modules(suite, "config")
+    monkeypatch.setenv("COGNEE_DATASET_SCOPE", "project")
+    selected = config._apply_project_dataset(
+        {"dataset": "picked", "_dataset_source": "picker"},
+        str(project_dir),
+    )
+    assert (selected["dataset"], selected["_dataset_source"]) == ("picked", "picker")
+
+
+def test_derived_dataset_is_not_persisted_globally(suite, isolated_modules, project_dir, monkeypatch):
+    config = isolated_modules(suite, "config")
+    monkeypatch.setenv("COGNEE_DATASET_SCOPE", "project")
+    monkeypatch.setattr(config, "derive_project_dataset", lambda workspace: "project_repo_abc123def456")
+    loaded = config.load_config(str(project_dir))
+    config.save_config(loaded)
+    saved = json.loads(config._CONFIG_FILE.read_text(encoding="utf-8"))
+    assert saved["dataset"] == "agent_sessions"
+    assert "_dataset_source" not in saved
+\`\`\`
+
+- [ ] **Step 2: Run the precedence tests and confirm RED**
+
+Run: \`uv run pytest tests/unit/test_project_dataset_config.py -v\`
+
+Expected: \`load_config\` rejects the workspace argument and has no source marker.
+
+- [ ] **Step 3: Implement selection and persistence**
+
+In both config copies, import the resolver, add \`COGNEE_DATASET_SCOPE\` to the environment map, and apply selection after the environment layer:
+
+\`\`\`python
+from _project_dataset import derive_project_dataset
+
+# in _ENV_MAP
+"COGNEE_DATASET_SCOPE": "_dataset_scope",
+
+
+def _workspace(workspace: str | None) -> str:
+    return str(workspace or os.environ.get(_HOST_CWD_ENV) or os.getcwd())
+
+
+def _apply_project_dataset(config: dict, workspace: str | None = None) -> dict:
+    source = str(config.get("_dataset_source") or "default")
+    config["_dataset_source"] = source
+    if source != "default":
+        return config
+    scope = str(config.get("_dataset_scope") or "").strip().lower()
+    if scope != "project":
+        return config
+    derived = derive_project_dataset(_workspace(workspace))
+    if derived:
+        config["dataset"] = derived
+        config["_dataset_source"] = "project"
+    return config
+\`\`\`
+
+Define \`_HOST_CWD_ENV = "CLAUDE_CWD"\` in Claude and \`"CODEX_CWD"\` in Codex. Change the signature to \`load_config(workspace: str | None = None) -> dict\`, initialize \`_dataset_source="default"\`, ignore underscore-prefixed config-file keys, mark a non-empty \`COGNEE_PLUGIN_DATASET\` as \`env\`, then return \`_apply_project_dataset(config, workspace)\`.
+
+Before writing \`to_save\`, keep project-specific values out of the global visibility file:
+
+\`\`\`python
+if config.get("_dataset_source") in {"picker", "project"}:
+    config = dict(config)
+    config["dataset"] = _DEFAULTS["dataset"]
+\`\`\`
+
+- [ ] **Step 4: Document the opt-in in the generated env template**
+
+Add this exact optional block to both \`_env_file.py\` templates:
+
+\`\`\`text
+# Derive one shared dataset per Git repository/workspace:
+# COGNEE_DATASET_SCOPE="project"
+# An explicit COGNEE_PLUGIN_DATASET always wins:
+# COGNEE_PLUGIN_DATASET="agent_sessions"
+\`\`\`
+
+- [ ] **Step 5: Run focused config/env tests**
+
+Run:
+
+\`\`\`bash
+uv run pytest tests/unit/test_project_dataset_config.py tests/unit/test_env_file.py -v
+\`\`\`
+
+Expected: all tests pass for Claude Code and Codex.
+
+- [ ] **Step 6: Commit**
+
+\`\`\`bash
+git add integrations/claude-code/scripts/config.py \
+  integrations/codex/plugins/cognee/scripts/config.py \
+  integrations/claude-code/scripts/_env_file.py \
+  integrations/codex/plugins/cognee/scripts/_env_file.py \
+  integrations/tests/tests/unit/test_project_dataset_config.py \
+  integrations/tests/tests/unit/test_env_file.py
+git commit -m "feat: select project datasets by precedence"
+\`\`\`
+
+### Task 3: Pin the selected dataset in launch state
+
+**Files:**
+- Modify: both \`scripts/_plugin_common.py\` copies
+- Create: \`integrations/tests/tests/unit/test_project_dataset_session_state.py\`
+
+- [ ] **Step 1: Write failing launch-state tests**
+
+\`\`\`python
+def test_launch_record_pins_dataset_and_source(suite, isolated_modules, monkeypatch):
+    common = isolated_modules(suite, "_plugin_common")
+    monkeypatch.setattr(
+        common,
+        "_json_http_request",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("offline test")),
+    )
+    common.ensure_launch_record(
+        "host-one",
+        "/repo",
+        dataset="project_repo_111111111111",
+        dataset_source="project",
+    )
+    resolved = common.load_resolved("host-one")
+    assert resolved["dataset"] == "project_repo_111111111111"
+    assert resolved["dataset_source"] == "project"
+
+
+def test_later_resolution_cannot_switch_pinned_dataset(suite, isolated_modules):
+    common = isolated_modules(suite, "_plugin_common")
+    common.ensure_launch_record(
+        "host-one", "/repo-a", dataset="project_a_111111111111", dataset_source="project"
+    )
+    common.ensure_launch_record(
+        "host-one", "/repo-b", dataset="project_b_222222222222", dataset_source="project"
+    )
+    assert common.get_launch_dataset("host-one") == ("project_a_111111111111", "project")
+
+
+def test_conversations_keep_distinct_sessions_in_one_dataset(suite, isolated_modules):
+    common = isolated_modules(suite, "_plugin_common")
+    dataset = "project_repo_111111111111"
+    first = common.ensure_launch_record("host-one", "/repo", dataset=dataset, dataset_source="project")
+    second = common.ensure_launch_record("host-two", "/repo", dataset=dataset, dataset_source="project")
+    assert first[0] != second[0]
+    assert common.get_launch_dataset("host-one")[0] == common.get_launch_dataset("host-two")[0]
+
+
+def test_exit_worker_receives_pinned_dataset(suite, hook_module, monkeypatch):
+    watcher = hook_module(suite, "exit-watcher.py")
+    captured = {}
+
+    class FakeProcess:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(watcher.subprocess, "Popen", FakeProcess)
+    watcher._spawn_sync(
+        "session-one",
+        "project_repo_111111111111",
+        session_key="host-one",
+    )
+    assert captured["env"]["COGNEE_SYNC_DATASET"] == "project_repo_111111111111"
+\`\`\`
+
+- [ ] **Step 2: Run and confirm RED**
+
+Run: \`uv run pytest tests/unit/test_project_dataset_session_state.py -v\`
+
+Expected: \`ensure_launch_record\` does not accept dataset fields.
+
+- [ ] **Step 3: Extend launch records without changing session semantics**
+
+Add optional keyword-only fields while preserving the existing tuple return:
+
+\`\`\`python
+def _pin_launch_dataset(host_key: str, record: dict, dataset: str, source: str) -> dict:
+    if not host_key or not dataset or record.get("dataset"):
+        return record
+    updated = dict(record)
+    updated["dataset"] = dataset
+    updated["dataset_source"] = source or "default"
+    _write_map_record(host_key, updated)
+    return _read_map_record(host_key) or updated
+
+
+def get_launch_dataset(host_key: str = "") -> tuple[str, str]:
+    record = _read_map_record(_sanitize_session_key(host_key) or get_session_key())
+    return (
+        str(record.get("dataset") or ""),
+        str(record.get("dataset_source") or ""),
+    )
+\`\`\`
+
+Change \`ensure_launch_record\` to accept \`dataset: str = ""\` and \`dataset_source: str = ""\`, include them in a new record, and fill them only when a legacy record has no dataset. In \`load_resolved\`, read the launch record before HTTP lookup and add \`dataset\` and \`dataset_source\` when present.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+\`\`\`bash
+uv run pytest tests/unit/test_project_dataset_session_state.py tests/unit/test_session_id.py -v
+\`\`\`
+
+Expected: all launch-state and existing session-ID tests pass.
+
+- [ ] **Step 5: Commit**
+
+\`\`\`bash
+git add integrations/claude-code/scripts/_plugin_common.py \
+  integrations/codex/plugins/cognee/scripts/_plugin_common.py \
+  integrations/tests/tests/unit/test_project_dataset_session_state.py
+git commit -m "feat: pin datasets to conversation state"
+\`\`\`
+
+### Task 4: Wire SessionStart, recall, workers, and final sync
+
+**Files:**
+- Modify: both \`scripts/session-start.py\` copies
+- Modify: both \`scripts/session-context-lookup.py\` copies
+- Modify: both \`scripts/sync-session-to-graph.py\` copies
+- Create: \`integrations/tests/tests/e2e/test_project_dataset_pipeline.py\`
+
+- [ ] **Step 1: Write a failing end-to-end pinning test**
+
+The test must initialize a Git project, start a session with project scope, then change the working directory before recall/write/sync and prove every request still uses the first dataset:
+
+\`\`\`python
+def test_pipeline_uses_session_start_dataset(
+    suite, run_hook, payloads, mock_server, project_dir, tmp_path
+):
+    subprocess.run(["git", "init"], cwd=project_dir, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:Org/SharedRepo.git"],
+        cwd=project_dir,
+        check=True,
+    )
+    other = tmp_path / "other"
+    other.mkdir()
+    env = {"COGNEE_DATASET_SCOPE": "project"}
+    host_id = "project-scope-host"
+
+    started = run_hook(
+        suite,
+        "session-start.py",
+        stdin=payloads.session_start(session_id=host_id, cwd=str(project_dir)),
+        cwd=project_dir,
+        service_url=mock_server.url,
+        env=env,
+    )
+    assert started.returncode == 0, started.stderr
+
+    recalled = run_hook(
+        suite,
+        "session-context-lookup.py",
+        stdin=payloads.user_prompt(session_id=host_id, cwd=str(other), prompt="recall project decision"),
+        cwd=other,
+        service_url=mock_server.url,
+        env=env,
+    )
+    assert recalled.returncode == 0, recalled.stderr
+
+    calls = [call for call in mock_server.calls if call["path"] == "/api/v1/recall"]
+    datasets = {tuple(call["json"].get("datasets") or []) for call in calls}
+    assert len(datasets) == 1
+    only = next(iter(datasets))
+    assert len(only) == 1 and only[0].startswith("project_sharedrepo_")
+\`\`\`
+
+Continue the same test after the recall assertion:
+
+\`\`\`python
+    prompted = run_hook(
+        suite,
+        "store-user-prompt.py",
+        stdin=payloads.user_prompt(
+            session_id=host_id,
+            cwd=str(other),
+            prompt="remember the pinned project decision",
+        ),
+        cwd=other,
+        service_url=mock_server.url,
+        env=env,
+    )
+    assert prompted.returncode == 0, prompted.stderr
+
+    stopped = run_hook(
+        suite,
+        "store-to-session.py",
+        "--stop",
+        stdin=payloads.stop(
+            session_id=host_id,
+            assistant_message="the pinned project decision is stable",
+            cwd=str(other),
+        ),
+        cwd=other,
+        service_url=mock_server.url,
+        env=env,
+    )
+    assert stopped.returncode == 0, stopped.stderr
+    writes = [call for call in mock_server.calls if call["path"] == "/api/v1/remember/entry"]
+    assert writes
+    assert {call["json"]["dataset_name"] for call in writes} == {only[0]}
+
+    synced = run_hook(
+        suite,
+        "sync-session-to-graph.py",
+        stdin={"hook_event_name": "ManualSync", "session_id": host_id, "cwd": str(other)},
+        cwd=other,
+        service_url=mock_server.url,
+        env=env,
+    )
+    assert synced.returncode == 0, synced.stderr
+    improves = [call for call in mock_server.calls if call["path"] == "/api/v1/improve"]
+    assert improves
+    assert improves[-1]["json"]["dataset_name"] == only[0]
+\`\`\`
+
+The exit-worker \`COGNEE_SYNC_DATASET\` propagation is pinned separately in
+\`test_exit_worker_receives_pinned_dataset\` from Task 3.
+
+- [ ] **Step 2: Run and confirm RED**
+
+Run: \`uv run pytest tests/e2e/test_project_dataset_pipeline.py -v\`
+
+Expected: recall targets the later cwd/default instead of pinned runtime state.
+
+- [ ] **Step 3: Pin at SessionStart**
+
+In each \`_start\`, parse payload/cwd before loading configuration, then pin and read back the winning record:
+
+\`\`\`python
+payload = payload or {}
+cwd = str(payload.get("cwd") or os.environ.get(_HOST_CWD_ENV) or os.getcwd())
+config = load_config(cwd)
+candidate_dataset = get_dataset(config)
+candidate_source = str(config.get("_dataset_source") or "default")
+
+session_id, conn_uuid = ensure_launch_record(
+    session_key,
+    cwd,
+    dataset=candidate_dataset,
+    dataset_source=candidate_source,
+)
+dataset, dataset_source = get_launch_dataset(session_key)
+dataset = dataset or candidate_dataset
+dataset_source = dataset_source or candidate_source
+\`\`\`
+
+Import \`get_launch_dataset\`, retain existing worker arguments, and include \`dataset\`/\`dataset_source\` in the \`session_resolved\` event.
+
+- [ ] **Step 4: Make recall consume pinned runtime state**
+
+Replace the session-ID-only helper with:
+
+\`\`\`python
+def _load_session(workspace: str = "") -> tuple[str, str]:
+    resolved = load_resolved()
+    session_id = str(resolved.get("session_id") or "")
+    dataset = str(resolved.get("dataset") or "")
+    if not session_id or not dataset:
+        config = load_config(workspace or None)
+        session_id = session_id or get_session_id(config, workspace or None)
+        dataset = dataset or get_dataset(config)
+    return session_id, dataset
+\`\`\`
+
+Pass the payload cwd into \`_run\`, use the returned \`dataset\` for every \`recall_via_http\` call, and leave session IDs unchanged.
+
+- [ ] **Step 5: Make final sync prefer pinned state**
+
+Keep \`COGNEE_SYNC_DATASET\` as the detached-worker override, then use \`data["dataset"]\` from \`load_resolved\` before any config fallback. Update the obsolete comment that says resolved state carries no dataset.
+
+- [ ] **Step 6: Run pipeline and regression tests**
+
+\`\`\`bash
+uv run pytest tests/e2e/test_project_dataset_pipeline.py \
+  tests/e2e/test_user_prompt_hooks.py \
+  tests/integration/test_sync_strict.py -v
+\`\`\`
+
+Expected: all tests pass for both suites.
+
+- [ ] **Step 7: Commit**
+
+\`\`\`bash
+git add integrations/claude-code/scripts/session-start.py \
+  integrations/codex/plugins/cognee/scripts/session-start.py \
+  integrations/claude-code/scripts/session-context-lookup.py \
+  integrations/codex/plugins/cognee/scripts/session-context-lookup.py \
+  integrations/claude-code/scripts/sync-session-to-graph.py \
+  integrations/codex/plugins/cognee/scripts/sync-session-to-graph.py \
+  integrations/tests/tests/e2e/test_project_dataset_pipeline.py
+git commit -m "feat: keep hook pipelines on pinned datasets"
+\`\`\`
+
+### Task 5: Update status, doctor, and direct CLI surfaces
+
+**Files:**
+- Modify: both \`scripts/cognee_statusline_render.py\` copies
+- Modify: both \`scripts/doctor.py\` copies
+- Modify: both \`scripts/cognee-search.sh\` copies
+- Modify: both \`scripts/cognee-remember.sh\` copies
+- Modify: \`integrations/tests/tests/e2e/test_statusline_bar.py\`
+- Modify: \`integrations/tests/tests/integration/test_doctor.py\`
+- Create: \`integrations/tests/tests/integration/test_project_dataset_cli.py\`
+
+- [ ] **Step 1: Write failing status and doctor tests**
+
+\`\`\`python
+def test_bar_prefers_pinned_dataset(suite, run_hook, temp_home):
+    if suite.name == "claude-code":
+        settings = temp_home / ".claude" / "settings.json"
+        settings.parent.mkdir(parents=True, exist_ok=True)
+        settings.write_text(
+            json.dumps({"enabledPlugins": {"cognee-memory@cognee": True}}),
+            encoding="utf-8",
+        )
+    sessions = temp_home / ".cognee-plugin" / suite.state_subdir / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    (sessions / "host-one.json").write_text(
+        json.dumps({"session_id": "sid", "dataset": "project_repo_111111111111"}),
+        encoding="utf-8",
+    )
+    result = run_hook(
+        suite,
+        "cognee_statusline_render.py",
+        stdin={"session_id": "host-one", "cwd": "/wrong/project"},
+        service_url="https://api.example-cognee.ai",
+        api_key=None,
+    )
+    assert "cognee: project_repo_111111111111" in result.stdout
+
+
+def test_bar_derives_before_launch_record_exists(
+    suite, run_hook, temp_home, project_dir
+):
+    if suite.name == "claude-code":
+        settings = temp_home / ".claude" / "settings.json"
+        settings.parent.mkdir(parents=True, exist_ok=True)
+        settings.write_text(
+            json.dumps({"enabledPlugins": {"cognee-memory@cognee": True}}),
+            encoding="utf-8",
+        )
+    subprocess.run(["git", "init"], cwd=project_dir, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:Org/StatusRepo.git"],
+        cwd=project_dir,
+        check=True,
+    )
+    result = run_hook(
+        suite,
+        "cognee_statusline_render.py",
+        stdin={"session_id": "new-host", "cwd": str(project_dir)},
+        cwd=project_dir,
+        service_url="https://api.example-cognee.ai",
+        api_key=None,
+        env={"COGNEE_DATASET_SCOPE": "project"},
+    )
+    assert "cognee: project_statusrepo_" in result.stdout
+\`\`\`
+
+Add \`dataset\` and \`dataset_source\` to \`_REPORT_KEYS\`, then add:
+
+\`\`\`python
+def test_report_includes_effective_project_dataset(
+    doctor, project_dir, monkeypatch
+):
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setenv("COGNEE_DATASET_SCOPE", "project")
+    report = doctor.collect_report()
+    assert report["dataset"].startswith("project_project_")
+    assert report["dataset_source"] == "project"
+\`\`\`
+
+- [ ] **Step 2: Run and confirm RED**
+
+Run:
+
+\`\`\`bash
+uv run pytest tests/e2e/test_statusline_bar.py \
+  tests/integration/test_doctor.py -v
+\`\`\`
+
+Expected: status shows \`agent_sessions\`; doctor lacks the new keys.
+
+- [ ] **Step 3: Implement network-free status resolution**
+
+In each renderer, define its suite-specific sessions directory and change the dataset helper signature:
+
+\`\`\`python
+def _active_dataset(host_id: str = "", cwd: str = "") -> str:
+    if _path_safe(host_id):
+        record = _read_json(_SESSIONS_MAP_DIR / f"{host_id}.json")
+        pinned = str(record.get("dataset") or "").strip()
+        if pinned:
+            return pinned
+    explicit = os.environ.get("COGNEE_PLUGIN_DATASET", "").strip()
+    if explicit:
+        return explicit
+    if os.environ.get("COGNEE_DATASET_SCOPE", "").strip().lower() == "project" and cwd:
+        try:
+            from _project_dataset import derive_project_dataset
+
+            derived = derive_project_dataset(cwd)
+            if derived:
+                return derived
+        except Exception:
+            pass
+    return _DEFAULT_DATASET
+\`\`\`
+
+Parse \`session_id\` and cwd from stdin in both main functions. Pass the host ID through \`render_status_for_host\` in Codex so imported hook-context rendering uses the pinned map.
+
+- [ ] **Step 4: Add doctor dataset diagnostics**
+
+\`\`\`python
+def _resolve_dataset() -> tuple[str, str]:
+    from config import get_dataset, load_config
+
+    cfg = load_config(os.getcwd())
+    return get_dataset(cfg), str(cfg.get("_dataset_source") or "default")
+\`\`\`
+
+Add \`dataset\` and \`dataset_source\` to \`collect_report\` and display rows \`Dataset\` and \`Dataset Source\`.
+
+- [ ] **Step 5: Route Bash wrappers through shared config**
+
+Inside each wrapper's embedded Python, replace direct \`COGNEE_PLUGIN_DATASET\` reads with:
+
+\`\`\`python
+sys.path.insert(0, sys.argv[2])
+from config import get_dataset, load_config
+
+dataset = get_dataset(load_config(os.getcwd()))
+\`\`\`
+
+Keep \`cognee-remember.sh --dataset\` parsing after this resolution so the flag remains highest precedence. Do not add a new search flag.
+
+- [ ] **Step 6: Test Bash wrappers against the mock server**
+
+Use \`build_env\` and \`subprocess.run(["bash", wrapper, ...])\` on POSIX. Assert \`/api/v1/recall.datasets\` and \`/api/v1/remember.datasetName\` use the derived dataset, and \`--dataset explicit\` wins for remember. Mark the file \`pytest.mark.skipif(os.name == "nt", reason="Bash wrapper contract")\`.
+
+- [ ] **Step 7: Run focused surface tests**
+
+\`\`\`bash
+uv run pytest tests/e2e/test_statusline_bar.py \
+  tests/integration/test_doctor.py \
+  tests/integration/test_project_dataset_cli.py -v
+\`\`\`
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+\`\`\`bash
+git add integrations/claude-code/scripts/cognee_statusline_render.py \
+  integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py \
+  integrations/claude-code/scripts/doctor.py \
+  integrations/codex/plugins/cognee/scripts/doctor.py \
+  integrations/claude-code/scripts/cognee-search.sh \
+  integrations/codex/plugins/cognee/scripts/cognee-search.sh \
+  integrations/claude-code/scripts/cognee-remember.sh \
+  integrations/codex/plugins/cognee/scripts/cognee-remember.sh \
+  integrations/tests/tests/e2e/test_statusline_bar.py \
+  integrations/tests/tests/integration/test_doctor.py \
+  integrations/tests/tests/integration/test_project_dataset_cli.py
+git commit -m "feat: surface effective project datasets"
+\`\`\`
+
+### Task 6: Document and version the feature
+
+**Files:**
+- Modify: \`integrations/claude-code/README.md\`
+- Modify: \`integrations/codex/README.md\`
+- Modify: \`integrations/claude-code/CHANGELOG.md\`
+- Modify: \`integrations/codex/plugins/cognee/CHANGELOG.md\`
+- Modify: \`integrations/claude-code/.claude-plugin/plugin.json\`
+- Modify: \`integrations/codex/plugins/cognee/.codex-plugin/plugin.json\`
+- Modify: \`.claude-plugin/marketplace.json\`
+
+- [ ] **Step 1: Add exact user documentation**
+
+Document:
+
+\`\`\`bash
+# Remove/comment a global fixed dataset first:
+# COGNEE_PLUGIN_DATASET="agent_sessions"
+
+# Then enable automatic project isolation:
+COGNEE_DATASET_SCOPE="project"
+\`\`\`
+
+State the precedence \`explicit env > #285 picker when present > derived project > agent_sessions\`, the \`project_<slug>_<hash12>\` format, stable Git remote/worktree behavior, per-conversation session IDs, no migration/deletion, and restart-on-next-session requirement. Update the launch-map example to show \`dataset\` and \`dataset_source\`.
+
+- [ ] **Step 2: Bump plugin patch versions**
+
+- Claude Code: \`1.3.3 -> 1.3.4\` in its manifest, marketplace entry, and changelog.
+- Codex: \`1.4.3 -> 1.4.4\` in its manifest and changelog.
+
+Add an \`Added\` changelog entry that links issue #356 and names the opt-in behavior.
+
+- [ ] **Step 3: Validate manifests and pins**
+
+\`\`\`bash
+python -m json.tool integrations/claude-code/.claude-plugin/plugin.json >/dev/null
+python -m json.tool integrations/codex/plugins/cognee/.codex-plugin/plugin.json >/dev/null
+python -m json.tool .claude-plugin/marketplace.json >/dev/null
+python scripts/check_version_pins.py
+\`\`\`
+
+Expected: all commands exit 0.
+
+- [ ] **Step 4: Commit**
+
+\`\`\`bash
+git add integrations/claude-code/README.md integrations/codex/README.md \
+  integrations/claude-code/CHANGELOG.md \
+  integrations/codex/plugins/cognee/CHANGELOG.md \
+  integrations/claude-code/.claude-plugin/plugin.json \
+  integrations/codex/plugins/cognee/.codex-plugin/plugin.json \
+  .claude-plugin/marketplace.json
+git commit -m "docs: explain project dataset isolation"
+\`\`\`
+
+### Task 7: Full verification and branch review
+
+**Files:**
+- Verify all branch changes; no new production file is introduced in this task.
+
+- [ ] **Step 1: Run formatting and lint**
+
+\`\`\`bash
+uvx ruff==0.16.0 format --check integrations/
+uvx ruff==0.16.0 check integrations/
+\`\`\`
+
+Expected: both commands exit 0.
+
+- [ ] **Step 2: Run the complete hermetic suite**
+
+\`\`\`bash
+cd integrations/tests
+uv sync --dev
+uv run pytest tests/ -v
+\`\`\`
+
+Expected: all non-live tests pass; only the repository's declared skips/deselections remain.
+
+- [ ] **Step 3: Run repository integrity checks**
+
+\`\`\`bash
+cd ../..
+git diff --check origin/main...HEAD
+python scripts/check_version_pins.py
+git status --short
+\`\`\`
+
+Expected: no whitespace errors, version pins agree, and the worktree is clean.
+
+- [ ] **Step 4: Review every changed path**
+
+\`\`\`bash
+git diff --stat origin/main...HEAD
+git diff --name-status origin/main...HEAD
+git log --oneline origin/main..HEAD
+\`\`\`
+
+Confirm there are no changes outside the spec, no secrets/raw remote values in logs, both resolver copies are byte-identical, and \`agent_sessions\` remains the opt-out default.
+
+### Task 8: Push and open the upstream PR
+
+**Files:**
+- No file modifications unless review finds a defect.
+
+- [ ] **Step 1: Recheck upstream integration status**
+
+\`\`\`bash
+git fetch origin --prune
+gh pr view 354 --repo topoteretes/cognee-integrations --json state,mergedAt,url
+gh pr view 355 --repo topoteretes/cognee-integrations --json state,mergedAt,url
+\`\`\`
+
+Expected at plan time: both are \`OPEN\`. If either is \`MERGED\`, rebase on \`origin/main\` and add that integration's byte-identical resolver/config/session/status parity before pushing.
+
+- [ ] **Step 2: Push the reviewed branch**
+
+\`\`\`bash
+git push -u fork feat/project-dataset-isolation-356
+\`\`\`
+
+- [ ] **Step 3: Open the PR**
+
+Create \`/tmp/cognee-project-isolation-pr.md\` with \`apply_patch\` after the
+verification run. Its Summary section states the implemented precedence and
+session pinning; its Safety section states opt-in/default preservation,
+empty-start behavior, and no migration/deletion; its Verification section
+copies the complete pytest and Ruff result lines produced in Task 7; and its
+Parity section records the current states and URLs of #354 and #355. End with
+\`Closes #356\`.
+
+\`\`\`bash
+gh pr create \
+  --repo topoteretes/cognee-integrations \
+  --base main \
+  --head netbrah:feat/project-dataset-isolation-356 \
+  --title "feat: add opt-in per-project dataset isolation" \
+  --body-file /tmp/cognee-project-isolation-pr.md
+\`\`\`
+
+- [ ] **Step 4: Verify hosted checks**
+
+\`\`\`bash
+gh pr checks --repo topoteretes/cognee-integrations --watch \
+  "$(gh pr view --repo topoteretes/cognee-integrations --json url --jq .url)"
+\`\`\`
+
+Expected: Linux shared tests, Windows shared tests, Ruff, and repository checks pass.
+
+### Task 9: Roll out locally without disrupting active sessions
+
+**Files/state:**
+- Back up and modify \`~/.cognee/.env\`.
+- Back up installed Claude Code, Codex, Qwen, and Antigravity plugin roots only after resolving their active paths.
+- Do not delete \`agent_sessions\` or restart/kill an active harness.
+
+- [ ] **Step 1: Inventory active processes and loaded plugin roots**
+
+\`\`\`bash
+ps -axo pid=,lstart=,command= | rg 'claude|codex|qwen|antigravity|agy'
+codex plugin list
+claude plugin list
+agy plugin list
+\`\`\`
+
+Resolve Qwen from its active extension/settings registration rather than \`~/.qwen/tmp\`, which contains session scratch state, not plugin source.
+
+- [ ] **Step 2: Create timestamped, recoverable backups**
+
+Use \`mktemp -d /tmp/cognee-project-scope-backup.XXXXXX\`, copy \`~/.cognee/.env\`, and copy each resolved plugin root with metadata preserved. Record the backup directory in the handoff.
+
+- [ ] **Step 3: Build and verify the Qwen/Antigravity local parity overlays**
+
+Fetch the exact open PR heads into dedicated worktrees:
+
+\`\`\`bash
+git fetch fork feat/qwen-cognee-351 feat/antigravity-cognee-352
+git worktree add -b local/qwen-project-scope \
+  /Users/palanisd/Projects/.worktrees/cognee-qwen-project-scope \
+  fork/feat/qwen-cognee-351
+git worktree add -b local/antigravity-project-scope \
+  /Users/palanisd/Projects/.worktrees/cognee-antigravity-project-scope \
+  fork/feat/antigravity-cognee-352
+\`\`\`
+
+Port the verified byte-identical resolver plus config selection, launch-record
+pinning, host workspace extraction, status/hook output, and direct wrapper
+behavior to each host shape. Qwen uses its PR's Qwen cwd/payload fields;
+Antigravity uses the first \`workspacePaths\` entry before payload cwd. In each
+worktree run \`cd integrations/tests && uv sync --dev && uv run pytest tests/ -v\`,
+then run the repository Ruff checks from Task 7. Keep these parity commits local
+until #354/#355 merge, then open focused follow-up PRs rather than expanding
+their integration PR review scope.
+
+- [ ] **Step 4: Install reviewed plugin files**
+
+Install Claude Code and Codex from the verified #356 branch commit. Install Qwen
+and Antigravity from the two verified local parity commits. Use the host's
+supported plugin installer when it owns the registered root; if a host has no
+installer, replace only its resolved Cognee plugin root after its active process
+exits. Preserve credentials, state directories, and unrelated integrations.
+
+- [ ] **Step 5: Change the shared env atomically**
+
+Remove/comment every active \`COGNEE_PLUGIN_DATASET=agent_sessions\` assignment, add one \`COGNEE_DATASET_SCOPE="project"\`, and verify \`COGNEE_SESSION_ID\` is absent. Preserve all API keys and backend settings byte-for-byte.
+
+- [ ] **Step 6: Restart one harness at a time**
+
+Wait for each current session to finish naturally. Launch a fresh session in the same repository, verify its status/hook log shows \`project_<slug>_<hash12>\`, then proceed to the next harness. Never kill a process to accelerate rollout.
+
+- [ ] **Step 7: Prove cross-harness project isolation**
+
+For two harnesses in this repository, inspect their host-keyed launch records and assert:
+
+\`\`\`text
+dataset A == dataset B
+session_id A != session_id B
+\`\`\`
+
+Launch one harness in another repository and assert its dataset differs. Confirm \`agent_sessions\` remains present and untouched for manual rollback/recall.
+
+- [ ] **Step 8: Verify health signals**
+
+- Claude Code: status line shows the derived dataset and healthy mode/glyph.
+- Codex: \`UserPromptSubmit\` context shows the derived dataset and saved/recall counts.
+- Qwen: its hook log records SessionStart and the derived dataset.
+- Antigravity: \`~/.cognee-plugin/antigravity/hook.log\` exists for a new session and records the derived dataset; no permanent status bar is expected from the current host.

--- a/docs/superpowers/specs/2026-08-19-project-dataset-isolation-design.md
+++ b/docs/superpowers/specs/2026-08-19-project-dataset-isolation-design.md
@@ -1,7 +1,7 @@
 # Opt-in Per-Project Dataset Isolation Design
 
-**Date:** 2026-08-19  
-**Issue:** [topoteretes/cognee-integrations#356](https://github.com/topoteretes/cognee-integrations/issues/356)  
+**Date:** 2026-08-19
+**Issue:** [topoteretes/cognee-integrations#356](https://github.com/topoteretes/cognee-integrations/issues/356)
 **Status:** Approved for implementation planning
 
 ## Goal

--- a/docs/superpowers/specs/2026-08-19-project-dataset-isolation-design.md
+++ b/docs/superpowers/specs/2026-08-19-project-dataset-isolation-design.md
@@ -1,0 +1,313 @@
+# Opt-in Per-Project Dataset Isolation Design
+
+**Date:** 2026-08-19  
+**Issue:** [topoteretes/cognee-integrations#356](https://github.com/topoteretes/cognee-integrations/issues/356)  
+**Status:** Approved for implementation planning
+
+## Goal
+
+Prevent graph recall from mixing unrelated repositories while preserving the
+existing rule that every host conversation has its own Cognee session.
+
+When `COGNEE_DATASET_SCOPE=project` is enabled, Claude Code, Codex, Qwen, and
+Antigravity conversations working in the same project use distinct session IDs
+inside one stable project dataset. Different projects use different datasets.
+
+The feature is opt-in. Existing installations continue to use
+`agent_sessions` unless they select a dataset explicitly or enable project
+scope.
+
+## Non-goals
+
+- Do not change how host conversation IDs become Cognee session IDs.
+- Do not globally set or pin `COGNEE_SESSION_ID`.
+- Do not migrate, merge, copy, delete, or rewrite `agent_sessions`.
+- Do not switch datasets during a running session; that remains #292.
+- Do not replace the explicit project picker proposed by #285.
+- Do not derive identity from branch names, commits, or worktree paths when a
+  stable Git remote is available.
+
+## User-visible contract
+
+The shared opt-in setting is:
+
+```bash
+COGNEE_DATASET_SCOPE=project
+```
+
+The effective dataset precedence is:
+
+1. `COGNEE_PLUGIN_DATASET` from the process environment or `~/.cognee/.env`.
+2. An explicit `.cognee/session-config.json` project picker from #285, when that
+   feature is present.
+3. A derived project dataset when `COGNEE_DATASET_SCOPE=project`.
+4. The existing `agent_sessions` default.
+
+`COGNEE_DATASET_SCOPE` accepts `project` case-insensitively after trimming
+whitespace. An absent, empty, or unknown value does not change the dataset
+selected by another layer and otherwise preserves the existing default. The
+global config file remains visibility-only for `dataset`; this feature does not
+make `~/.cognee-plugin/config.json` authoritative.
+
+The selected source is carried internally as one of `env`, `picker`, `project`,
+or `default`. Internal source metadata is never saved to user config or sent to
+Cognee.
+
+## Project identity
+
+Dataset identity is derived locally from the host-reported workspace directory.
+The resolver never performs network I/O and never invokes a shell.
+
+### Git repository with a supported `remote.origin.url`
+
+The resolver runs bounded Git subprocesses with argument arrays:
+
+```text
+git rev-parse --show-toplevel
+git config --get remote.origin.url
+```
+
+It normalizes common equivalent remote forms to one identity:
+
+```text
+git@github.com:Topoteretes/Cognee.git
+ssh://git@github.com/Topoteretes/Cognee.git
+https://github.com/Topoteretes/Cognee.git
+```
+
+become:
+
+```text
+git:github.com/Topoteretes/Cognee
+```
+
+Normalization rules are:
+
+- lowercase the host;
+- remove URL user information, including embedded credentials;
+- remove the default SSH port 22 while preserving a non-default port;
+- convert SCP-style SSH remotes to the same host/path form as URL remotes;
+- remove leading and trailing path separators and one trailing `.git` suffix;
+- preserve repository-path case so case-sensitive Git hosts cannot collide;
+- reject an empty host or repository path.
+
+The normalized identity, not the raw remote, is hashed. Raw remotes,
+credentials, and full local paths are never logged or placed in dataset names.
+An unsupported or malformed remote, including a local-path or `file://` remote,
+falls through to the Git-common-directory identity instead of disabling project
+isolation.
+
+### Git repository without a usable `origin`
+
+The resolver runs `git rev-parse --git-common-dir`, resolves a relative result
+against the workspace, canonicalizes it, and uses:
+
+```text
+gitdir:<canonical-common-directory>
+```
+
+Linked worktrees therefore share one identity even without a remote. If Git is
+unavailable or a bounded Git command fails, the resolver continues to the
+canonical workspace fallback.
+
+### Non-Git workspace
+
+The canonical host-reported workspace path becomes:
+
+```text
+workspace:<canonical-workspace-path>
+```
+
+The host-reported workspace is important: a hook process may execute from the
+plugin directory, which is not a valid project identity.
+
+### Dataset name
+
+The emitted name is:
+
+```text
+project_<slug>_<hash12>
+```
+
+- `slug` comes from the final repository path segment for a normalized remote,
+  the directory containing the shared `.git` directory for a Git-common-dir
+  identity, or the canonical workspace basename otherwise. It is lowercased,
+  converted to ASCII `[a-z0-9-]`, collapsed across repeated separators,
+  trimmed, and limited to 32 characters; an empty slug becomes `workspace`.
+  Because both identity and slug use shared Git state, linked worktrees emit
+  the same complete dataset name, not merely the same hash suffix.
+- `hash12` is the first 12 hexadecimal characters of SHA-256 over the normalized
+  identity.
+- The maximum emitted length is 53 characters.
+
+The readable slug is diagnostic only; the hash is the collision boundary.
+
+## Runtime architecture
+
+### Pure resolver module
+
+Each self-contained Python plugin ships an identical `_project_dataset.py`
+module. The module owns:
+
+- remote parsing and normalization;
+- bounded Git command execution;
+- Git-common-directory and non-Git fallback identity;
+- slug and dataset-name generation;
+- `derive_project_dataset(workspace: str) -> str | None`.
+
+The integrations remain independently installable, so they cannot import a
+runtime file outside their package. Shared tests compare behavior across copies
+to prevent drift.
+
+Every Git subprocess uses `shell=False`, captured text output, no stdin, and a
+fixed one-second timeout. Resolver failure returns `None`; it does not raise into
+a hook.
+
+### Configuration integration
+
+`config.load_config` gains an optional workspace argument and
+`COGNEE_DATASET_SCOPE` mapping. Dataset selection occurs after all available
+explicit selection layers have run:
+
+```text
+defaults -> global config (dataset excluded) -> picker when present -> env
+         -> project derivation only when the source is still default
+```
+
+The current branch has no #285 picker implementation. The resolver contract
+therefore accepts and preserves `_dataset_source="picker"` so a rebase with
+#285 has one explicit integration point. If #285 merges first, this branch must
+rebase and its picker layer must mark that source. If this feature merges first,
+#285 must set the marker when applying a picker value. A compatibility test
+pins that contract without copying #285's parser into this change.
+
+An explicit `COGNEE_PLUGIN_DATASET`, including `agent_sessions`, always wins.
+Derived dataset values and `_dataset_source` are runtime-only. When first-run
+setup creates the global visibility config, it must not persist a project- or
+picker-derived dataset as though it were the machine-wide selection.
+
+### One selection per session
+
+Session start resolves the dataset while the host workspace is known and writes
+the selected name and source into the existing host-keyed launch-map record.
+Subsequent prompt, tool, answer, recall, bridge, and improve paths consume that
+pinned value through the existing resolved-session interface.
+
+This prevents a transient Git failure in a later short-lived hook from splitting
+one session between the project dataset and `agent_sessions`.
+
+Detached workers continue to receive `COGNEE_SYNC_DATASET`; exit watchers and
+session-end sync must propagate the pinned value rather than deriving it again.
+Status surfaces prefer resolved-session state and derive only before a session
+record exists. Logs may include the source and final dataset name, but never the
+raw identity.
+
+### Host workspace inputs
+
+- Claude Code: payload `cwd`, then `CLAUDE_CWD`.
+- Codex: payload `cwd`, then `CODEX_CWD`.
+- Qwen: host payload workspace/current-directory field, then its host-specific
+  cwd environment variable as defined by #354.
+- Antigravity: first `workspacePaths` entry or normalized payload `cwd`, then
+  `AGY_CWD` as defined by #355.
+
+`os.getcwd()` is only the final fallback for direct scripts. It is never
+preferred over a host-provided workspace.
+
+Qwen and Antigravity are open upstream PRs, not part of current `main`. The
+first implementation targets Claude Code and Codex. If #354/#355 merge before
+the isolation PR is ready, their copies join the same PR; otherwise they receive
+follow-up parity changes without blocking the core feature. Local rollout may
+apply the reviewed resolver to all four installed integrations after upstream
+verification.
+
+## Explicit CLI tools and status surfaces
+
+`cognee-search.sh` and `cognee-remember.sh` currently resolve only
+`COGNEE_PLUGIN_DATASET` or `agent_sessions`. Under project scope they must call
+the same resolver using the invoking shell's current directory.
+`cognee-remember.sh --dataset` continues to override everything;
+`cognee-search.sh` keeps its current command-line interface.
+
+Status renderers show the pinned or derived dataset name. A renderer that keeps
+the existing standalone/no-network contract reads the host-keyed launch record
+using the host session ID in its input, and may import the pure resolver only as
+a pre-session fallback. Doctor output reports the effective dataset and source
+without exposing the normalized identity.
+
+## Failure handling
+
+- A missing Git binary, nonzero Git exit, timeout, malformed remote, or decoding
+  failure skips the affected Git identity layer and falls back to the next
+  local identity source. Only failure to produce any valid identity returns
+  `None` and preserves `agent_sessions`.
+- The resolver writes no files and changes no environment variables.
+- One derivation emits at most one bounded fallback/failure hook-log event
+  containing an error class, never command output or the raw remote/path.
+- An empty explicit dataset is treated as absent, matching current config
+  semantics.
+- A successfully pinned session dataset is never changed because a later
+  resolver attempt fails.
+
+## Testing strategy
+
+### Pure unit tests
+
+- SSH, SCP, HTTPS, credentials, default/non-default ports, `.git`, whitespace,
+  malformed remotes, and unsupported local/file remotes.
+- Equivalent SSH/HTTPS remotes produce identical names.
+- Different normalized repositories produce different names.
+- Slug character and length limits.
+- Git worktrees and remote-less Git repositories share the expected identity.
+- Non-Git canonical-path fallback.
+- Missing Git, timeout, nonzero exit, and malformed output fall through to the
+  canonical workspace identity; an invalid workspace returns `None`.
+
+### Configuration tests
+
+- scope absent/unknown preserves `agent_sessions`;
+- project scope derives only from the default source;
+- explicit environment dataset wins;
+- simulated picker source wins;
+- equivalent Claude Code and Codex workspaces resolve identically;
+- session IDs remain distinct across conversations and hosts.
+
+### Pipeline tests
+
+- remember, recall, status, bridge, improve, exit watcher, and final sync use the
+  same pinned dataset;
+- background workers receive `COGNEE_SYNC_DATASET`;
+- the remember wrapper honors `--dataset`; both direct wrappers honor explicit
+  env, project scope, and default precedence;
+- no test reads or writes the developer's real Git config, home directory,
+  credentials, datasets, or memory stores.
+
+The complete shared hermetic suite, Ruff format/lint, JSON/YAML checks, Linux
+CI, and Windows CI remain mandatory.
+
+## Documentation and versioning
+
+Claude Code and Codex READMEs document the opt-in setting, exact precedence,
+derived-name format, non-migration behavior, and the requirement to remove a
+global `COGNEE_PLUGIN_DATASET=agent_sessions` when enabling project scope.
+
+Each changed plugin receives the repository-standard patch-version and
+changelog update if required by its packaging convention. Qwen/Antigravity
+documentation follows the same wording when their parity changes land.
+
+## Local rollout
+
+Local activation happens only after the upstream branch passes review and
+verification:
+
+1. Back up `~/.cognee/.env` and every installed plugin root.
+2. Remove or comment the global `COGNEE_PLUGIN_DATASET="agent_sessions"` line.
+3. Add `COGNEE_DATASET_SCOPE="project"`.
+4. Keep `COGNEE_SESSION_ID` unset.
+5. Install the reviewed Claude Code, Codex, Qwen, and Antigravity plugin copies.
+6. Restart harnesses one at a time after their active conversations finish.
+7. Verify two harnesses in one repository report the same dataset but different
+   session IDs, and a harness in another repository reports a different dataset.
+
+The old `agent_sessions` data remains available for manual recall or rollback.
+No automatic migration or deletion occurs.

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": {
     "name": "Cognee"
   },

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,6 +10,15 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.4]
+
+### Added
+- **Opt-in project dataset isolation ([#356](https://github.com/topoteretes/cognee-integrations/issues/356)).**
+  Set `COGNEE_DATASET_SCOPE=project` after removing any fixed
+  `COGNEE_PLUGIN_DATASET` to derive one stable dataset per Git project. The
+  plugin keeps distinct conversation sessions inside that dataset; existing
+  datasets are neither migrated nor deleted.
+
 ## [1.3.3]
 
 ### Fixed

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -125,8 +125,18 @@ Each terminal launch maintains a small map file:
 
 ```
 ~/.cognee-plugin/claude-code/sessions/<host_session_id>.json
-  → { "conn_uuid": "...", "session_id": "...", "host_key": "..." }
+  → {
+       "conn_uuid": "...",
+       "session_id": "...",
+       "host_key": "...",
+       "dataset": "project_example_0123456789ab",
+       "dataset_source": "project"
+     }
 ```
+
+`dataset` and `dataset_source` are runtime launch state: they show the dataset
+selected for this conversation and why it was selected. They are not user
+configuration and are not fields sent to Cognee.
 
 - **`session_id`** — which Cognee session this terminal writes to and recalls from. Fixed at launch.
 - **`conn_uuid`** — per-launch liveness handle used for agent registration and server shutdown counting.
@@ -148,6 +158,39 @@ Set a custom dataset at launch:
 ```bash
 export COGNEE_PLUGIN_DATASET="my-project-memory"
 ```
+
+### Project dataset isolation
+
+Project isolation is opt-in. To move future conversations for a repository into
+one derived dataset, first remove or comment any fixed global dataset, then set
+the scope in `~/.cognee/.env` (or export it before launching Claude Code):
+
+```bash
+# Remove/comment a global fixed dataset first:
+# COGNEE_PLUGIN_DATASET="agent_sessions"
+
+# Then enable automatic project isolation:
+COGNEE_DATASET_SCOPE="project"
+```
+
+Dataset selection is: **explicit env > #285 picker when present > derived
+project > `agent_sessions`**. A non-empty `COGNEE_PLUGIN_DATASET` therefore
+always wins over project isolation. With `COGNEE_DATASET_SCOPE="project"`, the
+derived name is `project_<slug>_<hash12>`. Git repositories use their normalized
+`origin` remote as the identity, so separate clones and Git worktrees of the
+same remote resolve to the same dataset. A repository without a usable remote
+uses its shared Git worktree identity instead.
+
+The dataset is pinned when a conversation starts; changing the setting affects
+the next session only, so exit and start a new Claude Code conversation after
+editing it. Conversations in the same project dataset still receive distinct
+Cognee `session_id` values (unless you explicitly set the same
+`COGNEE_SESSION_ID`). The status line displays the active dataset, and `cognee
+doctor` reports both `Dataset` and `Dataset Source` so you can confirm the
+resolved choice.
+
+This opt-in does not migrate existing memories and does not delete any existing
+dataset. Existing installations continue to use `agent_sessions` until enabled.
 
 `~/.cognee-plugin/claude-code/config.json` may still show a `dataset` value for
 visibility, but runtime dataset selection does not read it.

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -358,7 +358,10 @@ It is configured automatically on first launch when no custom status line is alr
 The entry sets `refreshInterval: 2`, so Claude re-runs the (network-free, local-only) renderer every 2 seconds in addition to its event-driven updates. Without it, Claude only refreshes the status line on events (a new message, `/compact`, etc.), which go quiet while the session is idle — so a connection change detected right after launch (e.g. a rejected API key) wouldn't show until your next prompt. Tune it with `COGNEE_STATUSLINE_REFRESH_INTERVAL` (seconds; a value below `1`, e.g. `0`, disables idle polling and reverts to event-only refresh).
 
 The status line reads only local state — no network calls on every refresh:
-1. Dataset: `COGNEE_PLUGIN_DATASET` env var, otherwise `agent_sessions`
+1. Dataset: the dataset pinned in this conversation's launch map, otherwise
+   `COGNEE_PLUGIN_DATASET`, then a project-derived dataset when
+   `COGNEE_DATASET_SCOPE=project` and Claude Code provides a working directory,
+   otherwise `agent_sessions`
 2. Mode: `COGNEE_BACKEND` / `COGNEE_CLAUDE_BACKEND` switch, then `COGNEE_BASE_URL` env var, then `~/.cognee-plugin/claude-code/config.json` (`base_url`)
 3. Default mode: `local`
 4. Connection glyph: `conn-state/<session>.json`, then `server-ready.json` + `recall-breaker.json`

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -486,7 +486,10 @@ skips local-path (dev) installs. Turn it off with `COGNEE_UPDATE_CHECK=false`.
 - If a mode seems stuck, check for a forgotten `COGNEE_BACKEND` / `COGNEE_CLAUDE_BACKEND` export in the shell or in `~/.cognee/.env` — the plugin-specific name silently beats the shared one.
 
 **Recall returns empty but data was ingested**
-- Recall is scoped to the active dataset (`COGNEE_PLUGIN_DATASET` / `agent_sessions`).
+- Recall is scoped to the active dataset: a non-empty explicit
+  `COGNEE_PLUGIN_DATASET` wins; otherwise `COGNEE_DATASET_SCOPE=project` uses
+  the conversation's pinned project-derived dataset; otherwise it uses
+  `agent_sessions`.
 - Data written via the Python SDK or `client.py` goes to `default_dataset` by default, if dataset not otherwise specified.
 - To verify, call the recall API directly without a dataset filter: `curl -X POST "$COGNEE_BASE_URL/api/v1/recall" -d '{"query":"..."}'`
 

--- a/integrations/claude-code/scripts/_env_file.py
+++ b/integrations/claude-code/scripts/_env_file.py
@@ -74,6 +74,9 @@ _TEMPLATE = """\
 # LLM_MODEL="openai/gpt-4o-mini"
 
 ## Optional:
+# Derive one shared dataset per Git repository/workspace:
+# COGNEE_DATASET_SCOPE="project"
+# An explicit COGNEE_PLUGIN_DATASET always wins:
 # COGNEE_PLUGIN_DATASET="agent_sessions"
 """
 

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -255,27 +255,22 @@ def get_launch_dataset(host_key: str = "") -> tuple[str, str]:
 def _create_map_record_if_absent(host_key: str, record: dict) -> dict:
     """Atomically create the launch record, first-writer-wins.
 
-    Uses O_CREAT|O_EXCL so exactly one concurrent creator wins; losers read back
-    the winner's record instead of clobbering it. This is what makes concurrent
-    launches/hooks for the same host_key converge on a single session id rather
-    than diverge. Returns the record now on disk.
+    Serializes creation with the existing host-keyed lock, then publishes through
+    ``_write_map_record``'s atomic replace. The destination therefore appears only
+    after the complete JSON is durable; contenders retry the lock and read the
+    winner instead of observing an empty/partial file. Returns the record on disk.
     """
     if not host_key:
         return record
-    path = _session_map_path(host_key)
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            json.dump(record, fh, indent=2, sort_keys=True)
-        return record
-    except FileExistsError:
-        return _read_map_record(host_key) or record
-    except Exception as exc:
-        hook_log("map_create_failed", {"error": str(exc)[:200]})
-        # Best-effort fallback: plain write, then read back whatever landed.
-        _write_map_record(host_key, record)
-        return _read_map_record(host_key) or record
+    while True:
+        with improve_session_lock(host_key, "launch_record") as acquired:
+            if acquired:
+                current = _read_map_record(host_key)
+                if current:
+                    return current
+                _write_map_record(host_key, record)
+                return _read_map_record(host_key) or record
+        time.sleep(0.02)
 
 
 def resolve_cognee_session_id(host_key: str = "", cwd: str = "") -> str:

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -203,7 +203,8 @@ def _session_map_path(host_key: str) -> Path:
 def _read_map_record(host_key: str) -> dict:
     """Return the launch record for a host session id, or {}.
 
-    Record shape: ``{conn_uuid, session_id, host_key, created_at, touched: [...]}``.
+    Record shape: ``{conn_uuid, session_id, host_key, created_at, touched: [...],
+    dataset, dataset_source}``.
     ``session_id`` = current Cognee session (switchable); ``conn_uuid`` = the
     per-launch liveness handle used for registration/counting (never switched).
     """
@@ -224,6 +225,24 @@ def _write_map_record(host_key: str, record: dict) -> None:
     if not host_key or not isinstance(record, dict):
         return
     _write_json_file(_session_map_path(host_key), record)
+
+
+def _pin_launch_dataset(host_key: str, record: dict, dataset: str, source: str) -> dict:
+    if not host_key or not dataset or record.get("dataset"):
+        return record
+    updated = dict(record)
+    updated["dataset"] = dataset
+    updated["dataset_source"] = source or "default"
+    _write_map_record(host_key, updated)
+    return _read_map_record(host_key) or updated
+
+
+def get_launch_dataset(host_key: str = "") -> tuple[str, str]:
+    record = _read_map_record(_sanitize_session_key(host_key) or get_session_key())
+    return (
+        str(record.get("dataset") or ""),
+        str(record.get("dataset_source") or ""),
+    )
 
 
 def _create_map_record_if_absent(host_key: str, record: dict) -> dict:
@@ -285,7 +304,9 @@ def resolve_cognee_session_id(host_key: str = "", cwd: str = "") -> str:
     return str(winner.get("session_id") or new_id)
 
 
-def ensure_launch_record(host_key: str = "", cwd: str = "") -> tuple[str, str]:
+def ensure_launch_record(
+    host_key: str = "", cwd: str = "", *, dataset: str = "", dataset_source: str = ""
+) -> tuple[str, str]:
     """Create (first-writer-wins) and return this launch's (session_id, conn_uuid).
 
     Called by SessionStart. The session id honors an explicit ``COGNEE_SESSION_ID``
@@ -293,6 +314,7 @@ def ensure_launch_record(host_key: str = "", cwd: str = "") -> tuple[str, str]:
     """
     host_key = _sanitize_session_key(host_key) or get_session_key()
     rec = _read_map_record(host_key)
+    rec = _pin_launch_dataset(host_key, rec, dataset, dataset_source)
     if rec.get("session_id") and rec.get("conn_uuid"):
         return str(rec["session_id"]), str(rec["conn_uuid"])
 
@@ -307,6 +329,9 @@ def ensure_launch_record(host_key: str = "", cwd: str = "") -> tuple[str, str]:
         or datetime.now(timezone.utc).isoformat(timespec="seconds"),
         "touched": rec.get("touched") or [session_id],
     }
+    if dataset:
+        record["dataset"] = dataset
+        record["dataset_source"] = dataset_source or "default"
     if not host_key:
         return session_id, conn_uuid
     winner = _create_map_record_if_absent(host_key, record)
@@ -409,6 +434,10 @@ def load_resolved(session_key: str = "") -> dict:
     active_session_key = _sanitize_session_key(session_key) or get_session_key()
     if active_session_key:
         resolved["session_key"] = active_session_key
+    launch_record = _read_map_record(active_session_key)
+    if launch_record.get("dataset"):
+        resolved["dataset"] = str(launch_record["dataset"])
+        resolved["dataset_source"] = str(launch_record.get("dataset_source") or "")
 
     # session_id = data scoping key (switchable); conn_uuid = registration handle.
     cognee_session_id = resolve_cognee_session_id(active_session_key)

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -62,6 +62,12 @@ _API_KEY_CACHE = _SHARED_PLUGIN_ROOT / "api_key.json"
 # as an identity. A genuinely new launch gets a new host id -> new Cognee session;
 # a `resume` reuses the host id -> continues the same Cognee session.
 _SESSIONS_MAP_DIR = _PLUGIN_DIR / "sessions"
+# Launch-record publication is mandatory state, unlike best-effort improve
+# admission. Keep a stable lock inode per host conversation so kernel advisory
+# locking provides crash recovery without stale-file deletion races.
+_LAUNCH_PUBLICATION_LOCK_DIR = _PLUGIN_DIR / "launch-publication-locks"
+_LAUNCH_PUBLICATION_LOCK_TIMEOUT_SECONDS = 1.0
+_LAUNCH_PUBLICATION_LOCK_POLL_SECONDS = 0.02
 
 # Save-kinds tracked per turn. Keep this tuple in sync with bump_save_counter callers.
 SAVE_KINDS = ("prompt", "trace", "answer")
@@ -200,6 +206,128 @@ def _session_map_path(host_key: str) -> Path:
     return _SESSIONS_MAP_DIR / f"{_sanitize_session_key(host_key)}.json"
 
 
+def _launch_publication_lock_path(host_key: str) -> Path:
+    normalized = _sanitize_session_key(host_key)
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return _LAUNCH_PUBLICATION_LOCK_DIR / f"{digest}.lock"
+
+
+def _open_launch_lock_file(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        if os.name != "nt":
+            os.fchmod(fd, 0o600)
+        return os.fdopen(fd, "r+b", buffering=0)
+    except Exception:
+        os.close(fd)
+        raise
+
+
+def _try_acquire_launch_file_lock(file_handle) -> bool:
+    if os.name == "nt":
+        import msvcrt
+
+        file_handle.seek(0)
+        try:
+            msvcrt.locking(file_handle.fileno(), msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError as exc:
+            if exc.errno in {errno.EACCES, errno.EAGAIN, errno.EDEADLK} or getattr(
+                exc, "winerror", None
+            ) in {33, 36}:
+                return False
+            raise
+
+    import fcntl
+
+    try:
+        fcntl.flock(file_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except OSError as exc:
+        if exc.errno in {errno.EACCES, errno.EAGAIN}:
+            return False
+        raise
+
+
+def _release_launch_file_lock(file_handle) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        file_handle.seek(0)
+        msvcrt.locking(file_handle.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(file_handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def _launch_publication_lock(
+    host_key: str, *, timeout: float = _LAUNCH_PUBLICATION_LOCK_TIMEOUT_SECONDS
+):
+    """Bounded, fail-closed lock for first-writer launch-record publication.
+
+    The lock path is persistent by design. Kernel ownership, not file presence,
+    determines admission, so process death releases the lock and an old owner
+    can never unlink a successor's lock inode.
+    """
+    normalized = _sanitize_session_key(host_key)
+    if not normalized:
+        raise RuntimeError("launch record publication requires a host key")
+
+    lock_path = _launch_publication_lock_path(normalized)
+    try:
+        file_handle = _open_launch_lock_file(lock_path)
+    except Exception as exc:
+        hook_log("launch_publication_lock_open_failed", {"error": str(exc)[:200]})
+        raise RuntimeError("launch record publication lock could not be opened") from exc
+
+    acquired = False
+    try:
+        deadline = time.monotonic() + max(0.0, float(timeout))
+        while True:
+            try:
+                acquired = _try_acquire_launch_file_lock(file_handle)
+            except Exception as exc:
+                hook_log("launch_publication_lock_failed", {"error": str(exc)[:200]})
+                raise RuntimeError("launch record publication lock failed") from exc
+            if acquired:
+                break
+            if time.monotonic() >= deadline:
+                yield False
+                return
+            time.sleep(_LAUNCH_PUBLICATION_LOCK_POLL_SECONDS)
+
+        token = uuid.uuid4().hex
+        metadata = json.dumps(
+            {
+                "token": token,
+                "pid": os.getpid(),
+                "created_at": datetime.now(timezone.utc).timestamp(),
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+        try:
+            file_handle.seek(0)
+            file_handle.truncate()
+            file_handle.write(metadata)
+            os.fsync(file_handle.fileno())
+        except Exception as exc:
+            hook_log("launch_publication_metadata_failed", {"error": str(exc)[:200]})
+            raise RuntimeError("launch record publication metadata failed") from exc
+
+        yield token
+    finally:
+        if acquired:
+            try:
+                _release_launch_file_lock(file_handle)
+            except Exception as exc:
+                hook_log("launch_publication_lock_release_failed", {"error": str(exc)[:200]})
+        file_handle.close()
+
+
 def _read_map_record(host_key: str) -> dict:
     """Return the launch record for a host session id, or {}.
 
@@ -221,27 +349,10 @@ def _read_map_record(host_key: str) -> dict:
     return {}
 
 
-def _write_map_record(host_key: str, record: dict) -> None:
+def _write_map_record(host_key: str, record: dict) -> bool:
     if not host_key or not isinstance(record, dict):
-        return
-    _write_json_file(_session_map_path(host_key), record)
-
-
-def _pin_launch_dataset(host_key: str, record: dict, dataset: str, source: str) -> dict:
-    if not host_key or not dataset or not record or record.get("dataset"):
-        return record
-    while True:
-        with improve_session_lock(host_key, "dataset_pin") as acquired:
-            if acquired:
-                current = _read_map_record(host_key)
-                if not current or current.get("dataset"):
-                    return current or record
-                updated = dict(current)
-                updated["dataset"] = dataset
-                updated["dataset_source"] = source or "default"
-                _write_map_record(host_key, updated)
-                return _read_map_record(host_key) or updated
-        time.sleep(0.02)
+        return False
+    return _write_json_file(_session_map_path(host_key), record)
 
 
 def get_launch_dataset(host_key: str = "") -> tuple[str, str]:
@@ -255,22 +366,27 @@ def get_launch_dataset(host_key: str = "") -> tuple[str, str]:
 def _create_map_record_if_absent(host_key: str, record: dict) -> dict:
     """Atomically create the launch record, first-writer-wins.
 
-    Serializes creation with the existing host-keyed lock, then publishes through
+    Serializes creation with the dedicated host-keyed lock, then publishes through
     ``_write_map_record``'s atomic replace. The destination therefore appears only
-    after the complete JSON is durable; contenders retry the lock and read the
+    after the complete JSON is durable; contenders wait for the lock and read the
     winner instead of observing an empty/partial file. Returns the record on disk.
     """
     if not host_key:
         return record
-    while True:
-        with improve_session_lock(host_key, "launch_record") as acquired:
-            if acquired:
-                current = _read_map_record(host_key)
-                if current:
-                    return current
-                _write_map_record(host_key, record)
-                return _read_map_record(host_key) or record
-        time.sleep(0.02)
+    with _launch_publication_lock(host_key) as acquired:
+        if not acquired:
+            raise RuntimeError("launch record publication lock timed out")
+        current = _read_map_record(host_key)
+        if current:
+            return current
+        if _session_map_path(host_key).exists():
+            raise RuntimeError("launch record publication found unreadable state")
+        if not _write_map_record(host_key, record):
+            raise RuntimeError("launch record publication failed")
+        published = _read_map_record(host_key)
+        if not published:
+            raise RuntimeError("launch record publication could not be verified")
+        return published
 
 
 def resolve_cognee_session_id(host_key: str = "", cwd: str = "") -> str:
@@ -315,38 +431,53 @@ def ensure_launch_record(
     override, else the existing/generated id; the conn_uuid is minted once.
     """
     host_key = _sanitize_session_key(host_key) or get_session_key()
-    rec = _read_map_record(host_key)
-    rec = _pin_launch_dataset(host_key, rec, dataset, dataset_source)
-    if rec.get("session_id") and rec.get("conn_uuid"):
-        return str(rec["session_id"]), str(rec["conn_uuid"])
-
-    explicit = _sanitize_session_key(str(os.environ.get("COGNEE_SESSION_ID", "") or "").strip())
-    session_id = explicit or str(rec.get("session_id") or "") or _generate_session_id(cwd, host_key)
-    conn_uuid = str(rec.get("conn_uuid") or "") or _new_conn_uuid()
-    record = {
-        "session_id": session_id,
-        "conn_uuid": conn_uuid,
-        "host_key": host_key,
-        "created_at": rec.get("created_at")
-        or datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        "touched": rec.get("touched") or [session_id],
-    }
-    if dataset:
-        record["dataset"] = dataset
-        record["dataset_source"] = dataset_source or "default"
     if not host_key:
+        explicit = _sanitize_session_key(str(os.environ.get("COGNEE_SESSION_ID", "") or "").strip())
+        session_id = explicit or _generate_session_id(cwd)
+        conn_uuid = _new_conn_uuid()
         return session_id, conn_uuid
-    winner = _create_map_record_if_absent(host_key, record)
-    # If a prior resolve() created a session-only record (no handle), graft our
-    # conn_uuid onto it. SessionStart is the sole writer of conn_uuid, so this
-    # merge isn't contended in practice.
-    if not winner.get("conn_uuid"):
-        merged = dict(winner)
-        merged["conn_uuid"] = conn_uuid
-        merged.setdefault("host_key", host_key)
-        _write_map_record(host_key, merged)
-        winner = _read_map_record(host_key) or merged
-    return str(winner.get("session_id") or session_id), str(winner.get("conn_uuid") or conn_uuid)
+
+    with _launch_publication_lock(host_key) as acquired:
+        if not acquired:
+            raise RuntimeError("launch record publication lock timed out")
+        current = _read_map_record(host_key)
+        if not current and _session_map_path(host_key).exists():
+            raise RuntimeError("launch record publication found unreadable state")
+
+        record = dict(current)
+        session_id = str(record.get("session_id") or "")
+        if not session_id:
+            explicit = _sanitize_session_key(
+                str(os.environ.get("COGNEE_SESSION_ID", "") or "").strip()
+            )
+            session_id = explicit or _generate_session_id(cwd, host_key)
+            record["session_id"] = session_id
+
+        conn_uuid = str(record.get("conn_uuid") or "")
+        if not conn_uuid:
+            conn_uuid = _new_conn_uuid()
+            record["conn_uuid"] = conn_uuid
+
+        record.setdefault("host_key", host_key)
+        record.setdefault("created_at", datetime.now(timezone.utc).isoformat(timespec="seconds"))
+        record.setdefault("touched", [session_id])
+        if dataset and not record.get("dataset"):
+            record["dataset"] = dataset
+            record["dataset_source"] = dataset_source or "default"
+        elif record.get("dataset") and not record.get("dataset_source"):
+            same_candidate = dataset and str(record["dataset"]) == dataset
+            record["dataset_source"] = (
+                dataset_source if same_candidate and dataset_source else "default"
+            )
+
+        if record != current:
+            if not _write_map_record(host_key, record):
+                raise RuntimeError("launch record publication failed")
+            record = _read_map_record(host_key)
+            if not record:
+                raise RuntimeError("launch record publication could not be verified")
+
+        return str(record["session_id"]), str(record["conn_uuid"])
 
 
 def resolve_conn_uuid(host_key: str = "") -> str:
@@ -358,12 +489,22 @@ def resolve_conn_uuid(host_key: str = "") -> str:
         return cu
     cu = _new_conn_uuid()
     if host_key:
-        rec = _read_map_record(host_key)
-        if not rec.get("conn_uuid"):
+        with _launch_publication_lock(host_key) as acquired:
+            if not acquired:
+                raise RuntimeError("launch record publication lock timed out")
+            rec = _read_map_record(host_key)
+            if not rec and _session_map_path(host_key).exists():
+                raise RuntimeError("launch record publication found unreadable state")
+            if rec.get("conn_uuid"):
+                return str(rec["conn_uuid"])
             rec["conn_uuid"] = cu
             rec.setdefault("host_key", host_key)
-            _write_map_record(host_key, rec)
-        return str(_read_map_record(host_key).get("conn_uuid") or cu)
+            if not _write_map_record(host_key, rec):
+                raise RuntimeError("launch record publication failed")
+            published = _read_map_record(host_key)
+            if not published.get("conn_uuid"):
+                raise RuntimeError("launch record publication could not be verified")
+            return str(published["conn_uuid"])
     return cu
 
 
@@ -419,7 +560,7 @@ def _resolve_agent_name() -> str:
     try:
         from config import load_config  # type: ignore
 
-        configured = str(load_config().get("agent_name") or "").strip()
+        configured = str(load_config(derive_project=False).get("agent_name") or "").strip()
         if configured:
             normalized = _normalize(configured)
             os.environ["COGNEE_AGENT_NAME"] = normalized
@@ -525,16 +666,31 @@ def _load_json_file(path: Path) -> dict:
     return {}
 
 
-def _write_json_file(path: Path, data: dict) -> None:
+def _write_json_file(path: Path, data: dict) -> bool:
+    tmp: Path | None = None
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        # Atomic write: a concurrent reader never sees a half-written file.
-        # Per-pid tmp name so two writers can't collide on the tmp path.
-        tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
-        tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+        # Unique, private temp file: concurrent threads in one process cannot
+        # collide, and replacement never inherits a destination's wider mode.
+        tmp = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+        fd = os.open(str(tmp), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as file_handle:
+            json.dump(data, file_handle, indent=2, sort_keys=True)
         os.replace(tmp, path)
+        if os.name != "nt":
+            os.chmod(path, 0o600)
+        return True
     except Exception as exc:
         hook_log("json_write_failed", {"path": str(path), "error": str(exc)[:200]})
+        return False
+    finally:
+        if tmp is not None:
+            try:
+                tmp.unlink()
+            except FileNotFoundError:
+                pass
+            except Exception as exc:
+                hook_log("json_temp_cleanup_failed", {"path": str(tmp), "error": str(exc)[:200]})
 
 
 def _strip_surrogates(text: str) -> str:

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -228,13 +228,20 @@ def _write_map_record(host_key: str, record: dict) -> None:
 
 
 def _pin_launch_dataset(host_key: str, record: dict, dataset: str, source: str) -> dict:
-    if not host_key or not dataset or record.get("dataset"):
+    if not host_key or not dataset or not record or record.get("dataset"):
         return record
-    updated = dict(record)
-    updated["dataset"] = dataset
-    updated["dataset_source"] = source or "default"
-    _write_map_record(host_key, updated)
-    return _read_map_record(host_key) or updated
+    while True:
+        with improve_session_lock(host_key, "dataset_pin") as acquired:
+            if acquired:
+                current = _read_map_record(host_key)
+                if not current or current.get("dataset"):
+                    return current or record
+                updated = dict(current)
+                updated["dataset"] = dataset
+                updated["dataset_source"] = source or "default"
+                _write_map_record(host_key, updated)
+                return _read_map_record(host_key) or updated
+        time.sleep(0.02)
 
 
 def get_launch_dataset(host_key: str = "") -> tuple[str, str]:

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1210,13 +1210,25 @@ def improve_session_lock(session_id: str, owner: str):
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         now = datetime.now(timezone.utc).timestamp()
         if lock_path.exists():
+            metadata_complete = True
             try:
                 current = json.loads(lock_path.read_text(encoding="utf-8"))
                 created_at = float(current.get("created_at", 0))
                 pid = int(current.get("pid", 0))
             except Exception:
-                created_at, pid = 0.0, 0
-            if not (pid > 0 and _proc.pid_alive(pid)) or now - created_at > SYNC_LOCK_STALE_SECONDS:
+                metadata_complete = False
+                try:
+                    created_at = lock_path.stat().st_mtime
+                except FileNotFoundError:
+                    created_at = now
+                pid = 0
+            stale = (
+                now - created_at > SYNC_LOCK_STALE_SECONDS
+                if not metadata_complete
+                else not (pid > 0 and _proc.pid_alive(pid))
+                or now - created_at > SYNC_LOCK_STALE_SECONDS
+            )
+            if stale:
                 try:
                     lock_path.unlink()
                     hook_log(

--- a/integrations/claude-code/scripts/_project_dataset.py
+++ b/integrations/claude-code/scripts/_project_dataset.py
@@ -19,6 +19,14 @@ def _repository_path(value: str) -> str:
     return path.strip("/")
 
 
+def _format_host(value: str, port: int | None = None) -> str:
+    host = str(value or "").strip().strip("[]").lower()
+    if not host:
+        return ""
+    formatted = f"[{host}]" if ":" in host else host
+    return f"{formatted}:{port}" if port is not None else formatted
+
+
 def normalize_git_remote(remote: str) -> str | None:
     value = str(remote or "").strip()
     if not value:
@@ -34,7 +42,7 @@ def normalize_git_remote(remote: str) -> str | None:
             )
         ):
             return None
-        host = match["host"].strip("[]").lower()
+        host = _format_host(match["host"])
         path = _repository_path(match["path"])
         return f"git:{host}/{path}" if host and path else None
     try:
@@ -48,9 +56,7 @@ def normalize_git_remote(remote: str) -> str | None:
         return None
     if scheme == "ssh" and port == 22:
         port = None
-    host_part = f"[{host}]" if ":" in host else host
-    if port is not None:
-        host_part = f"{host_part}:{port}"
+    host_part = _format_host(host, port)
     path = _repository_path(parsed.path)
     return f"git:{host_part}/{path}" if path else None
 
@@ -80,12 +86,12 @@ def _run_git(workspace: Path, *args: str) -> str:
             capture_output=True,
             text=True,
             encoding="utf-8",
-            errors="replace",
+            errors="strict",
             timeout=GIT_TIMEOUT_SECONDS,
             check=False,
             shell=False,
         )
-    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+    except (FileNotFoundError, OSError, UnicodeError, subprocess.SubprocessError):
         return ""
     return result.stdout.strip() if result.returncode == 0 else ""
 

--- a/integrations/claude-code/scripts/_project_dataset.py
+++ b/integrations/claude-code/scripts/_project_dataset.py
@@ -27,7 +27,11 @@ def normalize_git_remote(remote: str) -> str | None:
         match = _SCP_REMOTE.fullmatch(value)
         if not match or (
             len(match["host"]) == 1
-            and (match["host"].isascii() and match["host"].isalpha() or match["path"].startswith(("\\", "/")))
+            and (
+                match["host"].isascii()
+                and match["host"].isalpha()
+                or match["path"].startswith(("\\", "/"))
+            )
         ):
             return None
         host = match["host"].strip("[]").lower()
@@ -110,6 +114,8 @@ def derive_project_dataset(workspace: str) -> str | None:
         common_raw = _run_git(root, "rev-parse", "--git-common-dir")
         common = _canonical_dir(common_raw, relative_to=root) if common_raw else None
         if common is not None:
-            slug_source = common.parent.name if common.name == ".git" else common.name.removesuffix(".git")
+            slug_source = (
+                common.parent.name if common.name == ".git" else common.name.removesuffix(".git")
+            )
             return dataset_name(f"gitdir:{common}", slug_source)
     return dataset_name(f"workspace:{root}", root.name)

--- a/integrations/claude-code/scripts/_project_dataset.py
+++ b/integrations/claude-code/scripts/_project_dataset.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+import unicodedata
+from pathlib import Path
+from urllib.parse import urlsplit
+
+GIT_TIMEOUT_SECONDS = 1.0
+_SUPPORTED_SCHEMES = {"git", "http", "https", "ssh"}
+_SCP_REMOTE = re.compile(r"^(?:[^@/\s]+@)?(?P<host>\[[^\]]+\]|[^:/\s]+):(?P<path>.+)$")
+
+
+def _repository_path(value: str) -> str:
+    path = str(value or "").strip().strip("/")
+    if path.lower().endswith(".git"):
+        path = path[:-4]
+    return path.strip("/")
+
+
+def normalize_git_remote(remote: str) -> str | None:
+    value = str(remote or "").strip()
+    if not value:
+        return None
+    if "://" not in value:
+        match = _SCP_REMOTE.fullmatch(value)
+        if not match or (len(match["host"]) == 1 and match["path"].startswith(("\\", "/"))):
+            return None
+        host = match["host"].strip("[]").lower()
+        path = _repository_path(match["path"])
+        return f"git:{host}/{path}" if host and path else None
+    try:
+        parsed = urlsplit(value)
+        scheme = parsed.scheme.lower()
+        if scheme not in _SUPPORTED_SCHEMES or not parsed.hostname:
+            return None
+        host = parsed.hostname.lower()
+        port = parsed.port
+    except (TypeError, ValueError):
+        return None
+    if scheme == "ssh" and port == 22:
+        port = None
+    host_part = f"[{host}]" if ":" in host else host
+    if port is not None:
+        host_part = f"{host_part}:{port}"
+    path = _repository_path(parsed.path)
+    return f"git:{host_part}/{path}" if path else None
+
+
+def _slug(value: str) -> str:
+    ascii_value = (
+        unicodedata.normalize("NFKD", str(value or ""))
+        .encode("ascii", "ignore")
+        .decode("ascii")
+        .lower()
+    )
+    slug = re.sub(r"[^a-z0-9]+", "-", ascii_value).strip("-")[:32].rstrip("-")
+    return slug or "workspace"
+
+
+def dataset_name(identity: str, slug_source: str) -> str:
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:12]
+    return f"project_{_slug(slug_source)}_{digest}"
+
+
+def _run_git(workspace: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(workspace),
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=GIT_TIMEOUT_SECONDS,
+            check=False,
+            shell=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _canonical_dir(value: str | Path, *, relative_to: Path | None = None) -> Path | None:
+    try:
+        path = Path(value).expanduser()
+        if relative_to is not None and not path.is_absolute():
+            path = relative_to / path
+        path = path.resolve(strict=True)
+        return path if path.is_dir() else None
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def derive_project_dataset(workspace: str) -> str | None:
+    root = _canonical_dir(workspace)
+    if root is None:
+        return None
+    top_raw = _run_git(root, "rev-parse", "--show-toplevel")
+    top = _canonical_dir(top_raw) if top_raw else None
+    if top is not None:
+        normalized = normalize_git_remote(_run_git(root, "config", "--get", "remote.origin.url"))
+        if normalized:
+            return dataset_name(normalized, normalized.rsplit("/", 1)[-1])
+        common_raw = _run_git(root, "rev-parse", "--git-common-dir")
+        common = _canonical_dir(common_raw, relative_to=root) if common_raw else None
+        if common is not None:
+            slug_source = common.parent.name if common.name == ".git" else common.name.removesuffix(".git")
+            return dataset_name(f"gitdir:{common}", slug_source)
+    return dataset_name(f"workspace:{root}", root.name)

--- a/integrations/claude-code/scripts/_project_dataset.py
+++ b/integrations/claude-code/scripts/_project_dataset.py
@@ -25,7 +25,10 @@ def normalize_git_remote(remote: str) -> str | None:
         return None
     if "://" not in value:
         match = _SCP_REMOTE.fullmatch(value)
-        if not match or (len(match["host"]) == 1 and match["path"].startswith(("\\", "/"))):
+        if not match or (
+            len(match["host"]) == 1
+            and (match["host"].isascii() and match["host"].isalpha() or match["path"].startswith(("\\", "/")))
+        ):
             return None
         host = match["host"].strip("[]").lower()
         path = _repository_path(match["path"])

--- a/integrations/claude-code/scripts/cognee-remember.sh
+++ b/integrations/claude-code/scripts/cognee-remember.sh
@@ -6,11 +6,11 @@
 #
 # --node-set: node set for categorization (default: user_context)
 #             user_context | project_docs | agent_actions
-# --dataset:  dataset name (default: COGNEE_PLUGIN_DATASET or agent_sessions)
+# --dataset:  dataset name (overrides shared config resolution)
 #
 # Configuration:
 #   Resolves auth from env/api_key.json.
-#   Dataset is env-driven: COGNEE_PLUGIN_DATASET, then agent_sessions.
+#   Dataset follows shared config resolution from the invoking shell cwd.
 #   Falls back to cognee-cli only if the server is unreachable.
 
 set -euo pipefail
@@ -31,6 +31,7 @@ try:
     load_env_file()
 except Exception:
     pass
+from config import get_dataset, load_config
 service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
 api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
 
@@ -47,7 +48,7 @@ if not api_key:
         except Exception:
             pass
 
-dataset = (os.environ.get("COGNEE_PLUGIN_DATASET") or "").strip()
+dataset = get_dataset(load_config(os.getcwd()))
 
 print(json.dumps({"service_url": service_url, "api_key": api_key, "dataset": dataset}))
 PY

--- a/integrations/claude-code/scripts/cognee-search.sh
+++ b/integrations/claude-code/scripts/cognee-search.sh
@@ -10,7 +10,7 @@
 #
 # Configuration:
 #   Resolves session ID from Cognee endpoints using API auth.
-#   Dataset is env-driven: COGNEE_PLUGIN_DATASET, then agent_sessions.
+#   Dataset follows shared config resolution from the invoking shell cwd.
 
 set -euo pipefail
 
@@ -33,6 +33,7 @@ try:
     load_env_file()
 except Exception:
     pass
+from config import get_dataset, load_config
 service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
 api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
 if not api_key:
@@ -49,7 +50,7 @@ if not api_key:
             pass
 
 session_id = ""
-dataset = (os.environ.get("COGNEE_PLUGIN_DATASET") or "").strip()
+dataset = get_dataset(load_config(os.getcwd()))
 if service_url and api_key:
     try:
         import ssl
@@ -152,7 +153,7 @@ esac
 # Only a 2xx response is authoritative (an empty list = genuinely no hits).
 # Any non-2xx / error / unreachable returns the UNREACHABLE sentinel so we fall
 # back to cognee-cli and warn — never reporting a server failure as "not found".
-# $DATASET is resolved above (COGNEE_PLUGIN_DATASET → default)
+# $DATASET is resolved above through shared config.
 # and scopes the search to the plugin's dataset so unrelated datasets don't bleed in.
 # Logic lives in _recall_http.py (stdlib-only, unit-tested); stderr is surfaced.
 export COGNEE_PLUGIN_STATE_DIR="$PLUGIN_DIR"

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -85,9 +85,20 @@ _USER_SETTINGS = Path.home() / ".claude" / "settings.json"
 _OWNED_STATUSLINE_MARKER = "cognee-statusline"
 
 
+def _sanitize_session_key(value: str) -> str:
+    safe = []
+    for ch in str(value or ""):
+        if ch.isalnum() or ch in ("-", "_", "."):
+            safe.append(ch)
+        else:
+            safe.append("_")
+    return "".join(safe).strip("._")[:120]
+
+
 def _active_dataset(host_id: str = "", cwd: str = "") -> str:
-    if _path_safe(host_id):
-        record = _read_json(_SESSIONS_MAP_DIR / f"{host_id}.json")
+    session_key = _sanitize_session_key(host_id)
+    if session_key:
+        record = _read_json(_SESSIONS_MAP_DIR / f"{session_key}.json")
         pinned = str(record.get("dataset") or "").strip()
         if pinned:
             return pinned

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -784,12 +784,10 @@ def main() -> None:
     if not isinstance(ctx, dict):
         ctx = {}
 
-    cwd = str(
-        ctx.get("cwd")
-        or (ctx.get("workspace") or {}).get("current_dir")
-        or (ctx.get("workspace") or {}).get("project_dir")
-        or ""
-    )
+    workspace = ctx.get("workspace")
+    if not isinstance(workspace, dict):
+        workspace = {}
+    cwd = str(ctx.get("cwd") or workspace.get("current_dir") or workspace.get("project_dir") or "")
     if not _plugin_enabled(cwd):
         # Plugin uninstalled/disabled but files linger: drop our own statusLine
         # entry and render nothing so the line disappears.

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -3,8 +3,8 @@
 
 Invoked by Claude Code's ``statusLine`` (via ``cognee-statusline.sh``), which
 pipes a JSON context on stdin. Deliberately standalone and pure-local: reads
-only env vars and ``~/.cognee-plugin/config.json`` — no network calls, no
-``_plugin_common`` import.
+only env vars, local launch state, and workspace metadata — no network calls,
+no ``_plugin_common`` import.
 
 Output: ``cognee: <dataset-name> · local`` or ``cognee: <dataset-name> · cloud``
 """
@@ -43,6 +43,7 @@ _CREDITS_PATH = _SHARED_ROOT / "claude-code" / "credits.json"
 # above are coordination state, these are what THIS terminal observed.
 _LLM_STATE_DIR = _SHARED_ROOT / "claude-code" / "llm-state"
 _CONN_STATE_DIR = _SHARED_ROOT / "claude-code" / "conn-state"
+_SESSIONS_MAP_DIR = _SHARED_ROOT / "claude-code" / "sessions"
 _DEFAULT_DATASET = "agent_sessions"
 # Must match _plugin_common._DEFAULT_LOCAL_SERVICE_URL: the hooks stamp this URL into
 # the markers this renderer compares against.
@@ -84,12 +85,24 @@ _USER_SETTINGS = Path.home() / ".claude" / "settings.json"
 _OWNED_STATUSLINE_MARKER = "cognee-statusline"
 
 
-def _active_dataset() -> str:
-    # 1. env var (inherited from the shell that launched Claude Code)
-    v = os.environ.get("COGNEE_PLUGIN_DATASET", "").strip()
-    if v:
-        return v
-    # 2. default
+def _active_dataset(host_id: str = "", cwd: str = "") -> str:
+    if _path_safe(host_id):
+        record = _read_json(_SESSIONS_MAP_DIR / f"{host_id}.json")
+        pinned = str(record.get("dataset") or "").strip()
+        if pinned:
+            return pinned
+    explicit = os.environ.get("COGNEE_PLUGIN_DATASET", "").strip()
+    if explicit:
+        return explicit
+    if os.environ.get("COGNEE_DATASET_SCOPE", "").strip().lower() == "project" and cwd:
+        try:
+            from _project_dataset import derive_project_dataset
+
+            derived = derive_project_dataset(cwd)
+            if derived:
+                return derived
+        except Exception:
+            pass
     return _DEFAULT_DATASET
 
 
@@ -780,7 +793,7 @@ def main() -> None:
     # of the steady-state line.
     sys.stdout.write(
         f"{_pipeline_health_glyph()}{_status_prefix(_session_id)}"
-        f"cognee: {_active_dataset()} · {_mode_label()}"
+        f"cognee: {_active_dataset(_session_id, cwd)} · {_mode_label()}"
         f"{_credits_segment()}{_recall_segment(_session_id)}{_update_segment()}"
     )
 

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Optional
 
 from _env_file import load_env_file
+from _project_dataset import derive_project_dataset
 
 # Must run before the _ENV_MAP scan in load_config() and before any importer's
 # module-level os.environ reads.
@@ -43,6 +44,7 @@ _STATE_DIR = _CONFIG_DIR
 _CONFIG_FILE = _CONFIG_DIR / "config.json"
 _BRIDGE_STATE_FILE = _STATE_DIR / "bridge_state.json"
 _HOOK_LOG = _STATE_DIR / "hook.log"
+_HOST_CWD_ENV = "CLAUDE_CWD"
 
 _DEFAULTS = {
     "dataset": "agent_sessions",
@@ -101,6 +103,7 @@ _ENV_MAP = {
     "COGNEE_CLAUDE_BACKEND": "backend",
     "COGNEE_AGENT_NAME": "agent_name",
     "COGNEE_PLUGIN_DATASET": "dataset",
+    "COGNEE_DATASET_SCOPE": "_dataset_scope",
     "COGNEE_SESSION_STRATEGY": "session_strategy",
     "COGNEE_SESSION_PREFIX": "session_prefix",
     "COGNEE_BASE_URL": "base_url",
@@ -122,9 +125,29 @@ _ENV_MAP = {
 }
 
 
-def load_config() -> dict:
+def _workspace(workspace: str | None) -> str:
+    return str(workspace or os.environ.get(_HOST_CWD_ENV) or os.getcwd())
+
+
+def _apply_project_dataset(config: dict, workspace: str | None = None) -> dict:
+    source = str(config.get("_dataset_source") or "default")
+    config["_dataset_source"] = source
+    if source != "default":
+        return config
+    scope = str(config.get("_dataset_scope") or "").strip().lower()
+    if scope != "project":
+        return config
+    derived = derive_project_dataset(_workspace(workspace))
+    if derived:
+        config["dataset"] = derived
+        config["_dataset_source"] = "project"
+    return config
+
+
+def load_config(workspace: str | None = None) -> dict:
     """Load merged config: defaults → file → env vars."""
     config = dict(_DEFAULTS)
+    config["_dataset_source"] = "default"
 
     # Layer 2: config file
     # dataset is intentionally excluded here: it is always driven by the default
@@ -139,7 +162,7 @@ def load_config() -> dict:
                 {
                     k: v
                     for k, v in file_cfg.items()
-                    if v is not None and v != "" and k not in _file_excluded
+                    if v is not None and v != "" and k not in _file_excluded and not k.startswith("_")
                 }
             )
         except Exception as exc:
@@ -152,6 +175,8 @@ def load_config() -> dict:
         val = os.environ.get(env_key, "")
         if val:
             config[config_key] = val
+            if env_key == "COGNEE_PLUGIN_DATASET":
+                config["_dataset_source"] = "env"
 
     backend = str(config.get("backend") or "auto").lower()
     if backend in ("native", "local", "sdk"):
@@ -173,12 +198,15 @@ def load_config() -> dict:
             config["api_key"] = ""
             config["base_url"] = ""
 
-    return config
+    return _apply_project_dataset(config, workspace)
 
 
 def save_config(config: dict) -> None:
     """Write config to disk. Creates directory if needed."""
     _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    if config.get("_dataset_source") in {"picker", "project"}:
+        config = dict(config)
+        config["dataset"] = _DEFAULTS["dataset"]
     # Only save non-secret, non-default values.
     # dataset is always written even when it equals the default so that users
     # who open the file can see which dataset the plugin is using.

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -144,8 +144,8 @@ def _apply_project_dataset(config: dict, workspace: str | None = None) -> dict:
     return config
 
 
-def load_config(workspace: str | None = None) -> dict:
-    """Load merged config: defaults → file → env vars."""
+def load_config(workspace: str | None = None, *, derive_project: bool = True) -> dict:
+    """Load merged config, optionally skipping workspace dataset derivation."""
     config = dict(_DEFAULTS)
     config["_dataset_source"] = "default"
 
@@ -176,6 +176,8 @@ def load_config(workspace: str | None = None) -> dict:
     # Layer 3: env vars (highest priority)
     for env_key, config_key in _ENV_MAP.items():
         val = os.environ.get(env_key, "")
+        if env_key == "COGNEE_PLUGIN_DATASET":
+            val = val.strip()
         if val:
             config[config_key] = val
             if env_key == "COGNEE_PLUGIN_DATASET":
@@ -201,7 +203,7 @@ def load_config(workspace: str | None = None) -> dict:
             config["api_key"] = ""
             config["base_url"] = ""
 
-    return _apply_project_dataset(config, workspace)
+    return _apply_project_dataset(config, workspace) if derive_project else config
 
 
 def save_config(config: dict) -> None:

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -162,7 +162,10 @@ def load_config(workspace: str | None = None) -> dict:
                 {
                     k: v
                     for k, v in file_cfg.items()
-                    if v is not None and v != "" and k not in _file_excluded and not k.startswith("_")
+                    if v is not None
+                    and v != ""
+                    and k not in _file_excluded
+                    and not k.startswith("_")
                 }
             )
         except Exception as exc:

--- a/integrations/claude-code/scripts/doctor.py
+++ b/integrations/claude-code/scripts/doctor.py
@@ -214,6 +214,13 @@ def _resolve_env_file() -> str:
     return desc
 
 
+def _resolve_dataset() -> tuple[str, str]:
+    from config import get_dataset, load_config
+
+    cfg = load_config(os.getcwd())
+    return get_dataset(cfg), str(cfg.get("_dataset_source") or "default")
+
+
 def collect_report() -> dict:
     """Gather all diagnostic fields into an ordered dict."""
     mode = _resolve_mode()
@@ -224,9 +231,12 @@ def collect_report() -> dict:
     cognee_local = _resolve_local_cognee_version()
     circuit_breaker = _resolve_circuit_breaker()
     embedding_model, embedding_dimensions = _resolve_embedding()
+    dataset, dataset_source = _resolve_dataset()
 
     return {
         "mode": mode + _mode_annotation(),
+        "dataset": dataset,
+        "dataset_source": dataset_source,
         "env_file": _resolve_env_file(),
         "server_url": display_url if display_url != "-" else None,
         "api_key_source": api_key_source,
@@ -242,6 +252,8 @@ def collect_report() -> dict:
 
 _DISPLAY_ORDER = [
     ("Mode", "mode"),
+    ("Dataset", "dataset"),
+    ("Dataset Source", "dataset_source"),
     ("Env File", "env_file"),
     ("Server URL", "server_url"),
     ("API Key Source", "api_key_source"),

--- a/integrations/claude-code/scripts/idle-watcher.py
+++ b/integrations/claude-code/scripts/idle-watcher.py
@@ -370,8 +370,9 @@ def main():
     try:
         from config import load_config  # type: ignore
 
-        config = load_config()
+        config = load_config(derive_project=False)
         config.update({k: v for k, v in bootstrap.get("config", {}).items() if v})
+        config["dataset"] = dataset
     except Exception as exc:
         _log("config_load_failed", error=str(exc)[:200])
         config = bootstrap.get("config", {})

--- a/integrations/claude-code/scripts/pre-compact.py
+++ b/integrations/claude-code/scripts/pre-compact.py
@@ -39,7 +39,9 @@ def _load_resolved_fields() -> tuple[str, str]:
     session_id = resolved.get("session_id", "")
     dataset = resolved.get("dataset", "")
     if not session_id or not dataset:
-        config = load_config()
+        config = load_config(derive_project=not bool(dataset))
+        if dataset:
+            config["dataset"] = dataset
         session_id = session_id or get_session_id(config)
         dataset = dataset or get_dataset(config)
     return session_id, dataset
@@ -196,7 +198,8 @@ async def _run():
         hook_log("no_session_id", {"event": "precompact"})
         return
 
-    config = load_config()
+    config = load_config(derive_project=False)
+    config["dataset"] = dataset
     await ensure_cognee_ready(config)
 
     # Short queries: use the session's recent activity as the seed

--- a/integrations/claude-code/scripts/pre-compact.py
+++ b/integrations/claude-code/scripts/pre-compact.py
@@ -116,7 +116,7 @@ async def _recall(
                 scope=scope,
                 only_context=True,
                 search_type=query_type,
-                dataset=get_dataset(config),
+                dataset=dataset,
             )
         else:
             import cognee

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -71,7 +71,9 @@ def _load_session(workspace: str = "") -> tuple[str, str]:
     session_id = str(resolved.get("session_id") or "")
     dataset = str(resolved.get("dataset") or "")
     if not session_id or not dataset:
-        config = load_config(workspace or None)
+        config = load_config(workspace or None, derive_project=not bool(dataset))
+        if dataset:
+            config["dataset"] = dataset
         session_id = session_id or get_session_id(config, workspace or None)
         dataset = dataset or get_dataset(config)
     return session_id, dataset
@@ -173,7 +175,7 @@ async def _recent_trace_fallback(session_id: str, user_id: str, top_k: int) -> l
 
 
 async def _run(prompt: str, workspace: str = "") -> dict | None:
-    config = load_config(workspace or None)
+    config = load_config(workspace or None, derive_project=False)
     runtime = resolve_runtime_mode()
     cloud_mode = runtime["mode"] == "http"
     hook_log(
@@ -233,13 +235,14 @@ async def _run(prompt: str, workspace: str = "") -> dict | None:
             hook_log("recall_skipped_not_ready", {"base_url": service_url, "state": state})
             return None
 
-    if not cloud_mode:
-        await ensure_cognee_ready(config)
-
     session_id, dataset = _load_session(workspace)
     if not session_id:
         hook_log("no_session_id", {"event": "context_lookup"})
         return None
+    config["dataset"] = dataset
+
+    if not cloud_mode:
+        await ensure_cognee_ready(config)
 
     # NOTE: the warmup-buffer drain deliberately does NOT run here. This hook
     # is synchronous on the keystroke->answer path, and replaying N buffered

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -66,13 +66,15 @@ RECENT_TRACE_FALLBACK_TOP_K = 5
 MIN_SCOPE_TIMEOUT = 0.2
 
 
-def _load_session_id() -> str:
+def _load_session(workspace: str = "") -> tuple[str, str]:
     resolved = load_resolved()
-    session_id = resolved.get("session_id", "")
-    if not session_id:
-        config = load_config()
-        session_id = get_session_id(config)
-    return session_id
+    session_id = str(resolved.get("session_id") or "")
+    dataset = str(resolved.get("dataset") or "")
+    if not session_id or not dataset:
+        config = load_config(workspace or None)
+        session_id = session_id or get_session_id(config, workspace or None)
+        dataset = dataset or get_dataset(config)
+    return session_id, dataset
 
 
 def _load_user_id() -> str:
@@ -170,8 +172,8 @@ async def _recent_trace_fallback(session_id: str, user_id: str, top_k: int) -> l
     return normalized
 
 
-async def _run(prompt: str) -> dict | None:
-    config = load_config()
+async def _run(prompt: str, workspace: str = "") -> dict | None:
+    config = load_config(workspace or None)
     runtime = resolve_runtime_mode()
     cloud_mode = runtime["mode"] == "http"
     hook_log(
@@ -234,7 +236,7 @@ async def _run(prompt: str) -> dict | None:
     if not cloud_mode:
         await ensure_cognee_ready(config)
 
-    session_id = _load_session_id()
+    session_id, dataset = _load_session(workspace)
     if not session_id:
         hook_log("no_session_id", {"event": "context_lookup"})
         return None
@@ -334,7 +336,7 @@ async def _run(prompt: str) -> dict | None:
                     only_context=True,
                     search_type=qtype,
                     context_profile=context_profile,
-                    dataset=get_dataset(config),
+                    dataset=dataset,
                     timeout=scope_timeout,
                 )
             else:
@@ -682,9 +684,10 @@ def main():
         return
 
     output = None
+    workspace = str(payload.get("cwd") or os.environ.get("CLAUDE_CWD") or os.getcwd())
     try:
         with quiet_hook_output("session-context-lookup"):
-            output = asyncio.run(_run(prompt))
+            output = asyncio.run(_run(prompt, workspace))
     except Exception as exc:
         hook_log("context_lookup_exception", {"error": str(exc)[:200]})
     if output:

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -345,6 +345,7 @@ async def _run(prompt: str, workspace: str = "") -> dict | None:
                     cognee.recall(
                         prompt,
                         session_id=session_id,
+                        datasets=[dataset] if "graph" in scope_list else None,
                         top_k=TOP_K,
                         scope=scope_list,
                         only_context=True,

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -40,6 +40,7 @@ from _plugin_common import (
     apply_cognee_env,
     clear_server_pidfile,
     ensure_launch_record,
+    get_launch_dataset,
     hook_log,
     probe_health,
     quiet_hook_output,
@@ -1391,10 +1392,10 @@ def _apply_update_nudge(output: dict) -> dict:
 
 
 async def _start(payload: dict | None = None) -> dict:
-    _ensure_statusline_configured()
-    config = load_config()
     payload = payload or {}
     cwd = str(payload.get("cwd") or os.environ.get("CLAUDE_CWD") or os.getcwd())
+    config = load_config(cwd)
+    _ensure_statusline_configured()
     # The service URL is the sole router (api_key is optional auth, with a
     # default-user fallback in registration). COGNEE_AGENT_MODE is NOT decided
     # here: it's set only when we actually boot a server (in
@@ -1445,7 +1446,17 @@ async def _start(payload: dict | None = None) -> dict:
     # Resolve (and persist) this launch's record: session_id (data scoping, unique
     # per launch) + conn_uuid (liveness handle for registration/counting). Written
     # synchronously here so prompt hooks read back the identical ids before any run.
-    session_id, conn_uuid = ensure_launch_record(session_key, cwd)
+    candidate_dataset = get_dataset(config)
+    candidate_source = str(config.get("_dataset_source") or "default")
+    session_id, conn_uuid = ensure_launch_record(
+        session_key,
+        cwd,
+        dataset=candidate_dataset,
+        dataset_source=candidate_source,
+    )
+    dataset, dataset_source = get_launch_dataset(session_key)
+    dataset = dataset or candidate_dataset
+    dataset_source = dataset_source or candidate_source
     os.environ["COGNEE_SESSION_ID"] = session_id
     agent_session_name = conn_uuid
     hook_log(
@@ -1455,9 +1466,10 @@ async def _start(payload: dict | None = None) -> dict:
             "session_key": session_key,
             "session_id": session_id,
             "conn_uuid": conn_uuid,
+            "dataset": dataset,
+            "dataset_source": dataset_source,
         },
     )
-    dataset = get_dataset(config)
 
     # Boot-vs-connect is decided purely by whether the server is already up:
     #   * up                -> connect (we don't boot, so agent mode is left as-is)

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -992,6 +992,8 @@ async def _run_heavy(
     Returns ``(user_id, agent_api_key, ok)``. ``ok`` is False only on a hard
     cloud-registration failure (mirrors the legacy early-abort).
     """
+    config = dict(config)
+    config["dataset"] = dataset
     if not managed_endpoint:
         try:
             _ensure_local_server_running(config, health_timeout=boot_timeout)

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -1155,11 +1155,13 @@ async def _run_bootstrap(bootstrap: dict) -> None:
          booted, because registration is per-session (the connection handle is
          the Cognee session id) under the single principal.
     """
-    config = load_config()
     cwd = str(bootstrap.get("cwd") or os.getcwd())
     session_id = str(bootstrap.get("session_id", "") or "")
     session_key = str(bootstrap.get("session_key", "") or "")
-    dataset = str(bootstrap.get("dataset", "") or get_dataset(config))
+    pinned_dataset = str(bootstrap.get("dataset", "") or "")
+    config = load_config(cwd, derive_project=not bool(pinned_dataset))
+    dataset = pinned_dataset or get_dataset(config)
+    config["dataset"] = dataset
     agent_session_name = str(bootstrap.get("agent_session_name", "") or session_id)
     if session_key:
         os.environ["COGNEE_SESSION_KEY"] = session_key
@@ -1337,7 +1339,7 @@ def _apply_memory_preference(output: dict) -> dict:
     ``COGNEE_PREFER_MEMORY=false``.
     """
     try:
-        val = load_config().get("prefer_cognee_memory", True)
+        val = load_config(derive_project=False).get("prefer_cognee_memory", True)
     except Exception:
         val = True
     if str(val).strip().lower() in {"0", "false", "no", "off"}:

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -142,7 +142,9 @@ def _load_session() -> tuple[str, str, str]:
     dataset = resolved.get("dataset", "")
     user_id = resolved.get("user_id", "")
     if not session_id or not dataset:
-        config = load_config()
+        config = load_config(derive_project=not bool(dataset))
+        if dataset:
+            config["dataset"] = dataset
         session_id = session_id or get_session_id(config)
         dataset = dataset or get_dataset(config)
     return session_id, dataset, user_id
@@ -182,7 +184,8 @@ async def _store_tool_call(payload: dict) -> None:
         hook_log("no_session_id", {"tool": tool_name})
         return
 
-    config = load_config()
+    config = load_config(derive_project=False)
+    config["dataset"] = dataset
     runtime = resolve_runtime_mode()
     use_http = runtime["mode"] == "http"
     hook_log(
@@ -335,7 +338,8 @@ async def _store_assistant_stop(payload: dict) -> None:
         hook_log("no_session_id", {"event": "stop"})
         return
 
-    config = load_config()
+    config = load_config(derive_project=False)
+    config["dataset"] = dataset
     runtime = resolve_runtime_mode()
     use_http = runtime["mode"] == "http"
     hook_log(

--- a/integrations/claude-code/scripts/store-user-prompt.py
+++ b/integrations/claude-code/scripts/store-user-prompt.py
@@ -53,7 +53,9 @@ def _load_session() -> tuple[str, str, str, str]:
     user_id = resolved.get("user_id", "")
     tenant_id = resolved.get("tenant_id", "")
     if not session_id or not dataset:
-        config = load_config()
+        config = load_config(derive_project=not bool(dataset))
+        if dataset:
+            config["dataset"] = dataset
         session_id = session_id or get_session_id(config)
         dataset = dataset or get_dataset(config)
     return session_id, dataset, user_id, tenant_id
@@ -135,7 +137,8 @@ async def _store(prompt: str, payload: dict):
         hook_log("no_session_id", {"event": "prompt"})
         return
 
-    config = load_config()
+    config = load_config(derive_project=False)
+    config["dataset"] = dataset
     touch_activity()
     _ensure_idle_watcher(session_id, dataset, user_id, config)
 

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -262,7 +262,8 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: 
             _stop_idle_watcher()
             hook_log("sync_stopped_watcher", {"session": session_id, "dataset": dataset})
 
-        config = load_config()
+        config = load_config(derive_project=False)
+        config["dataset"] = dataset
         api_mode = http_api_ready()
         lock = nullcontext(True) if api_mode else sync_lock("sync-session-to-graph")
         with lock as acquired:

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -215,9 +215,8 @@ def _load_resolved() -> tuple:
             os.environ["COGNEE_USER_ID"] = str(data.get("user_id"))
         return (
             env_session_id or data.get("session_id", ""),
-            # load_resolved() carries no dataset key, so without the env
-            # override (only the exit watcher sets it) this must fall back to
-            # config, or the SessionEnd worker syncs with an empty dataset.
+            # Detached exit workers keep their explicit override; direct syncs
+            # consume the dataset pinned in the SessionStart launch record.
             env_dataset or data.get("dataset", "") or get_dataset(load_config()),
             data.get("user_id", ""),
             env_agent_session_name or data.get("agent_session_name", ""),

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -134,8 +134,18 @@ Each terminal launch maintains a small map file:
 
 ```
 ~/.cognee-plugin/sessions/<host_session_id>.json
-  → { "conn_uuid": "...", "session_id": "...", "host_key": "..." }
+  → {
+       "conn_uuid": "...",
+       "session_id": "...",
+       "host_key": "...",
+       "dataset": "project_example_0123456789ab",
+       "dataset_source": "project"
+     }
 ```
+
+`dataset` and `dataset_source` are runtime launch state: they show the dataset
+selected for this conversation and why it was selected. They are not user
+configuration and are not fields sent to Cognee.
 
 - **`session_id`** — which Cognee session this terminal writes to and recalls from. Fixed at launch.
 - **`conn_uuid`** — per-launch liveness handle used for agent registration and server shutdown counting.
@@ -159,6 +169,38 @@ Set a custom dataset at launch:
 export COGNEE_PLUGIN_DATASET="my-project-memory"
 codex
 ```
+
+### Project dataset isolation
+
+Project isolation is opt-in. To move future conversations for a repository into
+one derived dataset, first remove or comment any fixed global dataset, then set
+the scope in `~/.cognee/.env` (or export it before launching Codex):
+
+```bash
+# Remove/comment a global fixed dataset first:
+# COGNEE_PLUGIN_DATASET="agent_sessions"
+
+# Then enable automatic project isolation:
+COGNEE_DATASET_SCOPE="project"
+```
+
+Dataset selection is: **explicit env > #285 picker when present > derived
+project > `agent_sessions`**. A non-empty `COGNEE_PLUGIN_DATASET` therefore
+always wins over project isolation. With `COGNEE_DATASET_SCOPE="project"`, the
+derived name is `project_<slug>_<hash12>`. Git repositories use their normalized
+`origin` remote as the identity, so separate clones and Git worktrees of the
+same remote resolve to the same dataset. A repository without a usable remote
+uses its shared Git worktree identity instead.
+
+The dataset is pinned when a conversation starts; changing the setting affects
+the next session only, so exit and start a new Codex conversation after editing
+it. Conversations in the same project dataset still receive distinct Cognee
+`session_id` values (unless you explicitly set the same `COGNEE_SESSION_ID`).
+The status line displays the active dataset, and `cognee doctor` reports both
+`Dataset` and `Dataset Source` so you can confirm the resolved choice.
+
+This opt-in does not migrate existing memories and does not delete any existing
+dataset. Existing installations continue to use `agent_sessions` until enabled.
 
 `~/.cognee-plugin/config.json` may still show a `dataset` value for visibility,
 but runtime dataset selection does not read it.

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -272,7 +272,10 @@ them during startup — and a stale value can misroute identity or session resol
 Use `COGNEE_SESSION_ID` to pin a session and `COGNEE_PLUGIN_DATASET` to pin a dataset.
 
 The renderer reads only local state — no network calls on every refresh:
-1. Dataset: `COGNEE_PLUGIN_DATASET` env var, otherwise `agent_sessions`
+1. Dataset: the dataset pinned in this conversation's launch map, otherwise
+   `COGNEE_PLUGIN_DATASET`, then a project-derived dataset when
+   `COGNEE_DATASET_SCOPE=project` and Codex provides a working directory,
+   otherwise `agent_sessions`
 2. Mode: `COGNEE_BACKEND` / `COGNEE_CODEX_BACKEND` switch, then `COGNEE_BASE_URL` env var, then `~/.cognee-plugin/config.json` (`base_url`)
 3. Default mode: `local`
 

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -133,7 +133,7 @@ The hooks emit `mode_decision` logs with `mode`, `service_url`, `url_source`, `k
 Each terminal launch maintains a small map file:
 
 ```
-~/.cognee-plugin/sessions/<host_session_id>.json
+~/.cognee-plugin/codex/sessions/<host_session_id>.json
   → {
        "conn_uuid": "...",
        "session_id": "...",
@@ -206,8 +206,8 @@ dataset. Existing installations continue to use `agent_sessions` until enabled.
 but runtime dataset selection does not read it.
 
 The dataset is fixed for the lifetime of a launch. Recall searches only the active dataset. If you want to
-change the active dataset, you have to exit Claude, change the dataset via env, and then start Claude again.
-Data added outside of Claude to the dataset (via SDK or the server for example) is visible in Claude via the Cognee plugin.
+change the active dataset, you have to exit Codex, change the dataset via env, and then start Codex again.
+Data added outside of Codex to the dataset (via SDK or the server for example) is visible in Codex via the Cognee plugin.
 
 ## Hooks
 
@@ -447,7 +447,10 @@ Keys are letters, digits, and underscores. Values are taken literally — no `$V
 - If a mode seems stuck, check for a forgotten `COGNEE_BACKEND` / `COGNEE_CODEX_BACKEND` export in the shell or in `~/.cognee/.env` — the plugin-specific name silently beats the shared one.
 
 **Recall returns empty but data was ingested**
-- Recall is scoped to the active dataset (`COGNEE_PLUGIN_DATASET` / `agent_sessions`).
+- Recall is scoped to the active dataset: a non-empty explicit
+  `COGNEE_PLUGIN_DATASET` wins; otherwise `COGNEE_DATASET_SCOPE=project` uses
+  the conversation's pinned project-derived dataset; otherwise it uses
+  `agent_sessions`.
 - Data written via the Python SDK or `client.py` goes to `default_dataset` by default, if dataset not otherwise specified.
 - To verify, call the recall API directly without a dataset filter: `curl -X POST "$COGNEE_BASE_URL/api/v1/recall" -d '{"query":"..."}'`
 

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,6 +10,15 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.4.4]
+
+### Added
+- **Opt-in project dataset isolation ([#356](https://github.com/topoteretes/cognee-integrations/issues/356)).**
+  Set `COGNEE_DATASET_SCOPE=project` after removing any fixed
+  `COGNEE_PLUGIN_DATASET` to derive one stable dataset per Git project. The
+  plugin keeps distinct conversation sessions inside that dataset; existing
+  datasets are neither migrated nor deleted.
+
 ## [1.4.3]
 
 ### Fixed

--- a/integrations/codex/plugins/cognee/scripts/_env_file.py
+++ b/integrations/codex/plugins/cognee/scripts/_env_file.py
@@ -74,6 +74,9 @@ _TEMPLATE = """\
 # LLM_MODEL="openai/gpt-4o-mini"
 
 ## Optional:
+# Derive one shared dataset per Git repository/workspace:
+# COGNEE_DATASET_SCOPE="project"
+# An explicit COGNEE_PLUGIN_DATASET always wins:
 # COGNEE_PLUGIN_DATASET="agent_sessions"
 """
 

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -197,13 +197,20 @@ def _write_map_record(host_key: str, record: dict) -> None:
 
 
 def _pin_launch_dataset(host_key: str, record: dict, dataset: str, source: str) -> dict:
-    if not host_key or not dataset or record.get("dataset"):
+    if not host_key or not dataset or not record or record.get("dataset"):
         return record
-    updated = dict(record)
-    updated["dataset"] = dataset
-    updated["dataset_source"] = source or "default"
-    _write_map_record(host_key, updated)
-    return _read_map_record(host_key) or updated
+    while True:
+        with improve_session_lock(host_key, "dataset_pin") as acquired:
+            if acquired:
+                current = _read_map_record(host_key)
+                if not current or current.get("dataset"):
+                    return current or record
+                updated = dict(current)
+                updated["dataset"] = dataset
+                updated["dataset_source"] = source or "default"
+                _write_map_record(host_key, updated)
+                return _read_map_record(host_key) or updated
+        time.sleep(0.02)
 
 
 def get_launch_dataset(host_key: str = "") -> tuple[str, str]:

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -62,6 +62,12 @@ _API_KEY_CACHE = _SHARED_PLUGIN_ROOT / "api_key.json"
 # as an identity. A genuinely new launch gets a new host id -> new Cognee session;
 # a `resume` reuses the host id -> continues the same Cognee session.
 _SESSIONS_MAP_DIR = _PLUGIN_DIR / "sessions"
+# Launch-record publication is mandatory state, unlike best-effort improve
+# admission. Keep a stable lock inode per host conversation so kernel advisory
+# locking provides crash recovery without stale-file deletion races.
+_LAUNCH_PUBLICATION_LOCK_DIR = _PLUGIN_DIR / "launch-publication-locks"
+_LAUNCH_PUBLICATION_LOCK_TIMEOUT_SECONDS = 1.0
+_LAUNCH_PUBLICATION_LOCK_POLL_SECONDS = 0.02
 
 # Save-kinds tracked per turn. Keep this tuple in sync with bump_save_counter callers.
 SAVE_KINDS = ("prompt", "trace", "answer")
@@ -169,6 +175,128 @@ def _session_map_path(host_key: str) -> Path:
     return _SESSIONS_MAP_DIR / f"{_sanitize_session_key(host_key)}.json"
 
 
+def _launch_publication_lock_path(host_key: str) -> Path:
+    normalized = _sanitize_session_key(host_key)
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return _LAUNCH_PUBLICATION_LOCK_DIR / f"{digest}.lock"
+
+
+def _open_launch_lock_file(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        if os.name != "nt":
+            os.fchmod(fd, 0o600)
+        return os.fdopen(fd, "r+b", buffering=0)
+    except Exception:
+        os.close(fd)
+        raise
+
+
+def _try_acquire_launch_file_lock(file_handle) -> bool:
+    if os.name == "nt":
+        import msvcrt
+
+        file_handle.seek(0)
+        try:
+            msvcrt.locking(file_handle.fileno(), msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError as exc:
+            if exc.errno in {errno.EACCES, errno.EAGAIN, errno.EDEADLK} or getattr(
+                exc, "winerror", None
+            ) in {33, 36}:
+                return False
+            raise
+
+    import fcntl
+
+    try:
+        fcntl.flock(file_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except OSError as exc:
+        if exc.errno in {errno.EACCES, errno.EAGAIN}:
+            return False
+        raise
+
+
+def _release_launch_file_lock(file_handle) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        file_handle.seek(0)
+        msvcrt.locking(file_handle.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(file_handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def _launch_publication_lock(
+    host_key: str, *, timeout: float = _LAUNCH_PUBLICATION_LOCK_TIMEOUT_SECONDS
+):
+    """Bounded, fail-closed lock for first-writer launch-record publication.
+
+    The lock path is persistent by design. Kernel ownership, not file presence,
+    determines admission, so process death releases the lock and an old owner
+    can never unlink a successor's lock inode.
+    """
+    normalized = _sanitize_session_key(host_key)
+    if not normalized:
+        raise RuntimeError("launch record publication requires a host key")
+
+    lock_path = _launch_publication_lock_path(normalized)
+    try:
+        file_handle = _open_launch_lock_file(lock_path)
+    except Exception as exc:
+        hook_log("launch_publication_lock_open_failed", {"error": str(exc)[:200]})
+        raise RuntimeError("launch record publication lock could not be opened") from exc
+
+    acquired = False
+    try:
+        deadline = time.monotonic() + max(0.0, float(timeout))
+        while True:
+            try:
+                acquired = _try_acquire_launch_file_lock(file_handle)
+            except Exception as exc:
+                hook_log("launch_publication_lock_failed", {"error": str(exc)[:200]})
+                raise RuntimeError("launch record publication lock failed") from exc
+            if acquired:
+                break
+            if time.monotonic() >= deadline:
+                yield False
+                return
+            time.sleep(_LAUNCH_PUBLICATION_LOCK_POLL_SECONDS)
+
+        token = uuid.uuid4().hex
+        metadata = json.dumps(
+            {
+                "token": token,
+                "pid": os.getpid(),
+                "created_at": datetime.now(timezone.utc).timestamp(),
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+        try:
+            file_handle.seek(0)
+            file_handle.truncate()
+            file_handle.write(metadata)
+            os.fsync(file_handle.fileno())
+        except Exception as exc:
+            hook_log("launch_publication_metadata_failed", {"error": str(exc)[:200]})
+            raise RuntimeError("launch record publication metadata failed") from exc
+
+        yield token
+    finally:
+        if acquired:
+            try:
+                _release_launch_file_lock(file_handle)
+            except Exception as exc:
+                hook_log("launch_publication_lock_release_failed", {"error": str(exc)[:200]})
+        file_handle.close()
+
+
 def _read_map_record(host_key: str) -> dict:
     """Return the launch record for a host session id, or {}.
 
@@ -190,27 +318,10 @@ def _read_map_record(host_key: str) -> dict:
     return {}
 
 
-def _write_map_record(host_key: str, record: dict) -> None:
+def _write_map_record(host_key: str, record: dict) -> bool:
     if not host_key or not isinstance(record, dict):
-        return
-    _write_json_file(_session_map_path(host_key), record)
-
-
-def _pin_launch_dataset(host_key: str, record: dict, dataset: str, source: str) -> dict:
-    if not host_key or not dataset or not record or record.get("dataset"):
-        return record
-    while True:
-        with improve_session_lock(host_key, "dataset_pin") as acquired:
-            if acquired:
-                current = _read_map_record(host_key)
-                if not current or current.get("dataset"):
-                    return current or record
-                updated = dict(current)
-                updated["dataset"] = dataset
-                updated["dataset_source"] = source or "default"
-                _write_map_record(host_key, updated)
-                return _read_map_record(host_key) or updated
-        time.sleep(0.02)
+        return False
+    return _write_json_file(_session_map_path(host_key), record)
 
 
 def get_launch_dataset(host_key: str = "") -> tuple[str, str]:
@@ -224,22 +335,27 @@ def get_launch_dataset(host_key: str = "") -> tuple[str, str]:
 def _create_map_record_if_absent(host_key: str, record: dict) -> dict:
     """Atomically create the launch record, first-writer-wins.
 
-    Serializes creation with the existing host-keyed lock, then publishes through
+    Serializes creation with the dedicated host-keyed lock, then publishes through
     ``_write_map_record``'s atomic replace. The destination therefore appears only
-    after the complete JSON is durable; contenders retry the lock and read the
+    after the complete JSON is durable; contenders wait for the lock and read the
     winner instead of observing an empty/partial file. Returns the record on disk.
     """
     if not host_key:
         return record
-    while True:
-        with improve_session_lock(host_key, "launch_record") as acquired:
-            if acquired:
-                current = _read_map_record(host_key)
-                if current:
-                    return current
-                _write_map_record(host_key, record)
-                return _read_map_record(host_key) or record
-        time.sleep(0.02)
+    with _launch_publication_lock(host_key) as acquired:
+        if not acquired:
+            raise RuntimeError("launch record publication lock timed out")
+        current = _read_map_record(host_key)
+        if current:
+            return current
+        if _session_map_path(host_key).exists():
+            raise RuntimeError("launch record publication found unreadable state")
+        if not _write_map_record(host_key, record):
+            raise RuntimeError("launch record publication failed")
+        published = _read_map_record(host_key)
+        if not published:
+            raise RuntimeError("launch record publication could not be verified")
+        return published
 
 
 def resolve_cognee_session_id(host_key: str = "", cwd: str = "") -> str:
@@ -284,38 +400,53 @@ def ensure_launch_record(
     override, else the existing/generated id; the conn_uuid is minted once.
     """
     host_key = _sanitize_session_key(host_key) or get_session_key()
-    rec = _read_map_record(host_key)
-    rec = _pin_launch_dataset(host_key, rec, dataset, dataset_source)
-    if rec.get("session_id") and rec.get("conn_uuid"):
-        return str(rec["session_id"]), str(rec["conn_uuid"])
-
-    explicit = _sanitize_session_key(str(os.environ.get("COGNEE_SESSION_ID", "") or "").strip())
-    session_id = explicit or str(rec.get("session_id") or "") or _generate_session_id(cwd, host_key)
-    conn_uuid = str(rec.get("conn_uuid") or "") or _new_conn_uuid()
-    record = {
-        "session_id": session_id,
-        "conn_uuid": conn_uuid,
-        "host_key": host_key,
-        "created_at": rec.get("created_at")
-        or datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        "touched": rec.get("touched") or [session_id],
-    }
-    if dataset:
-        record["dataset"] = dataset
-        record["dataset_source"] = dataset_source or "default"
     if not host_key:
+        explicit = _sanitize_session_key(str(os.environ.get("COGNEE_SESSION_ID", "") or "").strip())
+        session_id = explicit or _generate_session_id(cwd)
+        conn_uuid = _new_conn_uuid()
         return session_id, conn_uuid
-    winner = _create_map_record_if_absent(host_key, record)
-    # If a prior resolve() created a session-only record (no handle), graft our
-    # conn_uuid onto it. SessionStart is the sole writer of conn_uuid, so this
-    # merge isn't contended in practice.
-    if not winner.get("conn_uuid"):
-        merged = dict(winner)
-        merged["conn_uuid"] = conn_uuid
-        merged.setdefault("host_key", host_key)
-        _write_map_record(host_key, merged)
-        winner = _read_map_record(host_key) or merged
-    return str(winner.get("session_id") or session_id), str(winner.get("conn_uuid") or conn_uuid)
+
+    with _launch_publication_lock(host_key) as acquired:
+        if not acquired:
+            raise RuntimeError("launch record publication lock timed out")
+        current = _read_map_record(host_key)
+        if not current and _session_map_path(host_key).exists():
+            raise RuntimeError("launch record publication found unreadable state")
+
+        record = dict(current)
+        session_id = str(record.get("session_id") or "")
+        if not session_id:
+            explicit = _sanitize_session_key(
+                str(os.environ.get("COGNEE_SESSION_ID", "") or "").strip()
+            )
+            session_id = explicit or _generate_session_id(cwd, host_key)
+            record["session_id"] = session_id
+
+        conn_uuid = str(record.get("conn_uuid") or "")
+        if not conn_uuid:
+            conn_uuid = _new_conn_uuid()
+            record["conn_uuid"] = conn_uuid
+
+        record.setdefault("host_key", host_key)
+        record.setdefault("created_at", datetime.now(timezone.utc).isoformat(timespec="seconds"))
+        record.setdefault("touched", [session_id])
+        if dataset and not record.get("dataset"):
+            record["dataset"] = dataset
+            record["dataset_source"] = dataset_source or "default"
+        elif record.get("dataset") and not record.get("dataset_source"):
+            same_candidate = dataset and str(record["dataset"]) == dataset
+            record["dataset_source"] = (
+                dataset_source if same_candidate and dataset_source else "default"
+            )
+
+        if record != current:
+            if not _write_map_record(host_key, record):
+                raise RuntimeError("launch record publication failed")
+            record = _read_map_record(host_key)
+            if not record:
+                raise RuntimeError("launch record publication could not be verified")
+
+        return str(record["session_id"]), str(record["conn_uuid"])
 
 
 def resolve_conn_uuid(host_key: str = "") -> str:
@@ -327,12 +458,22 @@ def resolve_conn_uuid(host_key: str = "") -> str:
         return cu
     cu = _new_conn_uuid()
     if host_key:
-        rec = _read_map_record(host_key)
-        if not rec.get("conn_uuid"):
+        with _launch_publication_lock(host_key) as acquired:
+            if not acquired:
+                raise RuntimeError("launch record publication lock timed out")
+            rec = _read_map_record(host_key)
+            if not rec and _session_map_path(host_key).exists():
+                raise RuntimeError("launch record publication found unreadable state")
+            if rec.get("conn_uuid"):
+                return str(rec["conn_uuid"])
             rec["conn_uuid"] = cu
             rec.setdefault("host_key", host_key)
-            _write_map_record(host_key, rec)
-        return str(_read_map_record(host_key).get("conn_uuid") or cu)
+            if not _write_map_record(host_key, rec):
+                raise RuntimeError("launch record publication failed")
+            published = _read_map_record(host_key)
+            if not published.get("conn_uuid"):
+                raise RuntimeError("launch record publication could not be verified")
+            return str(published["conn_uuid"])
     return cu
 
 
@@ -388,7 +529,7 @@ def _resolve_agent_name() -> str:
     try:
         from config import load_config  # type: ignore
 
-        configured = str(load_config().get("agent_name") or "").strip()
+        configured = str(load_config(derive_project=False).get("agent_name") or "").strip()
         if configured:
             normalized = _normalize(configured)
             os.environ["COGNEE_AGENT_NAME"] = normalized
@@ -494,16 +635,31 @@ def _load_json_file(path: Path) -> dict:
     return {}
 
 
-def _write_json_file(path: Path, data: dict) -> None:
+def _write_json_file(path: Path, data: dict) -> bool:
+    tmp: Path | None = None
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        # Atomic write: a concurrent reader never sees a half-written file.
-        # Per-pid tmp name so two writers can't collide on the tmp path.
-        tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
-        tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+        # Unique, private temp file: concurrent threads in one process cannot
+        # collide, and replacement never inherits a destination's wider mode.
+        tmp = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+        fd = os.open(str(tmp), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as file_handle:
+            json.dump(data, file_handle, indent=2, sort_keys=True)
         os.replace(tmp, path)
+        if os.name != "nt":
+            os.chmod(path, 0o600)
+        return True
     except Exception as exc:
         hook_log("json_write_failed", {"path": str(path), "error": str(exc)[:200]})
+        return False
+    finally:
+        if tmp is not None:
+            try:
+                tmp.unlink()
+            except FileNotFoundError:
+                pass
+            except Exception as exc:
+                hook_log("json_temp_cleanup_failed", {"path": str(tmp), "error": str(exc)[:200]})
 
 
 def _strip_surrogates(text: str) -> str:
@@ -1286,7 +1442,7 @@ def _local_api_url_with_source() -> tuple[str, str]:
     try:
         from config import load_config  # type: ignore
 
-        configured = str(load_config().get("base_url") or "").strip()
+        configured = str(load_config(derive_project=False).get("base_url") or "").strip()
         if configured:
             return configured, "config_base_url"
     except Exception:

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -224,27 +224,22 @@ def get_launch_dataset(host_key: str = "") -> tuple[str, str]:
 def _create_map_record_if_absent(host_key: str, record: dict) -> dict:
     """Atomically create the launch record, first-writer-wins.
 
-    Uses O_CREAT|O_EXCL so exactly one concurrent creator wins; losers read back
-    the winner's record instead of clobbering it. This is what makes concurrent
-    launches/hooks for the same host_key converge on a single session id rather
-    than diverge. Returns the record now on disk.
+    Serializes creation with the existing host-keyed lock, then publishes through
+    ``_write_map_record``'s atomic replace. The destination therefore appears only
+    after the complete JSON is durable; contenders retry the lock and read the
+    winner instead of observing an empty/partial file. Returns the record on disk.
     """
     if not host_key:
         return record
-    path = _session_map_path(host_key)
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            json.dump(record, fh, indent=2, sort_keys=True)
-        return record
-    except FileExistsError:
-        return _read_map_record(host_key) or record
-    except Exception as exc:
-        hook_log("map_create_failed", {"error": str(exc)[:200]})
-        # Best-effort fallback: plain write, then read back whatever landed.
-        _write_map_record(host_key, record)
-        return _read_map_record(host_key) or record
+    while True:
+        with improve_session_lock(host_key, "launch_record") as acquired:
+            if acquired:
+                current = _read_map_record(host_key)
+                if current:
+                    return current
+                _write_map_record(host_key, record)
+                return _read_map_record(host_key) or record
+        time.sleep(0.02)
 
 
 def resolve_cognee_session_id(host_key: str = "", cwd: str = "") -> str:

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -172,7 +172,8 @@ def _session_map_path(host_key: str) -> Path:
 def _read_map_record(host_key: str) -> dict:
     """Return the launch record for a host session id, or {}.
 
-    Record shape: ``{conn_uuid, session_id, host_key, created_at, touched: [...]}``.
+    Record shape: ``{conn_uuid, session_id, host_key, created_at, touched: [...],
+    dataset, dataset_source}``.
     ``session_id`` = current Cognee session (switchable); ``conn_uuid`` = the
     per-launch liveness handle used for registration/counting (never switched).
     """
@@ -193,6 +194,24 @@ def _write_map_record(host_key: str, record: dict) -> None:
     if not host_key or not isinstance(record, dict):
         return
     _write_json_file(_session_map_path(host_key), record)
+
+
+def _pin_launch_dataset(host_key: str, record: dict, dataset: str, source: str) -> dict:
+    if not host_key or not dataset or record.get("dataset"):
+        return record
+    updated = dict(record)
+    updated["dataset"] = dataset
+    updated["dataset_source"] = source or "default"
+    _write_map_record(host_key, updated)
+    return _read_map_record(host_key) or updated
+
+
+def get_launch_dataset(host_key: str = "") -> tuple[str, str]:
+    record = _read_map_record(_sanitize_session_key(host_key) or get_session_key())
+    return (
+        str(record.get("dataset") or ""),
+        str(record.get("dataset_source") or ""),
+    )
 
 
 def _create_map_record_if_absent(host_key: str, record: dict) -> dict:
@@ -254,7 +273,9 @@ def resolve_cognee_session_id(host_key: str = "", cwd: str = "") -> str:
     return str(winner.get("session_id") or new_id)
 
 
-def ensure_launch_record(host_key: str = "", cwd: str = "") -> tuple[str, str]:
+def ensure_launch_record(
+    host_key: str = "", cwd: str = "", *, dataset: str = "", dataset_source: str = ""
+) -> tuple[str, str]:
     """Create (first-writer-wins) and return this launch's (session_id, conn_uuid).
 
     Called by SessionStart. The session id honors an explicit ``COGNEE_SESSION_ID``
@@ -262,6 +283,7 @@ def ensure_launch_record(host_key: str = "", cwd: str = "") -> tuple[str, str]:
     """
     host_key = _sanitize_session_key(host_key) or get_session_key()
     rec = _read_map_record(host_key)
+    rec = _pin_launch_dataset(host_key, rec, dataset, dataset_source)
     if rec.get("session_id") and rec.get("conn_uuid"):
         return str(rec["session_id"]), str(rec["conn_uuid"])
 
@@ -276,6 +298,9 @@ def ensure_launch_record(host_key: str = "", cwd: str = "") -> tuple[str, str]:
         or datetime.now(timezone.utc).isoformat(timespec="seconds"),
         "touched": rec.get("touched") or [session_id],
     }
+    if dataset:
+        record["dataset"] = dataset
+        record["dataset_source"] = dataset_source or "default"
     if not host_key:
         return session_id, conn_uuid
     winner = _create_map_record_if_absent(host_key, record)
@@ -378,6 +403,10 @@ def load_resolved(session_key: str = "") -> dict:
     active_session_key = _sanitize_session_key(session_key) or get_session_key()
     if active_session_key:
         resolved["session_key"] = active_session_key
+    launch_record = _read_map_record(active_session_key)
+    if launch_record.get("dataset"):
+        resolved["dataset"] = str(launch_record["dataset"])
+        resolved["dataset_source"] = str(launch_record.get("dataset_source") or "")
 
     # session_id = data scoping key (switchable); conn_uuid = registration handle.
     cognee_session_id = resolve_cognee_session_id(active_session_key)

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -1179,13 +1179,25 @@ def improve_session_lock(session_id: str, owner: str):
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         now = datetime.now(timezone.utc).timestamp()
         if lock_path.exists():
+            metadata_complete = True
             try:
                 current = json.loads(lock_path.read_text(encoding="utf-8"))
                 created_at = float(current.get("created_at", 0))
                 pid = int(current.get("pid", 0))
             except Exception:
-                created_at, pid = 0.0, 0
-            if not (pid > 0 and _proc.pid_alive(pid)) or now - created_at > SYNC_LOCK_STALE_SECONDS:
+                metadata_complete = False
+                try:
+                    created_at = lock_path.stat().st_mtime
+                except FileNotFoundError:
+                    created_at = now
+                pid = 0
+            stale = (
+                now - created_at > SYNC_LOCK_STALE_SECONDS
+                if not metadata_complete
+                else not (pid > 0 and _proc.pid_alive(pid))
+                or now - created_at > SYNC_LOCK_STALE_SECONDS
+            )
+            if stale:
                 try:
                     lock_path.unlink()
                     hook_log(

--- a/integrations/codex/plugins/cognee/scripts/_project_dataset.py
+++ b/integrations/codex/plugins/cognee/scripts/_project_dataset.py
@@ -19,6 +19,14 @@ def _repository_path(value: str) -> str:
     return path.strip("/")
 
 
+def _format_host(value: str, port: int | None = None) -> str:
+    host = str(value or "").strip().strip("[]").lower()
+    if not host:
+        return ""
+    formatted = f"[{host}]" if ":" in host else host
+    return f"{formatted}:{port}" if port is not None else formatted
+
+
 def normalize_git_remote(remote: str) -> str | None:
     value = str(remote or "").strip()
     if not value:
@@ -34,7 +42,7 @@ def normalize_git_remote(remote: str) -> str | None:
             )
         ):
             return None
-        host = match["host"].strip("[]").lower()
+        host = _format_host(match["host"])
         path = _repository_path(match["path"])
         return f"git:{host}/{path}" if host and path else None
     try:
@@ -48,9 +56,7 @@ def normalize_git_remote(remote: str) -> str | None:
         return None
     if scheme == "ssh" and port == 22:
         port = None
-    host_part = f"[{host}]" if ":" in host else host
-    if port is not None:
-        host_part = f"{host_part}:{port}"
+    host_part = _format_host(host, port)
     path = _repository_path(parsed.path)
     return f"git:{host_part}/{path}" if path else None
 
@@ -80,12 +86,12 @@ def _run_git(workspace: Path, *args: str) -> str:
             capture_output=True,
             text=True,
             encoding="utf-8",
-            errors="replace",
+            errors="strict",
             timeout=GIT_TIMEOUT_SECONDS,
             check=False,
             shell=False,
         )
-    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+    except (FileNotFoundError, OSError, UnicodeError, subprocess.SubprocessError):
         return ""
     return result.stdout.strip() if result.returncode == 0 else ""
 

--- a/integrations/codex/plugins/cognee/scripts/_project_dataset.py
+++ b/integrations/codex/plugins/cognee/scripts/_project_dataset.py
@@ -27,7 +27,11 @@ def normalize_git_remote(remote: str) -> str | None:
         match = _SCP_REMOTE.fullmatch(value)
         if not match or (
             len(match["host"]) == 1
-            and (match["host"].isascii() and match["host"].isalpha() or match["path"].startswith(("\\", "/")))
+            and (
+                match["host"].isascii()
+                and match["host"].isalpha()
+                or match["path"].startswith(("\\", "/"))
+            )
         ):
             return None
         host = match["host"].strip("[]").lower()
@@ -110,6 +114,8 @@ def derive_project_dataset(workspace: str) -> str | None:
         common_raw = _run_git(root, "rev-parse", "--git-common-dir")
         common = _canonical_dir(common_raw, relative_to=root) if common_raw else None
         if common is not None:
-            slug_source = common.parent.name if common.name == ".git" else common.name.removesuffix(".git")
+            slug_source = (
+                common.parent.name if common.name == ".git" else common.name.removesuffix(".git")
+            )
             return dataset_name(f"gitdir:{common}", slug_source)
     return dataset_name(f"workspace:{root}", root.name)

--- a/integrations/codex/plugins/cognee/scripts/_project_dataset.py
+++ b/integrations/codex/plugins/cognee/scripts/_project_dataset.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+import unicodedata
+from pathlib import Path
+from urllib.parse import urlsplit
+
+GIT_TIMEOUT_SECONDS = 1.0
+_SUPPORTED_SCHEMES = {"git", "http", "https", "ssh"}
+_SCP_REMOTE = re.compile(r"^(?:[^@/\s]+@)?(?P<host>\[[^\]]+\]|[^:/\s]+):(?P<path>.+)$")
+
+
+def _repository_path(value: str) -> str:
+    path = str(value or "").strip().strip("/")
+    if path.lower().endswith(".git"):
+        path = path[:-4]
+    return path.strip("/")
+
+
+def normalize_git_remote(remote: str) -> str | None:
+    value = str(remote or "").strip()
+    if not value:
+        return None
+    if "://" not in value:
+        match = _SCP_REMOTE.fullmatch(value)
+        if not match or (len(match["host"]) == 1 and match["path"].startswith(("\\", "/"))):
+            return None
+        host = match["host"].strip("[]").lower()
+        path = _repository_path(match["path"])
+        return f"git:{host}/{path}" if host and path else None
+    try:
+        parsed = urlsplit(value)
+        scheme = parsed.scheme.lower()
+        if scheme not in _SUPPORTED_SCHEMES or not parsed.hostname:
+            return None
+        host = parsed.hostname.lower()
+        port = parsed.port
+    except (TypeError, ValueError):
+        return None
+    if scheme == "ssh" and port == 22:
+        port = None
+    host_part = f"[{host}]" if ":" in host else host
+    if port is not None:
+        host_part = f"{host_part}:{port}"
+    path = _repository_path(parsed.path)
+    return f"git:{host_part}/{path}" if path else None
+
+
+def _slug(value: str) -> str:
+    ascii_value = (
+        unicodedata.normalize("NFKD", str(value or ""))
+        .encode("ascii", "ignore")
+        .decode("ascii")
+        .lower()
+    )
+    slug = re.sub(r"[^a-z0-9]+", "-", ascii_value).strip("-")[:32].rstrip("-")
+    return slug or "workspace"
+
+
+def dataset_name(identity: str, slug_source: str) -> str:
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:12]
+    return f"project_{_slug(slug_source)}_{digest}"
+
+
+def _run_git(workspace: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(workspace),
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=GIT_TIMEOUT_SECONDS,
+            check=False,
+            shell=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _canonical_dir(value: str | Path, *, relative_to: Path | None = None) -> Path | None:
+    try:
+        path = Path(value).expanduser()
+        if relative_to is not None and not path.is_absolute():
+            path = relative_to / path
+        path = path.resolve(strict=True)
+        return path if path.is_dir() else None
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def derive_project_dataset(workspace: str) -> str | None:
+    root = _canonical_dir(workspace)
+    if root is None:
+        return None
+    top_raw = _run_git(root, "rev-parse", "--show-toplevel")
+    top = _canonical_dir(top_raw) if top_raw else None
+    if top is not None:
+        normalized = normalize_git_remote(_run_git(root, "config", "--get", "remote.origin.url"))
+        if normalized:
+            return dataset_name(normalized, normalized.rsplit("/", 1)[-1])
+        common_raw = _run_git(root, "rev-parse", "--git-common-dir")
+        common = _canonical_dir(common_raw, relative_to=root) if common_raw else None
+        if common is not None:
+            slug_source = common.parent.name if common.name == ".git" else common.name.removesuffix(".git")
+            return dataset_name(f"gitdir:{common}", slug_source)
+    return dataset_name(f"workspace:{root}", root.name)

--- a/integrations/codex/plugins/cognee/scripts/_project_dataset.py
+++ b/integrations/codex/plugins/cognee/scripts/_project_dataset.py
@@ -25,7 +25,10 @@ def normalize_git_remote(remote: str) -> str | None:
         return None
     if "://" not in value:
         match = _SCP_REMOTE.fullmatch(value)
-        if not match or (len(match["host"]) == 1 and match["path"].startswith(("\\", "/"))):
+        if not match or (
+            len(match["host"]) == 1
+            and (match["host"].isascii() and match["host"].isalpha() or match["path"].startswith(("\\", "/")))
+        ):
             return None
         host = match["host"].strip("[]").lower()
         path = _repository_path(match["path"])

--- a/integrations/codex/plugins/cognee/scripts/cognee-remember.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-remember.sh
@@ -6,11 +6,11 @@
 #
 # --node-set: node set for categorization (default: user_context)
 #             user_context | project_docs | agent_actions
-# --dataset:  dataset name (default: COGNEE_PLUGIN_DATASET or agent_sessions)
+# --dataset:  dataset name (overrides shared config resolution)
 #
 # Configuration:
 #   Resolves auth from env/api_key.json.
-#   Dataset is env-driven: COGNEE_PLUGIN_DATASET, then agent_sessions.
+#   Dataset follows shared config resolution from the invoking shell cwd.
 #   Falls back to cognee-cli only if the server is unreachable.
 
 set -euo pipefail
@@ -31,6 +31,7 @@ try:
     load_env_file()
 except Exception:
     pass
+from config import get_dataset, load_config
 service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
 api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
 
@@ -47,7 +48,7 @@ if not api_key:
         except Exception:
             pass
 
-dataset = (os.environ.get("COGNEE_PLUGIN_DATASET") or "").strip()
+dataset = get_dataset(load_config(os.getcwd()))
 
 print(json.dumps({"service_url": service_url, "api_key": api_key, "dataset": dataset}))
 PY

--- a/integrations/codex/plugins/cognee/scripts/cognee-search.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-search.sh
@@ -10,7 +10,7 @@
 #
 # Configuration:
 #   Resolves session ID from Cognee endpoints using API auth.
-#   Dataset is env-driven: COGNEE_PLUGIN_DATASET, then agent_sessions.
+#   Dataset follows shared config resolution from the invoking shell cwd.
 
 set -euo pipefail
 
@@ -33,6 +33,7 @@ try:
     load_env_file()
 except Exception:
     pass
+from config import get_dataset, load_config
 service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
 api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
 if not api_key:
@@ -49,7 +50,7 @@ if not api_key:
             pass
 
 session_id = ""
-dataset = (os.environ.get("COGNEE_PLUGIN_DATASET") or "").strip()
+dataset = get_dataset(load_config(os.getcwd()))
 if service_url and api_key:
     try:
         import ssl
@@ -152,7 +153,7 @@ esac
 # Only a 2xx response is authoritative (an empty list = genuinely no hits).
 # Any non-2xx / error / unreachable returns the UNREACHABLE sentinel so we fall
 # back to cognee-cli and warn — never reporting a server failure as "not found".
-# $DATASET is resolved above (COGNEE_PLUGIN_DATASET → default)
+# $DATASET is resolved above through shared config.
 # and scopes the search to the plugin's dataset so unrelated datasets don't bleed in.
 # Logic lives in _recall_http.py (stdlib-only, unit-tested); stderr is surfaced.
 export COGNEE_PLUGIN_STATE_DIR="$PLUGIN_DIR"

--- a/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
@@ -2,9 +2,8 @@
 """Render the Cognee status line (Codex).
 
 Invoked via ``cognee-statusline.sh``, which pipes a JSON context on stdin.
-Deliberately standalone and pure-local: reads only env vars and
-``~/.cognee-plugin/config.json`` — no network calls, no ``_plugin_common``
-import.
+Deliberately standalone and pure-local: reads only env vars, local launch state,
+and workspace metadata — no network calls, no ``_plugin_common`` import.
 
 Output: ``cognee: <dataset-name> · local`` or ``cognee: <dataset-name> · cloud``
 """
@@ -40,6 +39,7 @@ _LLM_STATE_PATH = _SHARED_ROOT / "codex" / "llm-state.json"
 # above are coordination state, these are what THIS terminal observed.
 _LLM_STATE_DIR = _SHARED_ROOT / "codex" / "llm-state"
 _CONN_STATE_DIR = _SHARED_ROOT / "codex" / "conn-state"
+_SESSIONS_MAP_DIR = _SHARED_ROOT / "codex" / "sessions"
 
 # TTL for an LLM-key verdict. The marker is machine-wide and refreshed only when an
 # idle watcher LAUNCHES (session start, or a prompt that finds no live watcher) —
@@ -66,12 +66,24 @@ _DEFAULT_DATASET = "agent_sessions"
 _DEFAULT_LOCAL_BASE_URL = "http://localhost:8011"
 
 
-def _active_dataset() -> str:
-    # 1. env var (inherited from the shell that launched Codex)
-    v = os.environ.get("COGNEE_PLUGIN_DATASET", "").strip()
-    if v:
-        return v
-    # 2. default
+def _active_dataset(host_id: str = "", cwd: str = "") -> str:
+    if _path_safe(host_id):
+        record = _read_json(_SESSIONS_MAP_DIR / f"{host_id}.json")
+        pinned = str(record.get("dataset") or "").strip()
+        if pinned:
+            return pinned
+    explicit = os.environ.get("COGNEE_PLUGIN_DATASET", "").strip()
+    if explicit:
+        return explicit
+    if os.environ.get("COGNEE_DATASET_SCOPE", "").strip().lower() == "project" and cwd:
+        try:
+            from _project_dataset import derive_project_dataset
+
+            derived = derive_project_dataset(cwd)
+            if derived:
+                return derived
+        except Exception:
+            pass
     return _DEFAULT_DATASET
 
 
@@ -515,12 +527,12 @@ def _credits_segment() -> str:
     return seg
 
 
-def render_status_for_host(host_id: str) -> str:
+def render_status_for_host(host_id: str, cwd: str = "") -> str:
     """Return the status string. ``host_id`` is this session's key, used to show only
     LLM-key verdicts written by this session (the marker is machine-wide)."""
     return (
         f"{_pipeline_health_glyph()}{_status_prefix(str(host_id or ''))}"
-        f"cognee: {_active_dataset()} · {_active_mode()}"
+        f"cognee: {_active_dataset(host_id, cwd)} · {_active_mode()}"
         f"{_credits_segment()}{_update_segment()}"
     )
 
@@ -541,14 +553,18 @@ def main() -> None:
             pass
 
     try:
-        json.load(sys.stdin)  # consume stdin as required by the host
+        ctx = json.load(sys.stdin)  # consume stdin as required by the host
     except Exception:
-        pass
-    sys.stdout.write(
-        f"{_pipeline_health_glyph()}{_status_prefix()}"
-        f"cognee: {_active_dataset()} · {_active_mode()}"
-        f"{_credits_segment()}{_update_segment()}"
+        ctx = {}
+    if not isinstance(ctx, dict):
+        ctx = {}
+    cwd = str(
+        ctx.get("cwd")
+        or (ctx.get("workspace") or {}).get("current_dir")
+        or (ctx.get("workspace") or {}).get("project_dir")
+        or ""
     )
+    sys.stdout.write(render_status_for_host(str(ctx.get("session_id") or ""), cwd))
 
 
 if __name__ == "__main__":

--- a/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
@@ -66,9 +66,20 @@ _DEFAULT_DATASET = "agent_sessions"
 _DEFAULT_LOCAL_BASE_URL = "http://localhost:8011"
 
 
+def _sanitize_session_key(value: str) -> str:
+    safe = []
+    for ch in str(value or ""):
+        if ch.isalnum() or ch in ("-", "_", "."):
+            safe.append(ch)
+        else:
+            safe.append("_")
+    return "".join(safe).strip("._")[:120]
+
+
 def _active_dataset(host_id: str = "", cwd: str = "") -> str:
-    if _path_safe(host_id):
-        record = _read_json(_SESSIONS_MAP_DIR / f"{host_id}.json")
+    session_key = _sanitize_session_key(host_id)
+    if session_key:
+        record = _read_json(_SESSIONS_MAP_DIR / f"{session_key}.json")
         pinned = str(record.get("dataset") or "").strip()
         if pinned:
             return pinned

--- a/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
@@ -569,12 +569,10 @@ def main() -> None:
         ctx = {}
     if not isinstance(ctx, dict):
         ctx = {}
-    cwd = str(
-        ctx.get("cwd")
-        or (ctx.get("workspace") or {}).get("current_dir")
-        or (ctx.get("workspace") or {}).get("project_dir")
-        or ""
-    )
+    workspace = ctx.get("workspace")
+    if not isinstance(workspace, dict):
+        workspace = {}
+    cwd = str(ctx.get("cwd") or workspace.get("current_dir") or workspace.get("project_dir") or "")
     sys.stdout.write(render_status_for_host(str(ctx.get("session_id") or ""), cwd))
 
 

--- a/integrations/codex/plugins/cognee/scripts/config.py
+++ b/integrations/codex/plugins/cognee/scripts/config.py
@@ -132,8 +132,8 @@ def _apply_project_dataset(config: dict, workspace: str | None = None) -> dict:
     return config
 
 
-def load_config(workspace: str | None = None) -> dict:
-    """Load merged config: defaults → file → env vars."""
+def load_config(workspace: str | None = None, *, derive_project: bool = True) -> dict:
+    """Load merged config, optionally skipping workspace dataset derivation."""
     config = dict(_DEFAULTS)
     config["_dataset_source"] = "default"
 
@@ -164,6 +164,8 @@ def load_config(workspace: str | None = None) -> dict:
     # Layer 3: env vars (highest priority)
     for env_key, config_key in _ENV_MAP.items():
         val = os.environ.get(env_key, "")
+        if env_key == "COGNEE_PLUGIN_DATASET":
+            val = val.strip()
         if val:
             config[config_key] = val
             if env_key == "COGNEE_PLUGIN_DATASET":
@@ -189,7 +191,7 @@ def load_config(workspace: str | None = None) -> dict:
             config["api_key"] = ""
             config["base_url"] = ""
 
-    return _apply_project_dataset(config, workspace)
+    return _apply_project_dataset(config, workspace) if derive_project else config
 
 
 def save_config(config: dict) -> None:

--- a/integrations/codex/plugins/cognee/scripts/config.py
+++ b/integrations/codex/plugins/cognee/scripts/config.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Optional
 
 from _env_file import load_env_file
+from _project_dataset import derive_project_dataset
 
 # Must run before the _ENV_MAP scan in load_config() and before any importer's
 # module-level os.environ reads.
@@ -43,6 +44,7 @@ _STATE_DIR = _CONFIG_DIR / "codex"
 _CONFIG_FILE = _CONFIG_DIR / "config.json"
 _BRIDGE_STATE_FILE = _STATE_DIR / "bridge_state.json"
 _HOOK_LOG = _STATE_DIR / "hook.log"
+_HOST_CWD_ENV = "CODEX_CWD"
 
 _DEFAULTS = {
     "dataset": "agent_sessions",
@@ -90,6 +92,7 @@ _ENV_MAP = {
     "COGNEE_CODEX_BACKEND": "backend",
     "COGNEE_AGENT_NAME": "agent_name",
     "COGNEE_PLUGIN_DATASET": "dataset",
+    "COGNEE_DATASET_SCOPE": "_dataset_scope",
     "COGNEE_SESSION_STRATEGY": "session_strategy",
     "COGNEE_SESSION_PREFIX": "session_prefix",
     "COGNEE_BASE_URL": "base_url",
@@ -110,9 +113,29 @@ _ENV_MAP = {
 }
 
 
-def load_config() -> dict:
+def _workspace(workspace: str | None) -> str:
+    return str(workspace or os.environ.get(_HOST_CWD_ENV) or os.getcwd())
+
+
+def _apply_project_dataset(config: dict, workspace: str | None = None) -> dict:
+    source = str(config.get("_dataset_source") or "default")
+    config["_dataset_source"] = source
+    if source != "default":
+        return config
+    scope = str(config.get("_dataset_scope") or "").strip().lower()
+    if scope != "project":
+        return config
+    derived = derive_project_dataset(_workspace(workspace))
+    if derived:
+        config["dataset"] = derived
+        config["_dataset_source"] = "project"
+    return config
+
+
+def load_config(workspace: str | None = None) -> dict:
     """Load merged config: defaults → file → env vars."""
     config = dict(_DEFAULTS)
+    config["_dataset_source"] = "default"
 
     # Layer 2: config file
     # dataset is intentionally excluded here: it is always driven by the default
@@ -127,7 +150,7 @@ def load_config() -> dict:
                 {
                     k: v
                     for k, v in file_cfg.items()
-                    if v is not None and v != "" and k not in _file_excluded
+                    if v is not None and v != "" and k not in _file_excluded and not k.startswith("_")
                 }
             )
         except Exception as exc:
@@ -140,6 +163,8 @@ def load_config() -> dict:
         val = os.environ.get(env_key, "")
         if val:
             config[config_key] = val
+            if env_key == "COGNEE_PLUGIN_DATASET":
+                config["_dataset_source"] = "env"
 
     backend = str(config.get("backend") or "auto").lower()
     if backend in ("native", "local", "sdk"):
@@ -161,12 +186,15 @@ def load_config() -> dict:
             config["api_key"] = ""
             config["base_url"] = ""
 
-    return config
+    return _apply_project_dataset(config, workspace)
 
 
 def save_config(config: dict) -> None:
     """Write config to disk. Creates directory if needed."""
     _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    if config.get("_dataset_source") in {"picker", "project"}:
+        config = dict(config)
+        config["dataset"] = _DEFAULTS["dataset"]
     # Only save non-secret, non-default values.
     # dataset is always written even when it equals the default so that users
     # who open the file can see which dataset the plugin is using.

--- a/integrations/codex/plugins/cognee/scripts/config.py
+++ b/integrations/codex/plugins/cognee/scripts/config.py
@@ -150,7 +150,10 @@ def load_config(workspace: str | None = None) -> dict:
                 {
                     k: v
                     for k, v in file_cfg.items()
-                    if v is not None and v != "" and k not in _file_excluded and not k.startswith("_")
+                    if v is not None
+                    and v != ""
+                    and k not in _file_excluded
+                    and not k.startswith("_")
                 }
             )
         except Exception as exc:

--- a/integrations/codex/plugins/cognee/scripts/doctor.py
+++ b/integrations/codex/plugins/cognee/scripts/doctor.py
@@ -224,6 +224,13 @@ def _resolve_env_file() -> str:
     return desc
 
 
+def _resolve_dataset() -> tuple[str, str]:
+    from config import get_dataset, load_config
+
+    cfg = load_config(os.getcwd())
+    return get_dataset(cfg), str(cfg.get("_dataset_source") or "default")
+
+
 def collect_report() -> dict:
     """Gather all diagnostic fields into an ordered dict."""
     mode = _resolve_mode()
@@ -234,9 +241,12 @@ def collect_report() -> dict:
     cognee_local = _resolve_local_cognee_version()
     circuit_breaker = _resolve_circuit_breaker()
     embedding_model, embedding_dimensions = _resolve_embedding()
+    dataset, dataset_source = _resolve_dataset()
 
     return {
         "mode": mode + _mode_annotation(),
+        "dataset": dataset,
+        "dataset_source": dataset_source,
         "env_file": _resolve_env_file(),
         "server_url": display_url if display_url != "-" else None,
         "api_key_source": api_key_source,
@@ -252,6 +262,8 @@ def collect_report() -> dict:
 
 _DISPLAY_ORDER = [
     ("Mode", "mode"),
+    ("Dataset", "dataset"),
+    ("Dataset Source", "dataset_source"),
     ("Env File", "env_file"),
     ("Server URL", "server_url"),
     ("API Key Source", "api_key_source"),

--- a/integrations/codex/plugins/cognee/scripts/idle-watcher.py
+++ b/integrations/codex/plugins/cognee/scripts/idle-watcher.py
@@ -369,8 +369,9 @@ def main():
     try:
         from config import load_config  # type: ignore
 
-        config = load_config()
+        config = load_config(derive_project=False)
         config.update({k: v for k, v in bootstrap.get("config", {}).items() if v})
+        config["dataset"] = dataset
     except Exception as exc:
         _log("config_load_failed", error=str(exc)[:200])
         config = bootstrap.get("config", {})

--- a/integrations/codex/plugins/cognee/scripts/pre-compact.py
+++ b/integrations/codex/plugins/cognee/scripts/pre-compact.py
@@ -55,7 +55,9 @@ def _load_resolved_fields() -> tuple[str, str, str]:
     dataset = resolved.get("dataset", "")
     user_id = resolved.get("user_id", "")
     if not session_id or not dataset:
-        config = load_config()
+        config = load_config(derive_project=not bool(dataset))
+        if dataset:
+            config["dataset"] = dataset
         session_id = session_id or get_session_id(config)
         dataset = dataset or get_dataset(config)
     return session_id, dataset, user_id
@@ -185,7 +187,8 @@ async def _run():
         return ""
     hook_log("precompact_start", {"session": session_id, "dataset": dataset, "user_id": user_id})
 
-    config = load_config()
+    config = load_config(derive_project=False)
+    config["dataset"] = dataset
     await ensure_cognee_ready(config)
     user = None
     if not is_cloud_mode(config):

--- a/integrations/codex/plugins/cognee/scripts/pre-compact.py
+++ b/integrations/codex/plugins/cognee/scripts/pre-compact.py
@@ -122,7 +122,7 @@ async def _recall(
                 scope=scope,
                 only_context=True,
                 search_type=qtype,
-                dataset=get_dataset(config),
+                dataset=dataset,
             )
         else:
             import cognee

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -66,13 +66,15 @@ RECENT_TRACE_FALLBACK_TOP_K = 5
 MIN_SCOPE_TIMEOUT = 0.2
 
 
-def _load_session_id() -> str:
+def _load_session(workspace: str = "") -> tuple[str, str]:
     resolved = load_resolved()
-    session_id = resolved.get("session_id", "")
-    if not session_id:
-        config = load_config()
-        session_id = get_session_id(config)
-    return session_id
+    session_id = str(resolved.get("session_id") or "")
+    dataset = str(resolved.get("dataset") or "")
+    if not session_id or not dataset:
+        config = load_config(workspace or None)
+        session_id = session_id or get_session_id(config, workspace or None)
+        dataset = dataset or get_dataset(config)
+    return session_id, dataset
 
 
 def _load_user_id() -> str:
@@ -170,8 +172,8 @@ async def _recent_trace_fallback(session_id: str, user_id: str, top_k: int) -> l
     return normalized
 
 
-async def _run(prompt: str) -> dict | None:
-    config = load_config()
+async def _run(prompt: str, workspace: str = "") -> dict | None:
+    config = load_config(workspace or None)
     runtime = resolve_runtime_mode()
     cloud_mode = runtime["mode"] == "http"
     # Readiness gate, redesigned (SDK-356): the recall attempt itself is the
@@ -223,7 +225,7 @@ async def _run(prompt: str) -> dict | None:
     if not cloud_mode:
         await ensure_cognee_ready(config)
 
-    session_id = _load_session_id()
+    session_id, dataset = _load_session(workspace)
     if not session_id:
         hook_log("no_session_id", {"event": "context_lookup"})
         return None
@@ -322,7 +324,7 @@ async def _run(prompt: str) -> dict | None:
                     only_context=True,
                     search_type=qtype,
                     context_profile=context_profile,
-                    dataset=get_dataset(config),
+                    dataset=dataset,
                     timeout=scope_timeout,
                 )
             else:
@@ -654,9 +656,10 @@ def main():
         return
 
     output = None
+    workspace = str(payload.get("cwd") or os.environ.get("CODEX_CWD") or os.getcwd())
     try:
         with quiet_hook_output("session-context-lookup"):
-            output = asyncio.run(_run(prompt))
+            output = asyncio.run(_run(prompt, workspace))
     except Exception as exc:
         hook_log("context_lookup_exception", {"error": str(exc)[:200]})
     return output

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -333,6 +333,7 @@ async def _run(prompt: str, workspace: str = "") -> dict | None:
                     cognee.recall(
                         prompt,
                         session_id=session_id,
+                        datasets=[dataset] if "graph" in scope_list else None,
                         top_k=TOP_K,
                         scope=scope_list,
                         only_context=True,

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -71,7 +71,9 @@ def _load_session(workspace: str = "") -> tuple[str, str]:
     session_id = str(resolved.get("session_id") or "")
     dataset = str(resolved.get("dataset") or "")
     if not session_id or not dataset:
-        config = load_config(workspace or None)
+        config = load_config(workspace or None, derive_project=not bool(dataset))
+        if dataset:
+            config["dataset"] = dataset
         session_id = session_id or get_session_id(config, workspace or None)
         dataset = dataset or get_dataset(config)
     return session_id, dataset
@@ -173,7 +175,7 @@ async def _recent_trace_fallback(session_id: str, user_id: str, top_k: int) -> l
 
 
 async def _run(prompt: str, workspace: str = "") -> dict | None:
-    config = load_config(workspace or None)
+    config = load_config(workspace or None, derive_project=False)
     runtime = resolve_runtime_mode()
     cloud_mode = runtime["mode"] == "http"
     # Readiness gate, redesigned (SDK-356): the recall attempt itself is the
@@ -222,13 +224,14 @@ async def _run(prompt: str, workspace: str = "") -> dict | None:
             hook_log("recall_skipped_not_ready", {"base_url": service_url, "state": state})
             return None
 
-    if not cloud_mode:
-        await ensure_cognee_ready(config)
-
     session_id, dataset = _load_session(workspace)
     if not session_id:
         hook_log("no_session_id", {"event": "context_lookup"})
         return None
+    config["dataset"] = dataset
+
+    if not cloud_mode:
+        await ensure_cognee_ready(config)
 
     # NOTE: the warmup-buffer drain deliberately does NOT run here. This hook
     # is synchronous on the keystroke->answer path, and replaying N buffered

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -991,6 +991,8 @@ async def _run_heavy(
     Returns ``(user_id, agent_api_key, ok)``. ``ok`` is False only on a hard
     cloud-registration failure (mirrors the legacy early-abort).
     """
+    config = dict(config)
+    config["dataset"] = dataset
     if not managed_endpoint:
         try:
             _ensure_local_server_running(config, health_timeout=boot_timeout)

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -39,6 +39,7 @@ from _plugin_common import (
     apply_cognee_env,
     clear_server_pidfile,
     ensure_launch_record,
+    get_launch_dataset,
     hook_log,
     probe_health,
     quiet_hook_output,
@@ -1202,9 +1203,9 @@ async def _run_bootstrap(bootstrap: dict) -> None:
 
 
 async def _start(payload: dict | None = None) -> dict:
-    config = load_config()
     payload = payload or {}
     cwd = str(payload.get("cwd") or os.environ.get("CODEX_CWD") or os.getcwd())
+    config = load_config(cwd)
     # The service URL is the sole router (api_key is optional auth, with a
     # default-user fallback in registration). COGNEE_AGENT_MODE is NOT decided
     # here: it's set only when we actually boot a server (in
@@ -1252,7 +1253,17 @@ async def _start(payload: dict | None = None) -> dict:
     # Resolve (and persist) this launch's record: session_id (data scoping, unique
     # per launch) + conn_uuid (liveness handle for registration/counting). Written
     # synchronously here so prompt hooks read back the identical ids before any run.
-    session_id, conn_uuid = ensure_launch_record(session_key, cwd)
+    candidate_dataset = get_dataset(config)
+    candidate_source = str(config.get("_dataset_source") or "default")
+    session_id, conn_uuid = ensure_launch_record(
+        session_key,
+        cwd,
+        dataset=candidate_dataset,
+        dataset_source=candidate_source,
+    )
+    dataset, dataset_source = get_launch_dataset(session_key)
+    dataset = dataset or candidate_dataset
+    dataset_source = dataset_source or candidate_source
     os.environ["COGNEE_SESSION_ID"] = session_id
     agent_session_name = conn_uuid
     hook_log(
@@ -1262,9 +1273,10 @@ async def _start(payload: dict | None = None) -> dict:
             "session_key": session_key,
             "session_id": session_id,
             "conn_uuid": conn_uuid,
+            "dataset": dataset,
+            "dataset_source": dataset_source,
         },
     )
-    dataset = get_dataset(config)
 
     # Boot-vs-connect is decided purely by whether the server is already up:
     #   * up                -> connect (we don't boot, so agent mode is left as-is)

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -1153,11 +1153,13 @@ async def _run_bootstrap(bootstrap: dict) -> None:
          booted, because registration is per-agent (and concurrency-safe via
          the agent-keys / agent-lifecycle locks inside _run_heavy).
     """
-    config = load_config()
     cwd = str(bootstrap.get("cwd") or os.getcwd())
     session_id = str(bootstrap.get("session_id", "") or "")
     session_key = str(bootstrap.get("session_key", "") or "")
-    dataset = str(bootstrap.get("dataset", "") or get_dataset(config))
+    pinned_dataset = str(bootstrap.get("dataset", "") or "")
+    config = load_config(cwd, derive_project=not bool(pinned_dataset))
+    dataset = pinned_dataset or get_dataset(config)
+    config["dataset"] = dataset
     agent_session_name = str(bootstrap.get("agent_session_name", "") or session_id)
     if session_key:
         os.environ["COGNEE_SESSION_KEY"] = session_key

--- a/integrations/codex/plugins/cognee/scripts/store-to-session.py
+++ b/integrations/codex/plugins/cognee/scripts/store-to-session.py
@@ -128,7 +128,9 @@ def _load_session() -> tuple[str, str, str]:
     dataset = resolved.get("dataset", "")
     user_id = resolved.get("user_id", "")
     if not session_id or not dataset:
-        config = load_config()
+        config = load_config(derive_project=not bool(dataset))
+        if dataset:
+            config["dataset"] = dataset
         session_id = session_id or get_session_id(config)
         dataset = dataset or get_dataset(config)
     return session_id, dataset, user_id
@@ -168,7 +170,8 @@ async def _store_tool_call(payload: dict) -> None:
         hook_log("no_session_id", {"tool": tool_name})
         return
 
-    config = load_config()
+    config = load_config(derive_project=False)
+    config["dataset"] = dataset
     runtime = resolve_runtime_mode()
     use_http = runtime["mode"] == "http"
     entry = {
@@ -310,7 +313,8 @@ async def _store_assistant_stop(payload: dict) -> None:
         hook_log("no_session_id", {"event": "stop"})
         return
 
-    config = load_config()
+    config = load_config(derive_project=False)
+    config["dataset"] = dataset
     runtime = resolve_runtime_mode()
     use_http = runtime["mode"] == "http"
     pending = pop_pending_prompt(session_id, turn_id=str(payload.get("turn_id") or ""))

--- a/integrations/codex/plugins/cognee/scripts/store-user-prompt.py
+++ b/integrations/codex/plugins/cognee/scripts/store-user-prompt.py
@@ -53,7 +53,9 @@ def _load_session() -> tuple[str, str, str, str]:
     user_id = resolved.get("user_id", "")
     tenant_id = resolved.get("tenant_id", "")
     if not session_id or not dataset:
-        config = load_config()
+        config = load_config(derive_project=not bool(dataset))
+        if dataset:
+            config["dataset"] = dataset
         session_id = session_id or get_session_id(config)
         dataset = dataset or get_dataset(config)
     return session_id, dataset, user_id, tenant_id
@@ -135,7 +137,8 @@ async def _store(prompt: str, payload: dict):
         hook_log("no_session_id", {"event": "prompt"})
         return
 
-    config = load_config()
+    config = load_config(derive_project=False)
+    config["dataset"] = dataset
     touch_activity()
     _ensure_idle_watcher(session_id, dataset, user_id, config)
 

--- a/integrations/codex/plugins/cognee/scripts/sync-session-to-graph.py
+++ b/integrations/codex/plugins/cognee/scripts/sync-session-to-graph.py
@@ -262,7 +262,8 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: 
             _stop_idle_watcher()
             hook_log("sync_stopped_watcher", {"session": session_id, "dataset": dataset})
 
-        config = load_config()
+        config = load_config(derive_project=False)
+        config["dataset"] = dataset
         api_mode = http_api_ready()
         lock = nullcontext(True) if api_mode else sync_lock("sync-session-to-graph")
         with lock as acquired:

--- a/integrations/codex/plugins/cognee/scripts/sync-session-to-graph.py
+++ b/integrations/codex/plugins/cognee/scripts/sync-session-to-graph.py
@@ -215,9 +215,8 @@ def _load_resolved() -> tuple:
             os.environ["COGNEE_USER_ID"] = str(data.get("user_id"))
         return (
             env_session_id or data.get("session_id", ""),
-            # load_resolved() carries no dataset key, so without the env
-            # override (only the exit watcher sets it) this must fall back to
-            # config, or the SessionEnd worker syncs with an empty dataset.
+            # Detached exit workers keep their explicit override; direct syncs
+            # consume the dataset pinned in the SessionStart launch record.
             env_dataset or data.get("dataset", "") or get_dataset(load_config()),
             data.get("user_id", ""),
             env_agent_session_name or data.get("agent_session_name", ""),

--- a/integrations/openclaw/skills/cognee-memory/SKILL.md
+++ b/integrations/openclaw/skills/cognee-memory/SKILL.md
@@ -42,6 +42,7 @@ AI knowledge engine — a memory system in 6 lines of code.
 import cognee
 import asyncio
 
+
 async def main():
     # Store into the knowledge graph
     await cognee.remember("Cognee turns documents into AI memory.")
@@ -56,6 +57,7 @@ async def main():
 
     # Delete
     await cognee.forget(dataset="main_dataset")
+
 
 asyncio.run(main())
 ```
@@ -172,6 +174,7 @@ See the [plugin README](../../README.md) for required hook permissions
 import cognee
 import asyncio
 
+
 async def memory_loop():
     # 1. Learn new knowledge
     await cognee.remember("The user is learning Python programming")
@@ -185,6 +188,7 @@ async def memory_loop():
 
     # 4. Forget incorrect memories
     await cognee.forget("The incorrect assumption")
+
 
 asyncio.run(memory_loop())
 ```

--- a/integrations/tests/tests/e2e/test_project_dataset_pipeline.py
+++ b/integrations/tests/tests/e2e/test_project_dataset_pipeline.py
@@ -1,0 +1,97 @@
+"""Project-scoped datasets stay pinned across the full hook pipeline."""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def test_pipeline_uses_session_start_dataset(
+    suite, run_hook, payloads, mock_server, project_dir, tmp_path
+):
+    subprocess.run(["git", "init"], cwd=project_dir, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:Org/SharedRepo.git"],
+        cwd=project_dir,
+        check=True,
+    )
+    other = tmp_path / "other"
+    other.mkdir()
+    env = {"COGNEE_DATASET_SCOPE": "project"}
+    host_id = "project-scope-host"
+
+    started = run_hook(
+        suite,
+        "session-start.py",
+        stdin=payloads.session_start(session_id=host_id, cwd=str(project_dir)),
+        cwd=project_dir,
+        service_url=mock_server.url,
+        env=env,
+    )
+    assert started.returncode == 0, started.stderr
+
+    recalled = run_hook(
+        suite,
+        "session-context-lookup.py",
+        stdin=payloads.user_prompt(
+            session_id=host_id,
+            cwd=str(other),
+            prompt="recall project decision",
+        ),
+        cwd=other,
+        service_url=mock_server.url,
+        env=env,
+    )
+    assert recalled.returncode == 0, recalled.stderr
+
+    calls = [call for call in mock_server.calls if call["path"] == "/api/v1/recall"]
+    datasets = {tuple(call["json"].get("datasets") or []) for call in calls}
+    assert len(datasets) == 1
+    only = next(iter(datasets))
+    assert len(only) == 1 and only[0].startswith("project_sharedrepo_")
+
+    prompted = run_hook(
+        suite,
+        "store-user-prompt.py",
+        stdin=payloads.user_prompt(
+            session_id=host_id,
+            cwd=str(other),
+            prompt="remember the pinned project decision",
+        ),
+        cwd=other,
+        service_url=mock_server.url,
+        env=env,
+    )
+    assert prompted.returncode == 0, prompted.stderr
+
+    stopped = run_hook(
+        suite,
+        "store-to-session.py",
+        "--stop",
+        stdin=payloads.stop(
+            session_id=host_id,
+            assistant_message="the pinned project decision is stable",
+            cwd=str(other),
+        ),
+        cwd=other,
+        service_url=mock_server.url,
+        env=env,
+    )
+    assert stopped.returncode == 0, stopped.stderr
+    writes = [
+        call for call in mock_server.calls if call["path"] == "/api/v1/remember/entry"
+    ]
+    assert writes
+    assert {call["json"]["dataset_name"] for call in writes} == {only[0]}
+
+    synced = run_hook(
+        suite,
+        "sync-session-to-graph.py",
+        stdin={"hook_event_name": "ManualSync", "session_id": host_id, "cwd": str(other)},
+        cwd=other,
+        service_url=mock_server.url,
+        env=env,
+    )
+    assert synced.returncode == 0, synced.stderr
+    improves = [call for call in mock_server.calls if call["path"] == "/api/v1/improve"]
+    assert improves
+    assert improves[-1]["json"]["dataset_name"] == only[0]

--- a/integrations/tests/tests/e2e/test_project_dataset_pipeline.py
+++ b/integrations/tests/tests/e2e/test_project_dataset_pipeline.py
@@ -77,9 +77,7 @@ def test_pipeline_uses_session_start_dataset(
         env=env,
     )
     assert stopped.returncode == 0, stopped.stderr
-    writes = [
-        call for call in mock_server.calls if call["path"] == "/api/v1/remember/entry"
-    ]
+    writes = [call for call in mock_server.calls if call["path"] == "/api/v1/remember/entry"]
     assert writes
     assert {call["json"]["dataset_name"] for call in writes} == {only[0]}
 

--- a/integrations/tests/tests/e2e/test_statusline_bar.py
+++ b/integrations/tests/tests/e2e/test_statusline_bar.py
@@ -18,6 +18,7 @@ codex/tests/test_statusline_plain_text.py.
 from __future__ import annotations
 
 import json
+import subprocess
 import time
 
 from utils.statusline import mode_label, write_json
@@ -56,6 +57,47 @@ def test_bar_shows_dataset_and_mode(suite, run_hook, statusline, temp_home):
     assert result.stdout == f"cognee: {suite.default_dataset} · {expected_mode}", repr(
         result.stdout
     )
+
+
+def test_bar_prefers_pinned_dataset(suite, run_hook, temp_home):
+    _enable_plugin(suite, temp_home)
+    sessions = temp_home / ".cognee-plugin" / suite.state_subdir / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    (sessions / "host-one.json").write_text(
+        json.dumps({"session_id": "sid", "dataset": "project_repo_111111111111"}),
+        encoding="utf-8",
+    )
+    result = run_hook(
+        suite,
+        "cognee_statusline_render.py",
+        stdin={"session_id": "host-one", "cwd": "/wrong/project"},
+        service_url="https://api.example-cognee.ai",
+        api_key=None,
+        env={"COGNEE_PLUGIN_DATASET": "explicit-env"},
+    )
+    assert "cognee: project_repo_111111111111" in result.stdout
+
+
+def test_bar_derives_before_launch_record_exists(
+    suite, run_hook, temp_home, project_dir
+):
+    _enable_plugin(suite, temp_home)
+    subprocess.run(["git", "init"], cwd=project_dir, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:Org/StatusRepo.git"],
+        cwd=project_dir,
+        check=True,
+    )
+    result = run_hook(
+        suite,
+        "cognee_statusline_render.py",
+        stdin={"session_id": "new-host", "cwd": str(project_dir)},
+        cwd=project_dir,
+        service_url="https://api.example-cognee.ai",
+        api_key=None,
+        env={"COGNEE_DATASET_SCOPE": "project"},
+    )
+    assert "cognee: project_statusrepo_" in result.stdout
 
 
 def test_llm_failure_glyph_renders_left_of_the_label(suite, run_hook, statusline, temp_home):

--- a/integrations/tests/tests/e2e/test_statusline_bar.py
+++ b/integrations/tests/tests/e2e/test_statusline_bar.py
@@ -21,6 +21,7 @@ import json
 import subprocess
 import time
 
+import pytest
 from utils.statusline import mode_label, write_json
 
 _LOCAL_URL = "http://127.0.0.1:8000"
@@ -119,6 +120,21 @@ def test_bar_derives_before_launch_record_exists(suite, run_hook, temp_home, pro
     assert "cognee: project_statusrepo_" in result.stdout
 
 
+@pytest.mark.parametrize("workspace", ["malformed", ["malformed"]])
+def test_bar_tolerates_non_object_workspace(suite, run_hook, temp_home, workspace):
+    _enable_plugin(suite, temp_home)
+    result = run_hook(
+        suite,
+        "cognee_statusline_render.py",
+        stdin={"session_id": "host-one", "workspace": workspace},
+        service_url=_CLOUD_URL,
+        api_key=None,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "cognee: agent_sessions" in result.stdout
+
+
 def test_llm_failure_glyph_renders_left_of_the_label(suite, run_hook, statusline, temp_home):
     """A broken LLM key with a healthy server: the sign sits before "cognee:"."""
     _enable_plugin(suite, temp_home)
@@ -146,8 +162,6 @@ def test_llm_failure_glyph_renders_left_of_the_label(suite, run_hook, statusline
 def test_codex_bar_carries_no_ansi_escapes(suite, run_hook, statusline, temp_home):
     """codex's line is injected into the model's context, so it must stay plain."""
     if hasattr(statusline, "_mode_label"):
-        import pytest
-
         pytest.skip(f"{suite.name}: the bar is deliberately styled for a terminal")
 
     write_json(statusline._LLM_STATE_PATH, {"llm_state": "not_set", "checked_at": time.time()})

--- a/integrations/tests/tests/e2e/test_statusline_bar.py
+++ b/integrations/tests/tests/e2e/test_statusline_bar.py
@@ -78,9 +78,7 @@ def test_bar_prefers_pinned_dataset(suite, run_hook, temp_home):
     assert "cognee: project_repo_111111111111" in result.stdout
 
 
-def test_bar_normalizes_host_id_before_reading_pinned_dataset(
-    suite, run_hook, temp_home
-):
+def test_bar_normalizes_host_id_before_reading_pinned_dataset(suite, run_hook, temp_home):
     _enable_plugin(suite, temp_home)
     host_id = "._host/id with spaces?" + "x" * 140 + "..."
     normalized_host_id = "host_id_with_spaces_" + "x" * 100
@@ -101,9 +99,7 @@ def test_bar_normalizes_host_id_before_reading_pinned_dataset(
     assert "cognee: project_normalized_222222222222" in result.stdout
 
 
-def test_bar_derives_before_launch_record_exists(
-    suite, run_hook, temp_home, project_dir
-):
+def test_bar_derives_before_launch_record_exists(suite, run_hook, temp_home, project_dir):
     _enable_plugin(suite, temp_home)
     subprocess.run(["git", "init"], cwd=project_dir, check=True, capture_output=True)
     subprocess.run(

--- a/integrations/tests/tests/e2e/test_statusline_bar.py
+++ b/integrations/tests/tests/e2e/test_statusline_bar.py
@@ -78,6 +78,29 @@ def test_bar_prefers_pinned_dataset(suite, run_hook, temp_home):
     assert "cognee: project_repo_111111111111" in result.stdout
 
 
+def test_bar_normalizes_host_id_before_reading_pinned_dataset(
+    suite, run_hook, temp_home
+):
+    _enable_plugin(suite, temp_home)
+    host_id = "._host/id with spaces?" + "x" * 140 + "..."
+    normalized_host_id = "host_id_with_spaces_" + "x" * 100
+    sessions = temp_home / ".cognee-plugin" / suite.state_subdir / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    (sessions / f"{normalized_host_id}.json").write_text(
+        json.dumps({"session_id": "sid", "dataset": "project_normalized_222222222222"}),
+        encoding="utf-8",
+    )
+    result = run_hook(
+        suite,
+        "cognee_statusline_render.py",
+        stdin={"session_id": host_id, "cwd": "/wrong/project"},
+        service_url="https://api.example-cognee.ai",
+        api_key=None,
+        env={"COGNEE_PLUGIN_DATASET": "explicit-env"},
+    )
+    assert "cognee: project_normalized_222222222222" in result.stdout
+
+
 def test_bar_derives_before_launch_record_exists(
     suite, run_hook, temp_home, project_dir
 ):

--- a/integrations/tests/tests/integration/test_doctor.py
+++ b/integrations/tests/tests/integration/test_doctor.py
@@ -82,9 +82,7 @@ def test_report_marks_an_absent_server_unreachable(doctor, monkeypatch, closed_p
     assert report["reachable"] is False
 
 
-def test_report_includes_effective_project_dataset(
-    doctor, project_dir, monkeypatch
-):
+def test_report_includes_effective_project_dataset(doctor, project_dir, monkeypatch):
     monkeypatch.chdir(project_dir)
     monkeypatch.setenv("COGNEE_DATASET_SCOPE", "project")
     report = doctor.collect_report()

--- a/integrations/tests/tests/integration/test_doctor.py
+++ b/integrations/tests/tests/integration/test_doctor.py
@@ -32,6 +32,8 @@ _REPORT_KEYS = {
     "embedding_model",
     "embedding_dimensions",
     "circuit_breaker",
+    "dataset",
+    "dataset_source",
 }
 
 
@@ -80,9 +82,22 @@ def test_report_marks_an_absent_server_unreachable(doctor, monkeypatch, closed_p
     assert report["reachable"] is False
 
 
+def test_report_includes_effective_project_dataset(
+    doctor, project_dir, monkeypatch
+):
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setenv("COGNEE_DATASET_SCOPE", "project")
+    report = doctor.collect_report()
+    assert report["dataset"].startswith("project_project_")
+    assert report["dataset_source"] == "project"
+    assert str(project_dir) not in report["dataset"]
+
+
 def test_human_output_contains_header(doctor, mock_server):
     text = doctor.format_human(doctor.collect_report())
     assert "Cognee Doctor" in text
     assert "Mode:" in text
+    assert "Dataset:" in text
+    assert "Dataset Source:" in text
     assert "Cognee (local):" in text
     assert "Circuit Breaker:" in text

--- a/integrations/tests/tests/integration/test_project_dataset_cli.py
+++ b/integrations/tests/tests/integration/test_project_dataset_cli.py
@@ -1,0 +1,98 @@
+"""Direct Bash wrappers resolve project datasets from the invoking shell cwd."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+from utils.isolation import build_env
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="Bash wrapper contract")
+
+_DERIVED_DATASET = "project_clirepo_2742923114c7"
+
+
+@pytest.fixture
+def project_repo(project_dir):
+    subprocess.run(["git", "init"], cwd=project_dir, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:Org/CliRepo.git"],
+        cwd=project_dir,
+        check=True,
+    )
+    return project_dir
+
+
+def _run_wrapper(suite, temp_home, project_repo, mock_server, name, *args):
+    env = build_env(
+        suite,
+        temp_home,
+        service_url=mock_server.url,
+        api_key="test-api-key",
+        cwd=project_repo,
+        extra={
+            "COGNEE_DATASET_SCOPE": "project",
+            "COGNEE_REMEMBER_WAIT_SECONDS": "0",
+        },
+    )
+    return subprocess.run(
+        ["bash", str(suite.scripts_dir / name), *args],
+        cwd=project_repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_search_sends_dataset_derived_from_invoking_cwd(
+    suite, temp_home, project_repo, mock_server
+):
+    result = _run_wrapper(
+        suite,
+        temp_home,
+        project_repo,
+        mock_server,
+        "cognee-search.sh",
+        "where is the launch plan?",
+        "5",
+        "--graph",
+    )
+    assert result.returncode == 0, result.stderr
+    request = mock_server.assert_called("POST", "/api/v1/recall")
+    assert request["json"]["datasets"] == [_DERIVED_DATASET]
+
+
+def test_remember_sends_dataset_derived_from_invoking_cwd(
+    suite, temp_home, project_repo, mock_server
+):
+    result = _run_wrapper(
+        suite,
+        temp_home,
+        project_repo,
+        mock_server,
+        "cognee-remember.sh",
+        "launch plans live in the project graph",
+    )
+    assert result.returncode == 0, result.stderr
+    request = mock_server.assert_called("POST", "/api/v1/remember")
+    assert request["form"]["datasetName"] == _DERIVED_DATASET
+
+
+def test_remember_dataset_flag_wins_over_project_derivation(
+    suite, temp_home, project_repo, mock_server
+):
+    result = _run_wrapper(
+        suite,
+        temp_home,
+        project_repo,
+        mock_server,
+        "cognee-remember.sh",
+        "launch plans live in an explicit graph",
+        "--dataset",
+        "explicit",
+    )
+    assert result.returncode == 0, result.stderr
+    request = mock_server.assert_called("POST", "/api/v1/remember")
+    assert request["form"]["datasetName"] == "explicit"

--- a/integrations/tests/tests/integration/test_sync_strict.py
+++ b/integrations/tests/tests/integration/test_sync_strict.py
@@ -36,7 +36,7 @@ def sync_mod(suite, hook_module, mock_server, monkeypatch):
     module = hook_module(suite, "sync-session-to-graph.py")
     monkeypatch.setenv("COGNEE_BASE_URL", mock_server.url)
     monkeypatch.setenv("COGNEE_API_KEY", "principal-key")
-    monkeypatch.setattr(module, "load_config", lambda: {})
+    monkeypatch.setattr(module, "load_config", lambda *_args, **_kwargs: {})
     monkeypatch.setattr(module, "http_api_ready", lambda: True)
     monkeypatch.setattr(module, "hook_log", lambda *a, **k: None)
     return module

--- a/integrations/tests/tests/unit/test_env_file.py
+++ b/integrations/tests/tests/unit/test_env_file.py
@@ -192,6 +192,14 @@ def test_template_never_overwrites(env_file_env, temp_home):
     assert ef._DEFAULT_ENV_FILE.read_text(encoding="utf-8") == "USER_EDIT=kept\n"
 
 
+def test_template_documents_project_dataset_opt_in(env_file_env):
+    ef, _ = env_file_env
+    assert "# Derive one shared dataset per Git repository/workspace:" in ef._TEMPLATE
+    assert '# COGNEE_DATASET_SCOPE="project"' in ef._TEMPLATE
+    assert "# An explicit COGNEE_PLUGIN_DATASET always wins:" in ef._TEMPLATE
+    assert '# COGNEE_PLUGIN_DATASET="agent_sessions"' in ef._TEMPLATE
+
+
 def test_status_reports_names_not_values(env_file_env, monkeypatch):
     ef, fresh = env_file_env
     fresh("COGNEE_TEST_SECRET=super-secret\nPATH=/evil\nCOGNEE_TEST_SHADOWED=file-value\n")

--- a/integrations/tests/tests/unit/test_improve_session_lock.py
+++ b/integrations/tests/tests/unit/test_improve_session_lock.py
@@ -17,9 +17,12 @@ Migrated from {claude-code,codex}/tests/test_improve_session_lock.py.
 
 from __future__ import annotations
 
+import concurrent.futures
 import datetime as dt
 import hashlib
 import json
+import os
+import threading
 
 import pytest
 
@@ -90,6 +93,46 @@ def test_live_holder_lock_is_not_stolen(pc, monkeypatch):
     monkeypatch.setattr(pc._proc, "pid_alive", lambda pid: True)
     with pc.improve_session_lock("sess-A", "intruder") as claimed:
         assert claimed is False, "a live holder's lock must be respected"
+
+
+def test_fresh_partial_lock_metadata_is_not_unlinked_or_bypassed(pc, monkeypatch):
+    """A contender must respect the inode while its owner is still publishing metadata."""
+    publication_started = threading.Event()
+    release_publication = threading.Event()
+    real_dump = pc.json.dump
+
+    def delayed_first_dump(data, file_handle, *args, **kwargs):
+        if isinstance(data, dict) and data.get("owner") == "first":
+            publication_started.set()
+            assert release_publication.wait(timeout=2), "timed out releasing lock publication"
+        return real_dump(data, file_handle, *args, **kwargs)
+
+    monkeypatch.setattr(pc.json, "dump", delayed_first_dump)
+
+    def claim(owner):
+        with pc.improve_session_lock("sess-partial", owner) as acquired:
+            return acquired
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(claim, "first")
+        assert publication_started.wait(timeout=2), "first lock path never became visible"
+        second = executor.submit(claim, "second")
+        second_acquired = second.result(timeout=2)
+        release_publication.set()
+        first_acquired = first.result(timeout=2)
+
+    assert first_acquired is True
+    assert second_acquired is False, "contender bypassed a live lock with partial metadata"
+
+
+def test_old_unreadable_lock_is_reclaimed_after_the_existing_timeout(pc):
+    lock_path = _lock_file(pc, "sess-unreadable-stale")
+    lock_path.write_text("{", encoding="utf-8")
+    old = dt.datetime.now(dt.timezone.utc).timestamp() - pc.SYNC_LOCK_STALE_SECONDS - 1
+    os.utime(lock_path, (old, old))
+
+    with pc.improve_session_lock("sess-unreadable-stale", "reclaimer") as claimed:
+        assert claimed is True, "expired unreadable lock must remain recoverable"
 
 
 def test_missing_session_id_never_blocks(pc):

--- a/integrations/tests/tests/unit/test_project_dataset.py
+++ b/integrations/tests/tests/unit/test_project_dataset.py
@@ -42,7 +42,7 @@ def test_dataset_name_is_bounded_and_contains_no_credentials(suite, isolated_mod
 
 @pytest.mark.parametrize(
     "remote",
-    ["/tmp/local/repo.git", "file:///tmp/local/repo.git", "not a remote"],
+    ["/tmp/local/repo.git", "file:///tmp/local/repo.git", "not a remote", "C:repo"],
 )
 def test_unsupported_or_malformed_remote_returns_none(suite, isolated_modules, remote):
     resolver = isolated_modules(suite, "_project_dataset")

--- a/integrations/tests/tests/unit/test_project_dataset.py
+++ b/integrations/tests/tests/unit/test_project_dataset.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "remote",
+    [
+        "git@github.com:Topoteretes/Cognee.git",
+        "ssh://git@github.com/Topoteretes/Cognee.git",
+        "ssh://git@github.com:22/Topoteretes/Cognee.git",
+        "https://token:secret@github.com/Topoteretes/Cognee.git",
+    ],
+)
+def test_equivalent_remotes_normalize_identically(suite, isolated_modules, remote):
+    resolver = isolated_modules(suite, "_project_dataset")
+    assert resolver.normalize_git_remote(remote) == "git:github.com/Topoteretes/Cognee"
+
+
+def test_non_default_port_is_part_of_identity(suite, isolated_modules):
+    resolver = isolated_modules(suite, "_project_dataset")
+    assert (
+        resolver.normalize_git_remote("ssh://git@example.com:2222/Org/Repo.git")
+        == "git:example.com:2222/Org/Repo"
+    )
+
+
+def test_dataset_name_is_bounded_and_contains_no_credentials(suite, isolated_modules):
+    resolver = isolated_modules(suite, "_project_dataset")
+    name = resolver.dataset_name(
+        "git:example.com/Org/This Is A Very Long Repository Name With Ünicode",
+        "This Is A Very Long Repository Name With Ünicode",
+    )
+    assert re.fullmatch(r"project_[a-z0-9-]{1,32}_[0-9a-f]{12}", name)
+    assert len(name) <= 53
+    assert "secret" not in name
+
+
+@pytest.mark.parametrize(
+    "remote",
+    ["/tmp/local/repo.git", "file:///tmp/local/repo.git", "not a remote"],
+)
+def test_unsupported_or_malformed_remote_returns_none(suite, isolated_modules, remote):
+    resolver = isolated_modules(suite, "_project_dataset")
+    assert resolver.normalize_git_remote(remote) is None
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def test_remote_linked_worktrees_share_complete_name(suite, isolated_modules, tmp_path):
+    resolver = isolated_modules(suite, "_project_dataset")
+    repo = tmp_path / "primary"
+    linked = tmp_path / "different-worktree-name"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "remote", "add", "origin", "git@github.com:Org/Repo.git")
+    (repo / "seed").write_text("x", encoding="utf-8")
+    _git(repo, "add", "seed")
+    _git(repo, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed")
+    _git(repo, "worktree", "add", str(linked))
+    assert resolver.derive_project_dataset(str(repo)) == resolver.derive_project_dataset(str(linked))
+
+
+def test_remote_less_worktrees_share_complete_name(suite, isolated_modules, tmp_path):
+    resolver = isolated_modules(suite, "_project_dataset")
+    repo = tmp_path / "primary"
+    linked = tmp_path / "linked"
+    repo.mkdir()
+    _git(repo, "init")
+    (repo / "seed").write_text("x", encoding="utf-8")
+    _git(repo, "add", "seed")
+    _git(repo, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed")
+    _git(repo, "worktree", "add", str(linked))
+    assert resolver.derive_project_dataset(str(repo)) == resolver.derive_project_dataset(str(linked))
+
+
+def test_git_failure_falls_back_to_workspace(suite, isolated_modules, tmp_path, monkeypatch):
+    resolver = isolated_modules(suite, "_project_dataset")
+    workspace = tmp_path / "plain"
+    workspace.mkdir()
+    monkeypatch.setattr(resolver.subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()))
+    assert resolver.derive_project_dataset(str(workspace)).startswith("project_plain_")
+
+
+def test_git_timeout_falls_back_to_workspace(suite, isolated_modules, tmp_path, monkeypatch):
+    resolver = isolated_modules(suite, "_project_dataset")
+    workspace = tmp_path / "plain"
+    workspace.mkdir()
+    monkeypatch.setattr(
+        resolver.subprocess,
+        "run",
+        lambda *a, **k: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(cmd=["git"], timeout=1)
+        ),
+    )
+    assert resolver.derive_project_dataset(str(workspace)).startswith("project_plain_")
+
+
+def test_invalid_workspace_returns_none(suite, isolated_modules, tmp_path):
+    resolver = isolated_modules(suite, "_project_dataset")
+    assert resolver.derive_project_dataset(str(tmp_path / "missing")) is None
+
+
+def test_resolver_copies_are_byte_identical():
+    root = Path(__file__).resolve().parents[3]
+    claude = root / "claude-code" / "scripts" / "_project_dataset.py"
+    codex = root / "codex" / "plugins" / "cognee" / "scripts" / "_project_dataset.py"
+    assert claude.read_bytes() == codex.read_bytes()

--- a/integrations/tests/tests/unit/test_project_dataset.py
+++ b/integrations/tests/tests/unit/test_project_dataset.py
@@ -29,6 +29,18 @@ def test_non_default_port_is_part_of_identity(suite, isolated_modules):
     )
 
 
+@pytest.mark.parametrize(
+    "remote",
+    [
+        "git@[2001:db8::1]:Org/Repo.git",
+        "ssh://git@[2001:db8::1]/Org/Repo.git",
+    ],
+)
+def test_ipv6_scp_and_url_remotes_normalize_identically(suite, isolated_modules, remote):
+    resolver = isolated_modules(suite, "_project_dataset")
+    assert resolver.normalize_git_remote(remote) == "git:[2001:db8::1]/Org/Repo"
+
+
 def test_dataset_name_is_bounded_and_contains_no_credentials(suite, isolated_modules):
     resolver = isolated_modules(suite, "_project_dataset")
     name = resolver.dataset_name(
@@ -105,6 +117,24 @@ def test_git_timeout_falls_back_to_workspace(suite, isolated_modules, tmp_path, 
         lambda *a, **k: (_ for _ in ()).throw(subprocess.TimeoutExpired(cmd=["git"], timeout=1)),
     )
     assert resolver.derive_project_dataset(str(workspace)).startswith("project_plain_")
+
+
+def test_git_decoding_failure_falls_back_without_replacement_text(
+    suite, isolated_modules, tmp_path, monkeypatch
+):
+    resolver = isolated_modules(suite, "_project_dataset")
+    workspace = tmp_path / "plain"
+    workspace.mkdir()
+    invocation = {}
+
+    def decoding_failure(*args, **kwargs):
+        invocation.update(kwargs)
+        raise UnicodeDecodeError("utf-8", b"\xffsecret", 0, 1, "invalid start byte")
+
+    monkeypatch.setattr(resolver.subprocess, "run", decoding_failure)
+
+    assert resolver.derive_project_dataset(str(workspace)).startswith("project_plain_")
+    assert invocation["errors"] == "strict"
 
 
 def test_invalid_workspace_returns_none(suite, isolated_modules, tmp_path):

--- a/integrations/tests/tests/unit/test_project_dataset.py
+++ b/integrations/tests/tests/unit/test_project_dataset.py
@@ -50,9 +50,7 @@ def test_unsupported_or_malformed_remote_returns_none(suite, isolated_modules, r
 
 
 def _git(cwd: Path, *args: str) -> str:
-    result = subprocess.run(
-        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
-    )
+    result = subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
     return result.stdout.strip()
 
 
@@ -67,7 +65,9 @@ def test_remote_linked_worktrees_share_complete_name(suite, isolated_modules, tm
     _git(repo, "add", "seed")
     _git(repo, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed")
     _git(repo, "worktree", "add", str(linked))
-    assert resolver.derive_project_dataset(str(repo)) == resolver.derive_project_dataset(str(linked))
+    assert resolver.derive_project_dataset(str(repo)) == resolver.derive_project_dataset(
+        str(linked)
+    )
 
 
 def test_remote_less_worktrees_share_complete_name(suite, isolated_modules, tmp_path):
@@ -80,14 +80,18 @@ def test_remote_less_worktrees_share_complete_name(suite, isolated_modules, tmp_
     _git(repo, "add", "seed")
     _git(repo, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed")
     _git(repo, "worktree", "add", str(linked))
-    assert resolver.derive_project_dataset(str(repo)) == resolver.derive_project_dataset(str(linked))
+    assert resolver.derive_project_dataset(str(repo)) == resolver.derive_project_dataset(
+        str(linked)
+    )
 
 
 def test_git_failure_falls_back_to_workspace(suite, isolated_modules, tmp_path, monkeypatch):
     resolver = isolated_modules(suite, "_project_dataset")
     workspace = tmp_path / "plain"
     workspace.mkdir()
-    monkeypatch.setattr(resolver.subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()))
+    monkeypatch.setattr(
+        resolver.subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError())
+    )
     assert resolver.derive_project_dataset(str(workspace)).startswith("project_plain_")
 
 
@@ -98,9 +102,7 @@ def test_git_timeout_falls_back_to_workspace(suite, isolated_modules, tmp_path, 
     monkeypatch.setattr(
         resolver.subprocess,
         "run",
-        lambda *a, **k: (_ for _ in ()).throw(
-            subprocess.TimeoutExpired(cmd=["git"], timeout=1)
-        ),
+        lambda *a, **k: (_ for _ in ()).throw(subprocess.TimeoutExpired(cmd=["git"], timeout=1)),
     )
     assert resolver.derive_project_dataset(str(workspace)).startswith("project_plain_")
 

--- a/integrations/tests/tests/unit/test_project_dataset_config.py
+++ b/integrations/tests/tests/unit/test_project_dataset_config.py
@@ -40,6 +40,41 @@ def test_explicit_dataset_wins_over_project_scope(
     assert (loaded["dataset"], loaded["_dataset_source"]) == ("explicit", "env")
 
 
+def test_whitespace_explicit_dataset_is_absent_and_project_scope_still_derives(
+    suite, isolated_modules, project_dir, monkeypatch
+):
+    config = isolated_modules(suite, "config")
+    monkeypatch.setenv("COGNEE_DATASET_SCOPE", "project")
+    monkeypatch.setenv("COGNEE_PLUGIN_DATASET", " \t ")
+    monkeypatch.setattr(
+        config, "derive_project_dataset", lambda workspace: "project_repo_abc123def456"
+    )
+
+    loaded = config.load_config(str(project_dir))
+
+    assert (loaded["dataset"], loaded["_dataset_source"]) == (
+        "project_repo_abc123def456",
+        "project",
+    )
+
+
+def test_no_derivation_config_path_preserves_trimmed_explicit_dataset(
+    suite, isolated_modules, project_dir, monkeypatch
+):
+    config = isolated_modules(suite, "config")
+    monkeypatch.setenv("COGNEE_DATASET_SCOPE", "project")
+    monkeypatch.setenv("COGNEE_PLUGIN_DATASET", " explicit ")
+    monkeypatch.setattr(
+        config,
+        "derive_project_dataset",
+        lambda _workspace: (_ for _ in ()).throw(AssertionError("resolver invoked")),
+    )
+
+    loaded = config.load_config(str(project_dir), derive_project=False)
+
+    assert (loaded["dataset"], loaded["_dataset_source"]) == ("explicit", "env")
+
+
 def test_picker_marker_wins_over_project_scope(suite, isolated_modules, project_dir, monkeypatch):
     config = isolated_modules(suite, "config")
     monkeypatch.setenv("COGNEE_DATASET_SCOPE", "project")

--- a/integrations/tests/tests/unit/test_project_dataset_config.py
+++ b/integrations/tests/tests/unit/test_project_dataset_config.py
@@ -22,13 +22,17 @@ def test_unknown_scope_keeps_default(suite, isolated_modules, project_dir, monke
 def test_project_scope_derives_dataset(suite, isolated_modules, project_dir, monkeypatch):
     config = isolated_modules(suite, "config")
     monkeypatch.setenv("COGNEE_DATASET_SCOPE", " Project ")
-    monkeypatch.setattr(config, "derive_project_dataset", lambda workspace: "project_repo_abc123def456")
+    monkeypatch.setattr(
+        config, "derive_project_dataset", lambda workspace: "project_repo_abc123def456"
+    )
     loaded = config.load_config(str(project_dir))
     assert loaded["dataset"] == "project_repo_abc123def456"
     assert loaded["_dataset_source"] == "project"
 
 
-def test_explicit_dataset_wins_over_project_scope(suite, isolated_modules, project_dir, monkeypatch):
+def test_explicit_dataset_wins_over_project_scope(
+    suite, isolated_modules, project_dir, monkeypatch
+):
     config = isolated_modules(suite, "config")
     monkeypatch.setenv("COGNEE_DATASET_SCOPE", "project")
     monkeypatch.setenv("COGNEE_PLUGIN_DATASET", "explicit")
@@ -46,10 +50,14 @@ def test_picker_marker_wins_over_project_scope(suite, isolated_modules, project_
     assert (selected["dataset"], selected["_dataset_source"]) == ("picked", "picker")
 
 
-def test_derived_dataset_is_not_persisted_globally(suite, isolated_modules, project_dir, monkeypatch):
+def test_derived_dataset_is_not_persisted_globally(
+    suite, isolated_modules, project_dir, monkeypatch
+):
     config = isolated_modules(suite, "config")
     monkeypatch.setenv("COGNEE_DATASET_SCOPE", "project")
-    monkeypatch.setattr(config, "derive_project_dataset", lambda workspace: "project_repo_abc123def456")
+    monkeypatch.setattr(
+        config, "derive_project_dataset", lambda workspace: "project_repo_abc123def456"
+    )
     loaded = config.load_config(str(project_dir))
     config.save_config(loaded)
     saved = json.loads(config._CONFIG_FILE.read_text(encoding="utf-8"))

--- a/integrations/tests/tests/unit/test_project_dataset_config.py
+++ b/integrations/tests/tests/unit/test_project_dataset_config.py
@@ -1,0 +1,57 @@
+"""Dataset precedence and persistence tests shared by Claude Code and Codex."""
+
+from __future__ import annotations
+
+import json
+
+
+def test_scope_absent_keeps_default(suite, isolated_modules, project_dir):
+    config = isolated_modules(suite, "config")
+    loaded = config.load_config(str(project_dir))
+    assert loaded["dataset"] == "agent_sessions"
+    assert loaded["_dataset_source"] == "default"
+
+
+def test_unknown_scope_keeps_default(suite, isolated_modules, project_dir, monkeypatch):
+    config = isolated_modules(suite, "config")
+    monkeypatch.setenv("COGNEE_DATASET_SCOPE", "repository")
+    loaded = config.load_config(str(project_dir))
+    assert (loaded["dataset"], loaded["_dataset_source"]) == ("agent_sessions", "default")
+
+
+def test_project_scope_derives_dataset(suite, isolated_modules, project_dir, monkeypatch):
+    config = isolated_modules(suite, "config")
+    monkeypatch.setenv("COGNEE_DATASET_SCOPE", " Project ")
+    monkeypatch.setattr(config, "derive_project_dataset", lambda workspace: "project_repo_abc123def456")
+    loaded = config.load_config(str(project_dir))
+    assert loaded["dataset"] == "project_repo_abc123def456"
+    assert loaded["_dataset_source"] == "project"
+
+
+def test_explicit_dataset_wins_over_project_scope(suite, isolated_modules, project_dir, monkeypatch):
+    config = isolated_modules(suite, "config")
+    monkeypatch.setenv("COGNEE_DATASET_SCOPE", "project")
+    monkeypatch.setenv("COGNEE_PLUGIN_DATASET", "explicit")
+    loaded = config.load_config(str(project_dir))
+    assert (loaded["dataset"], loaded["_dataset_source"]) == ("explicit", "env")
+
+
+def test_picker_marker_wins_over_project_scope(suite, isolated_modules, project_dir, monkeypatch):
+    config = isolated_modules(suite, "config")
+    monkeypatch.setenv("COGNEE_DATASET_SCOPE", "project")
+    selected = config._apply_project_dataset(
+        {"dataset": "picked", "_dataset_source": "picker"},
+        str(project_dir),
+    )
+    assert (selected["dataset"], selected["_dataset_source"]) == ("picked", "picker")
+
+
+def test_derived_dataset_is_not_persisted_globally(suite, isolated_modules, project_dir, monkeypatch):
+    config = isolated_modules(suite, "config")
+    monkeypatch.setenv("COGNEE_DATASET_SCOPE", "project")
+    monkeypatch.setattr(config, "derive_project_dataset", lambda workspace: "project_repo_abc123def456")
+    loaded = config.load_config(str(project_dir))
+    config.save_config(loaded)
+    saved = json.loads(config._CONFIG_FILE.read_text(encoding="utf-8"))
+    assert saved["dataset"] == "agent_sessions"
+    assert "_dataset_source" not in saved

--- a/integrations/tests/tests/unit/test_project_dataset_runtime_paths.py
+++ b/integrations/tests/tests/unit/test_project_dataset_runtime_paths.py
@@ -3,8 +3,21 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import sys
 import types
+
+
+def _track_project_derivation(monkeypatch):
+    config = sys.modules.get("config") or importlib.import_module("config")
+    calls = []
+    monkeypatch.setenv("COGNEE_DATASET_SCOPE", "project")
+    monkeypatch.setattr(
+        config,
+        "derive_project_dataset",
+        lambda workspace: calls.append(workspace) or "project_wrong_999999999999",
+    )
+    return calls
 
 
 def test_session_start_winner_reaches_ready_and_agent_registration(suite, hook_module, monkeypatch):
@@ -80,6 +93,7 @@ def test_session_start_winner_reaches_ready_and_agent_registration(suite, hook_m
 def test_local_graph_recall_receives_pinned_dataset(suite, hook_module, monkeypatch):
     lookup = hook_module(suite, "session-context-lookup.py")
     calls = []
+    derivations = _track_project_derivation(monkeypatch)
 
     async def recall(_prompt, **kwargs):
         calls.append(kwargs)
@@ -95,7 +109,6 @@ def test_local_graph_recall_receives_pinned_dataset(suite, hook_module, monkeypa
         sys.modules, "cognee.modules.search", types.ModuleType("cognee.modules.search")
     )
     monkeypatch.setitem(sys.modules, "cognee.modules.search.types", fake_types)
-    monkeypatch.setattr(lookup, "load_config", lambda *_a, **_k: {"dataset": "candidate"})
     monkeypatch.setattr(lookup, "resolve_runtime_mode", lambda: {"mode": "local", "base_url": ""})
     monkeypatch.setattr(lookup, "read_connection_state", lambda: {})
     monkeypatch.setattr(lookup, "ensure_cognee_ready", lambda _config: asyncio.sleep(0))
@@ -116,6 +129,132 @@ def test_local_graph_recall_receives_pinned_dataset(suite, hook_module, monkeypa
 
     graph = next(call for call in calls if call["scope"] == ["graph"])
     assert graph["datasets"] == ["pinned"]
+    assert derivations == []
+
+
+def test_prompt_hook_does_not_derive_after_loading_pinned_state(suite, hook_module, monkeypatch):
+    prompt_hook = hook_module(suite, "store-user-prompt.py")
+    derivations = _track_project_derivation(monkeypatch)
+    monkeypatch.setattr(
+        prompt_hook,
+        "load_resolved",
+        lambda: {
+            "session_id": "session-id",
+            "dataset": "project_pinned_111111111111",
+            "user_id": "user-id",
+            "tenant_id": "tenant-id",
+        },
+    )
+    monkeypatch.setattr(
+        prompt_hook,
+        "resolve_runtime_mode",
+        lambda: {"mode": "http", "base_url": "https://memory.example"},
+    )
+    monkeypatch.setattr(prompt_hook, "_ensure_idle_watcher", lambda *_a, **_k: None)
+    monkeypatch.setattr(prompt_hook, "server_usable", lambda _url: False)
+
+    asyncio.run(prompt_hook._store("remember the pinned decision", {}))
+
+    assert derivations == []
+
+
+def test_tool_and_answer_hooks_do_not_derive_after_loading_pinned_state(
+    suite, hook_module, monkeypatch
+):
+    store_hook = hook_module(suite, "store-to-session.py")
+    derivations = _track_project_derivation(monkeypatch)
+    monkeypatch.setattr(
+        store_hook,
+        "_load_session",
+        lambda: ("session-id", "project_pinned_111111111111", "user-id"),
+    )
+    monkeypatch.setattr(
+        store_hook,
+        "resolve_runtime_mode",
+        lambda: {"mode": "http", "base_url": "https://memory.example"},
+    )
+    monkeypatch.setattr(store_hook, "server_usable", lambda _url: False)
+    monkeypatch.setattr(store_hook, "append_warmup_entry", lambda *_a, **_k: None)
+    monkeypatch.setattr(store_hook, "append_http_bridge_entry", lambda *_a, **_k: None)
+    monkeypatch.setattr(store_hook, "bump_save_counter", lambda *_a, **_k: None)
+    monkeypatch.setattr(store_hook, "hook_log", lambda *_a, **_k: None)
+
+    asyncio.run(
+        store_hook._store_tool_call(
+            {"tool_name": "Read", "tool_input": {"path": "README.md"}, "tool_output": "ok"}
+        )
+    )
+    asyncio.run(
+        store_hook._store_assistant_stop(
+            {"assistant_message": "The pinned answer is stable", "turn_id": "turn-one"}
+        )
+    )
+
+    assert derivations == []
+
+
+def test_precompact_does_not_derive_after_loading_pinned_state(suite, hook_module, monkeypatch):
+    precompact = hook_module(suite, "pre-compact.py")
+    derivations = _track_project_derivation(monkeypatch)
+    if suite.name == "claude-code":
+        monkeypatch.setattr(
+            precompact,
+            "_load_resolved_fields",
+            lambda: ("session-id", "project_pinned_111111111111"),
+        )
+    else:
+        monkeypatch.setattr(
+            precompact,
+            "_load_resolved_fields",
+            lambda: ("session-id", "project_pinned_111111111111", "user-id"),
+        )
+        monkeypatch.setattr(precompact, "_spawn_background_sync", lambda *_a, **_k: None)
+    monkeypatch.setattr(precompact, "ensure_cognee_ready", lambda _config: asyncio.sleep(0))
+    monkeypatch.setattr(precompact, "is_cloud_mode", lambda _config: True)
+    monkeypatch.setattr(precompact, "_recall", lambda *_a, **_k: asyncio.sleep(0, result=[]))
+    monkeypatch.setattr(precompact, "load_resolved", lambda: {})
+
+    asyncio.run(precompact._run())
+
+    assert derivations == []
+
+
+def test_final_sync_does_not_derive_after_loading_pinned_state(suite, hook_module, monkeypatch):
+    sync = hook_module(suite, "sync-session-to-graph.py")
+    derivations = _track_project_derivation(monkeypatch)
+    monkeypatch.setattr(
+        sync,
+        "_load_resolved",
+        lambda: (
+            "session-id",
+            "project_pinned_111111111111",
+            "user-id",
+            "connection-id",
+            True,
+            True,
+            "host-id",
+        ),
+    )
+    monkeypatch.setattr(sync, "http_api_ready", lambda: True)
+    monkeypatch.setattr(sync, "run_session_improve", lambda *_a, **_k: True)
+    monkeypatch.setattr(sync, "hook_log", lambda *_a, **_k: None)
+
+    asyncio.run(sync._sync(stop_watcher=False))
+
+    assert derivations == []
+
+
+def test_common_runtime_config_reads_do_not_derive_project_dataset(
+    suite, isolated_modules, monkeypatch
+):
+    common = isolated_modules(suite, "_plugin_common")
+    derivations = _track_project_derivation(monkeypatch)
+
+    assert common._resolve_agent_name()
+    if suite.name == "codex":
+        common._local_api_url_with_source()
+
+    assert derivations == []
 
 
 def test_precompact_http_recall_uses_resolved_dataset(suite, hook_module, monkeypatch):

--- a/integrations/tests/tests/unit/test_project_dataset_runtime_paths.py
+++ b/integrations/tests/tests/unit/test_project_dataset_runtime_paths.py
@@ -7,9 +7,7 @@ import sys
 import types
 
 
-def test_session_start_winner_reaches_ready_and_agent_registration(
-    suite, hook_module, monkeypatch
-):
+def test_session_start_winner_reaches_ready_and_agent_registration(suite, hook_module, monkeypatch):
     session_start = hook_module(suite, "session-start.py")
     common = sys.modules["_plugin_common"]
     common.ensure_launch_record(
@@ -93,7 +91,9 @@ def test_local_graph_recall_receives_pinned_dataset(suite, hook_module, monkeypa
     fake_types.SearchType = types.SimpleNamespace(HYBRID_COMPLETION="HYBRID_COMPLETION")
     monkeypatch.setitem(sys.modules, "cognee", fake_cognee)
     monkeypatch.setitem(sys.modules, "cognee.modules", types.ModuleType("cognee.modules"))
-    monkeypatch.setitem(sys.modules, "cognee.modules.search", types.ModuleType("cognee.modules.search"))
+    monkeypatch.setitem(
+        sys.modules, "cognee.modules.search", types.ModuleType("cognee.modules.search")
+    )
     monkeypatch.setitem(sys.modules, "cognee.modules.search.types", fake_types)
     monkeypatch.setattr(lookup, "load_config", lambda *_a, **_k: {"dataset": "candidate"})
     monkeypatch.setattr(lookup, "resolve_runtime_mode", lambda: {"mode": "local", "base_url": ""})

--- a/integrations/tests/tests/unit/test_project_dataset_runtime_paths.py
+++ b/integrations/tests/tests/unit/test_project_dataset_runtime_paths.py
@@ -1,0 +1,144 @@
+"""Pinned project datasets reach registration and every recall transport."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+
+def test_session_start_winner_reaches_ready_and_agent_registration(
+    suite, hook_module, monkeypatch
+):
+    session_start = hook_module(suite, "session-start.py")
+    common = sys.modules["_plugin_common"]
+    common.ensure_launch_record(
+        "shared-host",
+        "/winner",
+        dataset="project_winner_111111111111",
+        dataset_source="project",
+    )
+    session_id, conn_uuid = common.ensure_launch_record(
+        "shared-host",
+        "/loser",
+        dataset="project_loser_222222222222",
+        dataset_source="project",
+    )
+    winner, _source = common.get_launch_dataset("shared-host")
+    observed = {}
+
+    async def ready(config):
+        observed["ready"] = config["dataset"]
+
+    async def principal_key(_service_url, _config):
+        return "api-key"
+
+    async def user_id(_service_url, _api_key):
+        return "user-id"
+
+    def register_agent_via_http(**kwargs):
+        observed["registration"] = kwargs["dataset_names"]
+        return True, {"id": "connection-id"}
+
+    async def ensure_dataset(_service_url, _api_key, dataset):
+        observed["dataset_ready"] = dataset
+
+    monkeypatch.setattr(session_start, "_reexec_into_venv", lambda: None)
+    monkeypatch.setattr(session_start, "ensure_cognee_ready", ready)
+    monkeypatch.setattr(session_start, "is_cloud_mode", lambda _config: True)
+    monkeypatch.setattr(session_start, "_resolve_single_principal_key", principal_key)
+    monkeypatch.setattr(session_start, "_user_id_via_api", user_id)
+    monkeypatch.setattr(session_start, "ensure_dataset_ready_via_api", ensure_dataset)
+    monkeypatch.setattr(session_start, "probe_health", lambda *_a, **_k: "ready")
+    monkeypatch.setattr(session_start, "write_connection_state", lambda *_a, **_k: None)
+    monkeypatch.setattr(common, "register_agent_via_http", register_agent_via_http)
+
+    config = {
+        "base_url": "https://cloud.example",
+        "dataset": "project_loser_222222222222",
+        "agent_name": "test-agent",
+    }
+    result = asyncio.run(
+        session_start._run_heavy(
+            config,
+            "/loser",
+            session_id,
+            conn_uuid,
+            "shared-host",
+            winner,
+            managed_endpoint=True,
+            boot_timeout=1,
+        )
+    )
+
+    assert result[2] is True
+    assert observed == {
+        "ready": winner,
+        "registration": [winner],
+        "dataset_ready": winner,
+    }
+
+
+def test_local_graph_recall_receives_pinned_dataset(suite, hook_module, monkeypatch):
+    lookup = hook_module(suite, "session-context-lookup.py")
+    calls = []
+
+    async def recall(_prompt, **kwargs):
+        calls.append(kwargs)
+        return []
+
+    fake_cognee = types.ModuleType("cognee")
+    fake_cognee.recall = recall
+    fake_types = types.ModuleType("cognee.modules.search.types")
+    fake_types.SearchType = types.SimpleNamespace(HYBRID_COMPLETION="HYBRID_COMPLETION")
+    monkeypatch.setitem(sys.modules, "cognee", fake_cognee)
+    monkeypatch.setitem(sys.modules, "cognee.modules", types.ModuleType("cognee.modules"))
+    monkeypatch.setitem(sys.modules, "cognee.modules.search", types.ModuleType("cognee.modules.search"))
+    monkeypatch.setitem(sys.modules, "cognee.modules.search.types", fake_types)
+    monkeypatch.setattr(lookup, "load_config", lambda *_a, **_k: {"dataset": "candidate"})
+    monkeypatch.setattr(lookup, "resolve_runtime_mode", lambda: {"mode": "local", "base_url": ""})
+    monkeypatch.setattr(lookup, "read_connection_state", lambda: {})
+    monkeypatch.setattr(lookup, "ensure_cognee_ready", lambda _config: asyncio.sleep(0))
+    monkeypatch.setattr(lookup, "_load_session", lambda _workspace="": ("session-id", "pinned"))
+    monkeypatch.setattr(lookup, "_load_user_id", lambda: "user-id")
+    monkeypatch.setattr(lookup, "resolve_user", lambda _user_id: asyncio.sleep(0, result="user"))
+    monkeypatch.setattr(lookup, "_recent_trace_fallback", lambda *_a: asyncio.sleep(0, result=[]))
+    monkeypatch.setattr(
+        lookup,
+        "read_and_reset_save_counter",
+        lambda _session_id: {"prompt": 0, "trace": 0, "answer": 0},
+    )
+    monkeypatch.setattr(lookup, "hook_log", lambda *_a, **_k: None)
+    if hasattr(lookup, "render_status_for_host"):
+        monkeypatch.setattr(lookup, "render_status_for_host", lambda _session_id: "Cognee")
+
+    asyncio.run(lookup._run("recall the pinned project", "/later"))
+
+    graph = next(call for call in calls if call["scope"] == ["graph"])
+    assert graph["datasets"] == ["pinned"]
+
+
+def test_precompact_http_recall_uses_resolved_dataset(suite, hook_module, monkeypatch):
+    precompact = hook_module(suite, "pre-compact.py")
+    observed = {}
+
+    def recall_via_http(_query, **kwargs):
+        observed.update(kwargs)
+        return []
+
+    monkeypatch.setattr(precompact, "is_cloud_mode", lambda _config: True)
+    monkeypatch.setattr(precompact, "recall_via_http", recall_via_http)
+
+    results = asyncio.run(
+        precompact._recall(
+            "session-id",
+            "project_pinned_111111111111",
+            query="project decision",
+            scope=["graph"],
+            top_k=3,
+            config={"dataset": "project_later_222222222222"},
+        )
+    )
+
+    assert results == []
+    assert observed["dataset"] == "project_pinned_111111111111"

--- a/integrations/tests/tests/unit/test_project_dataset_session_state.py
+++ b/integrations/tests/tests/unit/test_project_dataset_session_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import threading
+import time
 
 
 def test_launch_record_pins_dataset_and_source(suite, isolated_modules, monkeypatch):
@@ -48,6 +49,54 @@ def test_new_dataset_record_persists_session_and_connection_ids(suite, isolated_
     assert record["conn_uuid"] == conn_uuid
     assert record["session_id"]
     assert record["conn_uuid"]
+
+
+def test_concurrent_new_record_publication_returns_only_the_complete_winner(
+    suite, isolated_modules, monkeypatch
+):
+    common = isolated_modules(suite, "_plugin_common")
+    publication_started = threading.Event()
+    release_publication = threading.Event()
+    real_dump = common.json.dump
+
+    def delayed_record_dump(record, file_handle, *args, **kwargs):
+        if isinstance(record, dict) and record.get("dataset"):
+            publication_started.set()
+            assert release_publication.wait(timeout=2), "timed out releasing first publication"
+        return real_dump(record, file_handle, *args, **kwargs)
+
+    monkeypatch.setattr(common.json, "dump", delayed_record_dump)
+
+    candidates = (
+        ("/repo-a", "project_a_111111111111"),
+        ("/repo-b", "project_b_222222222222"),
+    )
+
+    def create(candidate):
+        cwd, dataset = candidate
+        ids = common.ensure_launch_record(
+            "new-host", cwd, dataset=dataset, dataset_source="project"
+        )
+        return ids, common.get_launch_dataset("new-host")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(create, candidates[0])
+        # The vulnerable implementation exposes the destination before JSON is
+        # complete and therefore enters the delayed dump. An atomic implementation
+        # may finish without entering that seam; either way, launch the contender
+        # only after the first has had a chance to publish or block.
+        publication_started.wait(timeout=0.2)
+        second = executor.submit(create, candidates[1])
+        time.sleep(0.05)
+        release_publication.set()
+        observed = [first.result(timeout=2), second.result(timeout=2)]
+
+    record = common._read_map_record("new-host")
+    assert record["session_id"] and record["conn_uuid"]
+    assert record["dataset"] == candidates[0][1]
+    assert record["dataset_source"] == "project"
+    assert {ids for ids, _dataset in observed} == {(record["session_id"], record["conn_uuid"])}
+    assert {dataset for _ids, dataset in observed} == {(record["dataset"], "project")}
 
 
 def test_concurrent_legacy_pins_keep_the_first_dataset(suite, isolated_modules, monkeypatch):

--- a/integrations/tests/tests/unit/test_project_dataset_session_state.py
+++ b/integrations/tests/tests/unit/test_project_dataset_session_state.py
@@ -3,8 +3,21 @@
 from __future__ import annotations
 
 import concurrent.futures
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import sys
 import threading
 import time
+
+import pytest
+
+
+def _publication_lock_path(common, host_key: str):
+    digest = hashlib.sha256(host_key.encode("utf-8")).hexdigest()
+    return common._LAUNCH_PUBLICATION_LOCK_DIR / f"{digest}.lock"
 
 
 def test_launch_record_pins_dataset_and_source(suite, isolated_modules, monkeypatch):
@@ -51,6 +64,154 @@ def test_new_dataset_record_persists_session_and_connection_ids(suite, isolated_
     assert record["conn_uuid"]
 
 
+def test_launch_record_publication_does_not_use_improve_lock(suite, isolated_modules, monkeypatch):
+    common = isolated_modules(suite, "_plugin_common")
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("launch publication reused improve_session_lock")
+
+    monkeypatch.setattr(common, "improve_session_lock", forbidden)
+
+    session_id, conn_uuid = common.ensure_launch_record(
+        "dedicated-lock-host",
+        "/repo",
+        dataset="project_repo_111111111111",
+        dataset_source="project",
+    )
+
+    assert common._read_map_record("dedicated-lock-host") == {
+        "conn_uuid": conn_uuid,
+        "created_at": common._read_map_record("dedicated-lock-host")["created_at"],
+        "dataset": "project_repo_111111111111",
+        "dataset_source": "project",
+        "host_key": "dedicated-lock-host",
+        "session_id": session_id,
+        "touched": [session_id],
+    }
+
+
+def test_launch_publication_management_error_fails_closed_and_bounded(
+    suite, isolated_modules, monkeypatch
+):
+    common = isolated_modules(suite, "_plugin_common")
+
+    def denied(_path):
+        raise PermissionError("lock directory denied")
+
+    monkeypatch.setattr(common, "_open_launch_lock_file", denied, raising=False)
+    started = time.monotonic()
+
+    with pytest.raises(RuntimeError, match="launch record publication"):
+        common.ensure_launch_record(
+            "denied-host",
+            "/repo",
+            dataset="project_repo_111111111111",
+            dataset_source="project",
+        )
+
+    assert time.monotonic() - started < 0.5
+    assert not common._session_map_path("denied-host").exists()
+
+
+def test_stale_publication_metadata_without_a_live_lock_is_recovered(suite, isolated_modules):
+    common = isolated_modules(suite, "_plugin_common")
+    lock_path = _publication_lock_path(common, "stale-host")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text(
+        json.dumps({"token": "stale-owner", "pid": 999999, "created_at": 1}),
+        encoding="utf-8",
+    )
+
+    with common._launch_publication_lock("stale-host", timeout=0.2) as token:
+        assert token and token != "stale-owner"
+        metadata = json.loads(lock_path.read_text(encoding="utf-8"))
+        assert metadata["token"] == token
+
+
+def test_old_publication_owner_cannot_remove_successor_lock(suite, isolated_modules):
+    common = isolated_modules(suite, "_plugin_common")
+    first_acquired = threading.Event()
+    release_first = threading.Event()
+    second_acquired = threading.Event()
+    release_second = threading.Event()
+    tokens = {}
+
+    def first_owner():
+        with common._launch_publication_lock("owner-host", timeout=0.5) as token:
+            tokens["first"] = token
+            first_acquired.set()
+            assert release_first.wait(timeout=2)
+
+    def second_owner():
+        assert first_acquired.wait(timeout=2)
+        with common._launch_publication_lock("owner-host", timeout=1.0) as token:
+            tokens["second"] = token
+            second_acquired.set()
+            assert release_second.wait(timeout=2)
+
+    first = threading.Thread(target=first_owner)
+    second = threading.Thread(target=second_owner)
+    first.start()
+    second.start()
+    assert first_acquired.wait(timeout=2)
+    release_first.set()
+    assert second_acquired.wait(timeout=2)
+
+    lock_path = _publication_lock_path(common, "owner-host")
+    metadata = json.loads(lock_path.read_text(encoding="utf-8"))
+    assert metadata["token"] == tokens["second"]
+    assert tokens["first"] != tokens["second"]
+    assert lock_path.exists(), "the old owner's cleanup unlinked its successor"
+
+    release_second.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+    assert not first.is_alive() and not second.is_alive()
+    assert lock_path.exists(), "publication lock inode must remain stable across owners"
+
+
+def test_publication_lock_recovers_after_owner_process_exits_without_cleanup(
+    suite, isolated_modules
+):
+    common = isolated_modules(suite, "_plugin_common")
+    code = f"""
+import os
+import sys
+sys.path.insert(0, {str(suite.scripts_dir)!r})
+from _plugin_common import _launch_publication_lock
+with _launch_publication_lock('crashed-host', timeout=0.5) as token:
+    print(token or '', flush=True)
+    sys.stdin.read(1)
+    os._exit(17)
+"""
+    child = subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=os.environ.copy(),
+    )
+    try:
+        assert child.stdout is not None
+        child_token = child.stdout.readline().strip()
+        assert child_token
+        with common._launch_publication_lock("crashed-host", timeout=0.05) as token:
+            assert token is False
+
+        assert child.stdin is not None
+        child.stdin.write("x")
+        child.stdin.flush()
+        assert child.wait(timeout=2) == 17
+
+        with common._launch_publication_lock("crashed-host", timeout=0.5) as token:
+            assert token and token != child_token
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=2)
+
+
 def test_concurrent_new_record_publication_returns_only_the_complete_winner(
     suite, isolated_modules, monkeypatch
 ):
@@ -61,6 +222,7 @@ def test_concurrent_new_record_publication_returns_only_the_complete_winner(
 
     def delayed_record_dump(record, file_handle, *args, **kwargs):
         if isinstance(record, dict) and record.get("dataset"):
+            assert not common._session_map_path("new-host").exists()
             publication_started.set()
             assert release_publication.wait(timeout=2), "timed out releasing first publication"
         return real_dump(record, file_handle, *args, **kwargs)
@@ -99,6 +261,26 @@ def test_concurrent_new_record_publication_returns_only_the_complete_winner(
     assert {dataset for _ids, dataset in observed} == {(record["dataset"], "project")}
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+def test_launch_record_new_and_replacement_modes_are_private(suite, isolated_modules):
+    common = isolated_modules(suite, "_plugin_common")
+    common.ensure_launch_record(
+        "private-host",
+        "/repo",
+        dataset="project_repo_111111111111",
+        dataset_source="project",
+    )
+    path = common._session_map_path("private-host")
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    os.chmod(path, 0o644)
+    updated = common._read_map_record("private-host")
+    updated["touched"] = [updated["session_id"], "replacement"]
+    common._write_map_record("private-host", updated)
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
 def test_concurrent_legacy_pins_keep_the_first_dataset(suite, isolated_modules, monkeypatch):
     common = isolated_modules(suite, "_plugin_common")
     common._write_map_record(
@@ -122,7 +304,7 @@ def test_concurrent_legacy_pins_keep_the_first_dataset(suite, isolated_modules, 
                 pass
             with write_order_lock:
                 write_order.append(record["dataset"])
-        write_record(host_key, record)
+        return write_record(host_key, record)
 
     monkeypatch.setattr(common, "_write_map_record", synchronized_write)
 

--- a/integrations/tests/tests/unit/test_project_dataset_session_state.py
+++ b/integrations/tests/tests/unit/test_project_dataset_session_state.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import concurrent.futures
+import threading
+
 
 def test_launch_record_pins_dataset_and_source(suite, isolated_modules, monkeypatch):
     common = isolated_modules(suite, "_plugin_common")
@@ -30,6 +33,61 @@ def test_later_resolution_cannot_switch_pinned_dataset(suite, isolated_modules):
         "host-one", "/repo-b", dataset="project_b_222222222222", dataset_source="project"
     )
     assert common.get_launch_dataset("host-one") == ("project_a_111111111111", "project")
+
+
+def test_new_dataset_record_persists_session_and_connection_ids(suite, isolated_modules):
+    common = isolated_modules(suite, "_plugin_common")
+    session_id, conn_uuid = common.ensure_launch_record(
+        "host-one",
+        "/repo",
+        dataset="project_repo_111111111111",
+        dataset_source="project",
+    )
+    record = common._read_map_record("host-one")
+    assert record["session_id"] == session_id
+    assert record["conn_uuid"] == conn_uuid
+    assert record["session_id"]
+    assert record["conn_uuid"]
+
+
+def test_concurrent_legacy_pins_keep_the_first_dataset(suite, isolated_modules, monkeypatch):
+    common = isolated_modules(suite, "_plugin_common")
+    common._write_map_record(
+        "host-one",
+        {
+            "session_id": "legacy-session",
+            "conn_uuid": "conn_legacy",
+            "host_key": "host-one",
+        },
+    )
+    concurrent_writes = threading.Barrier(2)
+    write_order = []
+    write_order_lock = threading.Lock()
+    write_record = common._write_map_record
+
+    def synchronized_write(host_key, record):
+        if record.get("dataset"):
+            try:
+                concurrent_writes.wait(timeout=0.2)
+            except threading.BrokenBarrierError:
+                pass
+            with write_order_lock:
+                write_order.append(record["dataset"])
+        write_record(host_key, record)
+
+    monkeypatch.setattr(common, "_write_map_record", synchronized_write)
+
+    def pin(dataset):
+        common.ensure_launch_record("host-one", "/repo", dataset=dataset, dataset_source="project")
+        return common.get_launch_dataset("host-one")[0]
+
+    datasets = ("project_a_111111111111", "project_b_222222222222")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        observed = list(executor.map(pin, datasets))
+
+    assert common.get_launch_dataset("host-one")[0] == write_order[0]
+    assert len(set(observed)) == 1
+    assert common.get_launch_dataset("host-one")[0] == observed[0]
 
 
 def test_conversations_keep_distinct_sessions_in_one_dataset(suite, isolated_modules):

--- a/integrations/tests/tests/unit/test_project_dataset_session_state.py
+++ b/integrations/tests/tests/unit/test_project_dataset_session_state.py
@@ -1,0 +1,58 @@
+"""Behavioral coverage for launch-record dataset pinning."""
+
+from __future__ import annotations
+
+
+def test_launch_record_pins_dataset_and_source(suite, isolated_modules, monkeypatch):
+    common = isolated_modules(suite, "_plugin_common")
+    monkeypatch.setattr(
+        common,
+        "_json_http_request",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("offline test")),
+    )
+    common.ensure_launch_record(
+        "host-one",
+        "/repo",
+        dataset="project_repo_111111111111",
+        dataset_source="project",
+    )
+    resolved = common.load_resolved("host-one")
+    assert resolved["dataset"] == "project_repo_111111111111"
+    assert resolved["dataset_source"] == "project"
+
+
+def test_later_resolution_cannot_switch_pinned_dataset(suite, isolated_modules):
+    common = isolated_modules(suite, "_plugin_common")
+    common.ensure_launch_record(
+        "host-one", "/repo-a", dataset="project_a_111111111111", dataset_source="project"
+    )
+    common.ensure_launch_record(
+        "host-one", "/repo-b", dataset="project_b_222222222222", dataset_source="project"
+    )
+    assert common.get_launch_dataset("host-one") == ("project_a_111111111111", "project")
+
+
+def test_conversations_keep_distinct_sessions_in_one_dataset(suite, isolated_modules):
+    common = isolated_modules(suite, "_plugin_common")
+    dataset = "project_repo_111111111111"
+    first = common.ensure_launch_record("host-one", "/repo", dataset=dataset, dataset_source="project")
+    second = common.ensure_launch_record("host-two", "/repo", dataset=dataset, dataset_source="project")
+    assert first[0] != second[0]
+    assert common.get_launch_dataset("host-one")[0] == common.get_launch_dataset("host-two")[0]
+
+
+def test_exit_worker_receives_pinned_dataset(suite, hook_module, monkeypatch):
+    watcher = hook_module(suite, "exit-watcher.py")
+    captured = {}
+
+    class FakeProcess:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(watcher.subprocess, "Popen", FakeProcess)
+    watcher._spawn_sync(
+        "session-one",
+        "project_repo_111111111111",
+        session_key="host-one",
+    )
+    assert captured["env"]["COGNEE_SYNC_DATASET"] == "project_repo_111111111111"

--- a/integrations/tests/tests/unit/test_project_dataset_session_state.py
+++ b/integrations/tests/tests/unit/test_project_dataset_session_state.py
@@ -142,8 +142,12 @@ def test_concurrent_legacy_pins_keep_the_first_dataset(suite, isolated_modules, 
 def test_conversations_keep_distinct_sessions_in_one_dataset(suite, isolated_modules):
     common = isolated_modules(suite, "_plugin_common")
     dataset = "project_repo_111111111111"
-    first = common.ensure_launch_record("host-one", "/repo", dataset=dataset, dataset_source="project")
-    second = common.ensure_launch_record("host-two", "/repo", dataset=dataset, dataset_source="project")
+    first = common.ensure_launch_record(
+        "host-one", "/repo", dataset=dataset, dataset_source="project"
+    )
+    second = common.ensure_launch_record(
+        "host-two", "/repo", dataset=dataset, dataset_source="project"
+    )
     assert first[0] != second[0]
     assert common.get_launch_dataset("host-one")[0] == common.get_launch_dataset("host-two")[0]
 

--- a/integrations/tests/tests/unit/test_timing_metrics.py
+++ b/integrations/tests/tests/unit/test_timing_metrics.py
@@ -89,8 +89,9 @@ def run_bridge(pc, suite, tmp_path, monkeypatch):
         monkeypatch.setattr(
             pc,
             "_post_remember_document",
-            lambda *a, **k: post_result
-            or {"ok": True, "dataset_id": "d1", "pipeline_run_id": "p1"},
+            lambda *a, **k: (
+                post_result or {"ok": True, "dataset_id": "d1", "pipeline_run_id": "p1"}
+            ),
         )
         monkeypatch.setattr(pc, "wait_for_cognify", lambda *a, **k: outcome)
         monkeypatch.setattr(

--- a/integrations/tests/tests/unit/test_user_prompt_envelope.py
+++ b/integrations/tests/tests/unit/test_user_prompt_envelope.py
@@ -25,7 +25,7 @@ import pytest
 def lookup(suite, hook_module, monkeypatch):
     """session-context-lookup.py with every resolution seam stubbed."""
     module = hook_module(suite, "session-context-lookup.py")
-    monkeypatch.setattr(module, "load_config", lambda: {})
+    monkeypatch.setattr(module, "load_config", lambda *a, **k: {})
     monkeypatch.setattr(module, "resolve_runtime_mode", lambda: {"mode": "http", "base_url": ""})
     monkeypatch.setattr(module, "server_ready_hint", lambda _url: True)
     monkeypatch.setattr(module, "get_session_key", lambda: "session")

--- a/integrations/tests/utils/isolation.py
+++ b/integrations/tests/utils/isolation.py
@@ -32,6 +32,7 @@ from .suites import Suite
 ISOLATED_MODULES = (
     "config",
     "_plugin_common",
+    "_project_dataset",
     "_cognee_client",
     "_env_file",
     "_proc",

--- a/integrations/tests/utils/recall.py
+++ b/integrations/tests/utils/recall.py
@@ -105,7 +105,7 @@ def drive_recall(
     seams = {
         "hook_log": lambda event, detail=None: run.events.append((event, detail or {})),
         "notify": lambda *a, **k: None,
-        "load_config": lambda: {},
+        "load_config": lambda *a, **k: {},
         "resolve_runtime_mode": lambda: {"mode": "http", "base_url": URL},
         "read_connection_state": lambda: dict(prior_state or {}),
         "server_ready_hint": lambda url: ready_hint,
@@ -116,7 +116,7 @@ def drive_recall(
         "clear_slow_streak": lambda url: None,
         "record_slow_probe": lambda url: slow_streak,
         "slow_streak_threshold": lambda: slow_threshold,
-        "_load_session_id": lambda: "sid",
+        "_load_session": lambda workspace="": ("sid", "agent_sessions"),
         "read_and_reset_save_counter": lambda sid: {"prompt": 0, "trace": 0, "answer": 0},
         "recall_via_http": _recall,
     }


### PR DESCRIPTION
## Summary

- Add opt-in per-project dataset isolation for the Claude Code and Codex integrations with stable `project_<slug>_<hash12>` names derived from normalized Git/workspace identity.
- Preserve dataset precedence as: non-empty `COGNEE_PLUGIN_DATASET` environment selection, then the #285 picker integration point when present, then project derivation when `COGNEE_DATASET_SCOPE=project`, then the existing `agent_sessions` default.
- Resolve once while the host workspace is known and pin the winning dataset/source in the host-keyed launch record. Prompt, tool, answer, recall, compact, bridge, improve, watcher, and final-sync paths consume that pinned value instead of re-deriving mid-session.
- Surface the effective dataset/source through status and doctor while keeping status rendering network-free.

## Safety

- Project isolation is opt-in. An absent, empty, or unknown `COGNEE_DATASET_SCOPE` preserves existing behavior, and a non-empty explicit dataset continues to win.
- Fresh/empty starts are safe: an empty explicit dataset is treated as absent, and failure to derive any valid project identity falls back to `agent_sessions`.
- Conversations continue to receive distinct session IDs by default; this change does not globally set or pin `COGNEE_SESSION_ID`.
- Existing `agent_sessions` data is not migrated, merged, copied, rewritten, or deleted. No automatic migration or deletion occurs.

## Verification

Fresh independent controller verification at `da82066cbe922b68a9dc0172e19bef16bf8f65f9`:

```text
Ruff 0.16.0 format: 358 files already formatted
Ruff 0.16.0 lint: All checks passed!
Focused suite: 110 passed, 1 skipped in 15.13s
Full hermetic suite: 1085 passed, 72 skipped, 36 deselected in 54.96s
```

Integrity evidence:

- `git diff --check origin/main...HEAD` passed.
- `python3 scripts/check_version_pins.py` passed: 15 Python integrations checked; 8 non-Python integrations skipped; all Python dependencies properly bounded.
- Claude Code, Codex, and marketplace JSON manifests parsed successfully.
- Claude Code and Codex `_project_dataset.py` resolver copies are byte-identical (`cmp -s`).
- The verified worktree was clean at the reviewed head.

## Integration parity

- #354 is OPEN and unmerged: https://github.com/topoteretes/cognee-integrations/pull/354 (`feat/qwen-cognee-351`).
- #355 is OPEN and unmerged: https://github.com/topoteretes/cognee-integrations/pull/355 (`feat/antigravity-cognee-352`).
- Local Qwen/Antigravity parity follows in Task 9 and is intentionally not bundled here while those upstream PRs remain open.

Closes #356
