### PR TITLE
feat: enable codegraph pipeline in claude and codex

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "author": {
         "name": "Cognee"
       },

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ dify-plugin
 
 # Jest/vitest coverage output (integrations/*/coverage)
 coverage/
+
+# enola code-graph snapshots (written into an indexed repo by the cognee code pipeline)
+.enola/

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "author": {
     "name": "Cognee"
   },

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,6 +10,51 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.4.0]
+
+### Added
+- **Code graph.** Repositories can be indexed into cognee's deterministic,
+  enola-backed code graph (symbols, calls, imports, endpoints, dependencies)
+  and queried from the plugin — with **no LLM or embedding calls** on either
+  side. Requires a cognee server >= 1.5.3.
+  - **Automatic indexing**: opening a session inside a git repository indexes
+    it in the background at session start (never blocking the first prompt)
+    and refreshes an already-indexed repo whose tree changed. New repos are
+    auto-indexed only against a *local* server, where the code stays on the
+    machine; a remote server needs `COGNEE_CODE_AUTOINDEX=always` or an explicit
+    index. Non-git directories, repos with no source files, and repos over 3000
+    source files are skipped (explicit indexing has no cap).
+  - **Freshness**: the Stop hook re-submits an indexed repo when a turn changed
+    its working tree, detected by a git fingerprint (HEAD, dirty set, tracked
+    diff, untracked stats). Failures keep the fingerprint — the edits stay
+    pending — behind an escalating backoff (30s → 15min cap) so an unresolved
+    failure cannot re-submit once per turn forever; a new session always gets
+    one attempt.
+  - **Auto-recall code lane**: prompts naming an identifier-shaped token
+    (`process_payment`, `UserService`, `billing/api.py`) inside an indexed repo
+    get code facts injected under `=== Code graph facts ===`. The lane is
+    additive to the semantic scopes, gated syntactically, and contributes
+    nothing when it misses — conversational prompts are unchanged.
+  - **Explicit tools**: `cognee-index-repo.sh <path-or-git-url>`,
+    `cognee-search.sh "<seed>" --code [--code-query '<json>']` (operations:
+    `query_facts`, `explore`, `traverse`, `find_path`, `impact_analysis`,
+    `delta`), `cognee-remember.sh --file <path>` (uploads under the real
+    filename so code routes as code, not prose), and a new `cognee-code` skill.
+- One dataset per indexed repository, `codebase-<repo>-<digest>`. The path
+  digest is load-bearing: same-basename checkouts sharing a dataset would share
+  a graph database, where cognee's repo-scoped stale-node sweep would let each
+  re-index delete the other's nodes. `--code` searches resolve the dataset from
+  the current checkout.
+
+### Changed
+- **Pinned cognee version is now `1.5.3`** (was `1.5.0`) — the release that
+  opened `content_type="code"` on `/api/v1/remember` and the `code` recall
+  scope. Installed into the managed venv on next session start.
+- The freshness model is documented as a property of where the server runs:
+  a local server reflects the working tree (uncommitted changes included); a
+  cloud server reflects the last *pushed* commit, since its clone cannot see
+  local edits.
+
 ## [1.3.3]
 
 ### Fixed

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -215,6 +215,7 @@ Final sync on session end is triggered by the `SessionEnd` detached worker, with
 - `/cognee-memory:cognee-remember`
 - `/cognee-memory:cognee-search`
 - `/cognee-memory:cognee-sync`
+- `/cognee-memory:cognee-code`
 
 ## Remember (write) behavior
 
@@ -263,6 +264,11 @@ database, and two checkouts sharing a basename (`~/work/a/service`,
 `~/work/b/service`) landing in one database would let each re-index's
 stale-node sweep delete the other's nodes. `--code` searches resolve the
 dataset from the current checkout, so the generated name rarely needs typing.
+
+Indexing writes enola's snapshot into the indexed repository itself, at
+`<repo>/.enola/` (untracked). Add `.enola/` to the repository's `.gitignore` or
+your global excludes; the plugin's change detection already ignores it, so the
+indexer's own output never triggers a re-index.
 
 ### What the graph reflects: working tree vs. pushed commits
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -234,6 +234,66 @@ A write that *times out* is reported as "submitted; timed out waiting for confir
 and does **not** fall back to `cognee-cli` (the write likely landed — a fallback would
 risk a duplicate). Only a genuine connection failure falls back.
 
+## Code graph
+
+Repositories can be indexed into a deterministic **code graph** (symbols, calls,
+imports, endpoints, dependencies) via cognee's enola-backed pipeline. Indexing makes
+**no LLM or embedding calls** — it is fast and costs no tokens. Requires a cognee
+server >= 1.5.3.
+
+Opening the agent inside a git repository indexes it automatically at session start
+(background, never blocking the first prompt), and re-indexes it after any turn that
+changed the working tree. Index one explicitly — a different repo, a git URL, or one
+automation declined — with:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-index-repo.sh <repo-path-or-git-url> [--dataset <name>] [--index-vectors] [--wait <seconds>]
+```
+
+Query it with `cognee-search.sh ... --code` (see the `cognee-code` skill for the
+operations: `query_facts`, `explore`, `traverse`, `find_path`, `impact_analysis`,
+`delta`). Prompts that mention an identifier-shaped token inside an indexed repo also
+get code facts injected automatically by the per-prompt recall hook.
+
+Each indexed repository gets its own dataset, named
+`codebase-<repo-name>-<digest>` where the digest identifies the indexed path.
+Narrow datasets keep code searches fast, and the digest matters for
+correctness: with cognee's default backend every dataset is a separate graph
+database, and two checkouts sharing a basename (`~/work/a/service`,
+`~/work/b/service`) landing in one database would let each re-index's
+stale-node sweep delete the other's nodes. `--code` searches resolve the
+dataset from the current checkout, so the generated name rarely needs typing.
+
+### What the graph reflects: working tree vs. pushed commits
+
+**The freshness model differs by where the server runs.** This is a property of the
+architecture, not a limitation to work around — but it is worth knowing which one you
+are using, because the output looks identical either way.
+
+| Server | Indexed from | Graph reflects | Updated by |
+|---|---|---|---|
+| **Local** (default) | The repository path on this machine | Your working tree, **including uncommitted and untracked changes** | Every turn that changes a file |
+| **Cloud / remote** | A git URL the server clones | The **last pushed commit** on the cloned branch | Pushing, then re-indexing |
+
+A remote server cannot read your disk. It only ever sees code you have pushed, so a
+local edit — however recent — is invisible to it until it lands on the remote. The
+plugin therefore does not re-submit URL-indexed repositories after local edits: doing
+so would re-pull the same commits and change nothing.
+
+The practical consequence on cloud: if you refactor locally and ask about the old
+symbol, the graph answers from the pushed state and the answer *looks* authoritative.
+**Push before relying on code answers about work in progress**, or use a local server
+for branches you are actively editing. `{"operation": "delta"}` reports what the last
+index actually changed, which is the quickest way to confirm what the graph currently
+knows.
+
+| Env var | Default | Effect |
+|---|---|---|
+| `COGNEE_CODE_AUTOINDEX` | `auto` | `auto`: auto-index new repositories only when the server is local (code never leaves the machine) · `always`: also auto-index against a remote server · `off`: never auto-index new repositories (explicitly indexed ones still refresh) |
+
+Automatic indexing skips directories that are not git repositories, hold no source
+files, or exceed 3000 source files. Explicit indexing has no size cap.
+
 ## Status line
 
 The status line displays `cognee: <dataset> · <mode>`, for example:

--- a/integrations/claude-code/scripts/_code_graph.py
+++ b/integrations/claude-code/scripts/_code_graph.py
@@ -23,7 +23,10 @@ Four responsibilities, all shared by the wrapper CLI and the hooks:
    the repo is re-submitted in the background. The fingerprint is only a
    cheap client-side gate — the server re-hashes every covered file anyway
    (manifest content hash + enola snapshot identity), so a false positive
-   costs one skipped submission, never a wasted re-parse.
+   costs one skipped submission, never a wasted re-parse. A failed submission
+   leaves the fingerprint untouched so the edits stay pending, and an
+   escalating time backoff (``retry_backoff_seconds``) keeps an unresolved
+   failure from re-submitting once per turn forever.
 
 3. **Recall gating** (``auto_code_lane``): the per-prompt recall hook adds a
    ``code`` scope lane ONLY when (a) the prompt contains an
@@ -506,10 +509,21 @@ def do_index_repo(
         )
         return UNREACHABLE
 
+    # A 2xx the caller cannot parse is NOT reported as success, unlike the
+    # fire-and-forget remember path. Callers here treat "ok" as confirmation
+    # and advance the repo's stored fingerprint on it — so an unparseable body
+    # would mark this turn's edits as indexed, and the next turn would see an
+    # unchanged tree and never retry, leaving the graph silently stale. The
+    # opposite mistake is cheap: keeping the old fingerprint costs one
+    # re-submission, which the server's content hash skips if the write did
+    # land.
     try:
         data = json.loads(raw or "{}")
-    except (json.JSONDecodeError, ValueError):
-        return {"ok": True}
+    except (json.JSONDecodeError, ValueError) as e:
+        sys.stderr.write(
+            "[cognee-code-graph] malformed JSON from /api/v1/remember: %s\n" % str(e)[:160]
+        )
+        return _error(200, "malformed JSON response from /api/v1/remember")
     if isinstance(data, dict) and data.get("error"):
         msg = str(data.get("error"))[:200]
         sys.stderr.write("[cognee-code-graph] server returned error: %s\n" % msg)
@@ -640,6 +654,66 @@ def index_repo(
     return result
 
 
+# Escalating retry backoff for a repo whose re-index keeps failing.
+# A failed submission deliberately leaves the fingerprint alone so the edits
+# stay pending — but the tree then differs from the stored fingerprint on EVERY
+# later turn, conversation-only turns included, so an unresolved failure (a bad
+# API key, a server too old for content_type='code') would otherwise re-submit
+# once per turn forever and append a line to a hook log that never rotates.
+#
+# Time, not error class, is the gate. The failures worth calling "permanent"
+# here — 401, 403, a 400 from an old server — are all fixable by the user
+# mid-session, and fixing them is exactly when a prompt retry should catch the
+# graph up. Suppressing retries by error class (or, worse, advancing the
+# fingerprint to stop them) would trade a noisy failure for a silently stale
+# graph. The cap bounds recovery lag instead.
+_RETRY_BACKOFF_BASE_SECONDS = 30.0
+_RETRY_BACKOFF_MAX_SECONDS = 900.0
+
+
+def retry_backoff_seconds(error_count: int) -> float:
+    """Seconds to wait after ``error_count`` consecutive failures."""
+    if error_count <= 0:
+        return 0.0
+    return min(
+        _RETRY_BACKOFF_BASE_SECONDS * (2 ** (error_count - 1)),
+        _RETRY_BACKOFF_MAX_SECONDS,
+    )
+
+
+def _retry_suppressed(state: dict, now: float) -> bool:
+    """Whether a failing repo is still inside its backoff window."""
+    try:
+        error_count = int(state.get("error_count") or 0)
+        last_error_at = float(state.get("last_error_at") or 0.0)
+    except (TypeError, ValueError):
+        return False
+    if error_count <= 0 or last_error_at <= 0:
+        return False
+    # A clock that moved backwards (system time change) must not park a repo
+    # in backoff indefinitely — treat it as due.
+    if now < last_error_at:
+        return False
+    return (now - last_error_at) < retry_backoff_seconds(error_count)
+
+
+def _record_retry_failure(state: dict, error: str, now: float) -> None:
+    """Advance the backoff counters. Never touches ``fingerprint``."""
+    try:
+        state["error_count"] = int(state.get("error_count") or 0) + 1
+    except (TypeError, ValueError):
+        state["error_count"] = 1
+    state["last_error_at"] = now
+    state["last_error"] = str(error)[:200]
+    save_repo_state(state)
+
+
+def _clear_retry_failure(state: dict) -> None:
+    """Forget a past failure once an index succeeds."""
+    for field in ("error_count", "last_error_at", "last_error"):
+        state.pop(field, None)
+
+
 def reingest_if_changed(cwd, service_url, api_key, *, opener=urllib.request.urlopen) -> dict:
     """Stop-hook freshness pass: re-submit the cwd's indexed repo if it changed.
 
@@ -663,6 +737,14 @@ def reingest_if_changed(cwd, service_url, api_key, *, opener=urllib.request.urlo
         if fingerprint == str(state.get("fingerprint") or ""):
             return {"changed": False, "repo_root": root}
 
+        # Still inside the backoff window after earlier failures: make no
+        # request and return the "nothing to do" shape, which the Stop hook
+        # does not log. The pending edits stay pending (the fingerprint is
+        # untouched) and the next attempt happens when the window expires.
+        now = time.time()
+        if _retry_suppressed(state, now):
+            return {}
+
         result = do_index_repo(
             service_url,
             api_key,
@@ -674,20 +756,24 @@ def reingest_if_changed(cwd, service_url, api_key, *, opener=urllib.request.urlo
         outcome = {"changed": True, "repo_root": root, "dataset": state.get("dataset")}
         if isinstance(result, dict) and result.get("ok"):
             state["fingerprint"] = fingerprint
-            state["last_index_at"] = time.time()
+            state["last_index_at"] = now
             state["last_status"] = str(result.get("status") or "submitted")
+            _clear_retry_failure(state)
             save_repo_state(state)
             outcome["submitted"] = True
             if result.get("pipeline_run_id"):
                 outcome["pipeline_run_id"] = result["pipeline_run_id"]
         else:
-            # Keep the OLD fingerprint on failure so the next turn retries.
+            # Keep the OLD fingerprint on failure so the edits stay pending and
+            # a later turn retries; only the backoff counters advance.
             outcome["submitted"] = False
             outcome["error"] = (
                 "unreachable"
                 if result == UNREACHABLE
                 else str(result.get("error") if isinstance(result, dict) else result)[:200]
             )
+            _record_retry_failure(state, outcome["error"], now)
+            outcome["retry_in"] = round(retry_backoff_seconds(state["error_count"]))
         return outcome
     except Exception as exc:  # never break the Stop hook
         return {"changed": None, "error": str(exc)[:200]}
@@ -771,7 +857,16 @@ def autoindex_on_session_start(
         if not root:
             return {}
 
-        if find_indexed_repo(root):
+        indexed = find_indexed_repo(root)
+        if indexed:
+            # A session start is the gesture a user makes after fixing what
+            # broke indexing (a corrected API key, a restarted/upgraded
+            # server), so it always gets one attempt rather than waiting out a
+            # backoff window earned by the previous session. Bounded by
+            # launches, not turns — which is what the per-turn backoff guards.
+            if indexed.get("error_count"):
+                _clear_retry_failure(indexed)
+                save_repo_state(indexed)
             outcome = reingest_if_changed(root, service_url, api_key, opener=opener)
             if outcome:
                 outcome["reason"] = "refresh"

--- a/integrations/claude-code/scripts/_code_graph.py
+++ b/integrations/claude-code/scripts/_code_graph.py
@@ -87,8 +87,8 @@ _STATE_DIR = Path.home() / ".cognee-plugin" / _INTEGRATION / "code-graph"
 _GIT_TIMEOUT_SECONDS = 10.0
 
 # Mirrors cognee's CodeLoader SUPPORTED_CODE_EXTENSIONS (v1.5.3) — the
-# extensions the per-file CODE route claims. Used for the --file remember
-# path's hinting and the identifier extractor's filename pattern.
+# extensions the per-file CODE route claims. Used by the identifier
+# extractor's filename pattern and the auto-index source-file count.
 CODE_EXTENSIONS = frozenset(
     {
         "c",
@@ -252,29 +252,48 @@ def git_repo_root(cwd: str) -> str:
     return os.path.realpath(out) if out else ""
 
 
+# enola writes its snapshot INTO the indexed repository (<repo>/.enola/) and
+# rotates files there on every run. Left visible to the fingerprint, the
+# indexer's own output would change the fingerprint after every index, so the
+# next turn would see a "changed" tree and re-index — a full enola parse per
+# turn, forever, for every locally indexed repo (verified: two enola runs with
+# no source edit produce two different fingerprints). Excluded at the git level
+# so neither the dirty-path set nor the untracked stats can see it.
+_ENOLA_SNAPSHOT_DIR = ".enola"
+_FINGERPRINT_PATHSPEC = ["--", ".", f":(exclude){_ENOLA_SNAPSHOT_DIR}"]
+
+
 def git_fingerprint(root: str) -> str:
     """A cheap content fingerprint of the working tree.
 
     Covers HEAD, the dirty-path set, tracked content changes (``git diff
     HEAD``), and untracked files by (path, size, mtime) — porcelain alone
-    would miss a re-edit of an already-dirty file. Returns "" when the root
-    is not a usable git repo; callers treat "" as "cannot fingerprint" and
-    skip the freshness gate (the server-side hashes still dedupe).
+    would miss a re-edit of an already-dirty file. The enola snapshot dir the
+    indexer itself writes is excluded (see ``_FINGERPRINT_PATHSPEC``). Returns
+    "" when the root is not a usable git repo; callers treat "" as "cannot
+    fingerprint" and skip the freshness gate (the server-side hashes still
+    dedupe).
     """
     if not root:
         return ""
     head = _run_git(["rev-parse", "HEAD"], root).strip()
     if not head:
         return ""
-    porcelain = _run_git(["status", "--porcelain"], root)
+    porcelain = _run_git(["status", "--porcelain", *_FINGERPRINT_PATHSPEC], root)
     digest = hashlib.sha256()
     digest.update(head.encode("utf-8"))
     digest.update(porcelain.encode("utf-8"))
-    digest.update(_run_git(["diff", "HEAD"], root).encode("utf-8", errors="replace"))
+    digest.update(
+        _run_git(["diff", "HEAD", *_FINGERPRINT_PATHSPEC], root).encode("utf-8", errors="replace")
+    )
     for line in porcelain.splitlines():
         if not line.startswith("??"):
             continue
         rel = line[3:].strip().strip('"')
+        # Belt and braces: an older git that ignores the exclude pathspec must
+        # still never let the snapshot dir drive the fingerprint.
+        if rel.rstrip("/") == _ENOLA_SNAPSHOT_DIR or rel.startswith(_ENOLA_SNAPSHOT_DIR + "/"):
+            continue
         path = os.path.join(root, rel)
         try:
             stat = os.stat(path)

--- a/integrations/claude-code/scripts/_code_graph.py
+++ b/integrations/claude-code/scripts/_code_graph.py
@@ -1,0 +1,864 @@
+#!/usr/bin/env python3
+"""Code-graph (enola) pipeline helpers: repo indexing, freshness, recall gating.
+
+Standalone, stdlib-only, so it runs under the system ``python3`` without the
+plugin venv (the same constraint ``_remember_http.py`` / ``_recall_http.py``
+already work under). Requires a cognee server >= 1.5.3 (the release that
+opened ``content_type="code"`` on /api/v1/remember and the ``code`` recall
+scope).
+
+Four responsibilities, all shared by the wrapper CLI and the hooks:
+
+1. **Repo indexing** (``do_index_repo``): POST ``content_type="code"`` +
+   ``repositories`` to ``/api/v1/remember``. One code graph per repository
+   spec (a local path when the server shares this filesystem, or a git URL
+   the server clones). The transport contract mirrors ``_remember_http.py``:
+   ``{"ok": true, ...}`` on 2xx, an error envelope on HTTP errors (no CLI
+   fallback — there is no CLI equivalent for this route), and the
+   ``UNREACHABLE`` sentinel only when the server is positively absent.
+
+2. **Freshness** (``reingest_if_changed``): a per-repo state file records the
+   git fingerprint at the last successful index. The Stop hook calls this
+   with the turn's cwd; when the working tree changed since the last index,
+   the repo is re-submitted in the background. The fingerprint is only a
+   cheap client-side gate — the server re-hashes every covered file anyway
+   (manifest content hash + enola snapshot identity), so a false positive
+   costs one skipped submission, never a wasted re-parse.
+
+3. **Recall gating** (``auto_code_lane``): the per-prompt recall hook adds a
+   ``code`` scope lane ONLY when (a) the prompt contains an
+   identifier-shaped token and (b) the cwd sits inside a repo this plugin
+   has indexed. The lane is additive — it never replaces the semantic
+   scopes — and a seed the code graph cannot resolve contributes nothing
+   server-side, so misfires are cheap by design.
+
+4. **Session-start auto-indexing** (``autoindex_on_session_start``): opening
+   an agent in a repo should not require a setup step, so a new repo is
+   indexed and an already-indexed one refreshed. Indexing a repo nobody asked
+   about is gated (see ``autoindex_mode``); refreshing one that WAS asked for
+   is not.
+
+State lives under ``~/.cognee-plugin/<integration>/code-graph/<slug>.json``.
+A repo has a state file once it has been indexed — explicitly via the wrapper
+or skill, or automatically at session start — and only repos with a state file
+are ever refreshed or queried by the recall lane.
+
+**Freshness ceiling.** What a code graph can possibly reflect is set by how the
+server reads the repo, and the two cases differ permanently:
+
+* ``spec_kind == "path"`` — the server shares this filesystem and reads the
+  working tree in place, so the graph covers uncommitted and untracked changes
+  and the per-turn refresh keeps it current.
+* ``spec_kind == "url"`` — the server clones the repo and can only ever see
+  PUSHED commits. A local edit cannot reach it, so the freshness paths here
+  deliberately skip URL-indexed repos rather than re-submitting: a re-pull
+  would fetch the same commits and rewrite the same graph. Such a graph
+  advances only when the user pushes and the repo is indexed again.
+
+This is normal behavior, not a gap to close client-side — but the two produce
+identical-looking results, which is why the skills tell the agent to say which
+one it is answering from when the work is in progress.
+"""
+
+import hashlib
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+
+# The one line that differs between the claude-code and codex copies.
+_INTEGRATION = "claude-code"
+
+UNREACHABLE = "UNREACHABLE"
+
+_STATE_DIR = Path.home() / ".cognee-plugin" / _INTEGRATION / "code-graph"
+
+_GIT_TIMEOUT_SECONDS = 10.0
+
+# Mirrors cognee's CodeLoader SUPPORTED_CODE_EXTENSIONS (v1.5.3) — the
+# extensions the per-file CODE route claims. Used for the --file remember
+# path's hinting and the identifier extractor's filename pattern.
+CODE_EXTENSIONS = frozenset(
+    {
+        "c",
+        "cc",
+        "cpp",
+        "cs",
+        "cxx",
+        "dart",
+        "fs",
+        "go",
+        "h",
+        "hcl",
+        "hh",
+        "hpp",
+        "java",
+        "js",
+        "jsx",
+        "kt",
+        "kts",
+        "php",
+        "proto",
+        "py",
+        "rake",
+        "rb",
+        "rs",
+        "scala",
+        "svelte",
+        "swift",
+        "tf",
+        "ts",
+        "tsx",
+        "vb",
+        "vue",
+    }
+)
+
+# CamelCase words that are common prose, product names, or agent vocabulary —
+# not symbols worth seeding a code-graph query with. Misfires are cheap
+# (seed-not-found returns an empty lane), so this list stays small and only
+# covers the words that would fire on nearly every prompt in this ecosystem.
+_CAMEL_STOPLIST = frozenset(
+    {
+        "Claude",
+        "ClaudeCode",
+        "Codex",
+        "Cognee",
+        "GitHub",
+        "GitLab",
+        "JavaScript",
+        "TypeScript",
+        "PostgreSQL",
+        "MongoDB",
+        "OpenAI",
+        "MacOS",
+        "ReadMe",
+        "WiFi",
+        "OAuth",
+        "TODOs",
+    }
+)
+
+# Ordered by confidence: backticked wins, then file paths, dotted paths,
+# snake_case, CamelCase. Each pattern is deliberately conservative — the gate
+# exists to keep the code lane OFF conversational prompts, not to catch every
+# possible symbol.
+_BACKTICK_RE = re.compile(r"`([^`\n]{2,120})`")
+_FILEPATH_RE = re.compile(r"\b[\w./-]{1,120}\.(?:%s)\b" % "|".join(sorted(CODE_EXTENSIONS)))
+_DOTTED_RE = re.compile(r"\b[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+\b")
+_SNAKE_RE = re.compile(r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b")
+_CAMEL_RE = re.compile(r"\b[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]*)+\b")
+
+_IDENTIFIER_CHARS_RE = re.compile(r"^[\w./:-]+$")
+
+
+def extract_identifiers(prompt: str, limit: int = 2) -> list:
+    """Identifier-shaped tokens from a prompt, best first, at most ``limit``.
+
+    An empty list means the syntactic gate did not fire and the code lane
+    should be skipped for this prompt.
+    """
+    if not prompt:
+        return []
+    found: list = []
+    seen = set()
+
+    def _add(token: str) -> None:
+        token = token.strip().strip(".,:;()[]{}")
+        if len(token) < 3 or len(token) > 120:
+            return
+        if token in _CAMEL_STOPLIST:
+            return
+        key = token.casefold()
+        if key in seen:
+            return
+        seen.add(key)
+        found.append(token)
+
+    for match in _BACKTICK_RE.finditer(prompt):
+        inner = match.group(1).strip()
+        # Backticks quote commands and prose too; only take single
+        # identifier-shaped tokens (no spaces, identifier charset).
+        if " " not in inner and _IDENTIFIER_CHARS_RE.match(inner):
+            _add(inner)
+    for pattern in (_FILEPATH_RE, _DOTTED_RE, _SNAKE_RE, _CAMEL_RE):
+        for match in pattern.finditer(prompt):
+            token = match.group(0)
+            if pattern is _DOTTED_RE:
+                # Drop prose artifacts like "e.g" / "i.e": require some meat.
+                parts = token.split(".")
+                if len(token) < 5 or not any(len(p) >= 3 for p in parts):
+                    continue
+                # Version-ish or domain-ish tokens ("v1.5.3", "example.com")
+                # are not symbols; require an underscore-free camel or a
+                # known code extension to be safe? Keep it simple: skip pure
+                # lowercase two-part tokens that end in a TLD-looking part.
+                if len(parts) == 2 and parts[1].lower() in ("com", "org", "net", "io", "ai", "dev"):
+                    continue
+            _add(token)
+
+    return found[:limit]
+
+
+def build_code_query(identifier: str, limit: int = 5) -> dict:
+    """The auto-recall code_query: a bounded substring fact lookup.
+
+    query_facts (not explore) on purpose: explore needs a resolvable seed and
+    errors on ambiguity, while query_facts degrades to an empty page — the
+    right failure mode for a lane that must never disturb the prompt path.
+    """
+    return {"operation": "query_facts", "name": identifier, "limit": limit}
+
+
+# ---------------------------------------------------------------------------
+# Git fingerprint + per-repo state
+# ---------------------------------------------------------------------------
+
+
+def _run_git(args, cwd: str) -> str:
+    """Run git and return stdout, or "" on any failure (missing git included)."""
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            text=True,
+            errors="replace",
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout
+
+
+def git_repo_root(cwd: str) -> str:
+    """The repo root containing ``cwd``, or "" when not inside a git repo."""
+    if not cwd or not os.path.isdir(cwd):
+        return ""
+    out = _run_git(["rev-parse", "--show-toplevel"], cwd).strip()
+    return os.path.realpath(out) if out else ""
+
+
+def git_fingerprint(root: str) -> str:
+    """A cheap content fingerprint of the working tree.
+
+    Covers HEAD, the dirty-path set, tracked content changes (``git diff
+    HEAD``), and untracked files by (path, size, mtime) — porcelain alone
+    would miss a re-edit of an already-dirty file. Returns "" when the root
+    is not a usable git repo; callers treat "" as "cannot fingerprint" and
+    skip the freshness gate (the server-side hashes still dedupe).
+    """
+    if not root:
+        return ""
+    head = _run_git(["rev-parse", "HEAD"], root).strip()
+    if not head:
+        return ""
+    porcelain = _run_git(["status", "--porcelain"], root)
+    digest = hashlib.sha256()
+    digest.update(head.encode("utf-8"))
+    digest.update(porcelain.encode("utf-8"))
+    digest.update(_run_git(["diff", "HEAD"], root).encode("utf-8", errors="replace"))
+    for line in porcelain.splitlines():
+        if not line.startswith("??"):
+            continue
+        rel = line[3:].strip().strip('"')
+        path = os.path.join(root, rel)
+        try:
+            stat = os.stat(path)
+            digest.update(f"{rel}:{stat.st_size}:{stat.st_mtime_ns}".encode("utf-8"))
+        except OSError:
+            digest.update(f"{rel}:gone".encode("utf-8"))
+    return digest.hexdigest()
+
+
+def canonical_spec(spec: str) -> str:
+    """The stable identity of an indexed repository.
+
+    Local paths resolve through symlinks so the same checkout reached by two
+    routes is one repository; remote URLs drop a trailing slash and the ``.git``
+    suffix so ``…/repo`` and ``…/repo.git`` do not index twice.
+    """
+    spec = str(spec).strip()
+    if is_remote_repo(spec):
+        canonical = spec.rstrip("/")
+        if canonical.endswith(".git"):
+            canonical = canonical[: -len(".git")]
+        return canonical
+    return os.path.realpath(spec)
+
+
+def _readable_tail(canonical: str) -> str:
+    tail = os.path.basename(canonical.rstrip("/")) or "repo"
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", tail).strip("-.") or "repo"
+
+
+def _repo_slug(root_or_spec: str) -> str:
+    canonical = canonical_spec(root_or_spec)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:12]
+    return f"{_readable_tail(canonical)}-{digest}"
+
+
+def default_code_dataset(spec: str) -> str:
+    """A stable, readable, collision-free per-repo dataset name.
+
+    Narrow datasets keep the CODE snapshot cache and the delta pre-read small,
+    so one dataset per indexed repository is the default. The basename alone
+    cannot be that identity: checkouts routinely share one (``~/work/a/service``
+    and ``~/work/b/service``), and two repos landing in one dataset share a
+    graph database — where cognee's stale-node sweep, scoped by repo name,
+    would let each ingestion delete the other's nodes. The path digest makes
+    the name unique per checkout while the readable tail keeps it recognizable
+    in a dataset listing.
+    """
+    canonical = canonical_spec(spec)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:8]
+    return f"codebase-{_readable_tail(canonical).lower()}-{digest}"
+
+
+def is_remote_repo(spec: str) -> bool:
+    return isinstance(spec, str) and spec.startswith(("https://", "http://", "git@", "ssh://"))
+
+
+def _state_path(key: str) -> Path:
+    return _STATE_DIR / f"{_repo_slug(key)}.json"
+
+
+def save_repo_state(state: dict) -> None:
+    """Persist one repo's index state. ``state`` must carry ``spec``."""
+    key = state.get("repo_root") or state.get("spec") or ""
+    if not key:
+        return
+    _STATE_DIR.mkdir(parents=True, exist_ok=True)
+    _state_path(key).write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
+
+
+def load_repo_states() -> list:
+    """All recorded repo states (invalid files are skipped, never raised)."""
+    states = []
+    try:
+        entries = sorted(_STATE_DIR.glob("*.json"))
+    except OSError:
+        return states
+    for path in entries:
+        try:
+            state = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if isinstance(state, dict):
+            states.append(state)
+    return states
+
+
+def find_indexed_repo(cwd: str) -> dict:
+    """The index state whose repo_root contains ``cwd``, or {}.
+
+    Only locally-indexed repos (spec = path) are matched by cwd; a repo
+    indexed by URL has no local root to match. Longest matching root wins so
+    nested checkouts resolve to the innermost indexed repo.
+    """
+    real = os.path.realpath(cwd) if cwd else ""
+    if not real:
+        return {}
+    best: dict = {}
+    for state in load_repo_states():
+        root = str(state.get("repo_root") or "")
+        if not root:
+            continue
+        if real == root or real.startswith(root.rstrip(os.sep) + os.sep):
+            if len(root) > len(str(best.get("repo_root") or "")):
+                best = state
+    return best
+
+
+def auto_code_lane(prompt: str, cwd: str) -> dict:
+    """The per-prompt recall gate. Returns {} when the lane must not fire.
+
+    Fires only when the prompt carries an identifier-shaped token AND the
+    cwd sits inside a repo this plugin indexed — never on conversational
+    prompts, never on repos nobody asked to index.
+    """
+    identifiers = extract_identifiers(prompt)
+    if not identifiers:
+        return {}
+    state = find_indexed_repo(cwd)
+    if not state or not state.get("dataset"):
+        return {}
+    return {
+        "dataset": str(state["dataset"]),
+        "identifier": identifiers[0],
+        "code_query": build_code_query(identifiers[0]),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Transport: index / re-ingest via /api/v1/remember (content_type="code")
+# ---------------------------------------------------------------------------
+
+
+def _multipart_body(fields):
+    """Multipart encoder over (name, value) pairs — repeated names allowed,
+    which List[str] Form fields (repositories) require."""
+    boundary = f"----cogneeCodeGraph{uuid.uuid4().hex}"
+    chunks = []
+    for name, value in fields:
+        chunks.append(f"--{boundary}\r\n".encode("utf-8"))
+        chunks.append(f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode("utf-8"))
+        chunks.append(str(value).encode("utf-8"))
+        chunks.append(b"\r\n")
+    chunks.append(f"--{boundary}--\r\n".encode("utf-8"))
+    return b"".join(chunks), boundary
+
+
+def _error(status, message, *, transient=False):
+    """Reachable server, failed/rejected request — the caller must NOT treat
+    this as 'server absent' (there is no fallback path for this route)."""
+    envelope = {"error": message, "status": status, "authoritative": False}
+    if transient:
+        envelope["transient"] = True
+    return envelope
+
+
+def do_index_repo(
+    service_url,
+    api_key,
+    repo_spec,
+    dataset,
+    *,
+    index_vectors=False,
+    run_in_background=True,
+    opener=urllib.request.urlopen,
+    timeout=120.0,
+):
+    """Submit one repository for code-graph indexing.
+
+    Returns {"ok": true, ...} on 2xx, an error envelope on HTTP errors, and
+    UNREACHABLE only on a positively absent server. A timeout is NOT
+    unreachable: background submits return fast, so a timeout usually means
+    a slow synchronous run that may still land — surfaced as a transient
+    note, never retried blindly.
+    """
+    url = service_url.rstrip("/") + "/api/v1/remember"
+    body, boundary = _multipart_body(
+        [
+            ("datasetName", dataset),
+            ("content_type", "code"),
+            ("repositories", str(repo_spec)),
+            ("run_in_background", "true" if run_in_background else "false"),
+            ("index_vectors", "true" if index_vectors else "false"),
+        ]
+    )
+    headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
+    if api_key:
+        headers["X-Api-Key"] = api_key
+
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with opener(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        detail = ""
+        try:
+            payload = json.loads(e.read().decode("utf-8") or "{}")
+            detail = str(payload.get("detail") or payload.get("error") or "")[:300]
+        except Exception:
+            pass
+        if e.code in (401, 403):
+            msg = "unauthorized (HTTP %s) — check COGNEE_API_KEY / credentials" % e.code
+        elif e.code == 400 and "content_type" in detail:
+            # An older server (< 1.5.3) rejects content_type='code' outright.
+            msg = (
+                "server rejected content_type='code' (HTTP 400) — repo indexing "
+                "requires cognee >= 1.5.3; restart the session to upgrade the "
+                "plugin server, or upgrade the remote deployment. Detail: " + detail
+            )
+        else:
+            msg = "server returned HTTP %s for /api/v1/remember" % e.code
+            if detail:
+                msg += " — " + detail
+        sys.stderr.write("[cognee-code-graph] %s\n" % msg)
+        return _error(e.code, msg)
+    except (TimeoutError, socket.timeout):
+        sys.stderr.write(
+            "[cognee-code-graph] timed out after %ss waiting for confirmation; the "
+            "submission may have landed — not retrying\n" % timeout
+        )
+        return _error(0, "index submitted; timed out after %ss" % timeout, transient=True)
+    except urllib.error.URLError as e:
+        if isinstance(getattr(e, "reason", None), (TimeoutError, socket.timeout)):
+            return _error(0, "index submitted; timed out after %ss" % timeout, transient=True)
+        sys.stderr.write(
+            "[cognee-code-graph] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+        )
+        return UNREACHABLE
+    except Exception as e:
+        sys.stderr.write(
+            "[cognee-code-graph] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+        )
+        return UNREACHABLE
+
+    try:
+        data = json.loads(raw or "{}")
+    except (json.JSONDecodeError, ValueError):
+        return {"ok": True}
+    if isinstance(data, dict) and data.get("error"):
+        msg = str(data.get("error"))[:200]
+        sys.stderr.write("[cognee-code-graph] server returned error: %s\n" % msg)
+        return _error(200, msg)
+
+    result = {"ok": True, "repository": str(repo_spec)}
+    if isinstance(data, dict):
+        for field in ("dataset_id", "pipeline_run_id", "status"):
+            if data.get(field):
+                result[field] = str(data[field])
+        if data.get("items"):
+            result["items"] = data["items"]
+    return result
+
+
+def poll_code_graph_status(
+    service_url,
+    api_key,
+    dataset_id,
+    deadline_seconds,
+    *,
+    opener=urllib.request.urlopen,
+    interval_seconds=3.0,
+    request_timeout=10.0,
+):
+    """Poll /api/v1/datasets/status for the code_graph_pipeline.
+
+    Returns "completed" | "errored" | "timeout" | "unknown" — the plugins'
+    cognify poll targets pipeline=cognify_pipeline, which never sees code
+    runs, so this variant exists specifically for the code route.
+    """
+    if not dataset_id:
+        return "unknown"
+    url = (
+        service_url.rstrip("/")
+        + "/api/v1/datasets/status?dataset="
+        + urllib.parse.quote(str(dataset_id))
+        + "&pipeline=code_graph_pipeline"
+    )
+    headers = {}
+    if api_key:
+        headers["X-Api-Key"] = api_key
+    deadline = time.monotonic() + max(0.0, deadline_seconds)
+    while True:
+        status = ""
+        try:
+            req = urllib.request.Request(url, headers=headers, method="GET")
+            with opener(req, timeout=request_timeout) as resp:
+                raw = resp.read().decode("utf-8")
+            parsed = json.loads(raw or "{}")
+            if isinstance(parsed, dict) and parsed:
+                val = parsed.get(str(dataset_id))
+                if val is None and len(parsed) == 1:
+                    val = next(iter(parsed.values()))
+                if isinstance(val, dict):
+                    val = val.get("code_graph_pipeline")
+                status = str(val or "").upper()
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return "unknown"
+        except Exception:
+            pass
+        if status.endswith("COMPLETED"):
+            return "completed"
+        if status.endswith("ERRORED"):
+            return "errored"
+        if time.monotonic() >= deadline:
+            return "timeout"
+        time.sleep(max(0.1, interval_seconds))
+
+
+def index_repo(
+    service_url,
+    api_key,
+    spec,
+    dataset="",
+    *,
+    index_vectors=False,
+    wait_seconds=0.0,
+    opener=urllib.request.urlopen,
+):
+    """Index one repo AND record its state file (the opt-in the hooks honor).
+
+    Local paths are fingerprinted so the Stop hook can re-ingest on change;
+    URL specs record no fingerprint (server-side clones only see pushes).
+
+    ``repo_root`` is the indexed path itself, not its enclosing git root: the
+    indexed unit is exactly what the caller named, so cwd matching stays
+    precise (indexing one subdirectory must not claim the whole repository)
+    and two subdirectories of one repository cannot record the same root and
+    then match a cwd in arbitrary order.
+    """
+    spec = canonical_spec(spec)
+    remote = is_remote_repo(spec)
+    repo_root = "" if remote else spec
+    dataset = dataset or default_code_dataset(spec)
+
+    result = do_index_repo(
+        service_url,
+        api_key,
+        spec,
+        dataset,
+        index_vectors=index_vectors,
+        opener=opener,
+    )
+    if result == UNREACHABLE or (isinstance(result, dict) and result.get("error")):
+        return result
+
+    if wait_seconds > 0 and isinstance(result, dict) and result.get("dataset_id"):
+        outcome = poll_code_graph_status(
+            service_url, api_key, result["dataset_id"], wait_seconds, opener=opener
+        )
+        result["wait_outcome"] = outcome
+        result["queryable"] = outcome == "completed"
+
+    state = {
+        "spec": spec,
+        "spec_kind": "url" if remote else "path",
+        "repo_root": repo_root,
+        "dataset": dataset,
+        "index_vectors": bool(index_vectors),
+        "fingerprint": git_fingerprint(repo_root) if repo_root else "",
+        "last_index_at": time.time(),
+        "last_status": str(result.get("status") or "submitted") if isinstance(result, dict) else "",
+    }
+    save_repo_state(state)
+    result["dataset"] = dataset
+    return result
+
+
+def reingest_if_changed(cwd, service_url, api_key, *, opener=urllib.request.urlopen) -> dict:
+    """Stop-hook freshness pass: re-submit the cwd's indexed repo if it changed.
+
+    Returns a small outcome dict for logging; {} when there is nothing to do
+    (no indexed repo for this cwd, URL-indexed repo, or unchanged tree).
+    Never raises — this runs on the (async) Stop hook.
+
+    URL-indexed repos are skipped by design, not by omission: the server built
+    that graph from its own clone, which only ever holds pushed commits, so
+    re-submitting after a local edit would re-pull the same commits and produce
+    the same graph. Those graphs advance when the user pushes and re-indexes.
+    """
+    try:
+        state = find_indexed_repo(cwd)
+        if not state or state.get("spec_kind") != "path":
+            return {}
+        root = str(state.get("repo_root") or "")
+        fingerprint = git_fingerprint(root)
+        if not fingerprint:
+            return {}
+        if fingerprint == str(state.get("fingerprint") or ""):
+            return {"changed": False, "repo_root": root}
+
+        result = do_index_repo(
+            service_url,
+            api_key,
+            state.get("spec") or root,
+            str(state.get("dataset") or default_code_dataset(root)),
+            index_vectors=bool(state.get("index_vectors")),
+            opener=opener,
+        )
+        outcome = {"changed": True, "repo_root": root, "dataset": state.get("dataset")}
+        if isinstance(result, dict) and result.get("ok"):
+            state["fingerprint"] = fingerprint
+            state["last_index_at"] = time.time()
+            state["last_status"] = str(result.get("status") or "submitted")
+            save_repo_state(state)
+            outcome["submitted"] = True
+            if result.get("pipeline_run_id"):
+                outcome["pipeline_run_id"] = result["pipeline_run_id"]
+        else:
+            # Keep the OLD fingerprint on failure so the next turn retries.
+            outcome["submitted"] = False
+            outcome["error"] = (
+                "unreachable"
+                if result == UNREACHABLE
+                else str(result.get("error") if isinstance(result, dict) else result)[:200]
+            )
+        return outcome
+    except Exception as exc:  # never break the Stop hook
+        return {"changed": None, "error": str(exc)[:200]}
+
+
+# ---------------------------------------------------------------------------
+# Session-start auto-indexing
+# ---------------------------------------------------------------------------
+
+# A repo bigger than this many source files is not auto-indexed: the enola pass
+# is CPU-bound over the whole tree, and silently spending that on a monorepo
+# nobody asked to index is worse than doing nothing. Explicit indexing (the
+# wrapper / skill) has no cap — an explicit request IS the consent.
+_AUTOINDEX_MAX_FILES = 3000
+
+
+def autoindex_mode() -> str:
+    """How session start treats an unindexed repo: "auto" | "off" | "always".
+
+    - ``auto`` (default): index a new repo only when the server is LOCAL, where
+      the code never leaves this machine — the server reads the working tree in
+      place. A cloud server is skipped: shipping a private checkout to a hosted
+      tenant is not something a plugin should decide on the user's behalf (and
+      the server rejects local paths anyway, so it could only ever work by
+      pushing).
+    - ``always``: also auto-index against a cloud/remote server.
+    - ``off``: never auto-index; only refresh repos already indexed explicitly.
+
+    Refreshing an ALREADY-indexed repo is not governed by this setting — that
+    repo's index command was the consent, and a stale graph is the failure mode
+    the freshness loop exists to prevent.
+    """
+    value = str(os.environ.get("COGNEE_CODE_AUTOINDEX", "") or "").strip().lower()
+    if value in ("off", "0", "false", "no"):
+        return "off"
+    if value in ("always", "1", "true", "yes", "on"):
+        return "always"
+    return "auto"
+
+
+def _source_file_count(root: str, cap: int) -> int:
+    """Count code files under ``root``, stopping once ``cap`` is exceeded.
+
+    Bounded on purpose: this runs at session start, so it must cost the same
+    on a monorepo as on a small service.
+    """
+    skip = {".git", "node_modules", ".venv", "venv", "dist", "build", "target", "__pycache__"}
+    seen = 0
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in skip and not d.startswith(".")]
+        for name in filenames:
+            if name.rsplit(".", 1)[-1].lower() in CODE_EXTENSIONS:
+                seen += 1
+                if seen > cap:
+                    return seen
+    return seen
+
+
+def autoindex_on_session_start(
+    cwd,
+    service_url,
+    api_key,
+    *,
+    is_local_server=True,
+    opener=urllib.request.urlopen,
+) -> dict:
+    """Index (or refresh) the repo a session opened in. Never raises.
+
+    Runs from the detached session-start worker, so it never blocks the first
+    prompt. Returns a small outcome dict for logging; ``{}`` when there is
+    nothing to do.
+
+    Two distinct cases, deliberately governed by different rules:
+      * the repo is ALREADY indexed -> refresh it if the tree moved since the
+        last index (covers edits made while the agent was away);
+      * the repo is NEW -> index it only when ``autoindex_mode()`` allows,
+        which by default means a local server only.
+    """
+    try:
+        root = git_repo_root(cwd)
+        if not root:
+            return {}
+
+        if find_indexed_repo(root):
+            outcome = reingest_if_changed(root, service_url, api_key, opener=opener)
+            if outcome:
+                outcome["reason"] = "refresh"
+            return outcome
+
+        mode = autoindex_mode()
+        if mode == "off":
+            return {"skipped": "autoindex_off", "repo_root": root}
+        if mode == "auto" and not is_local_server:
+            # Remote server: indexing would mean shipping this checkout to a
+            # hosted tenant. Explicit opt-in only (COGNEE_CODE_AUTOINDEX=always
+            # or the index command).
+            return {"skipped": "remote_server", "repo_root": root}
+
+        count = _source_file_count(root, _AUTOINDEX_MAX_FILES)
+        if count == 0:
+            return {"skipped": "no_code_files", "repo_root": root}
+        if count > _AUTOINDEX_MAX_FILES:
+            return {
+                "skipped": "too_large",
+                "repo_root": root,
+                "source_files": f">{_AUTOINDEX_MAX_FILES}",
+            }
+
+        result = index_repo(service_url, api_key, root, opener=opener)
+        if result == UNREACHABLE or (isinstance(result, dict) and result.get("error")):
+            return {
+                "indexed": False,
+                "repo_root": root,
+                "error": "unreachable" if result == UNREACHABLE else str(result.get("error"))[:200],
+            }
+        return {
+            "indexed": True,
+            "reason": "first_seen",
+            "repo_root": root,
+            "dataset": result.get("dataset", ""),
+            "source_files": count,
+        }
+    except Exception as exc:  # never break session start
+        return {"error": str(exc)[:200]}
+
+
+def main(argv):
+    """CLI: ``index <repo-path-or-url> [dataset]`` or ``dataset <path>``.
+
+    argv mirrors the sibling scripts: service_url, api_key, command, spec,
+    dataset, index_vectors, wait_seconds. The ``dataset`` command prints the
+    code dataset covering a path (empty line when that path is not indexed) —
+    dataset names carry a path digest, so callers resolve the name from the
+    checkout instead of reconstructing it.
+    """
+    a = list(argv) + [""] * 7
+    service_url, api_key, command, spec = a[0], a[1], a[2], a[3]
+    dataset = a[4]
+    index_vectors = str(a[5]).strip().lower() in ("1", "true", "yes", "on")
+    try:
+        wait_seconds = float(a[6]) if str(a[6]).strip() else 0.0
+    except ValueError:
+        wait_seconds = 0.0
+
+    if command == "dataset":
+        state = find_indexed_repo(spec or os.getcwd())
+        print(str(state.get("dataset") or ""))
+        return
+
+    if command != "index" or not spec:
+        print(
+            json.dumps(
+                {
+                    "error": "usage: _code_graph.py <service_url> <api_key> "
+                    "index <repo-path-or-url> [dataset] [index_vectors] "
+                    "[wait_seconds] | dataset [path]",
+                    "status": 2,
+                }
+            )
+        )
+        return
+    result = index_repo(
+        service_url,
+        api_key,
+        spec,
+        dataset,
+        index_vectors=index_vectors,
+        wait_seconds=wait_seconds,
+    )
+    print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/integrations/claude-code/scripts/_cognee_client.py
+++ b/integrations/claude-code/scripts/_cognee_client.py
@@ -160,7 +160,18 @@ def record_success(service_url=""):
     _write(servers)
 
 
-def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *, timeout=None):
+def recall(
+    service_url,
+    api_key,
+    query,
+    session_id,
+    scope,
+    top_k,
+    dataset="",
+    code_query=None,
+    *,
+    timeout=None,
+):
     """Breaker-wrapped recall. Returns a list, an error-envelope dict, or UNREACHABLE.
 
     Only genuine backend trouble trips the breaker: UNREACHABLE (positively
@@ -185,6 +196,10 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
         scope,
         top_k,
         dataset,
+        # Keyword, not positional: do_recall takes context_profile between
+        # dataset and code_query, so a positional here silently sends the
+        # code query as a context profile.
+        code_query=code_query,
         timeout=timeout or _RECALL_TIMEOUT,
     )
     if result == UNREACHABLE:
@@ -201,9 +216,11 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
 
 
 def main(argv):
-    # argv: service_url, api_key, query, session_id, scope, top_k[, dataset]
-    a = list(argv) + [""] * 7
-    result = recall(a[0], a[1], a[2], a[3], a[4], a[5], a[6])
+    # argv: service_url, api_key, query, session_id, scope, top_k[, dataset[, code_query]]
+    # code_query (arg 8): JSON dict for the deterministic "code" scope (see
+    # _recall_http.coerce_code_query); requires scope to include "code".
+    a = list(argv) + [""] * 8
+    result = recall(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7])
     print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
 
 

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -2835,6 +2835,7 @@ def recall_via_http(
     search_type: str | None = None,
     context_profile: str | None = None,
     dataset: str = "",
+    code_query: dict | None = None,
     timeout: float = 10.0,
 ) -> list:
     payload = {
@@ -2844,6 +2845,10 @@ def recall_via_http(
         "scope": scope,
         "only_context": only_context,
     }
+    # Deterministic code-graph lane (cognee >= 1.5.3). Only meaningful when
+    # the scope includes "code": the server rejects code_query without it.
+    if code_query:
+        payload["code_query"] = code_query
     # Always scope to the plugin's dataset. Without it the server resolves EVERY
     # readable dataset and then reconciles against the session's binding, so the
     # graph scope depends on that binding existing: an unbound session with more

--- a/integrations/claude-code/scripts/_recall_http.py
+++ b/integrations/claude-code/scripts/_recall_http.py
@@ -148,6 +148,23 @@ def _error(status, message, *, transient=False):
     return envelope
 
 
+def coerce_code_query(value):
+    """Parse the JSON code_query arg; None on anything empty or malformed.
+
+    A malformed code_query must degrade to "no code lane", never to a server
+    422 that would read as a recall failure.
+    """
+    if not value:
+        return None
+    if isinstance(value, dict):
+        return value
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
 def do_recall(
     service_url,
     api_key,
@@ -157,6 +174,7 @@ def do_recall(
     top_k,
     dataset="",
     context_profile="",
+    code_query=None,
     *,
     opener=None,
     timeout=120.0,
@@ -169,6 +187,11 @@ def do_recall(
         "only_context": True,
         "scope": coerce_scope(scope),
     }
+    # Deterministic code-graph lane (cognee >= 1.5.3): only meaningful when
+    # the scope includes "code" — the server rejects code_query without it.
+    parsed_code_query = coerce_code_query(code_query)
+    if parsed_code_query is not None:
+        body["code_query"] = parsed_code_query
     if session_id:
         body["session_id"] = session_id
     # Scope the search to the caller's plugin dataset (resolved by the shell from
@@ -241,9 +264,12 @@ def do_recall(
 
 
 def main(argv):
-    # argv: service_url, api_key, query, session_id, scope, top_k[, dataset[, context_profile]]
-    a = list(argv) + [""] * 8
-    result = do_recall(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7])
+    # argv: service_url, api_key, query, session_id, scope, top_k[, dataset
+    #        [, context_profile[, code_query]]]
+    # code_query (arg 9): JSON dict for the deterministic "code" scope, e.g.
+    # '{"operation": "impact_analysis", "targets": ["process_payment"]}'.
+    a = list(argv) + [""] * 9
+    result = do_recall(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8])
     # UNREACHABLE → caller falls back to CLI; a list (results) or an error
     # object → caller prints as-is and does NOT fall back.
     print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))

--- a/integrations/claude-code/scripts/_remember_http.py
+++ b/integrations/claude-code/scripts/_remember_http.py
@@ -170,12 +170,29 @@ def do_remember(
     dataset,
     node_set,
     *,
+    file_path=None,
     opener=urllib.request.urlopen,
     timeout=120.0,
 ):
-    """POST content to the server. Return {"ok": true}, an error envelope, or UNREACHABLE."""
+    """POST content to the server. Return {"ok": true}, an error envelope, or UNREACHABLE.
+
+    With ``file_path``, the file's bytes are uploaded under its REAL basename
+    instead of the synthetic ``{node_set}.txt``. The filename extension is the
+    server's loader-routing signal: a ``.py``/``.ts``/... upload rides the
+    zero-LLM code-graph route (cognify CODE route, cognee >= 1.5.x), while the
+    ``.txt`` rename would silently ingest code as prose through the LLM
+    pipeline. Reading the file here (not in the shell) also avoids ARG_MAX
+    limits on large sources.
+    """
     url = service_url.rstrip("/") + "/api/v1/remember"
     filename = f"{node_set or 'content'}.txt"
+    if file_path:
+        try:
+            with open(file_path, "rb") as fh:
+                content = fh.read()
+        except OSError as e:
+            return _error(0, "cannot read %s: %s" % (file_path, str(e)[:160]))
+        filename = os.path.basename(str(file_path).rstrip("/")) or filename
     body, boundary = _multipart_body(
         {
             "datasetName": dataset,
@@ -264,9 +281,11 @@ def do_remember(
 
 
 def main(argv):
-    # argv: service_url, api_key, content, dataset, node_set
-    a = list(argv) + [""] * 5
-    result = do_remember(a[0], a[1], a[2], a[3], a[4])
+    # argv: service_url, api_key, content, dataset, node_set[, file_path]
+    # With file_path set (arg 6), content (arg 3) is ignored: the file's bytes
+    # are uploaded under their real basename so code files route as code.
+    a = list(argv) + [""] * 6
+    result = do_remember(a[0], a[1], a[2], a[3], a[4], file_path=a[5] or None)
     print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
     if result != UNREACHABLE:
         # Refresh the status-line credits marker, attributing the spend delta

--- a/integrations/claude-code/scripts/cognee-index-repo.sh
+++ b/integrations/claude-code/scripts/cognee-index-repo.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Index a code repository into Cognee's code graph (enola pipeline).
+#
+# Usage:
+#   cognee-index-repo.sh <repo-path-or-git-url> [--dataset <name>] [--index-vectors] [--wait <seconds>]
+#
+# <repo-path-or-git-url>: a local repository path (works when the Cognee
+#                         server shares this filesystem — the default local
+#                         plugin server does) or a remote git URL (the server
+#                         shallow-clones it; required for cloud servers).
+# --dataset:       target dataset (default: codebase-<repo-name>-<digest> —
+#                  one narrow dataset per repo keeps CODE searches fast. The
+#                  digest is the indexed path: two checkouts often share a
+#                  basename, and letting them share a dataset would let each
+#                  ingestion's stale-node sweep delete the other's nodes. The
+#                  resulting name is printed on success, and cognee-search.sh
+#                  --code resolves it from the checkout automatically).
+# --index-vectors: also embed the extracted code facts so semantic search can
+#                  see them (needs an embedding provider; default off — the
+#                  code graph pipeline makes no LLM/embedding calls).
+# --wait:          seconds to poll the code_graph_pipeline status before
+#                  returning (default 0: submit in background and return).
+#
+# Requires a Cognee server >= 1.5.3. There is deliberately NO CLI fallback:
+# an unreachable server prints UNREACHABLE and nothing is submitted.
+#
+# Indexing a repo here is also the opt-in for automatic freshness, and what
+# "fresh" means depends on how the server reads the code:
+#   * local path  -> the server reads the working tree in place, so the graph
+#     includes uncommitted and untracked changes. The plugin records a git
+#     fingerprint and re-submits in the background after any turn that changed
+#     a file, keeping the graph current per turn.
+#   * git URL     -> the server clones the repo and can only ever see PUSHED
+#     commits. Local edits are invisible to it, so the plugin does NOT
+#     re-submit these on edits (a re-pull would change nothing); the graph
+#     advances when you push and re-run this command. Normal behavior, but the
+#     results look identical to the local case, so it is worth saying out loud
+#     when answering from a cloud-indexed graph.
+
+set -euo pipefail
+
+PLUGIN_DIR="${HOME}/.cognee-plugin/claude-code"
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+runtime_json="$(python3 - <<'PY' "${PLUGIN_DIR}" "${SELF_DIR}" 2>/dev/null || true
+import json
+import pathlib
+import sys
+
+plugin_dir = pathlib.Path(sys.argv[1])
+import os
+# One-time config from ~/.cognee/.env (shell exports still win).
+sys.path.insert(0, sys.argv[2])
+try:
+    from _env_file import load_env_file
+    load_env_file()
+except Exception:
+    pass
+service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
+api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
+
+if not api_key:
+    cache_path = plugin_dir.parent / "api_key.json"
+    if cache_path.exists():
+        try:
+            cache = json.loads(cache_path.read_text())
+            if isinstance(cache, dict):
+                key = str(cache.get("api_key") or "").strip()
+                cached_url = str(cache.get("base_url") or "").strip().rstrip("/")
+                if key and (not cached_url or cached_url == service_url.rstrip("/")):
+                    api_key = key
+        except Exception:
+            pass
+
+print(json.dumps({"service_url": service_url, "api_key": api_key}))
+PY
+)"
+
+SERVICE_URL="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("service_url") or "").strip())
+except Exception:
+    pass
+PY
+)"
+API_KEY="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("api_key") or "").strip())
+except Exception:
+    pass
+PY
+)"
+
+[ -z "$SERVICE_URL" ] && SERVICE_URL="${COGNEE_BASE_URL:-${COGNEE_LOCAL_API_URL:-http://localhost:8011}}"
+[ -z "$API_KEY" ] && API_KEY="${COGNEE_API_KEY:-}"
+
+REPO="${1:-}"
+DATASET=""
+INDEX_VECTORS="false"
+WAIT_SECONDS="0"
+
+shift || true
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dataset|-d)
+            shift
+            DATASET="${1:-}"
+            ;;
+        --index-vectors)
+            INDEX_VECTORS="true"
+            ;;
+        --wait)
+            shift
+            WAIT_SECONDS="${1:-0}"
+            ;;
+        *)
+            ;;
+    esac
+    shift || true
+done
+
+if [ -z "$REPO" ]; then
+    echo "Error: no repository path or git URL provided" >&2
+    echo "Usage: cognee-index-repo.sh <repo-path-or-git-url> [--dataset <name>] [--index-vectors] [--wait <seconds>]" >&2
+    exit 1
+fi
+
+RESULT="$(python3 "${SELF_DIR}/_code_graph.py" "$SERVICE_URL" "$API_KEY" index "$REPO" "$DATASET" "$INDEX_VECTORS" "$WAIT_SECONDS" || true)"
+
+if [ -n "$RESULT" ] && [ "$RESULT" != "UNREACHABLE" ]; then
+    printf '%s\n' "$RESULT"
+else
+    echo "[cognee-index-repo] server unreachable at ${SERVICE_URL} — nothing was submitted. Start the server (new session) or fix COGNEE_BASE_URL, then re-run." >&2
+    echo "UNREACHABLE"
+    exit 1
+fi

--- a/integrations/claude-code/scripts/cognee-remember.sh
+++ b/integrations/claude-code/scripts/cognee-remember.sh
@@ -3,10 +3,16 @@
 #
 # Usage:
 #   cognee-remember.sh <content> [--node-set <node_set>] [--dataset <dataset>]
+#   cognee-remember.sh --file <path> [--node-set <node_set>] [--dataset <dataset>]
 #
 # --node-set: node set for categorization (default: user_context)
 #             user_context | project_docs | agent_actions
 # --dataset:  dataset name (default: COGNEE_PLUGIN_DATASET or agent_sessions)
+# --file:     upload a file under its REAL filename instead of inline text.
+#             The extension is the server's routing signal: code files
+#             (.py/.ts/.go/...) ride the zero-LLM code-graph route on
+#             cognee >= 1.5.x; anything else flows through its normal loader.
+#             With --file, positional <content> is not required.
 #
 # Configuration:
 #   Resolves auth from env/api_key.json.
@@ -82,11 +88,15 @@ PY
 [ -z "$API_KEY" ] && API_KEY="${COGNEE_API_KEY:-}"
 [ -z "$DATASET" ] && DATASET="${COGNEE_PLUGIN_DATASET:-agent_sessions}"
 
-# Parse arguments: content is first positional; flags follow
-CONTENT="${1:-}"
+# Parse arguments: content is first positional (unless --file leads); flags follow
+CONTENT=""
 NODE_SET="user_context"
+FILE_PATH=""
 
-shift || true
+if [ "${1:-}" != "--file" ]; then
+    CONTENT="${1:-}"
+    shift || true
+fi
 while [ $# -gt 0 ]; do
     case "$1" in
         --node-set)
@@ -97,13 +107,21 @@ while [ $# -gt 0 ]; do
             shift
             DATASET="${1:-$DATASET}"
             ;;
+        --file)
+            shift
+            FILE_PATH="${1:-}"
+            ;;
         *)
             ;;
     esac
     shift || true
 done
 
-if [ -z "$CONTENT" ]; then
+if [ -n "$FILE_PATH" ] && [ ! -f "$FILE_PATH" ]; then
+    echo "Error: --file path not found: $FILE_PATH" >&2
+    exit 1
+fi
+if [ -z "$CONTENT" ] && [ -z "$FILE_PATH" ]; then
     echo "Error: no content provided" >&2
     exit 1
 fi
@@ -111,10 +129,16 @@ fi
 # Server-first: POST to /api/v1/remember via _remember_http.py.
 # UNREACHABLE → fall back to cognee-cli and warn.
 # Any other result (ok or error) → authoritative; do not fall back.
-RESULT="$(python3 "${SELF_DIR}/_remember_http.py" "$SERVICE_URL" "$API_KEY" "$CONTENT" "$DATASET" "$NODE_SET" || true)"
+RESULT="$(python3 "${SELF_DIR}/_remember_http.py" "$SERVICE_URL" "$API_KEY" "$CONTENT" "$DATASET" "$NODE_SET" "$FILE_PATH" || true)"
 
 if [ -n "$RESULT" ] && [ "$RESULT" != "UNREACHABLE" ]; then
     printf '%s\n' "$RESULT"
+elif [ -n "$FILE_PATH" ]; then
+    # No CLI fallback for file uploads: the CLI path would re-read and rename
+    # the content, losing the extension-based code routing this mode exists for.
+    echo "[cognee-remember] server unreachable — file upload NOT stored; retry once the server is back" >&2
+    echo "UNREACHABLE"
+    exit 1
 else
     echo "[cognee-remember] falling back to cognee-cli (degraded — server unreachable; verify the store succeeded once the server is back)" >&2
     cognee-cli remember "$CONTENT" -d "$DATASET" --node-set "$NODE_SET" 2>/dev/null || true

--- a/integrations/claude-code/scripts/cognee-search.sh
+++ b/integrations/claude-code/scripts/cognee-search.sh
@@ -3,9 +3,18 @@
 #
 # Usage:
 #   cognee-search.sh <query> [top_k] [--session | --graph]
+#   cognee-search.sh <query> [top_k] --code [--dataset <name>] [--code-query '<json>']
 #
 # --session: search session cache only
 # --graph:   search permanent knowledge graph only
+# --code:    deterministic code-graph search (cognee >= 1.5.3). Query text is
+#            the seed; --code-query selects an exact operation instead, e.g.
+#            '{"operation": "impact_analysis", "targets": ["process_payment"]}'
+#            (operations: query_facts, explore, traverse, find_path,
+#            impact_analysis, delta). The repository's own code dataset is
+#            resolved from the current directory automatically.
+# --dataset: override the dataset to search (default: the plugin dataset, or
+#            the current repo's code dataset in --code mode)
 # No flag:   search session first, then graph if empty
 #
 # Configuration:
@@ -127,14 +136,39 @@ PY
 QUERY="${1:-}"
 TOP_K="${2:-5}"
 MODE="auto"
+CODE_QUERY=""
+DATASET_EXPLICIT=""
 
-# Parse flags from any position
-for arg in "$@"; do
-    case "$arg" in
+# Parse flags from any position (value flags consume the next argument)
+_args=("$@")
+_i=0
+while [ $_i -lt ${#_args[@]} ]; do
+    case "${_args[$_i]}" in
         --session) MODE="session" ;;
         --graph)   MODE="graph" ;;
+        --code)    MODE="code" ;;
+        --code-query)
+            _i=$((_i + 1))
+            CODE_QUERY="${_args[$_i]:-}"
+            ;;
+        --dataset|-d)
+            _i=$((_i + 1))
+            DATASET="${_args[$_i]:-$DATASET}"
+            DATASET_EXPLICIT="1"
+            ;;
     esac
+    _i=$((_i + 1))
 done
+
+# Code searches target the repository's OWN dataset, whose name carries a path
+# digest (two checkouts can share a basename, so the basename cannot be the
+# identity). Resolve it from the current checkout rather than making the caller
+# reconstruct it. An unindexed cwd leaves DATASET alone, and the search then
+# reports no code facts rather than silently querying the session dataset.
+if [ "$MODE" = "code" ] && [ -z "${DATASET_EXPLICIT:-}" ]; then
+    CODE_DATASET="$(python3 "${SELF_DIR}/_code_graph.py" "" "" dataset "$PWD" 2>/dev/null || true)"
+    [ -n "$CODE_DATASET" ] && DATASET="$CODE_DATASET"
+fi
 
 if [ -z "$QUERY" ]; then
     echo "Error: no query provided" >&2
@@ -145,6 +179,7 @@ fi
 case "$MODE" in
     session) SCOPE='["session"]' ;;
     graph)   SCOPE='["graph"]' ;;
+    code)    SCOPE='["code"]' ;;
     *)       SCOPE='["session", "graph"]' ;;
 esac
 
@@ -156,11 +191,18 @@ esac
 # and scopes the search to the plugin's dataset so unrelated datasets don't bleed in.
 # Logic lives in _recall_http.py (stdlib-only, unit-tested); stderr is surfaced.
 export COGNEE_PLUGIN_STATE_DIR="$PLUGIN_DIR"
-RECALL_JSON="$(python3 "${SELF_DIR}/_cognee_client.py" "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$SCOPE" "$TOP_K" "$DATASET" || true)"
+RECALL_JSON="$(python3 "${SELF_DIR}/_cognee_client.py" "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$SCOPE" "$TOP_K" "$DATASET" "$CODE_QUERY" || true)"
 
 if [ -n "$RECALL_JSON" ] && [ "$RECALL_JSON" != "UNREACHABLE" ]; then
     # Server answered — authoritative, even if the result is empty.
     printf '%s\n' "$RECALL_JSON"
+elif [ "$MODE" = "code" ]; then
+    # No CLI fallback for code searches: the deterministic code lane exists
+    # only on the server (>= 1.5.3); a CLI recall would answer from the wrong
+    # retriever and read as authoritative when it is not.
+    echo "[cognee-search] server unreachable — code search not run; retry once the server is back" >&2
+    echo "UNREACHABLE"
+    exit 1
 else
     echo "[cognee-search] falling back to cognee-cli (degraded — empty CLI output is NOT proof of absence; ground-truth via: curl -X POST \"\$COGNEE_BASE_URL/api/v1/recall\")" >&2
     if [ "$MODE" = "graph" ]; then

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -93,6 +93,12 @@ def _format_entry(entry: dict) -> str:
         content = str(entry.get("content", "") or entry.get("text", ""))[:TRUNCATE_GRAPH_CTX]
         return f"[agent-guidance]\n{content}"
 
+    if source == "code":
+        # Deterministic code-graph facts (ResponseCodeEntry): `text` is the
+        # normalized renderable field; raw payloads keep full structure.
+        content = str(entry.get("text", "") or entry.get("content", ""))[:TRUNCATE_GRAPH_CTX]
+        return f"[code-graph]\n{content}"
+
     if source == "trace":
         origin = entry.get("origin_function", "?")
         status = entry.get("status", "")
@@ -128,6 +134,8 @@ def _has_entry_content(entry: dict) -> bool:
         return bool(str(entry.get("content", "") or entry.get("text", "")).strip())
     if source == "session_context":
         return bool(str(entry.get("content", "") or entry.get("text", "")).strip())
+    if source == "code":
+        return bool(str(entry.get("text", "") or entry.get("content", "")).strip())
     if source == "trace":
         fields = ("origin_function", "status", "session_feedback", "method_return_value")
     else:
@@ -170,7 +178,7 @@ async def _recent_trace_fallback(session_id: str, user_id: str, top_k: int) -> l
     return normalized
 
 
-async def _run(prompt: str) -> dict | None:
+async def _run(prompt: str, cwd: str = "") -> dict | None:
     config = load_config()
     runtime = resolve_runtime_mode()
     cloud_mode = runtime["mode"] == "http"
@@ -265,6 +273,29 @@ async def _run(prompt: str) -> dict | None:
         (["session_context"], None, "agent"),
         (["graph"], "HYBRID_COMPLETION", None),
     ]
+    # Additive code-graph lane (cognee >= 1.5.3). Fires only when the prompt
+    # carries an identifier-shaped token AND the cwd sits inside a repo the
+    # user indexed via cognee-index-repo.sh — never on conversational prompts,
+    # never as a replacement for the semantic scopes. The server keeps this
+    # scope explicit-only (scope=auto never implies it), so the gate lives
+    # here. Placed before graph: the code lane is the cheapest call when its
+    # snapshot is warm, and graph is the long pole that must stay last.
+    code_lane = {}
+    try:
+        from _code_graph import auto_code_lane
+
+        code_lane = auto_code_lane(prompt, cwd) or {}
+    except Exception as exc:
+        hook_log("code_lane_gate_error", {"error": str(exc)[:200]})
+    if code_lane:
+        scope_specs.insert(3, (["code"], None, None))
+        hook_log(
+            "code_lane_armed",
+            {
+                "identifier": code_lane.get("identifier", ""),
+                "dataset": code_lane.get("dataset", ""),
+            },
+        )
     if not cloud_mode:
         import cognee
         from cognee.modules.search.types import SearchType
@@ -322,6 +353,11 @@ async def _run(prompt: str) -> dict | None:
             hook_log("recall_budget_exceeded", {"collected": len(results)})
             break
         scope_timeout = min(recall_timeout, remaining)
+        # The code lane searches the indexed repo's own (narrow) dataset with
+        # a structured query; every other scope keeps the session dataset.
+        is_code_scope = bool(code_lane) and scope_list == ["code"]
+        scope_dataset = code_lane["dataset"] if is_code_scope else get_dataset(config)
+        scope_code_query = code_lane["code_query"] if is_code_scope else None
         part = None
         t0 = time.monotonic()
         try:
@@ -334,7 +370,8 @@ async def _run(prompt: str) -> dict | None:
                     only_context=True,
                     search_type=qtype,
                     context_profile=context_profile,
-                    dataset=get_dataset(config),
+                    dataset=scope_dataset,
+                    code_query=scope_code_query,
                     timeout=scope_timeout,
                 )
             else:
@@ -349,6 +386,11 @@ async def _run(prompt: str) -> dict | None:
                         query_type=query_type,
                         user=user,
                         **({"context_profile": context_profile} if context_profile else {}),
+                        **(
+                            {"datasets": [scope_dataset], "code_query": scope_code_query}
+                            if is_code_scope
+                            else {}
+                        ),
                     ),
                     timeout=scope_timeout,
                 )
@@ -478,6 +520,7 @@ async def _run(prompt: str) -> dict | None:
         "trace": [],
         "graph_context": [],
         "session_context": [],
+        "code": [],
     }
     for r in results or []:
         if hasattr(r, "model_dump"):
@@ -551,7 +594,9 @@ async def _run(prompt: str) -> dict | None:
     header = (
         "Cognee memory: recall "
         f"{counts['session']} session / {counts['trace']} trace / "
-        f"{counts['graph_context']} graph / {counts['session_context']} agent; saved last turn "
+        f"{counts['graph_context']} graph / {counts['session_context']} agent"
+        + (f" / {counts['code']} code" if code_lane else "")
+        + "; saved last turn "
         f"{saves_last_turn['prompt']} prompt / {saves_last_turn['trace']} trace / "
         f"{saves_last_turn['answer']} answer"
     )
@@ -560,6 +605,11 @@ async def _run(prompt: str) -> dict | None:
     if by_source.get("session_context"):
         section_lines.append("=== Active agent guidance ===")
         for e in by_source["session_context"]:
+            section_lines.append(_format_entry(e))
+            section_lines.append("")
+    if by_source.get("code"):
+        section_lines.append("=== Code graph facts ===")
+        for e in by_source["code"]:
             section_lines.append(_format_entry(e))
             section_lines.append("")
     if by_source.get("graph_context"):
@@ -680,11 +730,12 @@ def main():
     prompt = payload.get("prompt", "")
     if not prompt or len(prompt) < 5:
         return
+    cwd = str(payload.get("cwd") or "") or os.getcwd()
 
     output = None
     try:
         with quiet_hook_output("session-context-lookup"):
-            output = asyncio.run(_run(prompt))
+            output = asyncio.run(_run(prompt, cwd))
     except Exception as exc:
         hook_log("context_lookup_exception", {"error": str(exc)[:200]})
     if output:

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -46,6 +46,7 @@ from _plugin_common import (
     resolve_session_key_from_payload,
     server_presence,
     server_ready_hint,
+    service_url_is_local,
     set_session_key,
     touch_activity,
     write_connection_state,
@@ -103,7 +104,7 @@ _UV_BIN = _UV_DIR / ("uv.exe" if os.name == "nt" else "uv")
 _UV_PYTHON_DIR = _GLOBAL_STATE_DIR / "python"
 _UV_INSTALL_URL = "https://astral.sh/uv/install.sh"
 _PINNED_PYTHON = os.environ.get("COGNEE_PLUGIN_PYTHON", "") or "3.12"
-_PINNED_COGNEE_VERSION = "1.5.0"
+_PINNED_COGNEE_VERSION = "1.5.3"
 _INSTALL_TIMEOUT_SECONDS = float(os.environ.get("COGNEE_INSTALL_TIMEOUT", "") or 600.0)
 
 # Install single-flight. Distinct from the server boot lock (which is short, on
@@ -1137,6 +1138,24 @@ async def _run_heavy(
                 hook_log("conn_state_unverified", {"base_url": service_url, "health": health})
     elif service_url and probe_health(service_url, timeout=1.5) == "ready":
         write_connection_state("ready", service_url)
+
+    # Code graph: index the repository this session opened in, or refresh it if
+    # the tree moved while the agent was away. Deliberately last and inside the
+    # detached worker — it must never delay the first prompt — and best-effort:
+    # a failure here costs code facts, not the session.
+    try:
+        from _code_graph import autoindex_on_session_start
+
+        code_outcome = autoindex_on_session_start(
+            cwd,
+            service_url,
+            os.environ.get("COGNEE_API_KEY", ""),
+            is_local_server=service_url_is_local(service_url),
+        )
+        if code_outcome:
+            hook_log("code_autoindex", code_outcome)
+    except Exception as exc:
+        hook_log("code_autoindex_error", {"error": str(exc)[:200]})
 
     return user_id, agent_api_key, True
 

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -459,6 +459,45 @@ async def _store_assistant_stop(payload: dict) -> None:
             await _fire_improve_background(dataset, session_id, user, reason=f"turn_{count}")
 
 
+def _maybe_reingest_code_repo(payload: dict) -> None:
+    """Freshness pass for indexed code repos (runs on the Stop hook only).
+
+    When this turn's cwd sits inside a repo indexed via cognee-index-repo.sh
+    and the working tree's git fingerprint changed since the last index, the
+    repo is re-submitted (background) so the code graph reflects the turn's
+    edits by the next prompt. The fingerprint is only a cheap client-side
+    gate — the server re-hashes every covered file anyway, so a false
+    positive costs one skipped submission. Repos indexed by git URL are NOT
+    re-submitted here: the server's clone only sees pushed commits, so local
+    edits cannot reach it. Never raises: this must not disturb the hook.
+    """
+    try:
+        from _code_graph import reingest_if_changed
+
+        cwd = str(payload.get("cwd") or "") or os.getcwd()
+        runtime = resolve_runtime_mode()
+        service_url = runtime.get("base_url", "")
+        if not service_url:
+            return
+        if not server_usable(service_url):
+            # Down server: skip quietly. The stale fingerprint is kept, so the
+            # next Stop retries once the server is back.
+            hook_log("code_reingest_skipped_server", {"base_url": service_url})
+            return
+        outcome = reingest_if_changed(cwd, service_url, os.environ.get("COGNEE_API_KEY", ""))
+        if not outcome:
+            return
+        if outcome.get("changed") and outcome.get("submitted"):
+            hook_log("code_reingest_submitted", outcome)
+            notify(f"code graph re-index submitted ({outcome.get('dataset', '')})")
+        elif outcome.get("changed"):
+            hook_log("code_reingest_failed", outcome)
+        else:
+            hook_log("code_reingest_unchanged", {"repo_root": outcome.get("repo_root", "")})
+    except Exception as exc:
+        hook_log("code_reingest_error", {"error": str(exc)[:200]})
+
+
 def main():
     payload_raw = sys.stdin.read()
     if not payload_raw.strip():
@@ -483,6 +522,9 @@ def main():
         with quiet_hook_output("store-to-session"):
             if is_stop:
                 asyncio.run(_store_assistant_stop(payload))
+                # End-of-turn code-graph freshness: independent of whether an
+                # assistant message was stored (edits happen either way).
+                _maybe_reingest_code_repo(payload)
             else:
                 asyncio.run(_store_tool_call(payload))
     except Exception as exc:

--- a/integrations/claude-code/skills/cognee-code/SKILL.md
+++ b/integrations/claude-code/skills/cognee-code/SKILL.md
@@ -34,6 +34,9 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/cognee-index-repo.sh <repo-path-or-git-url> [--dat
   the graph is queryable. Poll manually via
   `GET /api/v1/datasets/status?dataset=<id>&pipeline=code_graph_pipeline`.
 
+Indexing writes enola's snapshot to `<repo>/.enola/` (untracked) — add it to
+`.gitignore` or global excludes. The plugin's change detection ignores it.
+
 **Indexing is also the freshness opt-in**: for local-path repos the plugin
 records a git fingerprint and automatically re-submits the repo in the
 background when a turn changed the working tree, so the graph tracks your

--- a/integrations/claude-code/skills/cognee-code/SKILL.md
+++ b/integrations/claude-code/skills/cognee-code/SKILL.md
@@ -1,53 +1,44 @@
 ---
-name: codebase
-description: Use when indexing a code repository into Cognee's code graph or querying it (callers, impact analysis, paths, endpoints) from Codex.
+name: cognee-code
+description: Index a code repository into Cognee's code graph and query it deterministically (callers, impact analysis, paths, endpoints). Use for structural code questions, "index this repo", and checking what a re-index changed.
 ---
 
 # Cognee Code Graph
 
-Use this skill when the user asks Codex to build a Cognee memory of a
-repository, index code, or answer structural code questions (who calls X,
-what breaks if X changes, how does A reach B) from memory.
-
-Requires a Cognee server >= 1.5.3. Indexing runs the enola code-graph
-pipeline server-side and makes **no LLM or embedding calls** — it is fast,
+Build and query an architectural graph of a codebase (symbols, calls, imports,
+endpoints, dependencies) via Cognee's enola-backed pipeline. Requires a Cognee
+server >= 1.5.3. Indexing makes **no LLM or embedding calls** — it is fast,
 deterministic, and token-free.
-
-## Rules
-
-- Server-first: the scripts below POST to the running Cognee server. There is
-  deliberately no CLI fallback for code indexing/search — an unreachable
-  server means "not done", never "index some other way".
-- One narrow dataset per repository (default
-  `codebase-<repo-name>-<digest>`); do not mix repositories into one dataset.
-  The digest is the indexed path, so two checkouts sharing a basename stay in
-  separate graphs. `--code` searches resolve the name from the current
-  checkout, so it rarely needs to be typed.
-- Never index directories holding secrets you would not ingest as documents;
-  the pipeline skips `.env`/dotfiles/binaries itself, but a git URL to a
-  private repo still lands its code in the target dataset.
 
 ## Index a repository
 
 ```bash
-${CODEX_PLUGIN_ROOT}/scripts/cognee-index-repo.sh <repo-path-or-git-url> [--dataset <name>] [--index-vectors] [--wait <seconds>]
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-index-repo.sh <repo-path-or-git-url> [--dataset <name>] [--index-vectors] [--wait <seconds>]
 ```
 
-- **Local path** (e.g. `.`): works when the Cognee server shares this
-  filesystem — the default local plugin server does. Cloud servers reject
-  local paths; pass a git URL instead.
-- **Git URL**: the server shallow-clones it; freshness follows *pushed*
-  commits (local edits are invisible to it).
+- **Local path** (e.g. `.` or `/path/to/repo`): works when the Cognee server
+  shares this filesystem — the default local plugin server does. Cloud servers
+  reject local paths; pass a git URL instead.
+- **Git URL** (`https://github.com/org/repo`): the server shallow-clones it.
+  Freshness follows *pushed* commits — local edits are invisible to it.
+- Default dataset is `codebase-<repo-name>-<digest>`, one per indexed repo —
+  narrow datasets keep code searches fast, and the path digest keeps two
+  checkouts that share a basename (`~/work/a/service`, `~/work/b/service`) from
+  landing in one graph. The name is printed on success; you rarely need it,
+  because `--code` searches resolve it from the current checkout.
 - `--index-vectors`: also embeds the code facts so semantic/hybrid search can
   see them (needs an embedding provider). Without it, code knowledge is
-  reachable ONLY through code search below.
-- The submit returns quickly (background pipeline); `--wait 60` polls
-  `pipeline=code_graph_pipeline` until queryable.
+  reachable ONLY through code search below — conceptual questions about the
+  code then rely on ingested docs/READMEs.
+- The submit returns quickly (background pipeline). `--wait 60` polls until
+  the graph is queryable. Poll manually via
+  `GET /api/v1/datasets/status?dataset=<id>&pipeline=code_graph_pipeline`.
 
 **Indexing is also the freshness opt-in**: for local-path repos the plugin
 records a git fingerprint and automatically re-submits the repo in the
-background when a turn changed the working tree. Re-running the command on an
-unchanged repo is skipped server-side (content hashes), so it is always safe.
+background when a turn changed the working tree, so the graph tracks your
+edits. Re-indexing an unchanged repo is skipped server-side (content hashes),
+so re-running the command is always safe.
 
 ## Automatic indexing
 
@@ -88,8 +79,11 @@ servers reject local paths and need a git URL.
 ## Query the code graph
 
 ```bash
-${CODEX_PLUGIN_ROOT}/scripts/cognee-search.sh "<seed>" 10 --code [--code-query '<json>']
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "<seed>" 10 --code [--code-query '<json>']
 ```
+
+The repository's code dataset is resolved from the current directory, so
+`--dataset` is only needed to query a repo you are not standing in.
 
 Without `--code-query`, the query text is a seed name (exact/suffix/substring
 match). With it, pick one exact operation:
@@ -103,25 +97,24 @@ match). With it, pick one exact operation:
 | `impact_analysis` | what breaks if X changes | `{"operation":"impact_analysis","targets":["process_payment"]}` |
 | `delta` | what the last index changed | `{"operation":"delta"}` |
 
-An ambiguous seed returns an error **listing the candidates** — retry with an
-exact id or a `repo` filter. A seed that doesn't resolve returns empty (not
-an error): the graph has no such symbol.
+An ambiguous seed returns an error **listing the candidates** — pick one and
+retry with its exact id or a `repo` filter. A seed that doesn't resolve
+returns empty (not an error): the graph simply has no such symbol.
 
 ## When to use which search
 
-- **Structural question naming a symbol/file** → `--code`. Exact, instant,
-  no tokens.
+- **Structural question naming a symbol/file** ("what calls X", "what breaks
+  if I change X", "list all endpoints") → `--code`. Exact, instant, no tokens.
 - **Conceptual question naming nothing** ("how does auth work here?") →
-  regular `cognee-search.sh` (hybrid/graph). Graph-only code is invisible
-  there unless indexed with `--index-vectors` or the repo's docs were
-  ingested as documents.
-- **Chain them**: hybrid discovers the name, `--code` gives the exact
-  structure around it.
+  regular `cognee-search.sh` (hybrid/graph). Remember: graph-only code is
+  invisible there unless indexed with `--index-vectors` or docs were ingested.
+- **Chain them**: hybrid discovers the name ("the payment flow" →
+  `PaymentProcessor`), then `--code` gives the exact structure around it.
 - **Verify freshness**: after edits, `{"operation":"delta"}` shows what the
-  last re-index added/updated/removed.
+  last re-index added/updated/removed. Use it when facts look stale.
 
 Treat results as a map, not ground truth — verify important claims against
-the actual files before editing code.
+the actual files before editing.
 
 ## Per-file ingestion (no repo index)
 
@@ -129,13 +122,14 @@ To store a single code file in normal memory under its real filename (routes
 down the zero-LLM code path server-side, no cross-file edges):
 
 ```bash
-${CODEX_PLUGIN_ROOT}/scripts/cognee-remember.sh --file src/payments.py --node-set project_docs
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-remember.sh --file src/payments.py --node-set project_docs
 ```
 
-Prefer the repo index above when callers/imports across files matter.
+Prefer the repo index above when you care about callers/imports across files.
 
 ## Automatic recall
 
 Once a repo is indexed from its checkout, the per-prompt memory recall adds a
-code lane automatically when the prompt mentions an identifier-shaped token —
-the facts appear in the injected context as `=== Code graph facts ===`.
+code lane automatically when your prompt mentions an identifier-shaped token
+(`process_payment`, `UserService`, `billing/api.py`) — the facts appear in the
+injected context as `=== Code graph facts ===`. No action needed.

--- a/integrations/claude-code/skills/cognee-remember/SKILL.md
+++ b/integrations/claude-code/skills/cognee-remember/SKILL.md
@@ -36,6 +36,18 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/cognee-remember.sh "$ARGUMENTS" --node-set project
 ${CLAUDE_PLUGIN_ROOT}/scripts/cognee-remember.sh "$ARGUMENTS" --node-set agent_actions
 ```
 
+**Storing a file (code included)**: pass `--file` so the upload keeps its real
+filename — the extension is the server's routing signal, and a code file
+(`.py`/`.ts`/`.go`/...) then rides the zero-LLM code path instead of being
+ingested as prose:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-remember.sh --file src/payments.py --node-set project_docs
+```
+
+For a whole repository (cross-file calls/imports, impact analysis), index it
+instead — see the **cognee-code** skill.
+
 The wrapper POSTs to the running Cognee server (`/api/v1/remember`). A `{"ok": true}` response means the server accepted the data. An error response means the server rejected or failed the request — check `COGNEE_API_KEY` and server logs; do **not** re-run or conclude the data wasn't stored without confirming against the server.
 
 **Background by default + eventual consistency**: the wrapper submits with `run_in_background=true` (so a large cognify never holds one request open past the cloud's ~10-min request ceiling). The POST returns once the work is **enqueued**, with `dataset_id` and `pipeline_run_id`; `status: "running"` means *submitted, not yet in the permanent graph*. The session cache is searchable immediately, but the graph is queryable only after the cognify pipeline **completes**.

--- a/integrations/claude-code/skills/cognee-search/SKILL.md
+++ b/integrations/claude-code/skills/cognee-search/SKILL.md
@@ -38,7 +38,16 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "$ARGUMENTS" 10 --graph
 
 # current session only
 ${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "$ARGUMENTS" 10 --session
+
+# deterministic code graph (indexed repos only — see the cognee-code skill)
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "MyClass" 10 --code
 ```
+
+**Structural code questions belong to `--code`, not here.** "What calls X",
+"what breaks if I change X", "list all endpoints" are answered exactly and
+token-free by the code graph — see the **cognee-code** skill for the
+operations and for indexing a repository. Use this skill's semantic search for
+conceptual questions that name no symbol ("how does auth work here?").
 
 ### Filter by category (optional)
 
@@ -77,6 +86,7 @@ cognee-cli recall "$ARGUMENTS" -k 5 -f json
 Results include a `_source` field:
 - `"session"` — from the session cache (current conversation)
 - `"graph"` — from the permanent knowledge graph
+- `"code"` — deterministic facts from an indexed repository's code graph
 
 Session entries tagged with `[category:agent]` are automatic tool call logs.
 

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -226,6 +226,11 @@ database, and two checkouts sharing a basename (`~/work/a/service`,
 stale-node sweep delete the other's nodes. `--code` searches resolve the
 dataset from the current checkout, so the generated name rarely needs typing.
 
+Indexing writes enola's snapshot into the indexed repository itself, at
+`<repo>/.enola/` (untracked). Add `.enola/` to the repository's `.gitignore` or
+your global excludes; the plugin's change detection already ignores it, so the
+indexer's own output never triggers a re-index.
+
 ### What the graph reflects: working tree vs. pushed commits
 
 **The freshness model differs by where the server runs.** This is a property of the

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -196,6 +196,66 @@ An idle watcher runs in the background for the lifetime of each launch. It polls
 
 Final sync on session end is triggered by the `SessionEnd` detached worker, with an exit watcher as fallback if the process exits without firing `SessionEnd`.
 
+## Code graph
+
+Repositories can be indexed into a deterministic **code graph** (symbols, calls,
+imports, endpoints, dependencies) via cognee's enola-backed pipeline. Indexing makes
+**no LLM or embedding calls** — it is fast and costs no tokens. Requires a cognee
+server >= 1.5.3.
+
+Opening Codex inside a git repository indexes it automatically at session start
+(background, never blocking the first prompt), and re-indexes it after any turn that
+changed the working tree. Index one explicitly — a different repo, a git URL, or one
+automation declined — with:
+
+```bash
+${CODEX_PLUGIN_ROOT}/scripts/cognee-index-repo.sh <repo-path-or-git-url> [--dataset <name>] [--index-vectors] [--wait <seconds>]
+```
+
+Query it with `cognee-search.sh ... --code` (see the `codebase` skill for the
+operations: `query_facts`, `explore`, `traverse`, `find_path`, `impact_analysis`,
+`delta`). Prompts that mention an identifier-shaped token inside an indexed repo also
+get code facts injected automatically by the per-prompt recall hook.
+
+Each indexed repository gets its own dataset, named
+`codebase-<repo-name>-<digest>` where the digest identifies the indexed path.
+Narrow datasets keep code searches fast, and the digest matters for
+correctness: with cognee's default backend every dataset is a separate graph
+database, and two checkouts sharing a basename (`~/work/a/service`,
+`~/work/b/service`) landing in one database would let each re-index's
+stale-node sweep delete the other's nodes. `--code` searches resolve the
+dataset from the current checkout, so the generated name rarely needs typing.
+
+### What the graph reflects: working tree vs. pushed commits
+
+**The freshness model differs by where the server runs.** This is a property of the
+architecture, not a limitation to work around — but it is worth knowing which one you
+are using, because the output looks identical either way.
+
+| Server | Indexed from | Graph reflects | Updated by |
+|---|---|---|---|
+| **Local** (default) | The repository path on this machine | Your working tree, **including uncommitted and untracked changes** | Every turn that changes a file |
+| **Cloud / remote** | A git URL the server clones | The **last pushed commit** on the cloned branch | Pushing, then re-indexing |
+
+A remote server cannot read your disk. It only ever sees code you have pushed, so a
+local edit — however recent — is invisible to it until it lands on the remote. The
+plugin therefore does not re-submit URL-indexed repositories after local edits: doing
+so would re-pull the same commits and change nothing.
+
+The practical consequence on cloud: if you refactor locally and ask about the old
+symbol, the graph answers from the pushed state and the answer *looks* authoritative.
+**Push before relying on code answers about work in progress**, or use a local server
+for branches you are actively editing. `{"operation": "delta"}` reports what the last
+index actually changed, which is the quickest way to confirm what the graph currently
+knows.
+
+| Env var | Default | Effect |
+|---|---|---|
+| `COGNEE_CODE_AUTOINDEX` | `auto` | `auto`: auto-index new repositories only when the server is local (code never leaves the machine) · `always`: also auto-index against a remote server · `off`: never auto-index new repositories (explicitly indexed ones still refresh) |
+
+Automatic indexing skips directories that are not git repositories, hold no source
+files, or exceed 3000 source files. Explicit indexing has no size cap.
+
 ## Status visibility
 
 Cognee status is shown as `cognee: <dataset> · <mode>`, for example:

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,6 +10,51 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.0]
+
+### Added
+- **Code graph.** Repositories can be indexed into cognee's deterministic,
+  enola-backed code graph (symbols, calls, imports, endpoints, dependencies)
+  and queried from the plugin — with **no LLM or embedding calls** on either
+  side. Requires a cognee server >= 1.5.3.
+  - **Automatic indexing**: opening Codex inside a git repository indexes
+    it in the background at session start (never blocking the first prompt)
+    and refreshes an already-indexed repo whose tree changed. New repos are
+    auto-indexed only against a *local* server, where the code stays on the
+    machine; a remote server needs `COGNEE_CODE_AUTOINDEX=always` or an explicit
+    index. Non-git directories, repos with no source files, and repos over 3000
+    source files are skipped (explicit indexing has no cap).
+  - **Freshness**: the Stop hook re-submits an indexed repo when a turn changed
+    its working tree, detected by a git fingerprint (HEAD, dirty set, tracked
+    diff, untracked stats). Failures keep the fingerprint — the edits stay
+    pending — behind an escalating backoff (30s → 15min cap) so an unresolved
+    failure cannot re-submit once per turn forever; a new session always gets
+    one attempt.
+  - **Auto-recall code lane**: prompts naming an identifier-shaped token
+    (`process_payment`, `UserService`, `billing/api.py`) inside an indexed repo
+    get code facts injected under `=== Code graph facts ===`. The lane is
+    additive to the semantic scopes, gated syntactically, and contributes
+    nothing when it misses — conversational prompts are unchanged.
+  - **Explicit tools**: `cognee-index-repo.sh <path-or-git-url>`,
+    `cognee-search.sh "<seed>" --code [--code-query '<json>']` (operations:
+    `query_facts`, `explore`, `traverse`, `find_path`, `impact_analysis`,
+    `delta`), `cognee-remember.sh --file <path>` (uploads under the real
+    filename so code routes as code, not prose), and the `codebase` skill (rewritten off the CLI).
+- One dataset per indexed repository, `codebase-<repo>-<digest>`. The path
+  digest is load-bearing: same-basename checkouts sharing a dataset would share
+  a graph database, where cognee's repo-scoped stale-node sweep would let each
+  re-index delete the other's nodes. `--code` searches resolve the dataset from
+  the current checkout.
+
+### Changed
+- **Pinned cognee version is now `1.5.3`** (was `1.5.0`) — the release that
+  opened `content_type="code"` on `/api/v1/remember` and the `code` recall
+  scope. Installed into the managed venv on next session start.
+- The freshness model is documented as a property of where the server runs:
+  a local server reflects the working tree (uncommitted changes included); a
+  cloud server reflects the last *pushed* commit, since its clone cannot see
+  local edits.
+
 ## [1.4.3]
 
 ### Fixed

--- a/integrations/codex/plugins/cognee/scripts/_code_graph.py
+++ b/integrations/codex/plugins/cognee/scripts/_code_graph.py
@@ -23,7 +23,10 @@ Four responsibilities, all shared by the wrapper CLI and the hooks:
    the repo is re-submitted in the background. The fingerprint is only a
    cheap client-side gate — the server re-hashes every covered file anyway
    (manifest content hash + enola snapshot identity), so a false positive
-   costs one skipped submission, never a wasted re-parse.
+   costs one skipped submission, never a wasted re-parse. A failed submission
+   leaves the fingerprint untouched so the edits stay pending, and an
+   escalating time backoff (``retry_backoff_seconds``) keeps an unresolved
+   failure from re-submitting once per turn forever.
 
 3. **Recall gating** (``auto_code_lane``): the per-prompt recall hook adds a
    ``code`` scope lane ONLY when (a) the prompt contains an
@@ -506,10 +509,21 @@ def do_index_repo(
         )
         return UNREACHABLE
 
+    # A 2xx the caller cannot parse is NOT reported as success, unlike the
+    # fire-and-forget remember path. Callers here treat "ok" as confirmation
+    # and advance the repo's stored fingerprint on it — so an unparseable body
+    # would mark this turn's edits as indexed, and the next turn would see an
+    # unchanged tree and never retry, leaving the graph silently stale. The
+    # opposite mistake is cheap: keeping the old fingerprint costs one
+    # re-submission, which the server's content hash skips if the write did
+    # land.
     try:
         data = json.loads(raw or "{}")
-    except (json.JSONDecodeError, ValueError):
-        return {"ok": True}
+    except (json.JSONDecodeError, ValueError) as e:
+        sys.stderr.write(
+            "[cognee-code-graph] malformed JSON from /api/v1/remember: %s\n" % str(e)[:160]
+        )
+        return _error(200, "malformed JSON response from /api/v1/remember")
     if isinstance(data, dict) and data.get("error"):
         msg = str(data.get("error"))[:200]
         sys.stderr.write("[cognee-code-graph] server returned error: %s\n" % msg)
@@ -640,6 +654,66 @@ def index_repo(
     return result
 
 
+# Escalating retry backoff for a repo whose re-index keeps failing.
+# A failed submission deliberately leaves the fingerprint alone so the edits
+# stay pending — but the tree then differs from the stored fingerprint on EVERY
+# later turn, conversation-only turns included, so an unresolved failure (a bad
+# API key, a server too old for content_type='code') would otherwise re-submit
+# once per turn forever and append a line to a hook log that never rotates.
+#
+# Time, not error class, is the gate. The failures worth calling "permanent"
+# here — 401, 403, a 400 from an old server — are all fixable by the user
+# mid-session, and fixing them is exactly when a prompt retry should catch the
+# graph up. Suppressing retries by error class (or, worse, advancing the
+# fingerprint to stop them) would trade a noisy failure for a silently stale
+# graph. The cap bounds recovery lag instead.
+_RETRY_BACKOFF_BASE_SECONDS = 30.0
+_RETRY_BACKOFF_MAX_SECONDS = 900.0
+
+
+def retry_backoff_seconds(error_count: int) -> float:
+    """Seconds to wait after ``error_count`` consecutive failures."""
+    if error_count <= 0:
+        return 0.0
+    return min(
+        _RETRY_BACKOFF_BASE_SECONDS * (2 ** (error_count - 1)),
+        _RETRY_BACKOFF_MAX_SECONDS,
+    )
+
+
+def _retry_suppressed(state: dict, now: float) -> bool:
+    """Whether a failing repo is still inside its backoff window."""
+    try:
+        error_count = int(state.get("error_count") or 0)
+        last_error_at = float(state.get("last_error_at") or 0.0)
+    except (TypeError, ValueError):
+        return False
+    if error_count <= 0 or last_error_at <= 0:
+        return False
+    # A clock that moved backwards (system time change) must not park a repo
+    # in backoff indefinitely — treat it as due.
+    if now < last_error_at:
+        return False
+    return (now - last_error_at) < retry_backoff_seconds(error_count)
+
+
+def _record_retry_failure(state: dict, error: str, now: float) -> None:
+    """Advance the backoff counters. Never touches ``fingerprint``."""
+    try:
+        state["error_count"] = int(state.get("error_count") or 0) + 1
+    except (TypeError, ValueError):
+        state["error_count"] = 1
+    state["last_error_at"] = now
+    state["last_error"] = str(error)[:200]
+    save_repo_state(state)
+
+
+def _clear_retry_failure(state: dict) -> None:
+    """Forget a past failure once an index succeeds."""
+    for field in ("error_count", "last_error_at", "last_error"):
+        state.pop(field, None)
+
+
 def reingest_if_changed(cwd, service_url, api_key, *, opener=urllib.request.urlopen) -> dict:
     """Stop-hook freshness pass: re-submit the cwd's indexed repo if it changed.
 
@@ -663,6 +737,14 @@ def reingest_if_changed(cwd, service_url, api_key, *, opener=urllib.request.urlo
         if fingerprint == str(state.get("fingerprint") or ""):
             return {"changed": False, "repo_root": root}
 
+        # Still inside the backoff window after earlier failures: make no
+        # request and return the "nothing to do" shape, which the Stop hook
+        # does not log. The pending edits stay pending (the fingerprint is
+        # untouched) and the next attempt happens when the window expires.
+        now = time.time()
+        if _retry_suppressed(state, now):
+            return {}
+
         result = do_index_repo(
             service_url,
             api_key,
@@ -674,20 +756,24 @@ def reingest_if_changed(cwd, service_url, api_key, *, opener=urllib.request.urlo
         outcome = {"changed": True, "repo_root": root, "dataset": state.get("dataset")}
         if isinstance(result, dict) and result.get("ok"):
             state["fingerprint"] = fingerprint
-            state["last_index_at"] = time.time()
+            state["last_index_at"] = now
             state["last_status"] = str(result.get("status") or "submitted")
+            _clear_retry_failure(state)
             save_repo_state(state)
             outcome["submitted"] = True
             if result.get("pipeline_run_id"):
                 outcome["pipeline_run_id"] = result["pipeline_run_id"]
         else:
-            # Keep the OLD fingerprint on failure so the next turn retries.
+            # Keep the OLD fingerprint on failure so the edits stay pending and
+            # a later turn retries; only the backoff counters advance.
             outcome["submitted"] = False
             outcome["error"] = (
                 "unreachable"
                 if result == UNREACHABLE
                 else str(result.get("error") if isinstance(result, dict) else result)[:200]
             )
+            _record_retry_failure(state, outcome["error"], now)
+            outcome["retry_in"] = round(retry_backoff_seconds(state["error_count"]))
         return outcome
     except Exception as exc:  # never break the Stop hook
         return {"changed": None, "error": str(exc)[:200]}
@@ -771,7 +857,16 @@ def autoindex_on_session_start(
         if not root:
             return {}
 
-        if find_indexed_repo(root):
+        indexed = find_indexed_repo(root)
+        if indexed:
+            # A session start is the gesture a user makes after fixing what
+            # broke indexing (a corrected API key, a restarted/upgraded
+            # server), so it always gets one attempt rather than waiting out a
+            # backoff window earned by the previous session. Bounded by
+            # launches, not turns — which is what the per-turn backoff guards.
+            if indexed.get("error_count"):
+                _clear_retry_failure(indexed)
+                save_repo_state(indexed)
             outcome = reingest_if_changed(root, service_url, api_key, opener=opener)
             if outcome:
                 outcome["reason"] = "refresh"

--- a/integrations/codex/plugins/cognee/scripts/_code_graph.py
+++ b/integrations/codex/plugins/cognee/scripts/_code_graph.py
@@ -87,8 +87,8 @@ _STATE_DIR = Path.home() / ".cognee-plugin" / _INTEGRATION / "code-graph"
 _GIT_TIMEOUT_SECONDS = 10.0
 
 # Mirrors cognee's CodeLoader SUPPORTED_CODE_EXTENSIONS (v1.5.3) — the
-# extensions the per-file CODE route claims. Used for the --file remember
-# path's hinting and the identifier extractor's filename pattern.
+# extensions the per-file CODE route claims. Used by the identifier
+# extractor's filename pattern and the auto-index source-file count.
 CODE_EXTENSIONS = frozenset(
     {
         "c",
@@ -252,29 +252,48 @@ def git_repo_root(cwd: str) -> str:
     return os.path.realpath(out) if out else ""
 
 
+# enola writes its snapshot INTO the indexed repository (<repo>/.enola/) and
+# rotates files there on every run. Left visible to the fingerprint, the
+# indexer's own output would change the fingerprint after every index, so the
+# next turn would see a "changed" tree and re-index — a full enola parse per
+# turn, forever, for every locally indexed repo (verified: two enola runs with
+# no source edit produce two different fingerprints). Excluded at the git level
+# so neither the dirty-path set nor the untracked stats can see it.
+_ENOLA_SNAPSHOT_DIR = ".enola"
+_FINGERPRINT_PATHSPEC = ["--", ".", f":(exclude){_ENOLA_SNAPSHOT_DIR}"]
+
+
 def git_fingerprint(root: str) -> str:
     """A cheap content fingerprint of the working tree.
 
     Covers HEAD, the dirty-path set, tracked content changes (``git diff
     HEAD``), and untracked files by (path, size, mtime) — porcelain alone
-    would miss a re-edit of an already-dirty file. Returns "" when the root
-    is not a usable git repo; callers treat "" as "cannot fingerprint" and
-    skip the freshness gate (the server-side hashes still dedupe).
+    would miss a re-edit of an already-dirty file. The enola snapshot dir the
+    indexer itself writes is excluded (see ``_FINGERPRINT_PATHSPEC``). Returns
+    "" when the root is not a usable git repo; callers treat "" as "cannot
+    fingerprint" and skip the freshness gate (the server-side hashes still
+    dedupe).
     """
     if not root:
         return ""
     head = _run_git(["rev-parse", "HEAD"], root).strip()
     if not head:
         return ""
-    porcelain = _run_git(["status", "--porcelain"], root)
+    porcelain = _run_git(["status", "--porcelain", *_FINGERPRINT_PATHSPEC], root)
     digest = hashlib.sha256()
     digest.update(head.encode("utf-8"))
     digest.update(porcelain.encode("utf-8"))
-    digest.update(_run_git(["diff", "HEAD"], root).encode("utf-8", errors="replace"))
+    digest.update(
+        _run_git(["diff", "HEAD", *_FINGERPRINT_PATHSPEC], root).encode("utf-8", errors="replace")
+    )
     for line in porcelain.splitlines():
         if not line.startswith("??"):
             continue
         rel = line[3:].strip().strip('"')
+        # Belt and braces: an older git that ignores the exclude pathspec must
+        # still never let the snapshot dir drive the fingerprint.
+        if rel.rstrip("/") == _ENOLA_SNAPSHOT_DIR or rel.startswith(_ENOLA_SNAPSHOT_DIR + "/"):
+            continue
         path = os.path.join(root, rel)
         try:
             stat = os.stat(path)

--- a/integrations/codex/plugins/cognee/scripts/_code_graph.py
+++ b/integrations/codex/plugins/cognee/scripts/_code_graph.py
@@ -1,0 +1,864 @@
+#!/usr/bin/env python3
+"""Code-graph (enola) pipeline helpers: repo indexing, freshness, recall gating.
+
+Standalone, stdlib-only, so it runs under the system ``python3`` without the
+plugin venv (the same constraint ``_remember_http.py`` / ``_recall_http.py``
+already work under). Requires a cognee server >= 1.5.3 (the release that
+opened ``content_type="code"`` on /api/v1/remember and the ``code`` recall
+scope).
+
+Four responsibilities, all shared by the wrapper CLI and the hooks:
+
+1. **Repo indexing** (``do_index_repo``): POST ``content_type="code"`` +
+   ``repositories`` to ``/api/v1/remember``. One code graph per repository
+   spec (a local path when the server shares this filesystem, or a git URL
+   the server clones). The transport contract mirrors ``_remember_http.py``:
+   ``{"ok": true, ...}`` on 2xx, an error envelope on HTTP errors (no CLI
+   fallback — there is no CLI equivalent for this route), and the
+   ``UNREACHABLE`` sentinel only when the server is positively absent.
+
+2. **Freshness** (``reingest_if_changed``): a per-repo state file records the
+   git fingerprint at the last successful index. The Stop hook calls this
+   with the turn's cwd; when the working tree changed since the last index,
+   the repo is re-submitted in the background. The fingerprint is only a
+   cheap client-side gate — the server re-hashes every covered file anyway
+   (manifest content hash + enola snapshot identity), so a false positive
+   costs one skipped submission, never a wasted re-parse.
+
+3. **Recall gating** (``auto_code_lane``): the per-prompt recall hook adds a
+   ``code`` scope lane ONLY when (a) the prompt contains an
+   identifier-shaped token and (b) the cwd sits inside a repo this plugin
+   has indexed. The lane is additive — it never replaces the semantic
+   scopes — and a seed the code graph cannot resolve contributes nothing
+   server-side, so misfires are cheap by design.
+
+4. **Session-start auto-indexing** (``autoindex_on_session_start``): opening
+   an agent in a repo should not require a setup step, so a new repo is
+   indexed and an already-indexed one refreshed. Indexing a repo nobody asked
+   about is gated (see ``autoindex_mode``); refreshing one that WAS asked for
+   is not.
+
+State lives under ``~/.cognee-plugin/<integration>/code-graph/<slug>.json``.
+A repo has a state file once it has been indexed — explicitly via the wrapper
+or skill, or automatically at session start — and only repos with a state file
+are ever refreshed or queried by the recall lane.
+
+**Freshness ceiling.** What a code graph can possibly reflect is set by how the
+server reads the repo, and the two cases differ permanently:
+
+* ``spec_kind == "path"`` — the server shares this filesystem and reads the
+  working tree in place, so the graph covers uncommitted and untracked changes
+  and the per-turn refresh keeps it current.
+* ``spec_kind == "url"`` — the server clones the repo and can only ever see
+  PUSHED commits. A local edit cannot reach it, so the freshness paths here
+  deliberately skip URL-indexed repos rather than re-submitting: a re-pull
+  would fetch the same commits and rewrite the same graph. Such a graph
+  advances only when the user pushes and the repo is indexed again.
+
+This is normal behavior, not a gap to close client-side — but the two produce
+identical-looking results, which is why the skills tell the agent to say which
+one it is answering from when the work is in progress.
+"""
+
+import hashlib
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+
+# The one line that differs between the claude-code and codex copies.
+_INTEGRATION = "codex"
+
+UNREACHABLE = "UNREACHABLE"
+
+_STATE_DIR = Path.home() / ".cognee-plugin" / _INTEGRATION / "code-graph"
+
+_GIT_TIMEOUT_SECONDS = 10.0
+
+# Mirrors cognee's CodeLoader SUPPORTED_CODE_EXTENSIONS (v1.5.3) — the
+# extensions the per-file CODE route claims. Used for the --file remember
+# path's hinting and the identifier extractor's filename pattern.
+CODE_EXTENSIONS = frozenset(
+    {
+        "c",
+        "cc",
+        "cpp",
+        "cs",
+        "cxx",
+        "dart",
+        "fs",
+        "go",
+        "h",
+        "hcl",
+        "hh",
+        "hpp",
+        "java",
+        "js",
+        "jsx",
+        "kt",
+        "kts",
+        "php",
+        "proto",
+        "py",
+        "rake",
+        "rb",
+        "rs",
+        "scala",
+        "svelte",
+        "swift",
+        "tf",
+        "ts",
+        "tsx",
+        "vb",
+        "vue",
+    }
+)
+
+# CamelCase words that are common prose, product names, or agent vocabulary —
+# not symbols worth seeding a code-graph query with. Misfires are cheap
+# (seed-not-found returns an empty lane), so this list stays small and only
+# covers the words that would fire on nearly every prompt in this ecosystem.
+_CAMEL_STOPLIST = frozenset(
+    {
+        "Claude",
+        "ClaudeCode",
+        "Codex",
+        "Cognee",
+        "GitHub",
+        "GitLab",
+        "JavaScript",
+        "TypeScript",
+        "PostgreSQL",
+        "MongoDB",
+        "OpenAI",
+        "MacOS",
+        "ReadMe",
+        "WiFi",
+        "OAuth",
+        "TODOs",
+    }
+)
+
+# Ordered by confidence: backticked wins, then file paths, dotted paths,
+# snake_case, CamelCase. Each pattern is deliberately conservative — the gate
+# exists to keep the code lane OFF conversational prompts, not to catch every
+# possible symbol.
+_BACKTICK_RE = re.compile(r"`([^`\n]{2,120})`")
+_FILEPATH_RE = re.compile(r"\b[\w./-]{1,120}\.(?:%s)\b" % "|".join(sorted(CODE_EXTENSIONS)))
+_DOTTED_RE = re.compile(r"\b[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+\b")
+_SNAKE_RE = re.compile(r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b")
+_CAMEL_RE = re.compile(r"\b[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]*)+\b")
+
+_IDENTIFIER_CHARS_RE = re.compile(r"^[\w./:-]+$")
+
+
+def extract_identifiers(prompt: str, limit: int = 2) -> list:
+    """Identifier-shaped tokens from a prompt, best first, at most ``limit``.
+
+    An empty list means the syntactic gate did not fire and the code lane
+    should be skipped for this prompt.
+    """
+    if not prompt:
+        return []
+    found: list = []
+    seen = set()
+
+    def _add(token: str) -> None:
+        token = token.strip().strip(".,:;()[]{}")
+        if len(token) < 3 or len(token) > 120:
+            return
+        if token in _CAMEL_STOPLIST:
+            return
+        key = token.casefold()
+        if key in seen:
+            return
+        seen.add(key)
+        found.append(token)
+
+    for match in _BACKTICK_RE.finditer(prompt):
+        inner = match.group(1).strip()
+        # Backticks quote commands and prose too; only take single
+        # identifier-shaped tokens (no spaces, identifier charset).
+        if " " not in inner and _IDENTIFIER_CHARS_RE.match(inner):
+            _add(inner)
+    for pattern in (_FILEPATH_RE, _DOTTED_RE, _SNAKE_RE, _CAMEL_RE):
+        for match in pattern.finditer(prompt):
+            token = match.group(0)
+            if pattern is _DOTTED_RE:
+                # Drop prose artifacts like "e.g" / "i.e": require some meat.
+                parts = token.split(".")
+                if len(token) < 5 or not any(len(p) >= 3 for p in parts):
+                    continue
+                # Version-ish or domain-ish tokens ("v1.5.3", "example.com")
+                # are not symbols; require an underscore-free camel or a
+                # known code extension to be safe? Keep it simple: skip pure
+                # lowercase two-part tokens that end in a TLD-looking part.
+                if len(parts) == 2 and parts[1].lower() in ("com", "org", "net", "io", "ai", "dev"):
+                    continue
+            _add(token)
+
+    return found[:limit]
+
+
+def build_code_query(identifier: str, limit: int = 5) -> dict:
+    """The auto-recall code_query: a bounded substring fact lookup.
+
+    query_facts (not explore) on purpose: explore needs a resolvable seed and
+    errors on ambiguity, while query_facts degrades to an empty page — the
+    right failure mode for a lane that must never disturb the prompt path.
+    """
+    return {"operation": "query_facts", "name": identifier, "limit": limit}
+
+
+# ---------------------------------------------------------------------------
+# Git fingerprint + per-repo state
+# ---------------------------------------------------------------------------
+
+
+def _run_git(args, cwd: str) -> str:
+    """Run git and return stdout, or "" on any failure (missing git included)."""
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            text=True,
+            errors="replace",
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout
+
+
+def git_repo_root(cwd: str) -> str:
+    """The repo root containing ``cwd``, or "" when not inside a git repo."""
+    if not cwd or not os.path.isdir(cwd):
+        return ""
+    out = _run_git(["rev-parse", "--show-toplevel"], cwd).strip()
+    return os.path.realpath(out) if out else ""
+
+
+def git_fingerprint(root: str) -> str:
+    """A cheap content fingerprint of the working tree.
+
+    Covers HEAD, the dirty-path set, tracked content changes (``git diff
+    HEAD``), and untracked files by (path, size, mtime) — porcelain alone
+    would miss a re-edit of an already-dirty file. Returns "" when the root
+    is not a usable git repo; callers treat "" as "cannot fingerprint" and
+    skip the freshness gate (the server-side hashes still dedupe).
+    """
+    if not root:
+        return ""
+    head = _run_git(["rev-parse", "HEAD"], root).strip()
+    if not head:
+        return ""
+    porcelain = _run_git(["status", "--porcelain"], root)
+    digest = hashlib.sha256()
+    digest.update(head.encode("utf-8"))
+    digest.update(porcelain.encode("utf-8"))
+    digest.update(_run_git(["diff", "HEAD"], root).encode("utf-8", errors="replace"))
+    for line in porcelain.splitlines():
+        if not line.startswith("??"):
+            continue
+        rel = line[3:].strip().strip('"')
+        path = os.path.join(root, rel)
+        try:
+            stat = os.stat(path)
+            digest.update(f"{rel}:{stat.st_size}:{stat.st_mtime_ns}".encode("utf-8"))
+        except OSError:
+            digest.update(f"{rel}:gone".encode("utf-8"))
+    return digest.hexdigest()
+
+
+def canonical_spec(spec: str) -> str:
+    """The stable identity of an indexed repository.
+
+    Local paths resolve through symlinks so the same checkout reached by two
+    routes is one repository; remote URLs drop a trailing slash and the ``.git``
+    suffix so ``…/repo`` and ``…/repo.git`` do not index twice.
+    """
+    spec = str(spec).strip()
+    if is_remote_repo(spec):
+        canonical = spec.rstrip("/")
+        if canonical.endswith(".git"):
+            canonical = canonical[: -len(".git")]
+        return canonical
+    return os.path.realpath(spec)
+
+
+def _readable_tail(canonical: str) -> str:
+    tail = os.path.basename(canonical.rstrip("/")) or "repo"
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", tail).strip("-.") or "repo"
+
+
+def _repo_slug(root_or_spec: str) -> str:
+    canonical = canonical_spec(root_or_spec)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:12]
+    return f"{_readable_tail(canonical)}-{digest}"
+
+
+def default_code_dataset(spec: str) -> str:
+    """A stable, readable, collision-free per-repo dataset name.
+
+    Narrow datasets keep the CODE snapshot cache and the delta pre-read small,
+    so one dataset per indexed repository is the default. The basename alone
+    cannot be that identity: checkouts routinely share one (``~/work/a/service``
+    and ``~/work/b/service``), and two repos landing in one dataset share a
+    graph database — where cognee's stale-node sweep, scoped by repo name,
+    would let each ingestion delete the other's nodes. The path digest makes
+    the name unique per checkout while the readable tail keeps it recognizable
+    in a dataset listing.
+    """
+    canonical = canonical_spec(spec)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:8]
+    return f"codebase-{_readable_tail(canonical).lower()}-{digest}"
+
+
+def is_remote_repo(spec: str) -> bool:
+    return isinstance(spec, str) and spec.startswith(("https://", "http://", "git@", "ssh://"))
+
+
+def _state_path(key: str) -> Path:
+    return _STATE_DIR / f"{_repo_slug(key)}.json"
+
+
+def save_repo_state(state: dict) -> None:
+    """Persist one repo's index state. ``state`` must carry ``spec``."""
+    key = state.get("repo_root") or state.get("spec") or ""
+    if not key:
+        return
+    _STATE_DIR.mkdir(parents=True, exist_ok=True)
+    _state_path(key).write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
+
+
+def load_repo_states() -> list:
+    """All recorded repo states (invalid files are skipped, never raised)."""
+    states = []
+    try:
+        entries = sorted(_STATE_DIR.glob("*.json"))
+    except OSError:
+        return states
+    for path in entries:
+        try:
+            state = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if isinstance(state, dict):
+            states.append(state)
+    return states
+
+
+def find_indexed_repo(cwd: str) -> dict:
+    """The index state whose repo_root contains ``cwd``, or {}.
+
+    Only locally-indexed repos (spec = path) are matched by cwd; a repo
+    indexed by URL has no local root to match. Longest matching root wins so
+    nested checkouts resolve to the innermost indexed repo.
+    """
+    real = os.path.realpath(cwd) if cwd else ""
+    if not real:
+        return {}
+    best: dict = {}
+    for state in load_repo_states():
+        root = str(state.get("repo_root") or "")
+        if not root:
+            continue
+        if real == root or real.startswith(root.rstrip(os.sep) + os.sep):
+            if len(root) > len(str(best.get("repo_root") or "")):
+                best = state
+    return best
+
+
+def auto_code_lane(prompt: str, cwd: str) -> dict:
+    """The per-prompt recall gate. Returns {} when the lane must not fire.
+
+    Fires only when the prompt carries an identifier-shaped token AND the
+    cwd sits inside a repo this plugin indexed — never on conversational
+    prompts, never on repos nobody asked to index.
+    """
+    identifiers = extract_identifiers(prompt)
+    if not identifiers:
+        return {}
+    state = find_indexed_repo(cwd)
+    if not state or not state.get("dataset"):
+        return {}
+    return {
+        "dataset": str(state["dataset"]),
+        "identifier": identifiers[0],
+        "code_query": build_code_query(identifiers[0]),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Transport: index / re-ingest via /api/v1/remember (content_type="code")
+# ---------------------------------------------------------------------------
+
+
+def _multipart_body(fields):
+    """Multipart encoder over (name, value) pairs — repeated names allowed,
+    which List[str] Form fields (repositories) require."""
+    boundary = f"----cogneeCodeGraph{uuid.uuid4().hex}"
+    chunks = []
+    for name, value in fields:
+        chunks.append(f"--{boundary}\r\n".encode("utf-8"))
+        chunks.append(f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode("utf-8"))
+        chunks.append(str(value).encode("utf-8"))
+        chunks.append(b"\r\n")
+    chunks.append(f"--{boundary}--\r\n".encode("utf-8"))
+    return b"".join(chunks), boundary
+
+
+def _error(status, message, *, transient=False):
+    """Reachable server, failed/rejected request — the caller must NOT treat
+    this as 'server absent' (there is no fallback path for this route)."""
+    envelope = {"error": message, "status": status, "authoritative": False}
+    if transient:
+        envelope["transient"] = True
+    return envelope
+
+
+def do_index_repo(
+    service_url,
+    api_key,
+    repo_spec,
+    dataset,
+    *,
+    index_vectors=False,
+    run_in_background=True,
+    opener=urllib.request.urlopen,
+    timeout=120.0,
+):
+    """Submit one repository for code-graph indexing.
+
+    Returns {"ok": true, ...} on 2xx, an error envelope on HTTP errors, and
+    UNREACHABLE only on a positively absent server. A timeout is NOT
+    unreachable: background submits return fast, so a timeout usually means
+    a slow synchronous run that may still land — surfaced as a transient
+    note, never retried blindly.
+    """
+    url = service_url.rstrip("/") + "/api/v1/remember"
+    body, boundary = _multipart_body(
+        [
+            ("datasetName", dataset),
+            ("content_type", "code"),
+            ("repositories", str(repo_spec)),
+            ("run_in_background", "true" if run_in_background else "false"),
+            ("index_vectors", "true" if index_vectors else "false"),
+        ]
+    )
+    headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
+    if api_key:
+        headers["X-Api-Key"] = api_key
+
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with opener(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        detail = ""
+        try:
+            payload = json.loads(e.read().decode("utf-8") or "{}")
+            detail = str(payload.get("detail") or payload.get("error") or "")[:300]
+        except Exception:
+            pass
+        if e.code in (401, 403):
+            msg = "unauthorized (HTTP %s) — check COGNEE_API_KEY / credentials" % e.code
+        elif e.code == 400 and "content_type" in detail:
+            # An older server (< 1.5.3) rejects content_type='code' outright.
+            msg = (
+                "server rejected content_type='code' (HTTP 400) — repo indexing "
+                "requires cognee >= 1.5.3; restart the session to upgrade the "
+                "plugin server, or upgrade the remote deployment. Detail: " + detail
+            )
+        else:
+            msg = "server returned HTTP %s for /api/v1/remember" % e.code
+            if detail:
+                msg += " — " + detail
+        sys.stderr.write("[cognee-code-graph] %s\n" % msg)
+        return _error(e.code, msg)
+    except (TimeoutError, socket.timeout):
+        sys.stderr.write(
+            "[cognee-code-graph] timed out after %ss waiting for confirmation; the "
+            "submission may have landed — not retrying\n" % timeout
+        )
+        return _error(0, "index submitted; timed out after %ss" % timeout, transient=True)
+    except urllib.error.URLError as e:
+        if isinstance(getattr(e, "reason", None), (TimeoutError, socket.timeout)):
+            return _error(0, "index submitted; timed out after %ss" % timeout, transient=True)
+        sys.stderr.write(
+            "[cognee-code-graph] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+        )
+        return UNREACHABLE
+    except Exception as e:
+        sys.stderr.write(
+            "[cognee-code-graph] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+        )
+        return UNREACHABLE
+
+    try:
+        data = json.loads(raw or "{}")
+    except (json.JSONDecodeError, ValueError):
+        return {"ok": True}
+    if isinstance(data, dict) and data.get("error"):
+        msg = str(data.get("error"))[:200]
+        sys.stderr.write("[cognee-code-graph] server returned error: %s\n" % msg)
+        return _error(200, msg)
+
+    result = {"ok": True, "repository": str(repo_spec)}
+    if isinstance(data, dict):
+        for field in ("dataset_id", "pipeline_run_id", "status"):
+            if data.get(field):
+                result[field] = str(data[field])
+        if data.get("items"):
+            result["items"] = data["items"]
+    return result
+
+
+def poll_code_graph_status(
+    service_url,
+    api_key,
+    dataset_id,
+    deadline_seconds,
+    *,
+    opener=urllib.request.urlopen,
+    interval_seconds=3.0,
+    request_timeout=10.0,
+):
+    """Poll /api/v1/datasets/status for the code_graph_pipeline.
+
+    Returns "completed" | "errored" | "timeout" | "unknown" — the plugins'
+    cognify poll targets pipeline=cognify_pipeline, which never sees code
+    runs, so this variant exists specifically for the code route.
+    """
+    if not dataset_id:
+        return "unknown"
+    url = (
+        service_url.rstrip("/")
+        + "/api/v1/datasets/status?dataset="
+        + urllib.parse.quote(str(dataset_id))
+        + "&pipeline=code_graph_pipeline"
+    )
+    headers = {}
+    if api_key:
+        headers["X-Api-Key"] = api_key
+    deadline = time.monotonic() + max(0.0, deadline_seconds)
+    while True:
+        status = ""
+        try:
+            req = urllib.request.Request(url, headers=headers, method="GET")
+            with opener(req, timeout=request_timeout) as resp:
+                raw = resp.read().decode("utf-8")
+            parsed = json.loads(raw or "{}")
+            if isinstance(parsed, dict) and parsed:
+                val = parsed.get(str(dataset_id))
+                if val is None and len(parsed) == 1:
+                    val = next(iter(parsed.values()))
+                if isinstance(val, dict):
+                    val = val.get("code_graph_pipeline")
+                status = str(val or "").upper()
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return "unknown"
+        except Exception:
+            pass
+        if status.endswith("COMPLETED"):
+            return "completed"
+        if status.endswith("ERRORED"):
+            return "errored"
+        if time.monotonic() >= deadline:
+            return "timeout"
+        time.sleep(max(0.1, interval_seconds))
+
+
+def index_repo(
+    service_url,
+    api_key,
+    spec,
+    dataset="",
+    *,
+    index_vectors=False,
+    wait_seconds=0.0,
+    opener=urllib.request.urlopen,
+):
+    """Index one repo AND record its state file (the opt-in the hooks honor).
+
+    Local paths are fingerprinted so the Stop hook can re-ingest on change;
+    URL specs record no fingerprint (server-side clones only see pushes).
+
+    ``repo_root`` is the indexed path itself, not its enclosing git root: the
+    indexed unit is exactly what the caller named, so cwd matching stays
+    precise (indexing one subdirectory must not claim the whole repository)
+    and two subdirectories of one repository cannot record the same root and
+    then match a cwd in arbitrary order.
+    """
+    spec = canonical_spec(spec)
+    remote = is_remote_repo(spec)
+    repo_root = "" if remote else spec
+    dataset = dataset or default_code_dataset(spec)
+
+    result = do_index_repo(
+        service_url,
+        api_key,
+        spec,
+        dataset,
+        index_vectors=index_vectors,
+        opener=opener,
+    )
+    if result == UNREACHABLE or (isinstance(result, dict) and result.get("error")):
+        return result
+
+    if wait_seconds > 0 and isinstance(result, dict) and result.get("dataset_id"):
+        outcome = poll_code_graph_status(
+            service_url, api_key, result["dataset_id"], wait_seconds, opener=opener
+        )
+        result["wait_outcome"] = outcome
+        result["queryable"] = outcome == "completed"
+
+    state = {
+        "spec": spec,
+        "spec_kind": "url" if remote else "path",
+        "repo_root": repo_root,
+        "dataset": dataset,
+        "index_vectors": bool(index_vectors),
+        "fingerprint": git_fingerprint(repo_root) if repo_root else "",
+        "last_index_at": time.time(),
+        "last_status": str(result.get("status") or "submitted") if isinstance(result, dict) else "",
+    }
+    save_repo_state(state)
+    result["dataset"] = dataset
+    return result
+
+
+def reingest_if_changed(cwd, service_url, api_key, *, opener=urllib.request.urlopen) -> dict:
+    """Stop-hook freshness pass: re-submit the cwd's indexed repo if it changed.
+
+    Returns a small outcome dict for logging; {} when there is nothing to do
+    (no indexed repo for this cwd, URL-indexed repo, or unchanged tree).
+    Never raises — this runs on the (async) Stop hook.
+
+    URL-indexed repos are skipped by design, not by omission: the server built
+    that graph from its own clone, which only ever holds pushed commits, so
+    re-submitting after a local edit would re-pull the same commits and produce
+    the same graph. Those graphs advance when the user pushes and re-indexes.
+    """
+    try:
+        state = find_indexed_repo(cwd)
+        if not state or state.get("spec_kind") != "path":
+            return {}
+        root = str(state.get("repo_root") or "")
+        fingerprint = git_fingerprint(root)
+        if not fingerprint:
+            return {}
+        if fingerprint == str(state.get("fingerprint") or ""):
+            return {"changed": False, "repo_root": root}
+
+        result = do_index_repo(
+            service_url,
+            api_key,
+            state.get("spec") or root,
+            str(state.get("dataset") or default_code_dataset(root)),
+            index_vectors=bool(state.get("index_vectors")),
+            opener=opener,
+        )
+        outcome = {"changed": True, "repo_root": root, "dataset": state.get("dataset")}
+        if isinstance(result, dict) and result.get("ok"):
+            state["fingerprint"] = fingerprint
+            state["last_index_at"] = time.time()
+            state["last_status"] = str(result.get("status") or "submitted")
+            save_repo_state(state)
+            outcome["submitted"] = True
+            if result.get("pipeline_run_id"):
+                outcome["pipeline_run_id"] = result["pipeline_run_id"]
+        else:
+            # Keep the OLD fingerprint on failure so the next turn retries.
+            outcome["submitted"] = False
+            outcome["error"] = (
+                "unreachable"
+                if result == UNREACHABLE
+                else str(result.get("error") if isinstance(result, dict) else result)[:200]
+            )
+        return outcome
+    except Exception as exc:  # never break the Stop hook
+        return {"changed": None, "error": str(exc)[:200]}
+
+
+# ---------------------------------------------------------------------------
+# Session-start auto-indexing
+# ---------------------------------------------------------------------------
+
+# A repo bigger than this many source files is not auto-indexed: the enola pass
+# is CPU-bound over the whole tree, and silently spending that on a monorepo
+# nobody asked to index is worse than doing nothing. Explicit indexing (the
+# wrapper / skill) has no cap — an explicit request IS the consent.
+_AUTOINDEX_MAX_FILES = 3000
+
+
+def autoindex_mode() -> str:
+    """How session start treats an unindexed repo: "auto" | "off" | "always".
+
+    - ``auto`` (default): index a new repo only when the server is LOCAL, where
+      the code never leaves this machine — the server reads the working tree in
+      place. A cloud server is skipped: shipping a private checkout to a hosted
+      tenant is not something a plugin should decide on the user's behalf (and
+      the server rejects local paths anyway, so it could only ever work by
+      pushing).
+    - ``always``: also auto-index against a cloud/remote server.
+    - ``off``: never auto-index; only refresh repos already indexed explicitly.
+
+    Refreshing an ALREADY-indexed repo is not governed by this setting — that
+    repo's index command was the consent, and a stale graph is the failure mode
+    the freshness loop exists to prevent.
+    """
+    value = str(os.environ.get("COGNEE_CODE_AUTOINDEX", "") or "").strip().lower()
+    if value in ("off", "0", "false", "no"):
+        return "off"
+    if value in ("always", "1", "true", "yes", "on"):
+        return "always"
+    return "auto"
+
+
+def _source_file_count(root: str, cap: int) -> int:
+    """Count code files under ``root``, stopping once ``cap`` is exceeded.
+
+    Bounded on purpose: this runs at session start, so it must cost the same
+    on a monorepo as on a small service.
+    """
+    skip = {".git", "node_modules", ".venv", "venv", "dist", "build", "target", "__pycache__"}
+    seen = 0
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in skip and not d.startswith(".")]
+        for name in filenames:
+            if name.rsplit(".", 1)[-1].lower() in CODE_EXTENSIONS:
+                seen += 1
+                if seen > cap:
+                    return seen
+    return seen
+
+
+def autoindex_on_session_start(
+    cwd,
+    service_url,
+    api_key,
+    *,
+    is_local_server=True,
+    opener=urllib.request.urlopen,
+) -> dict:
+    """Index (or refresh) the repo a session opened in. Never raises.
+
+    Runs from the detached session-start worker, so it never blocks the first
+    prompt. Returns a small outcome dict for logging; ``{}`` when there is
+    nothing to do.
+
+    Two distinct cases, deliberately governed by different rules:
+      * the repo is ALREADY indexed -> refresh it if the tree moved since the
+        last index (covers edits made while the agent was away);
+      * the repo is NEW -> index it only when ``autoindex_mode()`` allows,
+        which by default means a local server only.
+    """
+    try:
+        root = git_repo_root(cwd)
+        if not root:
+            return {}
+
+        if find_indexed_repo(root):
+            outcome = reingest_if_changed(root, service_url, api_key, opener=opener)
+            if outcome:
+                outcome["reason"] = "refresh"
+            return outcome
+
+        mode = autoindex_mode()
+        if mode == "off":
+            return {"skipped": "autoindex_off", "repo_root": root}
+        if mode == "auto" and not is_local_server:
+            # Remote server: indexing would mean shipping this checkout to a
+            # hosted tenant. Explicit opt-in only (COGNEE_CODE_AUTOINDEX=always
+            # or the index command).
+            return {"skipped": "remote_server", "repo_root": root}
+
+        count = _source_file_count(root, _AUTOINDEX_MAX_FILES)
+        if count == 0:
+            return {"skipped": "no_code_files", "repo_root": root}
+        if count > _AUTOINDEX_MAX_FILES:
+            return {
+                "skipped": "too_large",
+                "repo_root": root,
+                "source_files": f">{_AUTOINDEX_MAX_FILES}",
+            }
+
+        result = index_repo(service_url, api_key, root, opener=opener)
+        if result == UNREACHABLE or (isinstance(result, dict) and result.get("error")):
+            return {
+                "indexed": False,
+                "repo_root": root,
+                "error": "unreachable" if result == UNREACHABLE else str(result.get("error"))[:200],
+            }
+        return {
+            "indexed": True,
+            "reason": "first_seen",
+            "repo_root": root,
+            "dataset": result.get("dataset", ""),
+            "source_files": count,
+        }
+    except Exception as exc:  # never break session start
+        return {"error": str(exc)[:200]}
+
+
+def main(argv):
+    """CLI: ``index <repo-path-or-url> [dataset]`` or ``dataset <path>``.
+
+    argv mirrors the sibling scripts: service_url, api_key, command, spec,
+    dataset, index_vectors, wait_seconds. The ``dataset`` command prints the
+    code dataset covering a path (empty line when that path is not indexed) —
+    dataset names carry a path digest, so callers resolve the name from the
+    checkout instead of reconstructing it.
+    """
+    a = list(argv) + [""] * 7
+    service_url, api_key, command, spec = a[0], a[1], a[2], a[3]
+    dataset = a[4]
+    index_vectors = str(a[5]).strip().lower() in ("1", "true", "yes", "on")
+    try:
+        wait_seconds = float(a[6]) if str(a[6]).strip() else 0.0
+    except ValueError:
+        wait_seconds = 0.0
+
+    if command == "dataset":
+        state = find_indexed_repo(spec or os.getcwd())
+        print(str(state.get("dataset") or ""))
+        return
+
+    if command != "index" or not spec:
+        print(
+            json.dumps(
+                {
+                    "error": "usage: _code_graph.py <service_url> <api_key> "
+                    "index <repo-path-or-url> [dataset] [index_vectors] "
+                    "[wait_seconds] | dataset [path]",
+                    "status": 2,
+                }
+            )
+        )
+        return
+    result = index_repo(
+        service_url,
+        api_key,
+        spec,
+        dataset,
+        index_vectors=index_vectors,
+        wait_seconds=wait_seconds,
+    )
+    print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/integrations/codex/plugins/cognee/scripts/_cognee_client.py
+++ b/integrations/codex/plugins/cognee/scripts/_cognee_client.py
@@ -160,7 +160,18 @@ def record_success(service_url=""):
     _write(servers)
 
 
-def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *, timeout=None):
+def recall(
+    service_url,
+    api_key,
+    query,
+    session_id,
+    scope,
+    top_k,
+    dataset="",
+    code_query=None,
+    *,
+    timeout=None,
+):
     """Breaker-wrapped recall. Returns a list, an error-envelope dict, or UNREACHABLE.
 
     Only genuine backend trouble trips the breaker: UNREACHABLE (positively
@@ -185,6 +196,10 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
         scope,
         top_k,
         dataset,
+        # Keyword, not positional: do_recall takes context_profile between
+        # dataset and code_query, so a positional here silently sends the
+        # code query as a context profile.
+        code_query=code_query,
         timeout=timeout or _RECALL_TIMEOUT,
     )
     if result == UNREACHABLE:
@@ -201,9 +216,11 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
 
 
 def main(argv):
-    # argv: service_url, api_key, query, session_id, scope, top_k[, dataset]
-    a = list(argv) + [""] * 7
-    result = recall(a[0], a[1], a[2], a[3], a[4], a[5], a[6])
+    # argv: service_url, api_key, query, session_id, scope, top_k[, dataset[, code_query]]
+    # code_query (arg 8): JSON dict for the deterministic "code" scope (see
+    # _recall_http.coerce_code_query); requires scope to include "code".
+    a = list(argv) + [""] * 8
+    result = recall(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7])
     print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
 
 

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -2749,6 +2749,7 @@ def recall_via_http(
     search_type: str | None = None,
     context_profile: str | None = None,
     dataset: str = "",
+    code_query: dict | None = None,
     timeout: float = 10.0,
 ) -> list:
     payload = {
@@ -2758,6 +2759,10 @@ def recall_via_http(
         "scope": scope,
         "only_context": only_context,
     }
+    # Deterministic code-graph lane (cognee >= 1.5.3). Only meaningful when
+    # the scope includes "code": the server rejects code_query without it.
+    if code_query:
+        payload["code_query"] = code_query
     # Always scope to the plugin's dataset. Without it the server resolves EVERY
     # readable dataset and then reconciles against the session's binding, so the
     # graph scope depends on that binding existing: an unbound session with more

--- a/integrations/codex/plugins/cognee/scripts/_recall_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_recall_http.py
@@ -148,6 +148,23 @@ def _error(status, message, *, transient=False):
     return envelope
 
 
+def coerce_code_query(value):
+    """Parse the JSON code_query arg; None on anything empty or malformed.
+
+    A malformed code_query must degrade to "no code lane", never to a server
+    422 that would read as a recall failure.
+    """
+    if not value:
+        return None
+    if isinstance(value, dict):
+        return value
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
 def do_recall(
     service_url,
     api_key,
@@ -157,6 +174,7 @@ def do_recall(
     top_k,
     dataset="",
     context_profile="",
+    code_query=None,
     *,
     opener=None,
     timeout=120.0,
@@ -169,6 +187,11 @@ def do_recall(
         "only_context": True,
         "scope": coerce_scope(scope),
     }
+    # Deterministic code-graph lane (cognee >= 1.5.3): only meaningful when
+    # the scope includes "code" — the server rejects code_query without it.
+    parsed_code_query = coerce_code_query(code_query)
+    if parsed_code_query is not None:
+        body["code_query"] = parsed_code_query
     if session_id:
         body["session_id"] = session_id
     # Scope the search to the caller's plugin dataset (resolved by the shell from
@@ -241,9 +264,12 @@ def do_recall(
 
 
 def main(argv):
-    # argv: service_url, api_key, query, session_id, scope, top_k[, dataset[, context_profile]]
-    a = list(argv) + [""] * 8
-    result = do_recall(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7])
+    # argv: service_url, api_key, query, session_id, scope, top_k[, dataset
+    #        [, context_profile[, code_query]]]
+    # code_query (arg 9): JSON dict for the deterministic "code" scope, e.g.
+    # '{"operation": "impact_analysis", "targets": ["process_payment"]}'.
+    a = list(argv) + [""] * 9
+    result = do_recall(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8])
     # UNREACHABLE → caller falls back to CLI; a list (results) or an error
     # object → caller prints as-is and does NOT fall back.
     print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))

--- a/integrations/codex/plugins/cognee/scripts/_remember_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_remember_http.py
@@ -170,12 +170,29 @@ def do_remember(
     dataset,
     node_set,
     *,
+    file_path=None,
     opener=urllib.request.urlopen,
     timeout=120.0,
 ):
-    """POST content to the server. Return {"ok": true}, an error envelope, or UNREACHABLE."""
+    """POST content to the server. Return {"ok": true}, an error envelope, or UNREACHABLE.
+
+    With ``file_path``, the file's bytes are uploaded under its REAL basename
+    instead of the synthetic ``{node_set}.txt``. The filename extension is the
+    server's loader-routing signal: a ``.py``/``.ts``/... upload rides the
+    zero-LLM code-graph route (cognify CODE route, cognee >= 1.5.x), while the
+    ``.txt`` rename would silently ingest code as prose through the LLM
+    pipeline. Reading the file here (not in the shell) also avoids ARG_MAX
+    limits on large sources.
+    """
     url = service_url.rstrip("/") + "/api/v1/remember"
     filename = f"{node_set or 'content'}.txt"
+    if file_path:
+        try:
+            with open(file_path, "rb") as fh:
+                content = fh.read()
+        except OSError as e:
+            return _error(0, "cannot read %s: %s" % (file_path, str(e)[:160]))
+        filename = os.path.basename(str(file_path).rstrip("/")) or filename
     body, boundary = _multipart_body(
         {
             "datasetName": dataset,
@@ -264,9 +281,11 @@ def do_remember(
 
 
 def main(argv):
-    # argv: service_url, api_key, content, dataset, node_set
-    a = list(argv) + [""] * 5
-    result = do_remember(a[0], a[1], a[2], a[3], a[4])
+    # argv: service_url, api_key, content, dataset, node_set[, file_path]
+    # With file_path set (arg 6), content (arg 3) is ignored: the file's bytes
+    # are uploaded under their real basename so code files route as code.
+    a = list(argv) + [""] * 6
+    result = do_remember(a[0], a[1], a[2], a[3], a[4], file_path=a[5] or None)
     print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
     if result != UNREACHABLE:
         # Refresh the status-line credits marker, attributing the spend delta

--- a/integrations/codex/plugins/cognee/scripts/cognee-index-repo.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-index-repo.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Index a code repository into Cognee's code graph (enola pipeline).
+#
+# Usage:
+#   cognee-index-repo.sh <repo-path-or-git-url> [--dataset <name>] [--index-vectors] [--wait <seconds>]
+#
+# <repo-path-or-git-url>: a local repository path (works when the Cognee
+#                         server shares this filesystem — the default local
+#                         plugin server does) or a remote git URL (the server
+#                         shallow-clones it; required for cloud servers).
+# --dataset:       target dataset (default: codebase-<repo-name>-<digest> —
+#                  one narrow dataset per repo keeps CODE searches fast. The
+#                  digest is the indexed path: two checkouts often share a
+#                  basename, and letting them share a dataset would let each
+#                  ingestion's stale-node sweep delete the other's nodes. The
+#                  resulting name is printed on success, and cognee-search.sh
+#                  --code resolves it from the checkout automatically).
+# --index-vectors: also embed the extracted code facts so semantic search can
+#                  see them (needs an embedding provider; default off — the
+#                  code graph pipeline makes no LLM/embedding calls).
+# --wait:          seconds to poll the code_graph_pipeline status before
+#                  returning (default 0: submit in background and return).
+#
+# Requires a Cognee server >= 1.5.3. There is deliberately NO CLI fallback:
+# an unreachable server prints UNREACHABLE and nothing is submitted.
+#
+# Indexing a repo here is also the opt-in for automatic freshness, and what
+# "fresh" means depends on how the server reads the code:
+#   * local path  -> the server reads the working tree in place, so the graph
+#     includes uncommitted and untracked changes. The plugin records a git
+#     fingerprint and re-submits in the background after any turn that changed
+#     a file, keeping the graph current per turn.
+#   * git URL     -> the server clones the repo and can only ever see PUSHED
+#     commits. Local edits are invisible to it, so the plugin does NOT
+#     re-submit these on edits (a re-pull would change nothing); the graph
+#     advances when you push and re-run this command. Normal behavior, but the
+#     results look identical to the local case, so it is worth saying out loud
+#     when answering from a cloud-indexed graph.
+
+set -euo pipefail
+
+PLUGIN_DIR="${HOME}/.cognee-plugin/codex"
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+runtime_json="$(python3 - <<'PY' "${PLUGIN_DIR}" "${SELF_DIR}" 2>/dev/null || true
+import json
+import pathlib
+import sys
+
+plugin_dir = pathlib.Path(sys.argv[1])
+import os
+# One-time config from ~/.cognee/.env (shell exports still win).
+sys.path.insert(0, sys.argv[2])
+try:
+    from _env_file import load_env_file
+    load_env_file()
+except Exception:
+    pass
+service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
+api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
+
+if not api_key:
+    cache_path = plugin_dir.parent / "api_key.json"
+    if cache_path.exists():
+        try:
+            cache = json.loads(cache_path.read_text())
+            if isinstance(cache, dict):
+                key = str(cache.get("api_key") or "").strip()
+                cached_url = str(cache.get("base_url") or "").strip().rstrip("/")
+                if key and (not cached_url or cached_url == service_url.rstrip("/")):
+                    api_key = key
+        except Exception:
+            pass
+
+print(json.dumps({"service_url": service_url, "api_key": api_key}))
+PY
+)"
+
+SERVICE_URL="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("service_url") or "").strip())
+except Exception:
+    pass
+PY
+)"
+API_KEY="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("api_key") or "").strip())
+except Exception:
+    pass
+PY
+)"
+
+[ -z "$SERVICE_URL" ] && SERVICE_URL="${COGNEE_BASE_URL:-${COGNEE_LOCAL_API_URL:-http://localhost:8011}}"
+[ -z "$API_KEY" ] && API_KEY="${COGNEE_API_KEY:-}"
+
+REPO="${1:-}"
+DATASET=""
+INDEX_VECTORS="false"
+WAIT_SECONDS="0"
+
+shift || true
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dataset|-d)
+            shift
+            DATASET="${1:-}"
+            ;;
+        --index-vectors)
+            INDEX_VECTORS="true"
+            ;;
+        --wait)
+            shift
+            WAIT_SECONDS="${1:-0}"
+            ;;
+        *)
+            ;;
+    esac
+    shift || true
+done
+
+if [ -z "$REPO" ]; then
+    echo "Error: no repository path or git URL provided" >&2
+    echo "Usage: cognee-index-repo.sh <repo-path-or-git-url> [--dataset <name>] [--index-vectors] [--wait <seconds>]" >&2
+    exit 1
+fi
+
+RESULT="$(python3 "${SELF_DIR}/_code_graph.py" "$SERVICE_URL" "$API_KEY" index "$REPO" "$DATASET" "$INDEX_VECTORS" "$WAIT_SECONDS" || true)"
+
+if [ -n "$RESULT" ] && [ "$RESULT" != "UNREACHABLE" ]; then
+    printf '%s\n' "$RESULT"
+else
+    echo "[cognee-index-repo] server unreachable at ${SERVICE_URL} — nothing was submitted. Start the server (new session) or fix COGNEE_BASE_URL, then re-run." >&2
+    echo "UNREACHABLE"
+    exit 1
+fi

--- a/integrations/codex/plugins/cognee/scripts/cognee-remember.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-remember.sh
@@ -3,10 +3,16 @@
 #
 # Usage:
 #   cognee-remember.sh <content> [--node-set <node_set>] [--dataset <dataset>]
+#   cognee-remember.sh --file <path> [--node-set <node_set>] [--dataset <dataset>]
 #
 # --node-set: node set for categorization (default: user_context)
 #             user_context | project_docs | agent_actions
 # --dataset:  dataset name (default: COGNEE_PLUGIN_DATASET or agent_sessions)
+# --file:     upload a file under its REAL filename instead of inline text.
+#             The extension is the server's routing signal: code files
+#             (.py/.ts/.go/...) ride the zero-LLM code-graph route on
+#             cognee >= 1.5.x; anything else flows through its normal loader.
+#             With --file, positional <content> is not required.
 #
 # Configuration:
 #   Resolves auth from env/api_key.json.
@@ -82,11 +88,15 @@ PY
 [ -z "$API_KEY" ] && API_KEY="${COGNEE_API_KEY:-}"
 [ -z "$DATASET" ] && DATASET="${COGNEE_PLUGIN_DATASET:-agent_sessions}"
 
-# Parse arguments: content is first positional; flags follow
-CONTENT="${1:-}"
+# Parse arguments: content is first positional (unless --file leads); flags follow
+CONTENT=""
 NODE_SET="user_context"
+FILE_PATH=""
 
-shift || true
+if [ "${1:-}" != "--file" ]; then
+    CONTENT="${1:-}"
+    shift || true
+fi
 while [ $# -gt 0 ]; do
     case "$1" in
         --node-set)
@@ -97,13 +107,21 @@ while [ $# -gt 0 ]; do
             shift
             DATASET="${1:-$DATASET}"
             ;;
+        --file)
+            shift
+            FILE_PATH="${1:-}"
+            ;;
         *)
             ;;
     esac
     shift || true
 done
 
-if [ -z "$CONTENT" ]; then
+if [ -n "$FILE_PATH" ] && [ ! -f "$FILE_PATH" ]; then
+    echo "Error: --file path not found: $FILE_PATH" >&2
+    exit 1
+fi
+if [ -z "$CONTENT" ] && [ -z "$FILE_PATH" ]; then
     echo "Error: no content provided" >&2
     exit 1
 fi
@@ -111,10 +129,16 @@ fi
 # Server-first: POST to /api/v1/remember via _remember_http.py.
 # UNREACHABLE → fall back to cognee-cli and warn.
 # Any other result (ok or error) → authoritative; do not fall back.
-RESULT="$(python3 "${SELF_DIR}/_remember_http.py" "$SERVICE_URL" "$API_KEY" "$CONTENT" "$DATASET" "$NODE_SET" || true)"
+RESULT="$(python3 "${SELF_DIR}/_remember_http.py" "$SERVICE_URL" "$API_KEY" "$CONTENT" "$DATASET" "$NODE_SET" "$FILE_PATH" || true)"
 
 if [ -n "$RESULT" ] && [ "$RESULT" != "UNREACHABLE" ]; then
     printf '%s\n' "$RESULT"
+elif [ -n "$FILE_PATH" ]; then
+    # No CLI fallback for file uploads: the CLI path would re-read and rename
+    # the content, losing the extension-based code routing this mode exists for.
+    echo "[cognee-remember] server unreachable — file upload NOT stored; retry once the server is back" >&2
+    echo "UNREACHABLE"
+    exit 1
 else
     echo "[cognee-remember] falling back to cognee-cli (degraded — server unreachable; verify the store succeeded once the server is back)" >&2
     uv run cognee-cli remember "$CONTENT" -d "$DATASET" --node-set "$NODE_SET" 2>/dev/null || true

--- a/integrations/codex/plugins/cognee/scripts/cognee-search.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-search.sh
@@ -3,9 +3,18 @@
 #
 # Usage:
 #   cognee-search.sh <query> [top_k] [--session | --graph]
+#   cognee-search.sh <query> [top_k] --code [--dataset <name>] [--code-query '<json>']
 #
 # --session: search session cache only
 # --graph:   search permanent knowledge graph only
+# --code:    deterministic code-graph search (cognee >= 1.5.3). Query text is
+#            the seed; --code-query selects an exact operation instead, e.g.
+#            '{"operation": "impact_analysis", "targets": ["process_payment"]}'
+#            (operations: query_facts, explore, traverse, find_path,
+#            impact_analysis, delta). The repository's own code dataset is
+#            resolved from the current directory automatically.
+# --dataset: override the dataset to search (default: the plugin dataset, or
+#            the current repo's code dataset in --code mode)
 # No flag:   search session first, then graph if empty
 #
 # Configuration:
@@ -127,14 +136,39 @@ PY
 QUERY="${1:-}"
 TOP_K="${2:-5}"
 MODE="auto"
+CODE_QUERY=""
+DATASET_EXPLICIT=""
 
-# Parse flags from any position
-for arg in "$@"; do
-    case "$arg" in
+# Parse flags from any position (value flags consume the next argument)
+_args=("$@")
+_i=0
+while [ $_i -lt ${#_args[@]} ]; do
+    case "${_args[$_i]}" in
         --session) MODE="session" ;;
         --graph)   MODE="graph" ;;
+        --code)    MODE="code" ;;
+        --code-query)
+            _i=$((_i + 1))
+            CODE_QUERY="${_args[$_i]:-}"
+            ;;
+        --dataset|-d)
+            _i=$((_i + 1))
+            DATASET="${_args[$_i]:-$DATASET}"
+            DATASET_EXPLICIT="1"
+            ;;
     esac
+    _i=$((_i + 1))
 done
+
+# Code searches target the repository's OWN dataset, whose name carries a path
+# digest (two checkouts can share a basename, so the basename cannot be the
+# identity). Resolve it from the current checkout rather than making the caller
+# reconstruct it. An unindexed cwd leaves DATASET alone, and the search then
+# reports no code facts rather than silently querying the session dataset.
+if [ "$MODE" = "code" ] && [ -z "${DATASET_EXPLICIT:-}" ]; then
+    CODE_DATASET="$(python3 "${SELF_DIR}/_code_graph.py" "" "" dataset "$PWD" 2>/dev/null || true)"
+    [ -n "$CODE_DATASET" ] && DATASET="$CODE_DATASET"
+fi
 
 if [ -z "$QUERY" ]; then
     echo "Error: no query provided" >&2
@@ -145,6 +179,7 @@ fi
 case "$MODE" in
     session) SCOPE='["session"]' ;;
     graph)   SCOPE='["graph"]' ;;
+    code)    SCOPE='["code"]' ;;
     *)       SCOPE='["session", "graph"]' ;;
 esac
 
@@ -156,11 +191,18 @@ esac
 # and scopes the search to the plugin's dataset so unrelated datasets don't bleed in.
 # Logic lives in _recall_http.py (stdlib-only, unit-tested); stderr is surfaced.
 export COGNEE_PLUGIN_STATE_DIR="$PLUGIN_DIR"
-RECALL_JSON="$(python3 "${SELF_DIR}/_cognee_client.py" "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$SCOPE" "$TOP_K" "$DATASET" || true)"
+RECALL_JSON="$(python3 "${SELF_DIR}/_cognee_client.py" "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$SCOPE" "$TOP_K" "$DATASET" "$CODE_QUERY" || true)"
 
 if [ -n "$RECALL_JSON" ] && [ "$RECALL_JSON" != "UNREACHABLE" ]; then
     # Server answered — authoritative, even if the result is empty.
     printf '%s\n' "$RECALL_JSON"
+elif [ "$MODE" = "code" ]; then
+    # No CLI fallback for code searches: the deterministic code lane exists
+    # only on the server (>= 1.5.3); a CLI recall would answer from the wrong
+    # retriever and read as authoritative when it is not.
+    echo "[cognee-search] server unreachable — code search not run; retry once the server is back" >&2
+    echo "UNREACHABLE"
+    exit 1
 else
     echo "[cognee-search] falling back to cognee-cli (degraded — empty CLI output is NOT proof of absence; ground-truth via: curl -X POST \"\$COGNEE_BASE_URL/api/v1/recall\")" >&2
     if [ "$MODE" = "graph" ]; then

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -93,6 +93,12 @@ def _format_entry(entry: dict) -> str:
         content = str(entry.get("content", "") or entry.get("text", ""))[:TRUNCATE_GRAPH_CTX]
         return f"[agent-guidance]\n{content}"
 
+    if source == "code":
+        # Deterministic code-graph facts (ResponseCodeEntry): `text` is the
+        # normalized renderable field; raw payloads keep full structure.
+        content = str(entry.get("text", "") or entry.get("content", ""))[:TRUNCATE_GRAPH_CTX]
+        return f"[code-graph]\n{content}"
+
     if source == "trace":
         origin = entry.get("origin_function", "?")
         status = entry.get("status", "")
@@ -128,6 +134,8 @@ def _has_entry_content(entry: dict) -> bool:
         return bool(str(entry.get("content", "") or entry.get("text", "")).strip())
     if source == "session_context":
         return bool(str(entry.get("content", "") or entry.get("text", "")).strip())
+    if source == "code":
+        return bool(str(entry.get("text", "") or entry.get("content", "")).strip())
     if source == "trace":
         fields = ("origin_function", "status", "session_feedback", "method_return_value")
     else:
@@ -170,7 +178,7 @@ async def _recent_trace_fallback(session_id: str, user_id: str, top_k: int) -> l
     return normalized
 
 
-async def _run(prompt: str) -> dict | None:
+async def _run(prompt: str, cwd: str = "") -> dict | None:
     config = load_config()
     runtime = resolve_runtime_mode()
     cloud_mode = runtime["mode"] == "http"
@@ -254,6 +262,29 @@ async def _run(prompt: str) -> dict | None:
         (["session_context"], None, "agent"),
         (["graph"], "HYBRID_COMPLETION", None),
     ]
+    # Additive code-graph lane (cognee >= 1.5.3). Fires only when the prompt
+    # carries an identifier-shaped token AND the cwd sits inside a repo the
+    # user indexed via cognee-index-repo.sh — never on conversational prompts,
+    # never as a replacement for the semantic scopes. The server keeps this
+    # scope explicit-only (scope=auto never implies it), so the gate lives
+    # here. Placed before graph: the code lane is the cheapest call when its
+    # snapshot is warm, and graph is the long pole that must stay last.
+    code_lane = {}
+    try:
+        from _code_graph import auto_code_lane
+
+        code_lane = auto_code_lane(prompt, cwd) or {}
+    except Exception as exc:
+        hook_log("code_lane_gate_error", {"error": str(exc)[:200]})
+    if code_lane:
+        scope_specs.insert(3, (["code"], None, None))
+        hook_log(
+            "code_lane_armed",
+            {
+                "identifier": code_lane.get("identifier", ""),
+                "dataset": code_lane.get("dataset", ""),
+            },
+        )
     if not cloud_mode:
         import cognee
         from cognee.modules.search.types import SearchType
@@ -310,6 +341,11 @@ async def _run(prompt: str) -> dict | None:
             hook_log("recall_budget_exceeded", {"collected": len(results)})
             break
         scope_timeout = min(recall_timeout, remaining)
+        # The code lane searches the indexed repo's own (narrow) dataset with
+        # a structured query; every other scope keeps the session dataset.
+        is_code_scope = bool(code_lane) and scope_list == ["code"]
+        scope_dataset = code_lane["dataset"] if is_code_scope else get_dataset(config)
+        scope_code_query = code_lane["code_query"] if is_code_scope else None
         part = None
         t0 = time.monotonic()
         try:
@@ -322,7 +358,8 @@ async def _run(prompt: str) -> dict | None:
                     only_context=True,
                     search_type=qtype,
                     context_profile=context_profile,
-                    dataset=get_dataset(config),
+                    dataset=scope_dataset,
+                    code_query=scope_code_query,
                     timeout=scope_timeout,
                 )
             else:
@@ -337,6 +374,11 @@ async def _run(prompt: str) -> dict | None:
                         query_type=query_type,
                         user=user,
                         **({"context_profile": context_profile} if context_profile else {}),
+                        **(
+                            {"datasets": [scope_dataset], "code_query": scope_code_query}
+                            if is_code_scope
+                            else {}
+                        ),
                     ),
                     timeout=scope_timeout,
                 )
@@ -466,6 +508,7 @@ async def _run(prompt: str) -> dict | None:
         "trace": [],
         "graph_context": [],
         "session_context": [],
+        "code": [],
     }
     for r in results or []:
         if hasattr(r, "model_dump"):
@@ -528,7 +571,9 @@ async def _run(prompt: str) -> dict | None:
         f"{status_line}\n"
         "Cognee memory: recall "
         f"{counts['session']} session / {counts['trace']} trace / "
-        f"{counts['graph_context']} graph / {counts['session_context']} agent; saved last turn "
+        f"{counts['graph_context']} graph / {counts['session_context']} agent"
+        + (f" / {counts['code']} code" if code_lane else "")
+        + "; saved last turn "
         f"{saves_last_turn['prompt']} prompt / {saves_last_turn['trace']} trace / "
         f"{saves_last_turn['answer']} answer"
     )
@@ -537,6 +582,11 @@ async def _run(prompt: str) -> dict | None:
     if by_source.get("session_context"):
         section_lines.append("=== Active agent guidance ===")
         for e in by_source["session_context"]:
+            section_lines.append(_format_entry(e))
+            section_lines.append("")
+    if by_source.get("code"):
+        section_lines.append("=== Code graph facts ===")
+        for e in by_source["code"]:
             section_lines.append(_format_entry(e))
             section_lines.append("")
     if by_source.get("graph_context"):
@@ -652,11 +702,12 @@ def main():
     prompt = payload.get("prompt", "")
     if not prompt or len(prompt) < 5:
         return
+    cwd = str(payload.get("cwd") or "") or os.getcwd()
 
     output = None
     try:
         with quiet_hook_output("session-context-lookup"):
-            output = asyncio.run(_run(prompt))
+            output = asyncio.run(_run(prompt, cwd))
     except Exception as exc:
         hook_log("context_lookup_exception", {"error": str(exc)[:200]})
     return output

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -44,6 +44,7 @@ from _plugin_common import (
     quiet_hook_output,
     resolve_session_key_from_payload,
     server_presence,
+    service_url_is_local,
     set_session_key,
     touch_activity,
     write_connection_state,
@@ -102,7 +103,7 @@ _UV_BIN = _UV_DIR / ("uv.exe" if os.name == "nt" else "uv")
 _UV_PYTHON_DIR = _GLOBAL_STATE_DIR / "python"
 _UV_INSTALL_URL = "https://astral.sh/uv/install.sh"
 _PINNED_PYTHON = os.environ.get("COGNEE_PLUGIN_PYTHON", "") or "3.12"
-_PINNED_COGNEE_VERSION = "1.5.0"
+_PINNED_COGNEE_VERSION = "1.5.3"
 _INSTALL_TIMEOUT_SECONDS = float(os.environ.get("COGNEE_INSTALL_TIMEOUT", "") or 600.0)
 
 # Install single-flight. Distinct from the server boot lock (which is short): a
@@ -1135,6 +1136,24 @@ async def _run_heavy(
                 hook_log("conn_state_unverified", {"base_url": service_url, "health": health})
     elif service_url and probe_health(service_url, timeout=1.5) == "ready":
         write_connection_state("ready", service_url)
+
+    # Code graph: index the repository this session opened in, or refresh it if
+    # the tree moved while the agent was away. Deliberately last and inside the
+    # detached worker — it must never delay the first prompt — and best-effort:
+    # a failure here costs code facts, not the session.
+    try:
+        from _code_graph import autoindex_on_session_start
+
+        code_outcome = autoindex_on_session_start(
+            cwd,
+            service_url,
+            os.environ.get("COGNEE_API_KEY", ""),
+            is_local_server=service_url_is_local(service_url),
+        )
+        if code_outcome:
+            hook_log("code_autoindex", code_outcome)
+    except Exception as exc:
+        hook_log("code_autoindex_error", {"error": str(exc)[:200]})
 
     return user_id, agent_api_key, True
 

--- a/integrations/codex/plugins/cognee/scripts/store-to-session.py
+++ b/integrations/codex/plugins/cognee/scripts/store-to-session.py
@@ -423,6 +423,45 @@ async def _store_assistant_stop(payload: dict) -> None:
             await _fire_improve_background(dataset, session_id, user, reason=f"turn_{count}")
 
 
+def _maybe_reingest_code_repo(payload: dict) -> None:
+    """Freshness pass for indexed code repos (runs on the Stop hook only).
+
+    When this turn's cwd sits inside a repo indexed via cognee-index-repo.sh
+    and the working tree's git fingerprint changed since the last index, the
+    repo is re-submitted (background) so the code graph reflects the turn's
+    edits by the next prompt. The fingerprint is only a cheap client-side
+    gate — the server re-hashes every covered file anyway, so a false
+    positive costs one skipped submission. Repos indexed by git URL are NOT
+    re-submitted here: the server's clone only sees pushed commits, so local
+    edits cannot reach it. Never raises: this must not disturb the hook.
+    """
+    try:
+        from _code_graph import reingest_if_changed
+
+        cwd = str(payload.get("cwd") or "") or os.getcwd()
+        runtime = resolve_runtime_mode()
+        service_url = runtime.get("base_url", "")
+        if not service_url:
+            return
+        if not server_usable(service_url):
+            # Down server: skip quietly. The stale fingerprint is kept, so the
+            # next Stop retries once the server is back.
+            hook_log("code_reingest_skipped_server", {"base_url": service_url})
+            return
+        outcome = reingest_if_changed(cwd, service_url, os.environ.get("COGNEE_API_KEY", ""))
+        if not outcome:
+            return
+        if outcome.get("changed") and outcome.get("submitted"):
+            hook_log("code_reingest_submitted", outcome)
+            notify(f"code graph re-index submitted ({outcome.get('dataset', '')})")
+        elif outcome.get("changed"):
+            hook_log("code_reingest_failed", outcome)
+        else:
+            hook_log("code_reingest_unchanged", {"repo_root": outcome.get("repo_root", "")})
+    except Exception as exc:
+        hook_log("code_reingest_error", {"error": str(exc)[:200]})
+
+
 def main():
     payload_raw = sys.stdin.read()
     if not payload_raw.strip():
@@ -447,6 +486,9 @@ def main():
         with quiet_hook_output("store-to-session"):
             if is_stop:
                 asyncio.run(_store_assistant_stop(payload))
+                # End-of-turn code-graph freshness: independent of whether an
+                # assistant message was stored (edits happen either way).
+                _maybe_reingest_code_repo(payload)
             else:
                 asyncio.run(_store_tool_call(payload))
     except Exception as exc:

--- a/integrations/codex/plugins/cognee/skills/codebase/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/codebase/SKILL.md
@@ -44,6 +44,9 @@ ${CODEX_PLUGIN_ROOT}/scripts/cognee-index-repo.sh <repo-path-or-git-url> [--data
 - The submit returns quickly (background pipeline); `--wait 60` polls
   `pipeline=code_graph_pipeline` until queryable.
 
+Indexing writes enola's snapshot to `<repo>/.enola/` (untracked) — add it to
+`.gitignore` or global excludes. The plugin's change detection ignores it.
+
 **Indexing is also the freshness opt-in**: for local-path repos the plugin
 records a git fingerprint and automatically re-submits the repo in the
 background when a turn changed the working tree. Re-running the command on an

--- a/integrations/codex/plugins/cognee/skills/memory/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/memory/SKILL.md
@@ -25,7 +25,15 @@ memory.
 ${CODEX_PLUGIN_ROOT}/scripts/cognee-remember.sh "<text>" --node-set user_context
 ```
 
-Use `--node-set project_docs` for project/code content, `--node-set agent_actions` for agent notes. The script POSTs directly to `/api/v1/remember`. A `{"ok": true}` response means the server accepted the data. An error response means the server rejected or failed the request — check `COGNEE_API_KEY` and server logs; do **not** re-run or conclude the data wasn't stored without confirming against the server.
+Use `--node-set project_docs` for project/code content, `--node-set agent_actions` for agent notes.
+
+To store a **file** under its real filename (so code files ride the zero-LLM code path instead of being ingested as prose), pass `--file`:
+
+```bash
+${CODEX_PLUGIN_ROOT}/scripts/cognee-remember.sh --file src/payments.py --node-set project_docs
+```
+
+For a whole repository (cross-file calls/imports, impact analysis), use the **codebase** skill instead. The script POSTs directly to `/api/v1/remember`. A `{"ok": true}` response means the server accepted the data. An error response means the server rejected or failed the request — check `COGNEE_API_KEY` and server logs; do **not** re-run or conclude the data wasn't stored without confirming against the server.
 
 **Background by default + eventual consistency**: the wrapper submits with `run_in_background=true` (so a large cognify never holds one request open past the cloud's ~10-min request ceiling). The POST returns once the work is **enqueued**, with `dataset_id` and `pipeline_run_id`; `status: "running"` means *submitted, not yet in the permanent graph*. The session cache is searchable immediately, but the graph is queryable only after the cognify pipeline **completes**.
 

--- a/integrations/obsidian/cognee_integration_obsidian/traversal.py
+++ b/integrations/obsidian/cognee_integration_obsidian/traversal.py
@@ -1,18 +1,19 @@
-import os
-import re
-import yaml
+import asyncio
 import hashlib
 import json
-import asyncio
-import cognee
-from pathlib import Path
+import os
+import re
 from collections import Counter
+from pathlib import Path
+
+import cognee
+import yaml
 
 VAULT_PATH: str = os.environ.get("VAULT", "")
 if not VAULT_PATH:
     raise SystemExit(
         "VAULT environment variable is required — set it to the path of your Obsidian vault, "
-        "e.g. export VAULT=\"/path/to/your/vault\""
+        'e.g. export VAULT="/path/to/your/vault"'
     )
 EXCLUDED_DIRS = {".obsidian", ".trash", "Templates"}
 dataset_name = Path(VAULT_PATH).name
@@ -33,15 +34,17 @@ def load_manifest():
             return {}
     return {}
 
+
 def save_manifest(manifest):
     MANIFEST_PATH.write_text(json.dumps(manifest, indent=4))
 
+
 def split_frontmatter(text):
-    frontmatter_pattern = r'^---\n(.*?)\n---\n'
+    frontmatter_pattern = r"^---\n(.*?)\n---\n"
     match = re.match(frontmatter_pattern, text, re.DOTALL)
     if match:
         frontmatter = match.group(1)
-        content = text[match.end():]
+        content = text[match.end() :]
         try:
             frontmatter_data = yaml.safe_load(frontmatter) if frontmatter else {}
         except yaml.YAMLError:
@@ -52,11 +55,13 @@ def split_frontmatter(text):
     else:
         return None, text
 
+
 def clean_link_target(raw):
-    target = raw.split('|', 1)[0]
-    target = target.split('#', 1)[0]
-    target = target.split('^', 1)[0]
+    target = raw.split("|", 1)[0]
+    target = target.split("#", 1)[0]
+    target = target.split("^", 1)[0]
     return target
+
 
 async def main():
     manifest = load_manifest()
@@ -76,9 +81,11 @@ async def main():
             try:
                 text = Path(full_path).read_text(encoding="utf-8")
                 frontmatter, content = split_frontmatter(text)
-                headings = re.findall(r'^(#{1,6})\s+(.*)', content, re.MULTILINE)
-                links = Counter(clean_link_target(link) for link in re.findall(r'\[\[([^\]]+)\]\]', text))
-                tags = [t for t in re.findall(r'(?<!\w)#([\w/-]+)', content) if not t.isdigit()]
+                headings = re.findall(r"^(#{1,6})\s+(.*)", content, re.MULTILINE)
+                links = Counter(
+                    clean_link_target(link) for link in re.findall(r"\[\[([^\]]+)\]\]", text)
+                )
+                tags = [t for t in re.findall(r"(?<!\w)#([\w/-]+)", content) if not t.isdigit()]
 
                 frontmatter_tags = (frontmatter or {}).get("tags", []) or []
                 if isinstance(frontmatter_tags, str):
@@ -89,7 +96,7 @@ async def main():
                 header = "\n".join(header_lines)
                 data = f"{header}\n\n{content}" if header else content
 
-                digest = hashlib.sha256(text.encode('utf-8')).hexdigest()
+                digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
 
                 if manifest.get(key) == digest:
                     print("SKIP (unchanged):", key)
@@ -111,12 +118,19 @@ async def main():
                 print("Key:", key)
 
             except Exception as e:
-                print(f"ERROR processing {key}: {e} — skipping this note, continuing with the rest of the vault.")
+                print(
+                    f"ERROR processing {key}: {e} — "
+                    f"skipping this note, continuing with the rest of the vault."
+                )
                 continue
 
     deleted_keys = set(manifest.keys()) - found_keys
     if deleted_keys:
-        print(f"Pruning {len(deleted_keys)} manifest entr{'y' if len(deleted_keys)==1 else 'ies'} for notes no longer found in the vault:")
+        print(
+            f"Pruning {len(deleted_keys)} manifest "
+            f"entr{'y' if len(deleted_keys) == 1 else 'ies'} "
+            f"for notes no longer found in the vault:"
+        )
         for k in deleted_keys:
             print("  -", k)
             del manifest[k]
@@ -124,7 +138,11 @@ async def main():
 
     if any_ingested:
         await cognee.cognify(datasets=[dataset_name])
-        await cognee.visualize_graph(destination_file_path=os.path.abspath(GRAPH_OUTPUT_PATH), dataset=dataset_name, full=True)
+        await cognee.visualize_graph(
+            destination_file_path=os.path.abspath(GRAPH_OUTPUT_PATH),
+            dataset=dataset_name,
+            full=True,
+        )
     else:
         print("No new or changed notes this run — skipping cognify and graph visualization.")
 

--- a/integrations/tests/tests/integration/test_code_autoindex.py
+++ b/integrations/tests/tests/integration/test_code_autoindex.py
@@ -1,0 +1,221 @@
+"""Session-start auto-indexing: what gets indexed without being asked.
+
+Opening a coding agent in a repo should give you a code graph without a setup
+step. But "index whatever directory the user happened to open" is also how a
+plugin ends up shipping a private checkout to a hosted tenant, or burning
+minutes of CPU on a monorepo nobody asked about. The policy these tests pin:
+
+  * a LOCAL server auto-indexes freely — the code never leaves the machine,
+    the server reads the working tree in place;
+  * a REMOTE server does not, unless explicitly opted in, because there
+    indexing means sending code somewhere;
+  * an already-indexed repo is always refreshed regardless of that setting —
+    the index command was the consent, and a stale graph is the failure the
+    freshness loop exists to prevent;
+  * a directory that is not a git repo, holds no code, or is enormous is left
+    alone.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+REMEMBER = "/api/v1/remember"
+
+
+@pytest.fixture
+def cg(suite, isolated_modules):
+    return isolated_modules(suite, "_code_graph")
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+
+    def git(*args):
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+    git("init", "-q")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    git("config", "commit.gpgsign", "false")
+    (repo / "app.py").write_text("def start():\n    return 1\n", encoding="utf-8")
+    git("add", ".")
+    git("commit", "-q", "-m", "init")
+    return repo
+
+
+# ── the local-server default ───────────────────────────────────────────────
+
+
+def test_local_server_indexes_a_new_repo(cg, mock_server, git_repo):
+    outcome = cg.autoindex_on_session_start(
+        str(git_repo), mock_server.url, "", is_local_server=True
+    )
+    assert outcome["indexed"] is True
+    assert outcome["reason"] == "first_seen"
+    assert mock_server.assert_called("POST", REMEMBER)["form"]["content_type"] == "code"
+    # The state file is what later turns key their freshness off.
+    assert cg.load_repo_states()[0]["repo_root"] == str(git_repo.resolve())
+
+
+def test_indexing_works_from_a_subdirectory(cg, mock_server, git_repo):
+    """Agents are opened deep inside repos as often as at the root."""
+    sub = git_repo / "src" / "deep"
+    sub.mkdir(parents=True)
+    outcome = cg.autoindex_on_session_start(str(sub), mock_server.url, "", is_local_server=True)
+    assert outcome["indexed"] is True
+    assert outcome["repo_root"] == str(git_repo.resolve())
+
+
+# ── the remote-server guard ────────────────────────────────────────────────
+
+
+def test_remote_server_does_not_index_a_new_repo(cg, mock_server, git_repo):
+    """Auto-shipping a private checkout to a hosted tenant is not a decision a
+    plugin gets to make silently."""
+    outcome = cg.autoindex_on_session_start(
+        str(git_repo), mock_server.url, "", is_local_server=False
+    )
+    assert outcome["skipped"] == "remote_server"
+    mock_server.assert_not_called("POST", REMEMBER)
+
+
+def test_remote_server_indexes_when_explicitly_opted_in(cg, mock_server, git_repo, monkeypatch):
+    monkeypatch.setenv("COGNEE_CODE_AUTOINDEX", "always")
+    outcome = cg.autoindex_on_session_start(
+        str(git_repo), mock_server.url, "", is_local_server=False
+    )
+    assert outcome["indexed"] is True
+
+
+def test_autoindex_can_be_turned_off(cg, mock_server, git_repo, monkeypatch):
+    monkeypatch.setenv("COGNEE_CODE_AUTOINDEX", "off")
+    outcome = cg.autoindex_on_session_start(
+        str(git_repo), mock_server.url, "", is_local_server=True
+    )
+    assert outcome["skipped"] == "autoindex_off"
+    mock_server.assert_not_called("POST", REMEMBER)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [("", "auto"), ("off", "off"), ("always", "always"), ("nonsense", "auto")],
+)
+def test_autoindex_mode_parsing(cg, monkeypatch, value, expected):
+    monkeypatch.setenv("COGNEE_CODE_AUTOINDEX", value)
+    assert cg.autoindex_mode() == expected
+
+
+# ── refreshing an already-indexed repo ─────────────────────────────────────
+
+
+def test_indexed_repo_is_refreshed_after_outside_edits(cg, mock_server, git_repo):
+    """Edits made while the agent was away are exactly what a session-start
+    refresh is for."""
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    mock_server.calls.clear()
+    (git_repo / "app.py").write_text("def start():\n    return 2\n", encoding="utf-8")
+
+    outcome = cg.autoindex_on_session_start(
+        str(git_repo), mock_server.url, "", is_local_server=True
+    )
+    assert outcome["reason"] == "refresh"
+    assert outcome["submitted"] is True
+    mock_server.assert_called("POST", REMEMBER)
+
+
+def test_unchanged_indexed_repo_submits_nothing(cg, mock_server, git_repo):
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    mock_server.calls.clear()
+
+    outcome = cg.autoindex_on_session_start(
+        str(git_repo), mock_server.url, "", is_local_server=True
+    )
+    assert outcome["changed"] is False
+    mock_server.assert_not_called("POST", REMEMBER)
+
+
+def test_refresh_ignores_the_autoindex_off_switch(cg, mock_server, git_repo, monkeypatch):
+    """The setting governs indexing repos nobody asked for — not keeping an
+    explicitly indexed one honest."""
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    mock_server.calls.clear()
+    monkeypatch.setenv("COGNEE_CODE_AUTOINDEX", "off")
+    (git_repo / "app.py").write_text("def start():\n    return 3\n", encoding="utf-8")
+
+    outcome = cg.autoindex_on_session_start(
+        str(git_repo), mock_server.url, "", is_local_server=True
+    )
+    assert outcome["submitted"] is True
+
+
+def test_remote_indexed_repo_is_still_refreshed(cg, mock_server, git_repo, monkeypatch):
+    """A repo indexed against a cloud server keeps working: the remote guard
+    only gates NEW repos."""
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    mock_server.calls.clear()
+    (git_repo / "app.py").write_text("def start():\n    return 4\n", encoding="utf-8")
+
+    outcome = cg.autoindex_on_session_start(
+        str(git_repo), mock_server.url, "", is_local_server=False
+    )
+    assert outcome["submitted"] is True
+
+
+# ── directories that must be left alone ────────────────────────────────────
+
+
+def test_non_git_directory_is_ignored(cg, mock_server, tmp_path):
+    plain = tmp_path / "notes"
+    plain.mkdir()
+    (plain / "a.py").write_text("x = 1\n", encoding="utf-8")
+    assert cg.autoindex_on_session_start(str(plain), mock_server.url, "") == {}
+    mock_server.assert_not_called("POST", REMEMBER)
+
+
+def test_repo_without_code_is_skipped(cg, mock_server, tmp_path):
+    """A docs or config repo has nothing for enola to extract."""
+    repo = tmp_path / "docs"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, capture_output=True)
+    (repo / "README.md").write_text("# hi\n", encoding="utf-8")
+
+    outcome = cg.autoindex_on_session_start(str(repo), mock_server.url, "", is_local_server=True)
+    assert outcome["skipped"] == "no_code_files"
+    mock_server.assert_not_called("POST", REMEMBER)
+
+
+def test_huge_repo_is_skipped(cg, mock_server, git_repo, monkeypatch):
+    """The enola pass covers the whole tree; spending that on a monorepo
+    nobody asked about is worse than doing nothing. Explicit indexing has no cap."""
+    monkeypatch.setattr(cg, "_AUTOINDEX_MAX_FILES", 2)
+    for i in range(5):
+        (git_repo / f"mod{i}.py").write_text("x = 1\n", encoding="utf-8")
+
+    outcome = cg.autoindex_on_session_start(
+        str(git_repo), mock_server.url, "", is_local_server=True
+    )
+    assert outcome["skipped"] == "too_large"
+    mock_server.assert_not_called("POST", REMEMBER)
+
+
+def test_vendored_directories_do_not_count_toward_the_cap(cg, git_repo):
+    """node_modules/.venv would blow the cap on an otherwise small repo."""
+    vendor = git_repo / "node_modules" / "pkg"
+    vendor.mkdir(parents=True)
+    for i in range(50):
+        (vendor / f"v{i}.js").write_text("x=1\n", encoding="utf-8")
+    assert cg._source_file_count(str(git_repo), 100) == 1
+
+
+def test_failures_never_escape(cg, git_repo):
+    """Session start must survive an unreachable server."""
+    outcome = cg.autoindex_on_session_start(
+        str(git_repo), "http://127.0.0.1:1", "", is_local_server=True
+    )
+    assert outcome["indexed"] is False
+    assert outcome["error"] == "unreachable"

--- a/integrations/tests/tests/integration/test_code_autoindex.py
+++ b/integrations/tests/tests/integration/test_code_autoindex.py
@@ -166,6 +166,28 @@ def test_remote_indexed_repo_is_still_refreshed(cg, mock_server, git_repo, monke
     assert outcome["submitted"] is True
 
 
+def test_session_start_retries_despite_an_active_backoff(cg, mock_server, git_repo):
+    """Restarting the agent is the gesture a user makes after fixing what broke
+    indexing (a corrected key, a restarted server), so a session start gets an
+    attempt instead of waiting out a window earned by the previous session.
+    Bounded by launches rather than turns, which is what the per-turn backoff
+    exists to limit."""
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    (git_repo / "app.py").write_text("x = 1\n", encoding="utf-8")
+    mock_server.force_response("POST", REMEMBER, 401, {"detail": "nope"})
+    cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+    assert cg.load_repo_states()[0]["error_count"] == 1
+
+    # The user fixes the credential and relaunches; no window has elapsed.
+    mock_server.clear_forced()
+    mock_server.calls.clear()
+    outcome = cg.autoindex_on_session_start(
+        str(git_repo), mock_server.url, "", is_local_server=True
+    )
+    assert outcome["submitted"] is True
+    assert "error_count" not in cg.load_repo_states()[0]
+
+
 # ── directories that must be left alone ────────────────────────────────────
 
 

--- a/integrations/tests/tests/integration/test_code_graph.py
+++ b/integrations/tests/tests/integration/test_code_graph.py
@@ -1,0 +1,322 @@
+"""The code-graph wire contract, driven against the mock Cognee server.
+
+Three things a real server has to confirm, because getting any of them wrong
+fails silently rather than loudly:
+
+  * an index submits ``content_type=code`` with the repo in ``repositories``
+    and NO file upload — the server rejects the two together, and a plain
+    upload would build a per-file graph instead of a repo one;
+  * a code file remembered with ``--file`` keeps its REAL filename, because
+    the extension is the server's loader-routing signal (a ``.txt`` rename
+    silently ingests code as prose through the LLM pipeline);
+  * the freshness pass re-submits only when the working tree actually changed,
+    and keeps the old fingerprint when a submission fails so the next turn
+    retries instead of skipping.
+
+The pure gate logic lives in unit/test_code_graph_gate.py.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+REMEMBER = "/api/v1/remember"
+RECALL = "/api/v1/recall"
+
+
+@pytest.fixture
+def cg(suite, isolated_modules):
+    return isolated_modules(suite, "_code_graph")
+
+
+@pytest.fixture
+def rh(suite, isolated_modules):
+    return isolated_modules(suite, "_remember_http")
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    """A real git repo — the freshness gate shells out to git for its fingerprint."""
+    repo = tmp_path / "proj"
+    repo.mkdir()
+
+    def git(*args):
+        subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+
+    git("init", "-q")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    git("config", "commit.gpgsign", "false")
+    (repo / "app.py").write_text("def start():\n    return 1\n", encoding="utf-8")
+    git("add", ".")
+    git("commit", "-q", "-m", "init")
+    return repo
+
+
+# ── indexing a repository ──────────────────────────────────────────────────
+
+
+def test_index_submits_repositories_not_a_file_upload(cg, mock_server):
+    """content_type=code + repositories, with no `data` file part.
+
+    The server rejects uploads combined with content_type='code', and an upload
+    without it would build a one-file graph with no cross-file edges.
+    """
+    res = cg.do_index_repo(mock_server.url, "", "/path/to/proj", "codebase-proj")
+    assert res["ok"] is True
+
+    call = mock_server.assert_called("POST", REMEMBER)
+    assert call["form"]["content_type"] == "code"
+    assert call["form"]["repositories"] == "/path/to/proj"
+    assert call["form"]["datasetName"] == "codebase-proj"
+    assert call["form"]["run_in_background"] == "true"
+    assert call.get("files", []) == []
+
+
+def test_index_vectors_is_off_by_default(cg, mock_server):
+    """The graph-only default needs no embedding provider; opting in is explicit."""
+    cg.do_index_repo(mock_server.url, "", "/path/to/proj", "ds")
+    assert mock_server.assert_called("POST", REMEMBER)["form"]["index_vectors"] == "false"
+
+    mock_server.calls.clear()
+    cg.do_index_repo(mock_server.url, "", "/path/to/proj", "ds", index_vectors=True)
+    assert mock_server.assert_called("POST", REMEMBER)["form"]["index_vectors"] == "true"
+
+
+def test_api_key_header_attached(cg, mock_server):
+    cg.do_index_repo(mock_server.url, "cloud-key", "https://github.com/org/repo", "ds")
+    assert mock_server.assert_called("POST", REMEMBER)["headers"].get("X-Api-Key") == "cloud-key"
+
+
+def test_old_server_rejection_names_the_version_requirement(cg, mock_server):
+    """A pre-1.5.3 server 400s content_type='code'. The message must say so —
+    otherwise it reads as a bad repo path and sends the user hunting."""
+    mock_server.force_response(
+        "POST", REMEMBER, 400, {"detail": "Unsupported content_type 'code'."}
+    )
+    res = cg.do_index_repo(mock_server.url, "", "/path/to/proj", "ds")
+    assert res != cg.UNREACHABLE
+    assert "1.5.3" in res["error"]
+
+
+@pytest.mark.parametrize("code", [401, 403, 500])
+def test_http_error_is_not_unreachable(cg, mock_server, code):
+    """Reachable-but-failing must stay distinguishable from absent: there is no
+    CLI fallback for this route, so a wrong verdict here just loses the error."""
+    mock_server.force_response("POST", REMEMBER, code, {"detail": "nope"})
+    res = cg.do_index_repo(mock_server.url, "", "/path/to/proj", "ds")
+    assert res != cg.UNREACHABLE
+    assert res["status"] == code
+
+
+def test_unreachable_server_is_the_sentinel(cg):
+    res = cg.do_index_repo("http://127.0.0.1:1", "", "/path/to/proj", "ds")
+    assert res == cg.UNREACHABLE
+
+
+def test_index_records_state_for_a_local_repo(cg, mock_server, git_repo):
+    """Indexing is the freshness opt-in: without a recorded state the hooks
+    must never touch a repo."""
+    res = cg.index_repo(mock_server.url, "", str(git_repo))
+    assert res["ok"] is True
+    # Readable prefix plus a path digest — the digest is what stops two
+    # same-named checkouts from sharing a dataset (and a graph database).
+    assert res["dataset"].startswith("codebase-proj-")
+
+    states = cg.load_repo_states()
+    assert len(states) == 1
+    assert states[0]["repo_root"] == str(git_repo.resolve())
+    assert states[0]["spec_kind"] == "path"
+    assert states[0]["fingerprint"]  # a real tree fingerprint was captured
+
+
+def test_url_indexed_repo_records_no_fingerprint(cg, mock_server):
+    """A server-side clone only ever sees pushed commits, so there is no local
+    tree to track — and the Stop hook must not pretend otherwise."""
+    cg.index_repo(mock_server.url, "", "https://github.com/org/repo")
+    state = cg.load_repo_states()[0]
+    assert state["spec_kind"] == "url"
+    assert state["fingerprint"] == ""
+
+
+# ── freshness ──────────────────────────────────────────────────────────────
+
+
+def test_unchanged_tree_submits_nothing(cg, mock_server, git_repo):
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    mock_server.calls.clear()
+
+    outcome = cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+    assert outcome["changed"] is False
+    mock_server.assert_not_called("POST", REMEMBER)
+
+
+def test_edited_tree_resubmits_and_advances_the_fingerprint(cg, mock_server, git_repo):
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    before = cg.load_repo_states()[0]["fingerprint"]
+    mock_server.calls.clear()
+
+    (git_repo / "app.py").write_text("def start():\n    return 2\n", encoding="utf-8")
+    outcome = cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+
+    assert outcome["changed"] is True and outcome["submitted"] is True
+    assert mock_server.assert_called("POST", REMEMBER)["form"]["content_type"] == "code"
+    assert cg.load_repo_states()[0]["fingerprint"] != before
+
+
+def test_untracked_file_counts_as_a_change(cg, mock_server, git_repo):
+    """porcelain alone would miss content edits; new files must count too."""
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    (git_repo / "extra.py").write_text("x = 1\n", encoding="utf-8")
+    assert cg.reingest_if_changed(str(git_repo), mock_server.url, "")["changed"] is True
+
+
+def test_failed_resubmit_keeps_the_old_fingerprint(cg, mock_server, git_repo):
+    """Advancing on failure would mark the turn's edits as indexed when they
+    were not — the graph would stay stale until the NEXT edit."""
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    before = cg.load_repo_states()[0]["fingerprint"]
+
+    (git_repo / "app.py").write_text("def start():\n    return 3\n", encoding="utf-8")
+    mock_server.force_response("POST", REMEMBER, 500, {"detail": "boom"})
+
+    outcome = cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+    assert outcome["changed"] is True and outcome["submitted"] is False
+    assert cg.load_repo_states()[0]["fingerprint"] == before
+
+
+def test_unindexed_repo_is_left_alone(cg, mock_server, git_repo):
+    """No opt-in, no traffic: the hooks never index a repo nobody asked for."""
+    assert cg.reingest_if_changed(str(git_repo), mock_server.url, "") == {}
+    mock_server.assert_not_called("POST", REMEMBER)
+
+
+def test_url_indexed_repo_is_not_resubmitted_from_the_working_tree(cg, mock_server, git_repo):
+    cg.index_repo(mock_server.url, "", "https://github.com/org/repo", "codebase-proj")
+    # Point the URL-indexed state at a local root to prove spec_kind, not the
+    # presence of a root, is what gates the local freshness path.
+    state = cg.load_repo_states()[0]
+    state["repo_root"] = str(git_repo.resolve())
+    cg.save_repo_state(state)
+    mock_server.calls.clear()
+
+    (git_repo / "app.py").write_text("changed\n", encoding="utf-8")
+    assert cg.reingest_if_changed(str(git_repo), mock_server.url, "") == {}
+    mock_server.assert_not_called("POST", REMEMBER)
+
+
+def test_non_git_directory_is_skipped_quietly(cg, mock_server, tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    cg.save_repo_state(
+        {
+            "spec": str(plain),
+            "spec_kind": "path",
+            "repo_root": str(plain),
+            "dataset": "codebase-plain",
+            "fingerprint": "old",
+        }
+    )
+    assert cg.reingest_if_changed(str(plain), mock_server.url, "") == {}
+    mock_server.assert_not_called("POST", REMEMBER)
+
+
+# ── per-file code uploads (the .txt-rename fix) ────────────────────────────
+
+
+def test_file_upload_keeps_its_real_filename(rh, mock_server, tmp_path):
+    """The filename extension IS the routing signal: `payments.py` rides the
+    zero-LLM code route, `user_context.txt` would be ingested as prose."""
+    src = tmp_path / "payments.py"
+    src.write_text("def charge():\n    pass\n", encoding="utf-8")
+
+    res = rh.do_remember(mock_server.url, "", "", "ds", "project_docs", file_path=str(src))
+    assert res["ok"] is True
+
+    call = mock_server.assert_called("POST", REMEMBER)
+    assert call["files"] == ["data"]
+    # content_type must NOT be set: per-file routing is by extension, and
+    # content_type='code' would reject the upload outright.
+    assert "content_type" not in call["form"]
+
+
+def test_inline_text_still_uses_the_node_set_filename(rh, mock_server):
+    """The default path is unchanged — only --file opts into real filenames."""
+    res = rh.do_remember(mock_server.url, "", "a fact", "ds", "user_context")
+    assert res["ok"] is True
+    assert mock_server.assert_called("POST", REMEMBER)["files"] == ["data"]
+
+
+def test_missing_file_is_an_error_not_a_write(rh, mock_server, tmp_path):
+    res = rh.do_remember(
+        mock_server.url, "", "", "ds", "project_docs", file_path=str(tmp_path / "nope.py")
+    )
+    assert res != rh.UNREACHABLE
+    assert "cannot read" in res["error"]
+    mock_server.assert_not_called("POST", REMEMBER)
+
+
+# ── recall plumbing ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def rc(suite, isolated_modules):
+    return isolated_modules(suite, "_recall_http")
+
+
+def test_code_query_reaches_the_wire_with_the_code_scope(rc, mock_server):
+    rc.do_recall(
+        mock_server.url,
+        "",
+        "process_payment",
+        "",
+        json.dumps(["code"]),
+        5,
+        "codebase-proj",
+        "",
+        json.dumps({"operation": "impact_analysis", "targets": ["process_payment"]}),
+    )
+    body = mock_server.assert_called("POST", RECALL)["json"]
+    assert body["scope"] == ["code"]
+    assert body["code_query"]["operation"] == "impact_analysis"
+    assert body["datasets"] == ["codebase-proj"]
+
+
+@pytest.fixture
+def client(suite, isolated_modules):
+    return isolated_modules(suite, "_cognee_client")
+
+
+def test_breaker_wrapped_recall_forwards_the_code_query(client, mock_server):
+    """The breaker wrapper sits between the CLI wrapper and do_recall, whose
+    signature has context_profile BETWEEN dataset and code_query — a positional
+    hand-off there silently ships the query as a context profile, and the lane
+    returns unfiltered results instead of failing."""
+    client.recall(
+        mock_server.url,
+        "",
+        "process_payment",
+        "",
+        json.dumps(["code"]),
+        10,
+        "codebase-proj",
+        json.dumps({"operation": "impact_analysis", "targets": ["process_payment"]}),
+    )
+    body = mock_server.assert_called("POST", RECALL)["json"]
+    assert body["code_query"]["operation"] == "impact_analysis"
+    assert "context_profile" not in body
+
+
+def test_absent_code_query_is_omitted_entirely(rc, mock_server):
+    """The server rejects code_query without the code scope, so an unused lane
+    must not leave the key behind on ordinary recalls."""
+    rc.do_recall(mock_server.url, "", "hello", "", json.dumps(["graph"]), 5, "ds")
+    assert "code_query" not in mock_server.assert_called("POST", RECALL)["json"]

--- a/integrations/tests/tests/integration/test_code_graph.py
+++ b/integrations/tests/tests/integration/test_code_graph.py
@@ -442,14 +442,23 @@ def test_real_source_edits_still_register_next_to_a_snapshot(cg, git_repo):
 
 
 def _find_enola():
+    """Locate a local enola binary, or "" (the real-binary test then skips).
+
+    Runs at collection time (inside a skipif), so it must never raise on any
+    platform: an exception here fails the whole module, not one test.
+    """
     import glob
     import os
-    import pwd
     import shutil
 
     candidates = [os.environ.get("ENOLA_PATH", ""), shutil.which("enola") or ""]
     try:
-        real_home = pwd.getpwuid(os.getuid()).pw_dir  # tests redirect HOME
+        import pwd  # POSIX only: the fixtures redirect HOME, so ask the passwd db
+
+        real_home = pwd.getpwuid(os.getuid()).pw_dir
+    except Exception:  # Windows has no pwd module; fall back to the process HOME
+        real_home = os.path.expanduser("~")
+    try:
         candidates += sorted(glob.glob(os.path.join(real_home, ".cognee", "bin", "enola-*")))
     except Exception:
         pass

--- a/integrations/tests/tests/integration/test_code_graph.py
+++ b/integrations/tests/tests/integration/test_code_graph.py
@@ -398,6 +398,79 @@ def test_non_git_directory_is_skipped_quietly(cg, mock_server, tmp_path):
     mock_server.assert_not_called("POST", REMEMBER)
 
 
+# ── the indexer's own output must not re-trigger indexing ─────────────────
+
+
+def _write_enola_snapshot(repo, marker: str) -> None:
+    """Mimic what `enola --generate` leaves in the indexed repo: an untracked
+    .enola/ dir whose files (and rotated `previous/` copies) change every run."""
+    snap = repo / ".enola"
+    (snap / "previous").mkdir(parents=True, exist_ok=True)
+    (snap / "receipt.json").write_text('{"snapshot_id": "%s"}' % marker, encoding="utf-8")
+    (snap / "facts.jsonl").write_text(marker * 50, encoding="utf-8")
+    (snap / "previous" / f"receipt-{marker}.json").write_text("{}", encoding="utf-8")
+
+
+def test_enola_snapshot_dir_does_not_change_the_fingerprint(cg, git_repo):
+    """enola writes its snapshot INTO the repo it indexes and rotates files
+    there on every run. If that were visible to the fingerprint, every index
+    would make the next turn look 'changed' and re-index — a full parse per
+    turn, forever, for every locally indexed repo."""
+    before = cg.git_fingerprint(str(git_repo))
+    _write_enola_snapshot(git_repo, "run1")
+    assert cg.git_fingerprint(str(git_repo)) == before
+    _write_enola_snapshot(git_repo, "run2")  # a second run rewrites/rotates
+    assert cg.git_fingerprint(str(git_repo)) == before
+
+
+def test_enola_snapshot_dir_does_not_trigger_a_reindex(cg, mock_server, git_repo):
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    mock_server.calls.clear()
+    _write_enola_snapshot(git_repo, "run1")  # the background index landed
+
+    outcome = cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+    assert outcome["changed"] is False
+    mock_server.assert_not_called("POST", REMEMBER)
+
+
+def test_real_source_edits_still_register_next_to_a_snapshot(cg, git_repo):
+    """Excluding .enola must not blind the fingerprint to actual edits."""
+    _write_enola_snapshot(git_repo, "run1")
+    before = cg.git_fingerprint(str(git_repo))
+    (git_repo / "app.py").write_text("def start():\n    return 7\n", encoding="utf-8")
+    assert cg.git_fingerprint(str(git_repo)) != before
+
+
+def _find_enola():
+    import glob
+    import os
+    import pwd
+    import shutil
+
+    candidates = [os.environ.get("ENOLA_PATH", ""), shutil.which("enola") or ""]
+    try:
+        real_home = pwd.getpwuid(os.getuid()).pw_dir  # tests redirect HOME
+        candidates += sorted(glob.glob(os.path.join(real_home, ".cognee", "bin", "enola-*")))
+    except Exception:
+        pass
+    return next((c for c in candidates if c and os.access(c, os.X_OK)), "")
+
+
+@pytest.mark.skipif(not _find_enola(), reason="enola binary not installed locally")
+def test_fingerprint_is_stable_across_real_enola_runs(cg, git_repo):
+    """The definitive check against the real binary, not a mimic of its
+    output: two generates with no source edit must leave the fingerprint
+    exactly where it was before the first one."""
+    enola = _find_enola()
+    before = cg.git_fingerprint(str(git_repo))
+    for _ in range(2):
+        subprocess.run(
+            [enola, "--generate"], cwd=git_repo, check=True, capture_output=True, timeout=180
+        )
+        assert cg.git_fingerprint(str(git_repo)) == before
+    assert (git_repo / ".enola").is_dir(), "enola did not write its snapshot where expected"
+
+
 # ── per-file code uploads (the .txt-rename fix) ────────────────────────────
 
 

--- a/integrations/tests/tests/integration/test_code_graph.py
+++ b/integrations/tests/tests/integration/test_code_graph.py
@@ -117,6 +117,49 @@ def test_http_error_is_not_unreachable(cg, mock_server, code):
     assert res["status"] == code
 
 
+def test_unparseable_body_is_not_success(cg, mock_server):
+    """A 2xx we cannot parse must not read as a confirmed write.
+
+    Unlike the fire-and-forget remember path, callers here advance the repo's
+    stored fingerprint on "ok" — so reporting success for a body that proves
+    nothing would mark edits as indexed that may never have been.
+    """
+    mock_server.force_response("POST", REMEMBER, 200, b"<html>502 Bad Gateway</html>")
+    res = cg.do_index_repo(mock_server.url, "", "/path/to/proj", "ds")
+    assert res != cg.UNREACHABLE  # reachable server: no CLI-fallback semantics
+    assert isinstance(res, dict) and "error" in res
+    assert res.get("ok") is not True
+
+
+def test_unparseable_body_does_not_advance_the_fingerprint(cg, mock_server, git_repo):
+    """The consequence that actually matters: the turn's edits stay pending.
+
+    If the fingerprint advanced here, the next turn would see an unchanged
+    tree, skip the re-index, and leave the code graph silently stale with no
+    error anywhere. Keeping the old fingerprint costs one re-submission, which
+    the server's content hash skips when the write did land.
+    """
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    before = cg.load_repo_states()[0]["fingerprint"]
+
+    (git_repo / "app.py").write_text("def start():\n    return 99\n", encoding="utf-8")
+    mock_server.force_response("POST", REMEMBER, 200, b"not json at all")
+
+    outcome = cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+    assert outcome["changed"] is True and outcome["submitted"] is False
+    assert cg.load_repo_states()[0]["fingerprint"] == before
+
+
+def test_unparseable_body_leaves_the_repo_unregistered(cg, mock_server, git_repo):
+    """An explicit index that could not be confirmed must not look indexed:
+    a state file would enable the recall lane and the freshness loop for a
+    graph we have no evidence exists."""
+    mock_server.force_response("POST", REMEMBER, 200, b"<html>oops</html>")
+    res = cg.index_repo(mock_server.url, "", str(git_repo))
+    assert "error" in res
+    assert cg.load_repo_states() == []
+
+
 def test_unreachable_server_is_the_sentinel(cg):
     res = cg.do_index_repo("http://127.0.0.1:1", "", "/path/to/proj", "ds")
     assert res == cg.UNREACHABLE
@@ -191,6 +234,132 @@ def test_failed_resubmit_keeps_the_old_fingerprint(cg, mock_server, git_repo):
     outcome = cg.reingest_if_changed(str(git_repo), mock_server.url, "")
     assert outcome["changed"] is True and outcome["submitted"] is False
     assert cg.load_repo_states()[0]["fingerprint"] == before
+
+
+# ── retry backoff on repeated failures ─────────────────────────────────────
+
+
+def _fail(mock_server, status=401):
+    mock_server.force_response("POST", REMEMBER, status, {"detail": "nope"})
+
+
+def test_repeated_failures_stop_hitting_the_network(cg, mock_server, git_repo):
+    """A failed submission leaves the fingerprint alone, so the tree stays
+    'changed' on every later turn — conversation-only turns included. Without a
+    throttle one unresolved failure re-submits once per turn forever and
+    appends to a hook log that never rotates."""
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    (git_repo / "app.py").write_text("def start():\n    return 2\n", encoding="utf-8")
+    _fail(mock_server)
+    mock_server.calls.clear()
+
+    for _ in range(6):
+        cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+
+    posts = [c for c in mock_server.calls if c["method"] == "POST" and c["path"] == REMEMBER]
+    assert len(posts) == 1, f"expected one attempt inside the window, got {len(posts)}"
+
+
+def test_backoff_never_advances_the_fingerprint(cg, mock_server, git_repo):
+    """Throttling must not be implemented by marking the edits done: the
+    pending work has to survive the quiet period, or the graph goes silently
+    stale the moment the underlying problem is fixed."""
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    before = cg.load_repo_states()[0]["fingerprint"]
+    (git_repo / "app.py").write_text("def start():\n    return 3\n", encoding="utf-8")
+    _fail(mock_server)
+
+    for _ in range(4):
+        cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+
+    assert cg.load_repo_states()[0]["fingerprint"] == before
+
+
+def test_throttled_turns_report_nothing_to_log(cg, mock_server, git_repo):
+    """The suppressed turn returns the 'nothing to do' shape, which the Stop
+    hook does not log — that is what actually stops the log noise."""
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    (git_repo / "app.py").write_text("x = 1\n", encoding="utf-8")
+    _fail(mock_server)
+
+    first = cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+    second = cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+    assert first["submitted"] is False and "retry_in" in first
+    assert second == {}
+
+
+def test_attempt_resumes_once_the_window_expires(cg, mock_server, git_repo):
+    """Backoff delays recovery, it must not prevent it."""
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    (git_repo / "app.py").write_text("x = 2\n", encoding="utf-8")
+    _fail(mock_server)
+    cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+
+    state = cg.load_repo_states()[0]
+    state["last_error_at"] = 0.1  # window long past
+    cg.save_repo_state(state)
+    mock_server.clear_forced()
+
+    outcome = cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+    assert outcome["submitted"] is True
+
+
+def test_success_clears_the_backoff(cg, mock_server, git_repo):
+    """A recovered repo must not carry a stale penalty into its next failure."""
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    (git_repo / "app.py").write_text("x = 3\n", encoding="utf-8")
+    _fail(mock_server)
+    cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+    assert cg.load_repo_states()[0]["error_count"] == 1
+
+    state = cg.load_repo_states()[0]
+    state["last_error_at"] = 0.1
+    cg.save_repo_state(state)
+    mock_server.clear_forced()
+    cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+
+    assert "error_count" not in cg.load_repo_states()[0]
+
+
+def test_backoff_escalates_and_is_capped(cg):
+    """Escalating keeps a long outage quiet; the cap bounds how late a fixed
+    credential is noticed."""
+    schedule = [cg.retry_backoff_seconds(n) for n in range(1, 8)]
+    assert schedule[0] == 30
+    assert schedule == sorted(schedule)
+    assert max(schedule) == cg._RETRY_BACKOFF_MAX_SECONDS
+    assert cg.retry_backoff_seconds(0) == 0
+
+
+def test_backwards_clock_does_not_park_a_repo_in_backoff(cg, mock_server, git_repo):
+    """A system clock moved backwards must not strand a repo forever."""
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    (git_repo / "app.py").write_text("x = 4\n", encoding="utf-8")
+    _fail(mock_server)
+    cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+
+    state = cg.load_repo_states()[0]
+    state["last_error_at"] = 9_999_999_999.0  # far future
+    cg.save_repo_state(state)
+    mock_server.calls.clear()
+
+    cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+    assert any(c["path"] == REMEMBER for c in mock_server.calls)
+
+
+def test_explicit_index_ignores_the_backoff(cg, mock_server, git_repo):
+    """An explicit request is the user asking directly — it must never be
+    silently swallowed by a throttle they cannot see."""
+    cg.index_repo(mock_server.url, "", str(git_repo))
+    (git_repo / "app.py").write_text("x = 5\n", encoding="utf-8")
+    _fail(mock_server)
+    cg.reingest_if_changed(str(git_repo), mock_server.url, "")
+    mock_server.clear_forced()
+    mock_server.calls.clear()
+
+    res = cg.index_repo(mock_server.url, "", str(git_repo))
+    assert res["ok"] is True
+    assert any(c["path"] == REMEMBER for c in mock_server.calls)
 
 
 def test_unindexed_repo_is_left_alone(cg, mock_server, git_repo):

--- a/integrations/tests/tests/unit/test_code_graph_gate.py
+++ b/integrations/tests/tests/unit/test_code_graph_gate.py
@@ -1,0 +1,288 @@
+"""The pure decision logic of the code-graph lane: what fires it and what must not.
+
+The auto-recall code lane runs on the keystroke->answer path, so its gate is
+deliberately syntactic (identifier-shaped token) rather than semantic. These
+tests pin the two halves of that contract:
+
+  * conversational prompts produce NO identifiers, so the lane never fires and
+    ordinary turns pay nothing;
+  * a prompt naming a symbol produces a seed, but the lane still stays off
+    unless the cwd sits inside a repository the user explicitly indexed.
+
+The transport half (submitting an index, re-ingesting on change) lives in
+integration/test_code_graph.py.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+def cg(suite, isolated_modules):
+    return isolated_modules(suite, "_code_graph")
+
+
+# ── the identifier gate ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "can you explain what this does",
+        "why did that fail?",
+        "let's think about the plan for tomorrow",
+        "thanks, that worked",
+        "",
+    ],
+)
+def test_conversational_prompts_do_not_arm_the_lane(cg, prompt):
+    """No identifier -> no seed -> the lane must not fire at all."""
+    assert cg.extract_identifiers(prompt) == []
+
+
+@pytest.mark.parametrize(
+    "prompt,expected",
+    [
+        ("what calls process_payment?", "process_payment"),
+        ("explain UserService please", "UserService"),
+        ("look at billing/api.py", "billing/api.py"),
+        ("check `resolve_repo_source` for me", "resolve_repo_source"),
+        ("where is cognee.modules.retrieval used", "cognee.modules.retrieval"),
+    ],
+)
+def test_identifier_shapes_are_recognized(cg, prompt, expected):
+    assert expected in cg.extract_identifiers(prompt)
+
+
+def test_prose_camelcase_is_not_a_seed(cg):
+    """Product/tool names appear in ordinary prose; seeding on them would fire
+    the lane on nearly every prompt in this ecosystem."""
+    assert cg.extract_identifiers("does Claude know about Cognee and GitHub?") == []
+
+
+def test_identifiers_are_capped_and_deduped(cg):
+    found = cg.extract_identifiers(
+        "process_payment and process_payment and refund_order and audit_log"
+    )
+    assert len(found) <= 2
+    assert len(set(found)) == len(found)
+
+
+def test_code_query_is_a_bounded_fact_lookup(cg):
+    """query_facts (not explore) on purpose: an unresolvable seed must return an
+    empty page rather than raise, so a misfire can never disturb the prompt."""
+    q = cg.build_code_query("process_payment")
+    assert q["operation"] == "query_facts"
+    assert q["name"] == "process_payment"
+    assert isinstance(q["limit"], int) and q["limit"] > 0
+
+
+# ── the indexed-repo requirement ───────────────────────────────────────────
+
+
+def test_lane_stays_off_without_an_indexed_repo(cg, tmp_path):
+    """An identifier alone is not enough: nobody asked for this repo to be indexed."""
+    assert cg.auto_code_lane("what calls process_payment?", str(tmp_path)) == {}
+
+
+def test_lane_arms_inside_an_indexed_repo(cg, tmp_path):
+    repo = tmp_path / "myrepo"
+    (repo / "src").mkdir(parents=True)
+    cg.save_repo_state(
+        {
+            "spec": str(repo),
+            "spec_kind": "path",
+            "repo_root": str(repo),
+            "dataset": "codebase-myrepo",
+            "fingerprint": "abc",
+        }
+    )
+
+    lane = cg.auto_code_lane("what calls process_payment?", str(repo / "src"))
+    assert lane["dataset"] == "codebase-myrepo"
+    assert lane["identifier"] == "process_payment"
+    assert lane["code_query"]["operation"] == "query_facts"
+
+
+def test_lane_stays_off_for_conversational_prompt_in_indexed_repo(cg, tmp_path):
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    cg.save_repo_state(
+        {
+            "spec": str(repo),
+            "spec_kind": "path",
+            "repo_root": str(repo),
+            "dataset": "codebase-myrepo",
+        }
+    )
+    assert cg.auto_code_lane("thanks, that looks good", str(repo)) == {}
+
+
+def test_nested_checkouts_resolve_to_the_innermost_repo(cg, tmp_path):
+    outer = tmp_path / "outer"
+    inner = outer / "vendor" / "inner"
+    inner.mkdir(parents=True)
+    for root, dataset in ((outer, "codebase-outer"), (inner, "codebase-inner")):
+        cg.save_repo_state(
+            {
+                "spec": str(root),
+                "spec_kind": "path",
+                "repo_root": str(root),
+                "dataset": dataset,
+            }
+        )
+    lane = cg.auto_code_lane("check UserService", str(inner))
+    assert lane["dataset"] == "codebase-inner"
+
+
+def test_sibling_directory_is_not_inside_the_repo(cg, tmp_path):
+    """Prefix matching must respect path boundaries: /repo-other is not in /repo."""
+    repo = tmp_path / "repo"
+    other = tmp_path / "repo-other"
+    repo.mkdir()
+    other.mkdir()
+    cg.save_repo_state(
+        {
+            "spec": str(repo),
+            "spec_kind": "path",
+            "repo_root": str(repo),
+            "dataset": "codebase-repo",
+        }
+    )
+    assert cg.auto_code_lane("check UserService", str(other)) == {}
+
+
+# ── dataset naming ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "spec,prefix",
+    [
+        ("/path/to/my-repo", "codebase-my-repo-"),
+        ("https://github.com/org/cognee.git", "codebase-cognee-"),
+        ("/path/to/Repo_Name", "codebase-repo_name-"),
+    ],
+)
+def test_default_dataset_is_readable_and_narrow(cg, spec, prefix):
+    """One dataset per repo — the CODE snapshot cache and the delta pre-read
+    both scale with dataset size — and the name stays recognizable in a
+    dataset listing despite the disambiguating digest."""
+    name = cg.default_code_dataset(spec)
+    assert name.startswith(prefix)
+    assert len(name) > len(prefix)  # a digest follows
+
+
+def test_default_dataset_is_stable_across_calls(cg):
+    """Re-indexing must target the same dataset, not mint a new one."""
+    assert cg.default_code_dataset("/path/to/repo") == cg.default_code_dataset("/path/to/repo")
+
+
+def test_same_basename_repos_get_different_datasets(cg):
+    """The collision that matters: distinct checkouts routinely share a
+    basename. Landing both in one dataset means one graph database, where
+    cognee's repo-scoped stale-node sweep would let each ingestion delete the
+    other's nodes — silent, mutual data loss."""
+    a = cg.default_code_dataset("/work/team-a/service")
+    b = cg.default_code_dataset("/work/team-b/service")
+    assert a != b
+    assert a.startswith("codebase-service-") and b.startswith("codebase-service-")
+
+
+def test_same_basename_remote_repos_get_different_datasets(cg):
+    """Basenames collide across hosts and orgs too."""
+    assert cg.default_code_dataset("https://github.com/org-a/api") != cg.default_code_dataset(
+        "https://github.com/org-b/api"
+    )
+
+
+def test_git_suffix_and_trailing_slash_do_not_fork_a_dataset(cg):
+    """The same remote written three ways is one repository, not three."""
+    base = cg.default_code_dataset("https://github.com/org/repo")
+    assert cg.default_code_dataset("https://github.com/org/repo.git") == base
+    assert cg.default_code_dataset("https://github.com/org/repo/") == base
+
+
+def test_state_files_do_not_collide_for_same_basename(cg, tmp_path):
+    """The dataset name is not the only identity in play: two same-named
+    checkouts must also keep separate state files, or the second index would
+    overwrite the first's fingerprint and dataset."""
+    for parent in ("team-a", "team-b"):
+        root = tmp_path / parent / "service"
+        root.mkdir(parents=True)
+        cg.save_repo_state(
+            {
+                "spec": str(root),
+                "spec_kind": "path",
+                "repo_root": str(root),
+                "dataset": cg.default_code_dataset(str(root)),
+            }
+        )
+    states = cg.load_repo_states()
+    assert len(states) == 2
+    assert len({state["dataset"] for state in states}) == 2
+
+
+@pytest.mark.parametrize(
+    "spec,remote",
+    [
+        ("https://github.com/org/repo", True),
+        ("git@github.com:org/repo.git", True),
+        ("/local/path/repo", False),
+        (".", False),
+    ],
+)
+def test_remote_repo_detection(cg, spec, remote):
+    assert cg.is_remote_repo(spec) is remote
+
+
+# ── dataset resolution for callers ─────────────────────────────────────────
+
+
+def test_dataset_resolves_from_a_checkout(cg, tmp_path):
+    """Dataset names carry a path digest, so no caller can reconstruct one.
+    They resolve it from the checkout instead — including from a subdirectory,
+    which is where agents usually run."""
+    repo = tmp_path / "service"
+    (repo / "src").mkdir(parents=True)
+    dataset = cg.default_code_dataset(str(repo))
+    cg.save_repo_state(
+        {
+            "spec": str(repo),
+            "spec_kind": "path",
+            "repo_root": str(repo),
+            "dataset": dataset,
+        }
+    )
+    assert cg.find_indexed_repo(str(repo / "src"))["dataset"] == dataset
+
+
+def test_dataset_is_empty_outside_an_indexed_repo(cg, tmp_path):
+    """No index, no dataset — the caller must not fall back to the session
+    dataset and search prose as if it were code."""
+    assert cg.find_indexed_repo(str(tmp_path)) == {}
+
+
+# ── recall arg plumbing ────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def rh(suite, isolated_modules):
+    return isolated_modules(suite, "_recall_http")
+
+
+def test_malformed_code_query_degrades_to_no_lane(rh):
+    """A bad code_query must never become a server 422 that reads as a recall
+    failure — it simply drops the lane."""
+    assert rh.coerce_code_query("not json") is None
+    assert rh.coerce_code_query("") is None
+    assert rh.coerce_code_query("[1,2]") is None
+    assert rh.coerce_code_query(None) is None
+
+
+def test_code_query_accepts_json_and_dicts(rh):
+    parsed = rh.coerce_code_query(json.dumps({"operation": "delta"}))
+    assert parsed == {"operation": "delta"}
+    assert rh.coerce_code_query({"operation": "explore"}) == {"operation": "explore"}

--- a/integrations/tests/tests/unit/test_recall_code_lane.py
+++ b/integrations/tests/tests/unit/test_recall_code_lane.py
@@ -1,0 +1,192 @@
+"""The code lane inside the per-prompt recall fan-out.
+
+This lane runs on the keystroke->answer path, so its whole design is "cost
+nothing unless it can pay for itself". These tests pin that bargain end to end
+through ``_run``:
+
+  * an ordinary prompt dispatches exactly the four standard scopes — no extra
+    request, no extra budget spent, and the visibility header keeps the shape
+    its consumers already parse;
+  * a prompt naming a symbol inside an INDEXED repo adds a fifth lane, carrying
+    the repo's own dataset and a structured ``code_query`` — the semantic
+    scopes are untouched, because the lane is additive, never a substitute;
+  * code facts are injected under their own heading and counted separately;
+  * a failure anywhere in the gate degrades to "no code lane" rather than
+    taking the prompt's memory down with it.
+
+The gate's pure logic lives in unit/test_code_graph_gate.py; the wire contract
+in integration/test_code_graph.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+from utils.recall import drive_recall
+
+STANDARD = ["session", "trace", "session_context", "graph"]
+
+
+def _header(output) -> str:
+    """The one-line visibility header, wherever the suite puts it.
+
+    claude-code nests systemMessage inside hookSpecificOutput; codex emits it
+    at the top level alongside it. The header text is identical.
+    """
+    hook_output = output["hookSpecificOutput"]
+    return str(hook_output.get("systemMessage") or output.get("systemMessage") or "")
+
+
+@pytest.fixture
+def lookup(suite, hook_module):
+    return hook_module(suite, "session-context-lookup.py")
+
+
+@pytest.fixture
+def indexed_repo(suite, isolated_modules, tmp_path):
+    """A repo recorded as indexed, so the lane's opt-in requirement is met."""
+    cg = isolated_modules(suite, "_code_graph")
+    repo = tmp_path / "proj"
+    (repo / "src").mkdir(parents=True)
+    cg.save_repo_state(
+        {
+            "spec": str(repo),
+            "spec_kind": "path",
+            "repo_root": str(repo),
+            "dataset": "codebase-proj",
+            "fingerprint": "seed",
+        }
+    )
+    return repo
+
+
+# ── the lane stays off ─────────────────────────────────────────────────────
+
+
+def test_conversational_prompt_dispatches_only_standard_scopes(lookup, monkeypatch, indexed_repo):
+    """Inside an indexed repo, prose still costs nothing extra."""
+    run = drive_recall(
+        lookup, monkeypatch, prompt="thanks, that looks right", cwd=str(indexed_repo)
+    )
+    assert run.calls == STANDARD
+    assert not run.fired("code_lane_armed")
+
+
+def test_identifier_outside_an_indexed_repo_does_not_arm(lookup, monkeypatch, tmp_path):
+    """No opt-in for this checkout — the lane must not query someone else's graph."""
+    run = drive_recall(lookup, monkeypatch, prompt="what calls process_payment?", cwd=str(tmp_path))
+    assert run.calls == STANDARD
+
+
+def test_header_shape_is_unchanged_when_the_lane_is_off(lookup, monkeypatch):
+    """The one-line header is parsed downstream; adding a code counter to every
+    turn would change a line that most turns have no code content for."""
+    run = drive_recall(
+        lookup,
+        monkeypatch,
+        prompt="what happened earlier",
+        recall={"session": [{"question": "q", "answer": "a"}]},
+    )
+    header = _header(run.output)
+    assert "code" not in header
+    assert "session" in header and "graph" in header
+
+
+# ── the lane fires ─────────────────────────────────────────────────────────
+
+
+def test_identifier_in_an_indexed_repo_adds_the_lane(lookup, monkeypatch, indexed_repo):
+    run = drive_recall(
+        lookup,
+        monkeypatch,
+        prompt="what calls process_payment?",
+        cwd=str(indexed_repo / "src"),
+    )
+    assert "code" in run.calls
+    # Additive: every semantic scope still ran, and the code lane precedes the
+    # graph long pole so a warm snapshot answers before the budget is spent.
+    assert [c for c in run.calls if c != "code"] == STANDARD
+    assert run.calls.index("code") < run.calls.index("graph")
+
+    armed = run.detail("code_lane_armed")
+    assert armed["identifier"] == "process_payment"
+    assert armed["dataset"] == "codebase-proj"
+
+
+def test_lane_carries_the_repo_dataset_and_structured_query(lookup, monkeypatch, indexed_repo):
+    """The repo's own narrow dataset — not the session dataset — and a
+    deterministic code_query the server can execute without an LLM."""
+    run = drive_recall(lookup, monkeypatch, prompt="explain UserService", cwd=str(indexed_repo))
+    code_kwargs = run.kwargs["code"]
+    assert code_kwargs["dataset"] == "codebase-proj"
+    assert code_kwargs["code_query"]["operation"] == "query_facts"
+    assert code_kwargs["code_query"]["name"] == "UserService"
+
+
+def test_semantic_scopes_keep_the_session_dataset(lookup, monkeypatch, indexed_repo):
+    """The code lane's dataset override must not leak into the other scopes."""
+    run = drive_recall(lookup, monkeypatch, prompt="explain UserService", cwd=str(indexed_repo))
+    for scope in STANDARD:
+        assert run.kwargs[scope].get("dataset") != "codebase-proj"
+        assert run.kwargs[scope].get("code_query") is None
+
+
+def test_code_facts_are_injected_and_counted(lookup, monkeypatch, indexed_repo):
+    run = drive_recall(
+        lookup,
+        monkeypatch,
+        prompt="what calls process_payment?",
+        cwd=str(indexed_repo),
+        recall={
+            "code": [{"source": "code", "text": "process_payment (function) — billing/pay.py:42"}]
+        },
+    )
+    context = run.output["hookSpecificOutput"]["additionalContext"]
+    assert "=== Code graph facts ===" in context
+    assert "billing/pay.py:42" in context
+
+    assert run.detail("context_lookup_hit")["counts"]["code"] == 1
+    assert "1 code" in _header(run.output)
+
+
+def test_empty_code_lane_is_not_an_error(lookup, monkeypatch, indexed_repo):
+    """A seed the graph cannot resolve returns nothing server-side; the turn
+    must look exactly like a normal turn that found no code facts."""
+    run = drive_recall(
+        lookup,
+        monkeypatch,
+        prompt="what calls process_payment?",
+        cwd=str(indexed_repo),
+        recall={"session": [{"question": "q", "answer": "a"}]},
+    )
+    context = run.output["hookSpecificOutput"]["additionalContext"]
+    assert "=== Code graph facts ===" not in context
+    assert "0 code" in _header(run.output)
+    assert not run.fired("recall_error")
+
+
+# ── failure containment ────────────────────────────────────────────────────
+
+
+def test_a_broken_gate_never_breaks_the_prompt(lookup, monkeypatch, indexed_repo):
+    """The gate is best-effort: if it raises, recall proceeds without the lane."""
+    import sys
+    import types
+
+    broken = types.ModuleType("_code_graph")
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("gate exploded")
+
+    broken.auto_code_lane = _boom
+    monkeypatch.setitem(sys.modules, "_code_graph", broken)
+
+    run = drive_recall(
+        lookup,
+        monkeypatch,
+        prompt="what calls process_payment?",
+        cwd=str(indexed_repo),
+        recall={"session": [{"question": "q", "answer": "a"}]},
+    )
+    assert run.calls == STANDARD
+    assert run.fired("code_lane_gate_error")
+    assert "q" in run.output["hookSpecificOutput"]["additionalContext"]

--- a/integrations/tests/tests/unit/test_stop_hook_code_reingest.py
+++ b/integrations/tests/tests/unit/test_stop_hook_code_reingest.py
@@ -1,0 +1,118 @@
+"""End-of-turn code-graph freshness, wired into the Stop hook.
+
+A code graph that lags the agent's own edits is worse than no graph: a stale
+fact is delivered with the same confidence as a fresh one and misdirects the
+next turn. The Stop hook closes that gap by re-submitting an indexed repo when
+the turn changed its working tree.
+
+What these tests pin is the wiring and its failure containment, not the git
+fingerprinting itself (that lives in integration/test_code_graph.py):
+
+  * the pass runs on Stop and never on a per-tool-call event, because
+    re-parsing a repo after every Edit would be pure waste;
+  * a down or unconfigured server is skipped quietly, leaving the fingerprint
+    stale so the next turn retries;
+  * nothing the pass does can escape into the hook — a Stop hook that raises
+    loses the turn's assistant message.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture
+def store(suite, hook_module):
+    return hook_module(suite, "store-to-session.py")
+
+
+@pytest.fixture
+def spy(monkeypatch):
+    """A stub _code_graph whose reingest_if_changed records its call."""
+    calls: list[tuple] = []
+    module = types.ModuleType("_code_graph")
+
+    def _reingest(cwd, service_url, api_key, **_kw):
+        calls.append((cwd, service_url, api_key))
+        return {"changed": True, "submitted": True, "dataset": "codebase-proj"}
+
+    module.reingest_if_changed = _reingest
+    monkeypatch.setitem(sys.modules, "_code_graph", module)
+    return calls
+
+
+def _seams(store, monkeypatch, *, usable=True, base_url="https://cloud.example"):
+    events: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        store, "hook_log", lambda event, detail=None: events.append((event, detail or {}))
+    )
+    monkeypatch.setattr(store, "notify", lambda *a, **k: None)
+    monkeypatch.setattr(
+        store, "resolve_runtime_mode", lambda: {"mode": "http", "base_url": base_url}
+    )
+    monkeypatch.setattr(store, "server_usable", lambda url="": usable)
+    return events
+
+
+def test_change_is_submitted_and_logged(store, monkeypatch, spy):
+    events = _seams(store, monkeypatch)
+    store._maybe_reingest_code_repo({"cwd": "/work/proj"})
+
+    assert spy == [("/work/proj", "https://cloud.example", "")]
+    assert any(name == "code_reingest_submitted" for name, _ in events)
+
+
+def test_unchanged_tree_logs_but_submits_nothing(store, monkeypatch):
+    events = _seams(store, monkeypatch)
+    module = types.ModuleType("_code_graph")
+    module.reingest_if_changed = lambda *a, **k: {"changed": False, "repo_root": "/work/proj"}
+    monkeypatch.setitem(sys.modules, "_code_graph", module)
+
+    store._maybe_reingest_code_repo({"cwd": "/work/proj"})
+    assert any(name == "code_reingest_unchanged" for name, _ in events)
+
+
+def test_unreachable_server_is_skipped_quietly(store, monkeypatch, spy):
+    """The stale fingerprint is kept on purpose: the next Stop retries rather
+    than treating this turn's edits as already indexed."""
+    events = _seams(store, monkeypatch, usable=False)
+    store._maybe_reingest_code_repo({"cwd": "/work/proj"})
+
+    assert spy == []
+    assert any(name == "code_reingest_skipped_server" for name, _ in events)
+
+
+def test_no_service_url_does_nothing(store, monkeypatch, spy):
+    _seams(store, monkeypatch, base_url="")
+    store._maybe_reingest_code_repo({"cwd": "/work/proj"})
+    assert spy == []
+
+
+def test_failures_are_contained(store, monkeypatch):
+    """A Stop hook that raises loses the turn's assistant message — the
+    freshness pass must never be the thing that does that."""
+    events = _seams(store, monkeypatch)
+    module = types.ModuleType("_code_graph")
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("git exploded")
+
+    module.reingest_if_changed = _boom
+    monkeypatch.setitem(sys.modules, "_code_graph", module)
+
+    store._maybe_reingest_code_repo({"cwd": "/work/proj"})  # must not raise
+    assert any(name == "code_reingest_error" for name, _ in events)
+
+
+def test_pass_is_wired_to_stop_only(store):
+    """Per-tool-call re-parsing would be waste: enola re-parses the whole repo,
+    while a turn's edits are only settled at Stop."""
+    import inspect
+
+    source = inspect.getsource(store.main)
+    stop_branch, tool_branch = source.split("else:", 1)
+    assert "_maybe_reingest_code_repo" in stop_branch
+    assert "_maybe_reingest_code_repo" not in tool_branch

--- a/integrations/tests/utils/isolation.py
+++ b/integrations/tests/utils/isolation.py
@@ -37,6 +37,7 @@ ISOLATED_MODULES = (
     "_proc",
     "_recall_http",
     "_remember_http",
+    "_code_graph",
     "cognee_plugin",
     "cognee_statusline_render",
     "doctor",

--- a/integrations/tests/utils/recall.py
+++ b/integrations/tests/utils/recall.py
@@ -22,7 +22,9 @@ import types
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
-#: The scopes ``_run`` fans out over, in dispatch order.
+#: The scopes ``_run`` fans out over, in dispatch order. The optional ``code``
+#: lane is inserted before ``graph`` only on prompts that arm it, so it is not
+#: part of the always-present set.
 SCOPES = ("session", "trace", "session_context", "graph")
 
 #: Base URL every driven run resolves to. Health state is keyed by service URL
@@ -49,6 +51,9 @@ class RecallRun:
     calls: list[str] = field(default_factory=list)
     #: ``{scope: timeout}`` as handed to ``recall_via_http``, for budget clamping.
     timeouts: dict[str, float] = field(default_factory=dict)
+    #: ``{scope: kwargs}`` as handed to ``recall_via_http`` — the code lane's
+    #: dataset/code_query override is only visible here.
+    kwargs: dict[str, dict] = field(default_factory=dict)
     #: Whatever ``_run`` returned (the injected context, or None).
     output: Any = None
 
@@ -74,6 +79,7 @@ def drive_recall(
     ready_hint: bool = False,
     slow_streak: int = 1,
     slow_threshold: int = 3,
+    cwd: str = "",
 ) -> RecallRun:
     """Run ``module._run(prompt)`` in cloud mode with every seam captured.
 
@@ -100,6 +106,7 @@ def drive_recall(
         run.calls.append(scope)
         if "timeout" in kw:
             run.timeouts[scope] = kw["timeout"]
+        run.kwargs[scope] = dict(kw)
         return _recall_fn(prompt_arg, **kw)
 
     seams = {
@@ -133,7 +140,7 @@ def drive_recall(
     )
     monkeypatch.setitem(sys.modules, "_cognee_client", fake_client)
 
-    run.output = asyncio.run(module._run(prompt))
+    run.output = asyncio.run(module._run(prompt, cwd))
     return run
 
 

--- a/n8n_workflows/cognee_skill_self_improve/advanced/run_self_improve_skill.py
+++ b/n8n_workflows/cognee_skill_self_improve/advanced/run_self_improve_skill.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any
 from uuid import UUID
 
-
 ROOT = Path(__file__).resolve().parent
 SKILLS_ROOT = ROOT / "my_skills"
 SKILL_NAME = os.environ.get("COGNEE_SKILL_NAME", "code-review")

--- a/scripts/check_version_pins.py
+++ b/scripts/check_version_pins.py
@@ -17,8 +17,8 @@ Usage:
     python scripts/check_version_pins.py
 """
 
-import sys
 import re
+import sys
 from pathlib import Path
 
 INTEGRATIONS_DIR = Path(__file__).resolve().parent.parent / "integrations"


### PR DESCRIPTION
This PR enables the enola code graph pipeline in the Claude Code and Codex plugins

Repositories can now be indexed into cognee's deterministic code graph (symbols, calls, imports, endpoints) and queried from both plugins. Indexing and querying make no LLM or embedding calls. Requires cognee ≥ 1.5.3 — both plugin pins bumped from 1.5.0.

Automatic
- Opening an agent in a git repo indexes it at session start (background, never blocks the first prompt). New repos are auto-indexed only against a local server, where the code stays on the machine; remote servers need explicit opt-in (COGNEE_CODE_AUTOINDEX=always).
- Any turn that changes the working tree re-indexes it, detected via a git fingerprint on the Stop hook.
- Prompts naming an identifier (process_payment, UserService, billing/api.py) inside an indexed repo get code facts injected by the per-prompt recall hook. The lane is additive, gated syntactically, and contributes nothing when it misses — conversational prompts are unchanged.

Explicit
- cognee-index-repo.sh <path-or-git-url> [--index-vectors] [--wait N] — index a repo.
- cognee-search.sh "<seed>" --code [--code-query '<json>'] — six operations: query_facts, explore, traverse, find_path, impact_analysis, delta. The repo's dataset resolves from the current checkout.
- cognee-remember.sh --file <path> — store a single file under its real name so code routes as code instead of prose.
- New cognee-code skill (Claude Code); Codex's codebase skill rewritten off the CLI.

Notes
- One dataset per indexed repo, named codebase-<repo>-<digest>. The path digest is load-bearing: same-basename checkouts sharing a dataset would share a graph database, where each re-index's stale-node sweep would delete the other's nodes.
- Freshness ceiling differs by server and is documented as such: local reflects the working tree including uncommitted changes; cloud reflects the last pushed commit.