### PR TITLE
test: add hermes and openclaw tests to nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.python != '[]' }}
     runs-on: ubuntu-latest
+    # A hung suite otherwise runs to GitHub's 6h default before anyone hears
+    # about it. The longest real cell is a cold `uv sync` of the cognee stack
+    # plus its tests, which lands around 5m.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -114,6 +118,7 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.typescript != '[]' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -5,11 +5,22 @@ name: Live E2E (real backends, no mocks)
 # Nightly plus on-demand is enough to catch regressions in the memory chain that
 # the hermetic suite cannot see.
 #
-# Two jobs, ONE test suite. The same 36 scenarios run against a locally booted
-# server and against a cloud tenant; the backend is chosen by a single env var
-# (COGNEE_LIVE_BASE_URL). Separate jobs rather than one, so a cloud outage cannot
-# discredit the local signal — and because they need different setup: the local
-# job builds/caches the plugin venv, the cloud job needs no venv at all.
+# Three jobs, two test suites. `local` and `cloud` run ONE suite — the same 36
+# claude-code/codex scenarios — against a locally booted server and against a
+# cloud tenant; the backend is chosen by a single env var (COGNEE_LIVE_BASE_URL).
+# Separate jobs rather than one, so a cloud outage cannot discredit the local
+# signal — and because they need different setup: the local job builds/caches
+# the plugin venv, the cloud job needs no venv at all.
+#
+# `hermes` and `openclaw` each run a different suite entirely — one SDK-based
+# Python plugin, one TypeScript plugin, both out of scope for the shared harness
+# in integrations/tests (see its README) and both carrying their own live tests
+# inside their own package. Same tier, same nightly, their own jobs.
+#
+# Neither of those two shares the cloud tenant. Both name their datasets
+# `live_<uuid>` and wipe every `live_` dataset either side of a run, exactly as
+# the shared harness does, so pointing two of these jobs at one tenant in
+# parallel would have each one's cleanup delete the other's in-flight data.
 on:
   workflow_dispatch:
     inputs:
@@ -207,10 +218,212 @@ jobs:
               print(f'cleanup: deleted {deleted} test dataset(s); failures={failures[:5]}')
           "
 
+  # hermes-agent boots its own cognee server and drives the plugin's provider
+  # API directly — no hooks, no temp HOME, no plugin venv to seed. So this job
+  # shares the tier's shape (nightly, real LLM, Slack on failure) but none of the
+  # other two's setup: its own package dir, its own pytest invocation, and the
+  # opt-in gate its tests already ship with (COGNEE_RUN_INTEGRATION).
+  hermes:
+    name: live tier (hermes-agent)
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    # Seven tests, but LLM-bound ones: the suite budgets 120s for a cold server
+    # boot, 600s for a graph write and 900s for an improve. Its own per-test
+    # ceiling is 30m (tests/conftest.py), so this is the outer bound on a run
+    # where several tests stall rather than fail.
+    timeout-minutes: 60
+    outputs:
+      failed_tests: ${{ steps.failures.outputs.list }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: integrations/hermes-agent/.python-version
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      # cognee is a direct dependency of the plugin, so this single sync gives
+      # the job both the test runner and the server it boots. Nothing to cache
+      # beyond uv's own wheel cache.
+      - name: Install dependencies
+        working-directory: integrations/hermes-agent
+        run: uv sync --locked --dev
+
+      - name: Run the live round trip against a self-booted server
+        working-directory: integrations/hermes-agent
+        env:
+          # The gate the tests read at import time. Without it all seven skip and
+          # the job would pass while proving nothing.
+          COGNEE_RUN_INTEGRATION: '1'
+          LLM_API_KEY: ${{ secrets.LIVE_E2E_LLM_API_KEY }}
+          # Same model the local tier pins, for the same reason: graph extraction
+          # is the only model spend here. The spawned server inherits this env.
+          LLM_MODEL: openai/gpt-4o-mini
+        run: |
+          if [ -z "${LLM_API_KEY}" ]; then
+            echo "::error::LIVE_E2E_LLM_API_KEY is not set — the hermes live tier cannot run."
+            exit 1
+          fi
+          set -o pipefail
+          uv run pytest \
+            tests/test_integration_roundtrip.py \
+            tests/test_integration_concurrency.py \
+            -v ${{ inputs.pytest_args }} 2>&1 | tee pytest-live.log
+
+      - name: Record failed tests for the Slack report
+        id: failures
+        if: failure()
+        working-directory: integrations/hermes-agent
+        run: |
+          {
+            echo 'list<<GITHUB_OUTPUT_EOF'
+            grep -E '^(FAILED|ERROR) ' pytest-live.log 2>/dev/null | cut -c1-200 | head -20 || true
+            echo 'GITHUB_OUTPUT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      # The server the tests spawn is detached and logs to the shared plugin
+      # state dir (server_bootstrap.default_server_log_path), so unlike the hook
+      # tiers its output survives the run — but only on the runner.
+      - name: Collect server logs on failure
+        if: failure()
+        run: |
+          {
+            echo "### hermes server log"
+            tail -200 "$HOME/.cognee-plugin/hermes/server.log" 2>/dev/null \
+              || echo "(no server log — the boot never got that far)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # openclaw's live tier will not boot anything: it requires a *named* server that
+  # already answers /health, deliberately, because there is no safe default (the
+  # conventional port usually holds a developer's real data). So this job boots one
+  # for it and hands over the URL.
+  #
+  # Loopback, not the cloud tenant, and not by preference: `liveConfig()` derives
+  # its mode from the URL, and its cloud branch drops the `/api/v1` prefix that the
+  # Python tiers use against that same tenant (`isCloud ? "/remember" : "/api/v1/
+  # remember"` in src/client.ts). Verified against a real server: with the prefix
+  # /datasets answers 200, without it 404. Loopback is the shape this tier is
+  # written for, and the one its own docstring documents.
+  openclaw:
+    name: live tier (openclaw)
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    # Three scenarios, each allowed 15m by the suite itself, and a graph write is
+    # polled for up to 10m before it gives up.
+    timeout-minutes: 60
+    outputs:
+      failed_tests: ${{ steps.failures.outputs.list }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # The server side of this job. hermes-agent is used purely as a packaged,
+      # version-pinned cognee plus a boot path this repo already tests
+      # (tests/test_integration_concurrency.py asserts exactly this spawn) — the
+      # alternative is a second, untested uvicorn incantation living in YAML.
+      - name: Set up Python for the server
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: integrations/hermes-agent/.python-version
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install the cognee server
+        working-directory: integrations/hermes-agent
+        run: uv sync --locked
+
+      - name: Boot a cognee server and mint a key for it
+        working-directory: integrations/hermes-agent
+        env:
+          LLM_API_KEY: ${{ secrets.LIVE_E2E_LLM_API_KEY }}
+          # Graph extraction is the only model spend here; the server inherits this.
+          LLM_MODEL: openai/gpt-4o-mini
+        run: |
+          if [ -z "${LLM_API_KEY}" ]; then
+            echo "::error::LIVE_E2E_LLM_API_KEY is not set — the openclaw live tier cannot run."
+            exit 1
+          fi
+          # 9100, not cognee's conventional 8011: the same port the tier's own
+          # docstring uses, and nothing else on the runner will be near it.
+          #
+          # `_resolve_api_key` is private, and reused on purpose: the server rejects
+          # an unauthenticated /api/v1/datasets with 401, so the tier needs a real
+          # key, and this is the login-then-mint flow the plugin already ships and
+          # tests. Reimplementing it in shell would be a second copy to keep true.
+          key="$(uv run python -c '
+          from cognee_integration_hermes.http_backend import HttpBackend
+          from cognee_integration_hermes.server_bootstrap import ensure_local_server
+
+          backend = HttpBackend()
+          backend.url = ensure_local_server(9100, boot_timeout=600.0)
+          print(backend._resolve_api_key("", timeout=60.0))
+          ' | tail -1)"
+          if [ -z "$key" ]; then
+            echo "::error::could not mint an API key against the booted server."
+            exit 1
+          fi
+          echo "::add-mask::$key"
+          echo "COGNEE_LIVE_API_KEY=$key" >> "$GITHUB_ENV"
+
+      - name: Install openclaw dependencies
+        working-directory: integrations/openclaw
+        run: npm install
+
+      - name: Run the live tier against the booted server
+        working-directory: integrations/openclaw
+        env:
+          COGNEE_RUN_LIVE: '1'
+          COGNEE_LIVE_BASE_URL: http://127.0.0.1:9100
+          # COGNEE_LIVE_API_KEY comes from the boot step via GITHUB_ENV.
+        run: |
+          set -o pipefail
+          npm run test:live 2>&1 | tee jest-live.log
+          # The tier is `describe.skip` when its two variables are not both set, and
+          # a skipped suite exits 0. Without this the job's green would mean
+          # "nothing ran" just as readily as "everything passed".
+          if grep -q '\[live\] skipped' jest-live.log; then
+            echo "::error::the live suite skipped itself — it ran nothing."
+            exit 1
+          fi
+
+      - name: Record failed tests for the Slack report
+        id: failures
+        if: failure()
+        working-directory: integrations/openclaw
+        run: |
+          {
+            echo 'list<<GITHUB_OUTPUT_EOF'
+            grep -E '^(FAIL |  ● )' jest-live.log 2>/dev/null | cut -c1-200 | head -20 || true
+            echo 'GITHUB_OUTPUT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Collect server logs on failure
+        if: failure()
+        run: |
+          {
+            echo "### cognee server log (openclaw tier)"
+            tail -200 "$HOME/.cognee-plugin/hermes/server.log" 2>/dev/null \
+              || echo "(no server log — the boot never got that far)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   notify:
     name: Slack failure report
     runs-on: ubuntu-latest
-    needs: [local, cloud]
+    needs: [local, cloud, hermes, openclaw]
     # Failure-only by design: silence means green. `always()` is required for
     # the condition to be evaluated at all — without it a failed dependency
     # skips this job before the contains() is ever read.
@@ -235,6 +448,10 @@ jobs:
           CLOUD_RESULT: ${{ needs.cloud.result }}
           LOCAL_FAILED: ${{ needs.local.outputs.failed_tests }}
           CLOUD_FAILED: ${{ needs.cloud.outputs.failed_tests }}
+          HERMES_RESULT: ${{ needs.hermes.result }}
+          HERMES_FAILED: ${{ needs.hermes.outputs.failed_tests }}
+          OPENCLAW_RESULT: ${{ needs.openclaw.result }}
+          OPENCLAW_FAILED: ${{ needs.openclaw.outputs.failed_tests }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TRIGGER: ${{ github.event_name }}
         run: |
@@ -299,6 +516,8 @@ jobs:
                   f":rotating_light: *Nightly live e2e failed* ({os.environ.get('TRIGGER', '?')})",
                   tier("local tier", os.environ.get("LOCAL_RESULT", ""), os.environ.get("LOCAL_FAILED", "")),
                   tier("cloud tier", os.environ.get("CLOUD_RESULT", ""), os.environ.get("CLOUD_FAILED", "")),
+                  tier("hermes tier", os.environ.get("HERMES_RESULT", ""), os.environ.get("HERMES_FAILED", "")),
+                  tier("openclaw tier", os.environ.get("OPENCLAW_RESULT", ""), os.environ.get("OPENCLAW_FAILED", "")),
                   f"<{os.environ.get('RUN_URL', '')}|Open the run>",
               ]
           )

--- a/integrations/hermes-agent/pyproject.toml
+++ b/integrations/hermes-agent/pyproject.toml
@@ -36,6 +36,20 @@ cognee_integration_hermes = ["_plugin_root/*"]
 [dependency-groups]
 dev = [
     "pytest>=8.0",
+    "pytest-timeout>=2.3",
     "ruff>=0.14.6",
 ]
 
+[tool.pytest.ini_options]
+# Without a pytest section here, rootdir resolution walks up to the monorepo
+# root's pyproject.toml and this suite adopts its `asyncio_mode = "auto"` — an
+# option pytest-asyncio owns and hermes does not install, so every run, local
+# and CI alike, printed a PytestConfigWarning about it.
+testpaths = ["tests"]
+
+# A hung run is the failure mode this suite was reported for (SDK-454), and a
+# hang has no natural bound: a socket that never answers or a child that is
+# never reaped just sits there until CI's 6h default gives up. The slowest
+# honest test here is the exit-watcher's ~2s poll, so 60s only ever fires on a
+# genuine hang — and fires as a named, stack-dumping failure instead of silence.
+timeout = 60

--- a/integrations/hermes-agent/tests/conftest.py
+++ b/integrations/hermes-agent/tests/conftest.py
@@ -1,0 +1,73 @@
+"""Isolates the unit suite from the developer's own cognee setup.
+
+Almost every env patch in this suite is ``clear=False`` — deliberately, because
+each test declares only the handful of variables it cares about. That leaves the
+rest of ``os.environ`` showing through, and the plugin reads two dozen
+``COGNEE_*`` variables to decide its transport, its key, and its roots. On a CI
+runner nothing is set and the suite is green; on the machine of anyone who
+actually *runs* cognee it is not. A single exported variable is enough:
+
+    COGNEE_API_KEY=...   -> 7 failures (TestApiKeyResolution: a configured key
+                            skips the minting path those tests exercise)
+    COGNEE_EMBEDDED=true -> 3 failures (TestTransportSelection: embedded mode
+    COGNEE_TRANSPORT=sdk -> 3 failures  outranks the HTTP default under test)
+
+So the baseline is scrubbed here instead of at two dozen call sites. Tests that
+want a variable still set it themselves; what they no longer inherit is the
+developer's shell. See SDK-454.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# The plugin's whole configuration surface: COGNEE_* (transport, key, roots,
+# timeouts), LLM_* (model selection, and the creds a spawned server inherits),
+# and HERMES_HOME (the profile whose cognee.json layers under the env).
+_SCRUBBED_PREFIXES = ("COGNEE_", "LLM_", "HERMES_")
+
+# The opt-in live modules are the exception: they talk to a real server on
+# purpose, and ``server_bootstrap._spawn`` hands it ``dict(os.environ)`` — strip
+# LLM_API_KEY here and the server they boot comes up without credentials. Their
+# skip gates read the environment at import time, so scrubbing could not have
+# unselected them anyway; this keeps the run they opted into intact.
+_LIVE_MODULES = frozenset(
+    {
+        "test_integration_concurrency",
+        "test_integration_roundtrip",
+    }
+)
+
+# The test modules import their shared helpers as ``from _char_helpers import
+# ...``, which resolves only because pytest prepends a test file's own directory
+# to sys.path. Stating it here makes that dependency explicit rather than a
+# property of the default import mode.
+_TESTS_DIR = Path(__file__).resolve().parent
+if str(_TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TESTS_DIR))
+
+
+# The live modules budget in minutes, not seconds: a cold server boot is 120s, a
+# graph write 600s, an improve 900s. The 60s ini timeout that bounds the hermetic
+# suite would guillotine every one of them, so they get a ceiling above their own
+# slowest wait instead — still a bound, just an honest one. A marker outranks the
+# ini value, and setting it here keeps the whole hermetic/live split in one file.
+_LIVE_TIMEOUT = 1800
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if item.module.__name__.rsplit(".", 1)[-1] in _LIVE_MODULES:
+            item.add_marker(pytest.mark.timeout(_LIVE_TIMEOUT))
+
+
+@pytest.fixture(autouse=True)
+def hermetic_env(request, monkeypatch):
+    """Drop every ambient cognee variable, for every test but the live ones."""
+    if request.module.__name__.rsplit(".", 1)[-1] in _LIVE_MODULES:
+        return
+    for name in list(os.environ):
+        if name.startswith(_SCRUBBED_PREFIXES):
+            monkeypatch.delenv(name, raising=False)

--- a/integrations/hermes-agent/uv.lock
+++ b/integrations/hermes-agent/uv.lock
@@ -762,6 +762,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 
@@ -771,6 +772,7 @@ requires-dist = [{ name = "cognee", specifier = ">=1.2.1,<=1.4.0" }]
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
     { name = "ruff", specifier = ">=0.14.6" },
 ]
 
@@ -2914,6 +2916,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds hermes and openclaw tests to nightly CI.