### PR TITLE
feat: enable dataset switching mid-session

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "author": {
         "name": "Cognee"
       },

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "author": {
     "name": "Cognee"
   },

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,6 +10,35 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.4.0]
+
+### Added
+- **Switch datasets mid-session: `/cognee-memory:cognee-switch-datasets`.** Lists the
+  datasets you can write to (owned by the principal behind your API key — `GET
+  /api/v1/datasets` returns everything readable, so read-only ones are filtered out
+  and counted), lets you pick one, and moves the launch: the current session is
+  synced into its dataset first (`sync-session-to-graph.py --strict`; the switch
+  aborts if that fails, `--force` to proceed anyway), a **new** Cognee session is
+  registered on the target dataset under a fresh connection handle, and only then
+  is the old handle released — so a local agent-mode server never drops to zero
+  connections. Backed by `scripts/switch-dataset.py` (`--list [--json]`, `<name>
+  [--force] [--json]`, `--session-key`).
+
+### Changed
+- **The active dataset now lives in the launch record**
+  (`~/.cognee-plugin/claude-code/sessions/<host id>.json`), seeded at SessionStart
+  from `COGNEE_PLUGIN_DATASET`/default. `config.get_dataset`, `load_resolved`, the
+  `cognee-search.sh`/`cognee-remember.sh` wrappers, the idle and exit watchers and
+  the status line all read it, so a switch is followed everywhere and survives
+  `--resume`. A switched record beats an exported `COGNEE_SESSION_ID`.
+- **Status line** shows the launch's recorded dataset and a faint `· switched` tag
+  once it differs from the launch-time one.
+- **Final sync covers every session the launch touched.** The record keeps a
+  `touched` list of `{session_id, dataset, conn_uuid}` triples; the SessionEnd /
+  exit-watcher sync bridges each pair (current last) and releases every handle, so a
+  write that raced a switch is never lost.
+- `sync-session-to-graph.py --strict` exits non-zero on an incomplete bridge.
+
 ## [1.3.3]
 
 ### Fixed

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -152,9 +152,31 @@ export COGNEE_PLUGIN_DATASET="my-project-memory"
 `~/.cognee-plugin/claude-code/config.json` may still show a `dataset` value for
 visibility, but runtime dataset selection does not read it.
 
-The dataset is fixed for the lifetime of a launch. Recall searches only the active dataset. If you want to
-change the active dataset, you have to exit Claude, change the dataset via env, and then start Claude again.
+`COGNEE_PLUGIN_DATASET` seeds the dataset at launch. Recall searches only the active dataset.
 Data added outside of Claude to the dataset (via SDK or the server for example) is visible in Claude via the Cognee plugin.
+
+### Switching datasets mid-session
+
+Run `/cognee-memory:cognee-switch-datasets` (optionally with a dataset name) to move the
+running session to another dataset. Without a name it lists the datasets you can write to —
+those owned by the principal behind your API key; datasets you can only read are counted but
+never offered — and asks you to pick one. A name that is not listed is created for you.
+
+A Cognee session never spans two datasets, so the switch:
+
+1. syncs the current session into its dataset (aborts if that fails — nothing changes);
+2. registers a **new** Cognee session on the chosen dataset under a fresh connection handle,
+   then releases the old handle (register-then-unregister, so a local agent-mode server never
+   sees zero connections);
+3. repoints this launch's record so every hook, the shell wrappers, the idle/exit watchers and
+   the status line follow it, and appends `· switched` to the status line.
+
+The choice lives in the launch record (`~/.cognee-plugin/claude-code/sessions/<host id>.json`),
+so it survives `--resume` and beats the shell's `COGNEE_PLUGIN_DATASET` (and a pinned
+`COGNEE_SESSION_ID`) for the rest of the launch. Retired sessions stay in the record's `touched`
+list and the session-end sync covers them again as a safety net. The script behind the skill is
+`scripts/switch-dataset.py` (`--list [--json]`, `<name> [--force] [--json]`,
+`--session-key <host id>` when several launches share a directory).
 
 ## Hooks
 
@@ -215,6 +237,7 @@ Final sync on session end is triggered by the `SessionEnd` detached worker, with
 - `/cognee-memory:cognee-remember`
 - `/cognee-memory:cognee-search`
 - `/cognee-memory:cognee-sync`
+- `/cognee-memory:cognee-switch-datasets`
 
 ## Remember (write) behavior
 
@@ -308,14 +331,15 @@ through), `COGNEE_AGENT_SESSION_NAME`, `COGNEE_PLUGIN_IN_VENV` (the re-exec guar
 and `COGNEE_SYNC_DATASET` / `COGNEE_SYNC_SESSION_ID` (arguments to the final-sync
 worker). Setting them yourself does not configure anything — the plugin overwrites
 them during startup — and a stale value can misroute identity or session resolution.
-Use `COGNEE_SESSION_ID` to pin a session and `COGNEE_PLUGIN_DATASET` to pin a dataset.
+Use `COGNEE_SESSION_ID` to pin a session and `COGNEE_PLUGIN_DATASET` to seed the dataset
+(a mid-session `/cognee-memory:cognee-switch-datasets` overrides both for that launch).
 
 It is configured automatically on first launch when no custom status line is already configured. SessionStart writes the correct path into `~/.claude/settings.json` and Claude Code hot-reloads it, so the status line appears from your first interaction onward. Existing non-Cognee `statusLine` settings are preserved; set `COGNEE_STATUSLINE=false` before launching Claude Code to opt out entirely.
 
 The entry sets `refreshInterval: 2`, so Claude re-runs the (network-free, local-only) renderer every 2 seconds in addition to its event-driven updates. Without it, Claude only refreshes the status line on events (a new message, `/compact`, etc.), which go quiet while the session is idle — so a connection change detected right after launch (e.g. a rejected API key) wouldn't show until your next prompt. Tune it with `COGNEE_STATUSLINE_REFRESH_INTERVAL` (seconds; a value below `1`, e.g. `0`, disables idle polling and reverts to event-only refresh).
 
 The status line reads only local state — no network calls on every refresh:
-1. Dataset: `COGNEE_PLUGIN_DATASET` env var, otherwise `agent_sessions`
+1. Dataset: this launch's record (`sessions/<host id>.json`, written at SessionStart and by a dataset switch), otherwise `COGNEE_PLUGIN_DATASET`, otherwise `agent_sessions`
 2. Mode: `COGNEE_BACKEND` / `COGNEE_CLAUDE_BACKEND` switch, then `COGNEE_BASE_URL` env var, then `~/.cognee-plugin/claude-code/config.json` (`base_url`)
 3. Default mode: `local`
 4. Connection glyph: `conn-state/<session>.json`, then `server-ready.json` + `recall-breaker.json`
@@ -440,7 +464,7 @@ skips local-path (dev) installs. Turn it off with `COGNEE_UPDATE_CHECK=false`.
 - If a mode seems stuck, check for a forgotten `COGNEE_BACKEND` / `COGNEE_CLAUDE_BACKEND` export in the shell or in `~/.cognee/.env` — the plugin-specific name silently beats the shared one.
 
 **Recall returns empty but data was ingested**
-- Recall is scoped to the active dataset (`COGNEE_PLUGIN_DATASET` / `agent_sessions`).
+- Recall is scoped to the active dataset (the one in the status line — `COGNEE_PLUGIN_DATASET` / `agent_sessions` at launch, or whatever you switched to).
 - Data written via the Python SDK or `client.py` goes to `default_dataset` by default, if dataset not otherwise specified.
 - To verify, call the recall API directly without a dataset filter: `curl -X POST "$COGNEE_BASE_URL/api/v1/recall" -d '{"query":"..."}'`
 
@@ -516,7 +540,7 @@ Keys are letters, digits, and underscores. Values are taken literally — no `$V
 
 | Key | Env var(s) | Default | Notes |
 |---|---|---|---|
-| `dataset` | `COGNEE_PLUGIN_DATASET` | `agent_sessions` | Dataset for writes and recall (config value is informational-only) |
+| `dataset` | `COGNEE_PLUGIN_DATASET` | `agent_sessions` | Dataset for writes and recall at launch; `/cognee-memory:cognee-switch-datasets` changes it mid-session (config value is informational-only) |
 | `session_id` | `COGNEE_SESSION_ID` | auto-generated per launch | Override to resume a named session |
 | `session_strategy` | `COGNEE_SESSION_STRATEGY` | `per-directory` | `per-directory`, `git-branch`, `static` |
 | `session_prefix` | `COGNEE_SESSION_PREFIX` | `cc` | Prefix for auto-generated session IDs |

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -203,9 +203,18 @@ def _session_map_path(host_key: str) -> Path:
 def _read_map_record(host_key: str) -> dict:
     """Return the launch record for a host session id, or {}.
 
-    Record shape: ``{conn_uuid, session_id, host_key, created_at, touched: [...]}``.
-    ``session_id`` = current Cognee session (switchable); ``conn_uuid`` = the
-    per-launch liveness handle used for registration/counting (never switched).
+    Record shape::
+
+        {conn_uuid, session_id, dataset, host_key, host_pid, cwd, created_at,
+         switched_at, touched: [{session_id, dataset, conn_uuid, from, to}, ...]}
+
+    ``session_id`` / ``dataset`` / ``conn_uuid`` describe the CURRENT Cognee
+    session of this launch. A dataset switch (``switch-dataset.py``) replaces all
+    three at once — a Cognee session never spans two datasets, and each session
+    is registered under its own connection handle — and appends the retired
+    triple to ``touched`` so the final sync/unregister still covers it.
+    Legacy records store ``touched`` as a list of session-id strings; see
+    ``touched_pairs``.
     """
     if not host_key:
         return {}
@@ -256,17 +265,23 @@ def resolve_cognee_session_id(host_key: str = "", cwd: str = "") -> str:
     """Resolve the Cognee session id that scopes all saves/recalls this launch.
 
     Precedence:
-      1. ``COGNEE_SESSION_ID`` env — explicit launch-time override.
-      2. host-keyed map record — the current session for this launch (stable
-         across the launch's separate hook processes; updated by the picker).
-      3. freshly generated id (new launch), persisted to the map.
+      1. host-keyed map record AFTER a dataset switch (``switched_at`` set) —
+         the user explicitly moved this launch, which beats a shell export
+         that would otherwise pin every hook to the pre-switch session.
+      2. ``COGNEE_SESSION_ID`` env — explicit launch-time override.
+      3. host-keyed map record — the current session for this launch (stable
+         across the launch's separate hook processes).
+      4. freshly generated id (new launch), persisted to the map.
     """
+    host_key = _sanitize_session_key(host_key) or get_session_key()
+    rec = _read_map_record(host_key)
+    if rec.get("switched_at") and rec.get("session_id"):
+        return _sanitize_session_key(str(rec["session_id"]))
+
     explicit = _sanitize_session_key(str(os.environ.get("COGNEE_SESSION_ID", "") or "").strip())
     if explicit:
         return explicit
 
-    host_key = _sanitize_session_key(host_key) or get_session_key()
-    rec = _read_map_record(host_key)
     if rec.get("session_id"):
         return _sanitize_session_key(str(rec["session_id"]))
 
@@ -285,15 +300,29 @@ def resolve_cognee_session_id(host_key: str = "", cwd: str = "") -> str:
     return str(winner.get("session_id") or new_id)
 
 
-def ensure_launch_record(host_key: str = "", cwd: str = "") -> tuple[str, str]:
+def ensure_launch_record(
+    host_key: str = "",
+    cwd: str = "",
+    *,
+    dataset: str = "",
+    host_pid: int = 0,
+) -> tuple[str, str]:
     """Create (first-writer-wins) and return this launch's (session_id, conn_uuid).
 
     Called by SessionStart. The session id honors an explicit ``COGNEE_SESSION_ID``
     override, else the existing/generated id; the conn_uuid is minted once.
+
+    ``dataset`` seeds the record's active dataset (from the env/default at launch)
+    the first time it is seen; a record that already carries one — a resume, or
+    a launch that was switched — keeps it, so the switch survives hook restarts
+    and is not undone by the shell's ``COGNEE_PLUGIN_DATASET``. ``cwd`` and
+    ``host_pid`` are stored so a process that has no hook payload (the switch
+    command running under the host's shell tool) can find its own record.
     """
     host_key = _sanitize_session_key(host_key) or get_session_key()
     rec = _read_map_record(host_key)
     if rec.get("session_id") and rec.get("conn_uuid"):
+        _backfill_launch_record(host_key, rec, dataset=dataset, cwd=cwd, host_pid=host_pid)
         return str(rec["session_id"]), str(rec["conn_uuid"])
 
     explicit = _sanitize_session_key(str(os.environ.get("COGNEE_SESSION_ID", "") or "").strip())
@@ -307,6 +336,12 @@ def ensure_launch_record(host_key: str = "", cwd: str = "") -> tuple[str, str]:
         or datetime.now(timezone.utc).isoformat(timespec="seconds"),
         "touched": rec.get("touched") or [session_id],
     }
+    if dataset:
+        record["dataset"] = str(rec.get("dataset") or dataset)
+    if cwd:
+        record["cwd"] = str(rec.get("cwd") or cwd)
+    if host_pid:
+        record["host_pid"] = int(rec.get("host_pid") or host_pid)
     if not host_key:
         return session_id, conn_uuid
     winner = _create_map_record_if_absent(host_key, record)
@@ -319,7 +354,306 @@ def ensure_launch_record(host_key: str = "", cwd: str = "") -> tuple[str, str]:
         merged.setdefault("host_key", host_key)
         _write_map_record(host_key, merged)
         winner = _read_map_record(host_key) or merged
+    _backfill_launch_record(host_key, winner, dataset=dataset, cwd=cwd, host_pid=host_pid)
     return str(winner.get("session_id") or session_id), str(winner.get("conn_uuid") or conn_uuid)
+
+
+def _backfill_launch_record(
+    host_key: str, rec: dict, *, dataset: str = "", cwd: str = "", host_pid: int = 0
+) -> None:
+    """Add launch metadata a pre-existing record lacks (never overwrites)."""
+    if not host_key or not isinstance(rec, dict):
+        return
+    updates = {}
+    if dataset and not rec.get("dataset"):
+        updates["dataset"] = dataset
+    if cwd and not rec.get("cwd"):
+        updates["cwd"] = cwd
+    if host_pid and not rec.get("host_pid"):
+        updates["host_pid"] = int(host_pid)
+    if not updates:
+        return
+    merged = dict(_read_map_record(host_key) or rec)
+    for key, value in updates.items():
+        merged.setdefault(key, value)
+    _write_map_record(host_key, merged)
+
+
+# ── Dataset switching ──────────────────────────────────────────────────────
+#
+# A launch's active dataset lives in its launch record. Every hook reads it from
+# there (via config.get_dataset -> resolve_active_dataset); the shell's
+# COGNEE_PLUGIN_DATASET only seeds the record at SessionStart. The switch command
+# (switch-dataset.py) rewrites session_id + dataset + conn_uuid atomically and
+# retires the previous triple into ``touched``.
+
+_DEFAULT_DATASET_NAME = "agent_sessions"
+
+
+def resolve_active_dataset(host_key: str = "") -> str:
+    """The dataset this launch writes to: launch record → env → default.
+
+    Without a host key (a process outside any launch, e.g. a bare CLI call) the
+    env/default rule applies unchanged.
+    """
+    host_key = _sanitize_session_key(host_key) or get_session_key()
+    if host_key:
+        rec = _read_map_record(host_key)
+        ds = str(rec.get("dataset") or "").strip()
+        if ds:
+            return ds
+    return str(os.environ.get("COGNEE_PLUGIN_DATASET", "") or "").strip() or _DEFAULT_DATASET_NAME
+
+
+def touched_pairs(host_key: str = "") -> list[dict]:
+    """Every (session_id, dataset, conn_uuid) this launch has used, oldest first.
+
+    The current triple is always last. Legacy records hold ``touched`` as plain
+    session-id strings — those are paired with the record's current dataset (a
+    pre-switch record only ever had one).
+    """
+    host_key = _sanitize_session_key(host_key) or get_session_key()
+    rec = _read_map_record(host_key)
+    if not rec:
+        return []
+    current = {
+        "session_id": str(rec.get("session_id") or ""),
+        "dataset": str(rec.get("dataset") or "") or resolve_active_dataset(host_key),
+        "conn_uuid": str(rec.get("conn_uuid") or ""),
+    }
+    out: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+    for item in rec.get("touched") or []:
+        if isinstance(item, dict):
+            entry = {
+                "session_id": str(item.get("session_id") or ""),
+                "dataset": str(item.get("dataset") or current["dataset"]),
+                "conn_uuid": str(item.get("conn_uuid") or ""),
+            }
+        else:
+            entry = {
+                "session_id": str(item or ""),
+                "dataset": current["dataset"],
+                "conn_uuid": "",
+            }
+        key = (entry["session_id"], entry["dataset"])
+        if (
+            not entry["session_id"]
+            or key in seen
+            or key == (current["session_id"], current["dataset"])
+        ):
+            continue
+        seen.add(key)
+        out.append(entry)
+    if current["session_id"]:
+        out.append(current)
+    return out
+
+
+def mint_switch_session_id(host_key: str = "") -> str:
+    """A new, self-describing Cognee session id for a switched launch.
+
+    ``_generate_session_id`` is deterministic per host session (``{agent}_{host}``),
+    so a switch appends an ordinal: ``{agent}_{host}__2``, ``__3``, ... — never
+    colliding with the pre-switch id while staying readable in the dashboard.
+    """
+    host_key = _sanitize_session_key(host_key) or get_session_key()
+    base = _generate_session_id("", host_key)
+    used = {p["session_id"] for p in touched_pairs(host_key)}
+    n = max(2, len(used) + 1)
+    candidate = f"{base}__{n}"
+    while candidate in used:
+        n += 1
+        candidate = f"{base}__{n}"
+    return candidate
+
+
+def switch_launch_record(
+    host_key: str,
+    *,
+    session_id: str,
+    dataset: str,
+    conn_uuid: str,
+) -> dict:
+    """Atomically point the launch at a new (session, dataset, connection).
+
+    The previous triple is appended to ``touched`` (with ``to`` stamped) so the
+    final sync and unregister still cover it; ``switched_at`` marks the record as
+    user-moved (see ``resolve_cognee_session_id`` precedence). Returns the record
+    now on disk.
+    """
+    host_key = _sanitize_session_key(host_key) or get_session_key()
+    if not host_key:
+        raise ValueError("switch_launch_record: no host session key")
+    rec = _read_map_record(host_key)
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    touched = touched_pairs(host_key)
+    # touched_pairs() returns the current triple last; stamp it as retired.
+    if touched:
+        touched[-1] = {**touched[-1], "to": now}
+        touched[-1].setdefault("from", str(rec.get("switched_at") or rec.get("created_at") or ""))
+    touched.append(
+        {"session_id": session_id, "dataset": dataset, "conn_uuid": conn_uuid, "from": now}
+    )
+    merged = dict(rec)
+    merged.update(
+        {
+            "host_key": host_key,
+            "session_id": _sanitize_session_key(session_id),
+            "dataset": str(dataset).strip(),
+            "conn_uuid": str(conn_uuid),
+            "switched_at": now,
+            "touched": touched,
+        }
+    )
+    merged.setdefault("created_at", now)
+    _write_map_record(host_key, merged)
+    hook_log(
+        "dataset_switched",
+        {
+            "host_key": host_key,
+            "session_id": merged["session_id"],
+            "dataset": merged["dataset"],
+            "conn_uuid": conn_uuid,
+            "touched": len(touched),
+        },
+    )
+    return _read_map_record(host_key) or merged
+
+
+def resolve_host_key_outside_hook(cwd: str = "") -> tuple[str, str]:
+    """Find this launch's host session key from a process that got no hook payload.
+
+    The switch command runs under the host's shell tool, which has no hook stdin.
+    Resolution, in order — returns ``(host_key, source)``, ``("", reason)`` when
+    nothing matched:
+      1. ``COGNEE_SESSION_KEY`` — already inside a hook.
+      2. The host's own session-id export (Claude Code: ``CLAUDE_CODE_SESSION_ID``).
+      3. The host's pid export or our process ancestry, matched against the
+         ``host_pid`` each SessionStart stores in its record.
+      4. A single live record whose ``cwd`` equals ours.
+    """
+    key = get_session_key()
+    if key:
+        return key, "env_session_key"
+
+    for var in ("CLAUDE_CODE_SESSION_ID", "CODEX_SESSION_ID", "CODEX_THREAD_ID"):
+        val = _sanitize_session_key(str(os.environ.get(var, "") or "").strip())
+        if val and _session_map_path(val).exists():
+            return val, var
+
+    records = _live_launch_records()
+    pids = _candidate_host_pids()
+    if pids:
+        by_pid = [r for r in records if int(r.get("host_pid") or 0) in pids]
+        if len(by_pid) == 1:
+            return str(by_pid[0].get("host_key") or ""), "host_pid"
+
+    cwd = str(cwd or os.getcwd())
+    by_cwd = [r for r in records if str(r.get("cwd") or "") == cwd]
+    if len(by_cwd) == 1:
+        return str(by_cwd[0].get("host_key") or ""), "cwd"
+    if len(by_cwd) > 1:
+        return "", "ambiguous_cwd"
+    return "", "not_found"
+
+
+def _live_launch_records() -> list[dict]:
+    """Launch records whose host process is still alive (or whose pid is unknown)."""
+    from _proc import pid_alive
+
+    out: list[dict] = []
+    try:
+        paths = sorted(_SESSIONS_MAP_DIR.glob("*.json"), key=lambda p: p.stat().st_mtime)
+    except Exception:
+        return out
+    for path in paths:
+        rec = _load_json_file(path)
+        if not rec or not rec.get("session_id"):
+            continue
+        rec.setdefault("host_key", path.stem)
+        pid = int(rec.get("host_pid") or 0)
+        if pid and not pid_alive(pid):
+            continue
+        out.append(rec)
+    return out
+
+
+def _candidate_host_pids() -> set[int]:
+    """Pids that could be this process's host: the host's pid export + ancestry."""
+    pids: set[int] = set()
+    for var in ("CLAUDE_PID", "CODEX_PID"):
+        try:
+            v = int(str(os.environ.get(var, "") or "0").strip() or 0)
+        except ValueError:
+            v = 0
+        if v > 1:
+            pids.add(v)
+    if sys.platform != "win32":
+        try:
+            raw = subprocess.check_output(
+                ["ps", "-axo", "pid=,ppid="], text=True, stderr=subprocess.DEVNULL
+            )
+            table: dict[int, int] = {}
+            for line in raw.splitlines():
+                parts = line.split()
+                if len(parts) == 2:
+                    try:
+                        table[int(parts[0])] = int(parts[1])
+                    except ValueError:
+                        continue
+            pid = os.getppid()
+            seen: set[int] = set()
+            while pid > 1 and pid not in seen:
+                seen.add(pid)
+                pids.add(pid)
+                pid = table.get(pid, 0)
+        except Exception:
+            pass
+    return pids
+
+
+def list_writable_datasets(user_id: str = "", *, timeout: float = 15.0) -> dict:
+    """Datasets this principal can switch to, from ``GET /api/v1/datasets``.
+
+    The endpoint lists datasets the caller can READ; only those it OWNS are
+    guaranteed writable (creation grants read/write/share/delete). Returns::
+
+        {"datasets": [{"name", "id", "owner_id", "writable": True|None}],
+         "hidden_readonly": N, "filtered": bool}
+
+    A dataset owned by someone else is dropped (counted in ``hidden_readonly``).
+    ``writable`` is None — and the row kept — when ownership cannot be judged:
+    no ``user_id`` to compare against, or a server whose DTO carries no owner
+    (pre-1.6 releases). ``filtered`` is True only when every row was judged, so
+    the caller can say whether the list is proven-writable or merely readable;
+    the switch itself still rejects a non-writable dataset loudly.
+    """
+    raw = _json_http_request("/api/v1/datasets", method="GET", timeout=timeout)
+    items = raw if isinstance(raw, list) else []
+    rows = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "").strip()
+        if not name:
+            continue
+        # OutDTO serialises camelCase on the wire (ownerId); accept both spellings.
+        owner = str(item.get("owner_id") or item.get("ownerId") or "").strip()
+        writable = None
+        if owner and user_id:
+            writable = owner == str(user_id)
+        rows.append(
+            {"name": name, "id": str(item.get("id") or ""), "owner_id": owner, "writable": writable}
+        )
+    rows.sort(key=lambda r: r["name"].lower())
+    kept = [r for r in rows if r["writable"] is not False]
+    return {
+        "datasets": kept,
+        "readonly": [r["name"] for r in rows if r["writable"] is False],
+        "hidden_readonly": len(rows) - len(kept),
+        "filtered": bool(rows) and all(r["writable"] is not None for r in rows),
+    }
 
 
 def resolve_conn_uuid(host_key: str = "") -> str:
@@ -414,6 +748,9 @@ def load_resolved(session_key: str = "") -> dict:
     cognee_session_id = resolve_cognee_session_id(active_session_key)
     if cognee_session_id:
         resolved["session_id"] = cognee_session_id
+    # The launch's active dataset (switchable) — read from the record so every
+    # hook and worker follows a switch, not the shell it was launched from.
+    resolved["dataset"] = resolve_active_dataset(active_session_key)
     conn_uuid = resolve_conn_uuid(active_session_key)
     if conn_uuid:
         resolved["agent_session_name"] = conn_uuid

--- a/integrations/claude-code/scripts/cognee-remember.sh
+++ b/integrations/claude-code/scripts/cognee-remember.sh
@@ -6,11 +6,12 @@
 #
 # --node-set: node set for categorization (default: user_context)
 #             user_context | project_docs | agent_actions
-# --dataset:  dataset name (default: COGNEE_PLUGIN_DATASET or agent_sessions)
+# --dataset:  dataset name (default: this launch's active dataset)
 #
 # Configuration:
 #   Resolves auth from env/api_key.json.
-#   Dataset is env-driven: COGNEE_PLUGIN_DATASET, then agent_sessions.
+#   Dataset comes from this launch's record (follows a dataset switch), then
+#   COGNEE_PLUGIN_DATASET, then agent_sessions.
 #   Falls back to cognee-cli only if the server is unreachable.
 
 set -euo pipefail
@@ -48,6 +49,15 @@ if not api_key:
             pass
 
 dataset = (os.environ.get("COGNEE_PLUGIN_DATASET") or "").strip()
+# The launch record wins: it carries the dataset chosen with switch-dataset.py.
+try:
+    from _plugin_common import _read_map_record, resolve_host_key_outside_hook
+    _host_key, _ = resolve_host_key_outside_hook()
+    _rec = _read_map_record(_host_key) if _host_key else {}
+    if str(_rec.get("dataset") or "").strip():
+        dataset = str(_rec["dataset"]).strip()
+except Exception:
+    pass
 
 print(json.dumps({"service_url": service_url, "api_key": api_key, "dataset": dataset}))
 PY

--- a/integrations/claude-code/scripts/cognee-search.sh
+++ b/integrations/claude-code/scripts/cognee-search.sh
@@ -9,8 +9,9 @@
 # No flag:   search session first, then graph if empty
 #
 # Configuration:
-#   Resolves session ID from Cognee endpoints using API auth.
-#   Dataset is env-driven: COGNEE_PLUGIN_DATASET, then agent_sessions.
+#   Session ID and dataset come from this launch's record (~/.cognee-plugin/
+#   claude-code/sessions/<host id>.json — follows a dataset switch), falling
+#   back to the Cognee connection endpoint and COGNEE_PLUGIN_DATASET / agent_sessions.
 
 set -euo pipefail
 
@@ -50,7 +51,19 @@ if not api_key:
 
 session_id = ""
 dataset = (os.environ.get("COGNEE_PLUGIN_DATASET") or "").strip()
-if service_url and api_key:
+# The launch record wins: it carries the dataset + session chosen with
+# switch-dataset.py, which the shell env and a first-connection lookup lack.
+try:
+    from _plugin_common import _read_map_record, resolve_host_key_outside_hook
+    _host_key, _ = resolve_host_key_outside_hook()
+    _rec = _read_map_record(_host_key) if _host_key else {}
+    if str(_rec.get("dataset") or "").strip():
+        dataset = str(_rec["dataset"]).strip()
+    if str(_rec.get("session_id") or "").strip():
+        session_id = str(_rec["session_id"]).strip()
+except Exception:
+    pass
+if not session_id and service_url and api_key:
     try:
         import ssl
         try:

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -84,13 +84,39 @@ _USER_SETTINGS = Path.home() / ".claude" / "settings.json"
 _OWNED_STATUSLINE_MARKER = "cognee-statusline"
 
 
-def _active_dataset() -> str:
-    # 1. env var (inherited from the shell that launched Claude Code)
+_SESSIONS_DIR = _SHARED_ROOT / "claude-code" / "sessions"
+
+
+def _launch_record(session_id: str) -> dict:
+    """This launch's record (``sessions/<host id>.json``), or {}.
+
+    The host session id in the statusline context is the same key SessionStart
+    files the record under, so the bar reads the dataset the launch is actually
+    writing to — including one chosen with ``/cognee-memory:cognee-switch-datasets``.
+    """
+    if not _path_safe(session_id):
+        return {}
+    return _read_json(_SESSIONS_DIR / f"{session_id}.json")
+
+
+def _active_dataset(session_id: str = "") -> str:
+    # 1. the launch record (authoritative once SessionStart has run; switchable)
+    recorded = str(_launch_record(session_id).get("dataset") or "").strip()
+    if recorded:
+        return recorded
+    # 2. env var (inherited from the shell that launched Claude Code)
     v = os.environ.get("COGNEE_PLUGIN_DATASET", "").strip()
     if v:
         return v
-    # 2. default
+    # 3. default
     return _DEFAULT_DATASET
+
+
+def _switched_marker(session_id: str = "") -> str:
+    """A faint ``· switched`` tag once the launch left its launch-time dataset."""
+    if _launch_record(session_id).get("switched_at"):
+        return " \033[2m· switched\033[0m"
+    return ""
 
 
 _LOOPBACK = {"localhost", "127.0.0.1", "::1", ""}
@@ -780,7 +806,7 @@ def main() -> None:
     # of the steady-state line.
     sys.stdout.write(
         f"{_pipeline_health_glyph()}{_status_prefix(_session_id)}"
-        f"cognee: {_active_dataset()} · {_mode_label()}"
+        f"cognee: {_active_dataset(_session_id)} · {_mode_label()}{_switched_marker(_session_id)}"
         f"{_credits_segment()}{_recall_segment(_session_id)}{_update_segment()}"
     )
 

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -206,7 +206,7 @@ def get_session_id(config: dict, cwd: Optional[str] = None) -> str:
 
     Hooks call this after setting the host session key from their payload, so the
     resolver finds the launch's id in the map. An explicit ``COGNEE_SESSION_ID``
-    env (or ``.cognee/session-config.json`` picker) overrides.
+    env overrides, unless the launch was moved with ``switch-dataset.py``.
     """
     from _plugin_common import get_session_key, resolve_cognee_session_id
 
@@ -216,7 +216,23 @@ def get_session_id(config: dict, cwd: Optional[str] = None) -> str:
 
 
 def get_dataset(config: dict) -> str:
-    """Get the dataset name from config."""
+    """The dataset this launch writes to.
+
+    Inside a launch (host session key set) the launch record is authoritative —
+    it carries the dataset chosen with ``switch-dataset.py``, seeded at
+    SessionStart from the env/default. Outside a launch, the config value
+    (``COGNEE_PLUGIN_DATASET`` → default) applies as before.
+    """
+    try:
+        from _plugin_common import _read_map_record, get_session_key
+
+        host_key = get_session_key()
+        if host_key:
+            recorded = str(_read_map_record(host_key).get("dataset") or "").strip()
+            if recorded:
+                return recorded
+    except Exception:
+        pass
     return config.get("dataset", "agent_sessions")
 
 

--- a/integrations/claude-code/scripts/exit-watcher.py
+++ b/integrations/claude-code/scripts/exit-watcher.py
@@ -180,6 +180,23 @@ def main() -> None:
         _log("pidfile_replaced", parent_pid=parent_pid, pidfile=str(pidfile))
         return
 
+    # A dataset switch mid-session replaced the session, dataset and connection
+    # handle this watcher was spawned with. Re-read the launch record so the
+    # final sync targets the live triple (the sync worker itself also covers the
+    # retired sessions in the record's ``touched`` list).
+    if session_key:
+        try:
+            from _plugin_common import _read_map_record
+
+            rec = _read_map_record(session_key)
+            if rec.get("switched_at"):
+                session_id = str(rec.get("session_id") or session_id)
+                dataset = str(rec.get("dataset") or dataset)
+                agent_session_name = str(rec.get("conn_uuid") or agent_session_name)
+                _log("exit_target_switched", session=session_id, dataset=dataset)
+        except Exception as exc:
+            _log("exit_target_resolve_failed", error=str(exc)[:200])
+
     _log("parent_exited", parent_pid=parent_pid, session=session_id, dataset=dataset)
     _spawn_sync(
         session_id,

--- a/integrations/claude-code/scripts/idle-watcher.py
+++ b/integrations/claude-code/scripts/idle-watcher.py
@@ -289,6 +289,26 @@ async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
     exit_reason = "loop_complete"
     bridge_disabled = False
 
+    def _current_pair() -> tuple[str, str]:
+        """The launch's live (session_id, dataset), re-read before every bridge.
+
+        A dataset switch rewrites the launch record mid-session; the bootstrap
+        values this watcher was spawned with would otherwise bridge the retired
+        session into the old dataset. Falls back to the bootstrap pair when the
+        record is unavailable.
+        """
+        try:
+            from _plugin_common import resolve_active_dataset, resolve_cognee_session_id
+
+            sid = resolve_cognee_session_id() or session_id
+            ds = resolve_active_dataset() or dataset
+            if (sid, ds) != (session_id, dataset):
+                _log("bridge_target_switched", session=sid, dataset=ds)
+            return sid, ds
+        except Exception as exc:
+            _log("bridge_target_resolve_failed", error=str(exc)[:200])
+            return session_id, dataset
+
     while not _should_stop:
         if _STOPFILE.exists():
             _log("stop_sentinel_seen")
@@ -313,7 +333,7 @@ async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
             and time_since_improve >= IMPROVE_COOLDOWN
         ):
             _log("idle_trigger", idle_for=round(idle_for, 1))
-            ok = await _improve_once(session_id, dataset, config)
+            ok = await _improve_once(*_current_pair(), config)
             if ok:
                 last_improved_at = time.time()
                 _log("bridge_done")
@@ -335,7 +355,7 @@ async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
         and ts > last_improved_at
     ):
         _log("shutdown_trigger", reason=exit_reason, activity_age=round(time.time() - ts, 1))
-        ok = await _improve_once(session_id, dataset, config)
+        ok = await _improve_once(*_current_pair(), config)
         if ok:
             last_improved_at = time.time()
             _log("shutdown_bridge_done")

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -1453,9 +1453,22 @@ async def _start(payload: dict | None = None) -> dict:
     # Resolve (and persist) this launch's record: session_id (data scoping, unique
     # per launch) + conn_uuid (liveness handle for registration/counting). Written
     # synchronously here so prompt hooks read back the identical ids before any run.
-    session_id, conn_uuid = ensure_launch_record(session_key, cwd)
+    # The record also seeds the launch's active dataset (env/default) and stores
+    # the host pid + cwd so switch-dataset.py, which runs under the shell tool
+    # with no hook payload, can find this launch. A resumed record keeps the
+    # dataset it already has — including one chosen by a switch.
+    session_id, conn_uuid = ensure_launch_record(
+        session_key,
+        cwd,
+        dataset=str(config.get("dataset", "") or "").strip(),
+        host_pid=_find_claude_parent_pid(),
+    )
     os.environ["COGNEE_SESSION_ID"] = session_id
     agent_session_name = conn_uuid
+    dataset = get_dataset(config)
+    # Registration and the bootstrap worker read the dataset off config: keep it
+    # in step with the record so a resumed, switched launch re-binds correctly.
+    config["dataset"] = dataset
     hook_log(
         "session_resolved",
         {
@@ -1463,9 +1476,9 @@ async def _start(payload: dict | None = None) -> dict:
             "session_key": session_key,
             "session_id": session_id,
             "conn_uuid": conn_uuid,
+            "dataset": dataset,
         },
     )
-    dataset = get_dataset(config)
 
     # Boot-vs-connect is decided purely by whether the server is already up:
     #   * up                -> connect (we don't boot, so agent mode is left as-is)

--- a/integrations/claude-code/scripts/switch-dataset.py
+++ b/integrations/claude-code/scripts/switch-dataset.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Move this launch to another Cognee dataset (``/cognee-memory:cognee-switch-datasets``).
+
+A Cognee session never spans two datasets, so a switch is: sync the current
+session into its dataset, register a NEW session bound to the new dataset,
+retire the old one, and repoint every hook at the new triple.
+
+Usage:
+    switch-dataset.py --list [--json]          # datasets you can switch to
+    switch-dataset.py <dataset-name> [--force] [--json]
+
+Runs under the host's shell tool (no hook payload), so it finds its own launch
+record via ``resolve_host_key_outside_hook``; pass ``--session-key <host id>``
+to pin one when several launches share a directory.
+
+Exit codes:
+    0  switched / listed            3  sync of the current session failed (use --force)
+    1  unexpected error              4  registering the new session failed (nothing changed)
+    2  launch record not found       5  dataset not writable / not found for this principal
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _plugin_common import (  # noqa: E402
+    _new_conn_uuid,
+    _read_map_record,
+    hook_log,
+    list_writable_datasets,
+    load_resolved,
+    mint_switch_session_id,
+    register_agent_via_http,
+    resolve_host_key_outside_hook,
+    resolved_http_endpoint_auth,
+    set_session_key,
+    switch_launch_record,
+    touch_activity,
+    unregister_agent_via_http,
+)
+from _proc import pid_alive  # noqa: E402
+from config import ensure_dataset_ready_via_api, load_config  # noqa: E402
+
+_STATE_DIR = Path.home() / ".cognee-plugin" / "claude-code"
+_WATCHER_PID = _STATE_DIR / "watcher.pid"
+_WATCHER_STOP = _STATE_DIR / "watcher.stop"
+_HERE = Path(__file__).resolve().parent
+_SYNC_SCRIPT = _HERE / "sync-session-to-graph.py"
+_WATCHER_SCRIPT = _HERE / "idle-watcher.py"
+
+EXIT_OK, EXIT_ERROR, EXIT_NO_RECORD, EXIT_SYNC_FAILED, EXIT_REGISTER_FAILED, EXIT_NOT_WRITABLE = (
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+)
+
+
+class SwitchError(Exception):
+    def __init__(self, code: int, message: str, **detail):
+        super().__init__(message)
+        self.code = code
+        self.detail = detail
+
+
+# ── launch resolution ──────────────────────────────────────────────────────
+
+
+def _resolve_launch(explicit_key: str) -> tuple[str, dict]:
+    host_key = explicit_key.strip()
+    source = "flag"
+    if not host_key:
+        host_key, source = resolve_host_key_outside_hook()
+    rec = _read_map_record(host_key) if host_key else {}
+    if not rec.get("session_id"):
+        hint = (
+            "several Cognee launches share this directory — rerun with "
+            "--session-key <host session id>"
+            if source == "ambiguous_cwd"
+            else "start a Claude Code session with the Cognee plugin active first"
+        )
+        raise SwitchError(EXIT_NO_RECORD, f"no launch record found ({source}); {hint}")
+    set_session_key(host_key)
+    return host_key, rec
+
+
+# ── listing ────────────────────────────────────────────────────────────────
+
+
+def _list(host_key: str, rec: dict) -> dict:
+    resolved = load_resolved(session_key=host_key)
+    user_id = str(resolved.get("user_id") or "")
+    try:
+        listing = list_writable_datasets(user_id)
+    except urllib.error.HTTPError as exc:
+        raise SwitchError(EXIT_ERROR, f"GET /api/v1/datasets failed (HTTP {exc.code})")
+    except Exception as exc:
+        raise SwitchError(EXIT_ERROR, f"GET /api/v1/datasets failed ({exc})")
+    current = str(rec.get("dataset") or resolved.get("dataset") or "")
+    rows = [{**row, "current": row["name"] == current} for row in listing["datasets"]]
+    return {
+        "current": current,
+        "session_id": str(rec.get("session_id") or ""),
+        "datasets": rows,
+        "hidden_readonly": listing["hidden_readonly"],
+        "filtered": listing["filtered"],
+    }
+
+
+# ── the switch ─────────────────────────────────────────────────────────────
+
+
+def _sync_current(host_key: str, session_id: str, dataset: str) -> None:
+    """Bridge the session we are about to retire, strictly (non-zero = failure)."""
+    env = os.environ.copy()
+    env["COGNEE_SESSION_KEY"] = host_key
+    env["COGNEE_SYNC_SESSION_ID"] = session_id
+    env["COGNEE_SYNC_DATASET"] = dataset
+    started = time.monotonic()
+    proc = subprocess.run(
+        [sys.executable, str(_SYNC_SCRIPT), "--strict"],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=float(os.environ.get("COGNEE_SWITCH_SYNC_TIMEOUT", "") or 900),
+    )
+    hook_log(
+        "switch_sync_result",
+        {
+            "session": session_id,
+            "dataset": dataset,
+            "returncode": proc.returncode,
+            "elapsed_ms": int((time.monotonic() - started) * 1000),
+            "stderr": (proc.stderr or "")[-400:],
+        },
+    )
+    if proc.returncode != 0:
+        tail = (proc.stderr or "").strip().splitlines()[-1:] or ["no detail"]
+        raise SwitchError(
+            EXIT_SYNC_FAILED,
+            f"sync of session {session_id} (dataset {dataset}) failed: {tail[0]}",
+        )
+
+
+def _register_new(session_id: str, dataset: str) -> str:
+    """Register the new session under a fresh connection handle; returns the handle.
+
+    Fresh handle first, old one released after: the server's agent-mode count
+    goes 1→2→1 and never touches 0, which would shut a local server down.
+    """
+    conn_uuid = _new_conn_uuid()
+    ok, _ = register_agent_via_http(
+        agent_session_name=conn_uuid, session_id=session_id, dataset_names=[dataset]
+    )
+    if not ok:
+        raise SwitchError(
+            EXIT_REGISTER_FAILED,
+            f"registering session {session_id} on dataset {dataset} failed; nothing was changed",
+        )
+    return conn_uuid
+
+
+def _ensure_dataset(dataset: str) -> None:
+    service_url, api_key = resolved_http_endpoint_auth()
+    try:
+        asyncio.run(ensure_dataset_ready_via_api(service_url, api_key, dataset))
+    except Exception as exc:
+        text = str(exc)
+        code = EXIT_NOT_WRITABLE if any(s in text for s in ("401", "403", "404")) else EXIT_ERROR
+        raise SwitchError(code, f"dataset {dataset!r} is not available to this principal ({text})")
+
+
+def _restart_idle_watcher(host_key: str, session_id: str, dataset: str, user_id: str) -> None:
+    """Replace the idle watcher so its bootstrap names the new triple.
+
+    The watcher re-reads the record before each bridge anyway; this keeps its
+    log/bootstrap honest and clears a pending bridge aimed at the old session.
+    """
+    if os.environ.get("COGNEE_IDLE_DISABLED", "").lower() in ("1", "true", "yes"):
+        return
+    try:
+        if _WATCHER_PID.exists():
+            pid = int(_WATCHER_PID.read_text(encoding="utf-8").strip() or 0)
+            if pid and pid_alive(pid):
+                _WATCHER_STOP.write_text("stop", encoding="utf-8")
+                os.kill(pid, signal.SIGTERM)
+                deadline = time.monotonic() + 5.0
+                while pid_alive(pid) and time.monotonic() < deadline:
+                    time.sleep(0.1)
+        if _WATCHER_STOP.exists():
+            _WATCHER_STOP.unlink()
+    except Exception as exc:
+        hook_log("switch_watcher_stop_failed", {"error": str(exc)[:200]})
+
+    config = load_config()
+    bootstrap = {
+        "session_id": session_id,
+        "dataset": dataset,
+        "user_id": user_id,
+        "session_key": host_key,
+        "config": {
+            "base_url": config.get("base_url", ""),
+            "llm_model": config.get("llm_model", ""),
+            "dataset": dataset,
+        },
+    }
+    try:
+        log_fh = (_STATE_DIR / "watcher.log").open("a", encoding="utf-8")
+    except Exception:
+        log_fh = subprocess.DEVNULL
+    try:
+        env = os.environ.copy()
+        env["COGNEE_SESSION_KEY"] = host_key
+        subprocess.Popen(
+            [sys.executable, str(_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            env=env,
+            start_new_session=True,
+            close_fds=True,
+        )
+        hook_log("switch_watcher_restarted", {"session": session_id, "dataset": dataset})
+    except Exception as exc:
+        hook_log("switch_watcher_restart_failed", {"error": str(exc)[:200]})
+
+
+def _switch(host_key: str, rec: dict, target: str, *, force: bool) -> dict:
+    target = target.strip()
+    if not target:
+        raise SwitchError(EXIT_ERROR, "dataset name is empty")
+    old_session = str(rec.get("session_id") or "")
+    old_dataset = str(
+        rec.get("dataset") or load_resolved(session_key=host_key).get("dataset") or ""
+    )
+    old_conn = str(rec.get("conn_uuid") or "")
+    if target == old_dataset:
+        return {
+            "switched": False,
+            "reason": "already_active",
+            "dataset": target,
+            "session_id": old_session,
+        }
+
+    resolved = load_resolved(session_key=host_key)
+    user_id = str(resolved.get("user_id") or "")
+
+    # The target must be one this principal can write to. Owned datasets are
+    # guaranteed writable; anything else is refused up front rather than failing
+    # half-way through.
+    listing = list_writable_datasets(user_id)
+    if target in listing["readonly"]:
+        raise SwitchError(
+            EXIT_NOT_WRITABLE,
+            f"dataset {target!r} is readable but owned by someone else (not writable); "
+            "run --list to see the options",
+            hidden_readonly=listing["hidden_readonly"],
+        )
+    # A name that is not listed at all is created for this principal by the
+    # ensure step below (owner = us, hence writable).
+
+    # 1. Sync the session we are leaving. Abort on failure unless forced — the
+    #    retired triple stays in `touched`, so the final sync retries it.
+    sync_ok = True
+    sync_error = ""
+    try:
+        _sync_current(host_key, old_session, old_dataset)
+    except SwitchError as exc:
+        if not force:
+            raise
+        sync_ok, sync_error = False, str(exc)
+        hook_log("switch_sync_forced_past_failure", {"error": sync_error[:300]})
+
+    # 2. Make sure the dataset exists for this principal (idempotent).
+    _ensure_dataset(target)
+
+    # 3. Register the new session first (fresh handle) ...
+    new_session = mint_switch_session_id(host_key)
+    new_conn = _register_new(new_session, target)
+
+    # 4. ... repoint the launch record (atomic) ...
+    switch_launch_record(host_key, session_id=new_session, dataset=target, conn_uuid=new_conn)
+
+    # 5. ... then release the old handle. Best-effort: a lingering active
+    #    connection is harmless and the final unregister sweeps `touched`.
+    old_released = False
+    if old_conn:
+        old_released, _ = unregister_agent_via_http(agent_session_name=old_conn)
+        hook_log("switch_old_handle_released", {"conn_uuid": old_conn, "ok": old_released})
+
+    # 6. Fresh watcher + reset the idle clock for the new session.
+    _restart_idle_watcher(host_key, new_session, target, user_id)
+    touch_activity()
+
+    return {
+        "switched": True,
+        "dataset": target,
+        "session_id": new_session,
+        "conn_uuid": new_conn,
+        "previous": {
+            "dataset": old_dataset,
+            "session_id": old_session,
+            "synced": sync_ok,
+            **({"sync_error": sync_error} if sync_error else {}),
+            "unregistered": old_released,
+        },
+    }
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+
+def _print_listing(result: dict, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(result))
+        return
+    print(f"Current dataset: {result['current']}  (session {result['session_id']})")
+    if not result["datasets"]:
+        print("No other writable datasets found.")
+    for row in result["datasets"]:
+        mark = "*" if row["current"] else " "
+        print(f" {mark} {row['name']}")
+    if result["hidden_readonly"]:
+        print(f"({result['hidden_readonly']} read-only dataset(s) not shown)")
+    if not result["filtered"]:
+        print("(write access could not be verified — showing every readable dataset)")
+
+
+def _print_switch(result: dict, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(result))
+        return
+    if not result.get("switched"):
+        print(f"Already on dataset {result['dataset']!r} (session {result['session_id']}).")
+        return
+    prev = result["previous"]
+    synced = "synced" if prev["synced"] else f"NOT synced ({prev.get('sync_error', '')})"
+    print(
+        f"Switched to dataset {result['dataset']!r} — new session {result['session_id']}. "
+        f"Previous session {prev['session_id']} ({prev['dataset']}) {synced}."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    as_json = "--json" in args
+    force = "--force" in args
+    do_list = "--list" in args
+    explicit_key = ""
+    if "--session-key" in args:
+        i = args.index("--session-key")
+        explicit_key = args[i + 1] if i + 1 < len(args) else ""
+        del args[i : i + 2]
+    positional = [a for a in args if not a.startswith("--")]
+
+    try:
+        host_key, rec = _resolve_launch(explicit_key)
+        if do_list or not positional:
+            _print_listing(_list(host_key, rec), as_json)
+            return EXIT_OK
+        result = _switch(host_key, rec, positional[0], force=force)
+        _print_switch(result, as_json)
+        return EXIT_OK
+    except SwitchError as exc:
+        hook_log("switch_failed", {"code": exc.code, "error": str(exc)[:300], **exc.detail})
+        if as_json:
+            print(json.dumps({"error": str(exc), "code": exc.code, **exc.detail}))
+        else:
+            print(f"cognee-switch-datasets: {exc}", file=sys.stderr)
+        return exc.code
+    except Exception as exc:  # pragma: no cover - defensive
+        hook_log("switch_crashed", {"error": str(exc)[:300]})
+        if as_json:
+            print(json.dumps({"error": str(exc), "code": EXIT_ERROR}))
+        else:
+            print(f"cognee-switch-datasets: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -49,6 +49,7 @@ _WATCHER_PID = _STATE_DIR / "watcher.pid"
 _WATCHER_STOP = _STATE_DIR / "watcher.stop"
 _DETACHED_ARG = "--detached-final"
 _SESSION_END_ARG = "--session-end"
+_STRICT_ARG = "--strict"
 _FINAL_SYNC_ONCE_DIR = _STATE_DIR / "final-sync-once"
 _FINAL_SYNC_ONCE_TTL_SECONDS = 3600
 _DETACHED_RETRIES_DEFAULT = 3
@@ -242,16 +243,69 @@ def _load_resolved() -> tuple:
     )
 
 
-async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: bool = False):
+def _sync_targets(
+    session_id: str, dataset: str, session_key: str, include_touched: bool
+) -> list[tuple[str, str]]:
+    """(session_id, dataset) pairs to bridge, current pair last.
+
+    A launch that switched datasets has retired sessions in its record's
+    ``touched`` list. The final sync covers them too — a write that raced the
+    switch (landing in the old session after its switch-time sync) is otherwise
+    lost. Re-bridging an already-synced pair is cheap: the bridge state is keyed
+    by (dataset, session) and the server's improve is idempotent per session.
+    """
+    pairs: list[tuple[str, str]] = []
+    if include_touched and session_key:
+        try:
+            from _plugin_common import touched_pairs
+
+            for entry in touched_pairs(session_key):
+                pair = (str(entry.get("session_id") or ""), str(entry.get("dataset") or ""))
+                if pair[0] and pair[1] and pair not in pairs:
+                    pairs.append(pair)
+        except Exception as exc:
+            hook_log("sync_touched_pairs_failed", {"error": str(exc)[:200]})
+    current = (session_id, dataset)
+    if session_id:
+        pairs = [p for p in pairs if p != current] + [current]
+    return pairs
+
+
+def _unregister_handles(session_key: str, agent_session_name: str) -> list[str]:
+    """Connection handles to release at the end: the live one plus any retired
+    by a switch (the switch unregisters those itself; this is the safety net)."""
+    handles: list[str] = []
+    if session_key:
+        try:
+            from _plugin_common import touched_pairs
+
+            for entry in touched_pairs(session_key):
+                cu = str(entry.get("conn_uuid") or "").strip()
+                if cu and cu not in handles:
+                    handles.append(cu)
+        except Exception as exc:
+            hook_log("sync_touched_handles_failed", {"error": str(exc)[:200]})
+    live = str(agent_session_name or "").strip()
+    if live:
+        handles = [h for h in handles if h != live] + [live]
+    return handles
+
+
+async def _sync(
+    stop_watcher: bool,
+    unregister_on_finish: bool = False,
+    strict: bool = False,
+    include_touched: bool = False,
+):
     session_id, dataset, user_id, agent_session_name, was_registered, has_api_key, session_key = (
         _load_resolved()
     )
-    target_sessions = [session_id] if session_id else []
+    targets = _sync_targets(session_id, dataset, session_key, include_touched)
     hook_log(
         "sync_start",
         {
             "session": session_id,
-            "targets": target_sessions,
+            "targets": [f"{ds}:{sid}" for sid, ds in targets],
             "dataset": dataset,
             "user_id": user_id,
             "stop_watcher": stop_watcher,
@@ -270,30 +324,31 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: 
             if not acquired:
                 hook_log("sync_skipped_lock_busy", {"session": session_id, "dataset": dataset})
                 print("cognee-sync: skipped, another sync is running", file=sys.stderr)
+                if strict:
+                    raise RuntimeError("another sync is running")
                 return
 
-            if not target_sessions:
+            if not targets:
                 hook_log("sync_no_target_sessions", {"dataset": dataset})
                 return
 
             incomplete: list[str] = []
             if api_mode:
-                for sid in target_sessions:
-                    wrote = run_session_improve(dataset, sid)
+                for sid, ds in targets:
+                    wrote = run_session_improve(ds, sid)
                     if not wrote:
-                        incomplete.append(sid)
+                        incomplete.append(f"{ds}:{sid}")
                     hook_log(
                         "sync_bridge_done",
                         {
                             "session": sid,
-                            "dataset": dataset,
+                            "dataset": ds,
                             "via": "http_improve",
                             "wrote": wrote,
                         },
                     )
                     print(
-                        f"cognee-sync: dataset={dataset} session={sid} "
-                        f"via=http_improve wrote={wrote}",
+                        f"cognee-sync: dataset={ds} session={sid} via=http_improve wrote={wrote}",
                         file=sys.stderr,
                     )
                 if strict and incomplete:
@@ -308,23 +363,23 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: 
 
             await ensure_cognee_ready(config)
             user = await resolve_user(user_id)
-            await ensure_dataset_ready(dataset, user)
-            for sid in target_sessions:
-                result = await improve_session_local(dataset, sid, user)
+            for sid, ds in targets:
+                await ensure_dataset_ready(ds, user)
+                result = await improve_session_local(ds, sid, user)
                 if not result.get("ok"):
-                    incomplete.append(sid)
+                    incomplete.append(f"{ds}:{sid}")
                 hook_log(
                     "sync_bridge_done",
                     {
                         "session": sid,
-                        "dataset": dataset,
+                        "dataset": ds,
                         "user_id": str(getattr(user, "id", "")),
                         "via": "local_improve",
                         "ok": bool(result.get("ok")),
                     },
                 )
                 print(
-                    f"cognee-sync: dataset={dataset} session={sid} "
+                    f"cognee-sync: dataset={ds} session={sid} "
                     f"via=local_improve ok={result.get('ok')}",
                     file=sys.stderr,
                 )
@@ -338,13 +393,15 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: 
                     {"session": session_id, "dataset": dataset},
                 )
             else:
-                unregister_name = str(agent_session_name or session_key or "").strip()
-                if not unregister_name:
+                handles = _unregister_handles(
+                    session_key, str(agent_session_name or session_key or "").strip()
+                )
+                if not handles:
                     hook_log(
                         "agent_unregister_skipped_no_session_name",
                         {"session": session_id, "dataset": dataset},
                     )
-                else:
+                for unregister_name in handles:
                     ok, active = unregister_agent_via_http(agent_session_name=unregister_name)
                     hook_log(
                         "agent_unregister_result",
@@ -417,6 +474,12 @@ def main():
             os.environ.get("COGNEE_SYNC_RETRY_DELAY", str(_DETACHED_RETRY_DELAY_DEFAULT))
         )
 
+    # --strict: the caller (switch-dataset.py, syncing the session it is about
+    # to retire) needs a verdict — exit non-zero when the bridge is incomplete
+    # instead of the hook-friendly swallow below.
+    strict_cli = _STRICT_ARG in sys.argv
+
+    last_error: Exception | None = None
     for attempt in range(1, max(1, attempts) + 1):
         try:
             asyncio.run(
@@ -425,11 +488,15 @@ def main():
                     unregister_on_finish=unregister_on_finish,
                     # The detached-final run is the session's last sync: an
                     # incomplete result raises so this loop retries it.
-                    strict=detached_final,
+                    strict=detached_final or strict_cli,
+                    # ...and it covers every session this launch touched (a
+                    # dataset switch retires sessions mid-launch).
+                    include_touched=detached_final,
                 )
             )
             return
         except Exception as exc:
+            last_error = exc
             # Non-fatal: session sync failure should not crash Codex.
             hook_log(
                 "sync_failed",
@@ -439,6 +506,8 @@ def main():
             if attempt < attempts:
                 hook_log("sync_retry_scheduled", {"attempt": attempt + 1, "delay": retry_delay})
                 time.sleep(retry_delay)
+    if strict_cli and last_error is not None:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/skills/cognee-switch-datasets/SKILL.md
+++ b/integrations/claude-code/skills/cognee-switch-datasets/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: cognee-switch-datasets
+description: Switch this session to another Cognee dataset. Lists the datasets you can write to, lets you pick one, syncs the current session into its dataset, then starts a fresh Cognee session bound to the chosen dataset. All later saves and recalls target the new dataset and the status line shows it.
+---
+
+# Switch Datasets
+
+Move this Claude Code session to a different Cognee dataset. A Cognee session
+never spans two datasets, so the switch retires the current session (after
+syncing it into the graph) and starts a new one on the chosen dataset.
+
+## Instructions
+
+### 1. If the user named a dataset, switch directly
+
+When `$ARGUMENTS` contains a dataset name, skip the picker:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/switch-dataset.py "$ARGUMENTS" --json
+```
+
+### 2. Otherwise, list and let the user choose
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/switch-dataset.py --list --json
+```
+
+The JSON has `current`, `datasets` (`[{name, id, writable, current}]`),
+`hidden_readonly` (datasets you can read but not write — never offered) and
+`filtered` (`true` when write access was verified for every row).
+
+Present the choice with **AskUserQuestion** (single select), listing the
+dataset names from `datasets` with the current one marked "(current)". The
+tool allows four options per question, so if there are more than four, put
+the first three plus a "More…" option and page on the next question. The
+user can always type a name via the built-in "Other" — a name that is not
+listed is created for them on switch. If `filtered` is `false`, say so in the
+question text ("write access could not be verified for these").
+
+Then run the switch with the chosen name:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/switch-dataset.py "<chosen name>" --json
+```
+
+### 3. Report the result
+
+On success the JSON is
+`{"switched": true, "dataset", "session_id", "previous": {"dataset", "session_id", "synced": true|false}}`.
+Tell the user in one line which dataset and Cognee session are now active and
+that the previous session was synced. The status line updates within a couple
+of seconds. If `"switched": false` with `"reason": "already_active"`, say the
+session is already on that dataset.
+
+On failure the JSON is `{"error", "code"}`:
+
+| code | meaning | what to do |
+|------|---------|------------|
+| 2 | launch record not found | the plugin did not initialise this session; run `/cognee-memory:cognee-doctor` |
+| 3 | syncing the current session failed | nothing was changed; show the error. Re-run with `--force` **only if the user explicitly accepts** that unsynced entries of the current session are retried at session end instead |
+| 4 | registering the new session failed | nothing was changed; the server rejected the registration — check the connection |
+| 5 | dataset not writable | the name is readable but owned by another principal; pick from `--list` |
+
+## What the switch does
+
+1. Syncs the current session into its dataset (`sync-session-to-graph.py --strict`) — aborts if this fails.
+2. Ensures the target dataset exists for this principal.
+3. Registers a **new** Cognee session on the target dataset under a fresh connection handle, then releases the old handle (register-then-unregister, so a local agent-mode server never sees zero connections).
+4. Repoints this launch's record: every hook, the shell wrappers, the idle/exit watchers and the status line follow it.
+5. Retired sessions stay in the record's `touched` list; the session-end sync covers them again as a safety net.
+
+## Notes
+
+- `COGNEE_PLUGIN_DATASET` only seeds the dataset at launch; a switch overrides it for the rest of the session and survives `--resume`.
+- Recall is scoped to the active dataset, so after a switch earlier context from the previous dataset is no longer injected — switch back to see it again.

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -163,9 +163,31 @@ codex
 `~/.cognee-plugin/config.json` may still show a `dataset` value for visibility,
 but runtime dataset selection does not read it.
 
-The dataset is fixed for the lifetime of a launch. Recall searches only the active dataset. If you want to
-change the active dataset, you have to exit Claude, change the dataset via env, and then start Claude again.
-Data added outside of Claude to the dataset (via SDK or the server for example) is visible in Claude via the Cognee plugin.
+`COGNEE_PLUGIN_DATASET` seeds the dataset at launch. Recall searches only the active dataset.
+Data added outside of Codex to the dataset (via SDK or the server for example) is visible in Codex via the Cognee plugin.
+
+### Switching datasets mid-session
+
+Ask Codex to switch datasets (the `cognee-switch-datasets` skill). Without a name it lists the
+datasets you can write to — those owned by the principal behind your API key; datasets you can
+only read are counted but never offered — as a numbered list and asks you to pick. A name that
+is not listed is created for you.
+
+A Cognee session never spans two datasets, so the switch:
+
+1. syncs the current session into its dataset (aborts if that fails — nothing changes);
+2. registers a **new** Cognee session on the chosen dataset under a fresh connection handle,
+   then releases the old handle (register-then-unregister, so a local agent-mode server never
+   sees zero connections);
+3. repoints this launch's record so every hook, the shell wrappers, the idle/exit watchers and
+   the in-context status line follow it (it gains a `· switched` tag on the next prompt).
+
+The choice lives in the launch record (`~/.cognee-plugin/codex/sessions/<host id>.json`), so it
+survives a resume and beats the shell's `COGNEE_PLUGIN_DATASET` (and a pinned
+`COGNEE_SESSION_ID`) for the rest of the launch. Retired sessions stay in the record's `touched`
+list and the session-end sync covers them again as a safety net. The script behind the skill is
+`scripts/switch-dataset.py` (`--list [--json]`, `<name> [--force] [--json]`,
+`--session-key <host id>` when several launches share a directory).
 
 ## Hooks
 
@@ -227,10 +249,11 @@ through), `COGNEE_AGENT_SESSION_NAME`, `COGNEE_PLUGIN_IN_VENV` (the re-exec guar
 and `COGNEE_SYNC_DATASET` / `COGNEE_SYNC_SESSION_ID` (arguments to the final-sync
 worker). Setting them yourself does not configure anything — the plugin overwrites
 them during startup — and a stale value can misroute identity or session resolution.
-Use `COGNEE_SESSION_ID` to pin a session and `COGNEE_PLUGIN_DATASET` to pin a dataset.
+Use `COGNEE_SESSION_ID` to pin a session and `COGNEE_PLUGIN_DATASET` to seed the dataset
+(a mid-session dataset switch overrides both for that launch).
 
 The renderer reads only local state — no network calls on every refresh:
-1. Dataset: `COGNEE_PLUGIN_DATASET` env var, otherwise `agent_sessions`
+1. Dataset: this launch's record (`sessions/<host id>.json`, written at SessionStart and by a dataset switch), otherwise `COGNEE_PLUGIN_DATASET`, otherwise `agent_sessions`
 2. Mode: `COGNEE_BACKEND` / `COGNEE_CODEX_BACKEND` switch, then `COGNEE_BASE_URL` env var, then `~/.cognee-plugin/config.json` (`base_url`)
 3. Default mode: `local`
 
@@ -377,7 +400,7 @@ Keys are letters, digits, and underscores. Values are taken literally — no `$V
 
 | Key | Env var(s) | Default | Notes |
 |---|---|---|---|
-| `dataset` | `COGNEE_PLUGIN_DATASET` | `agent_sessions` | Dataset for writes and recall (config value is informational-only) |
+| `dataset` | `COGNEE_PLUGIN_DATASET` | `agent_sessions` | Dataset for writes and recall at launch; the `cognee-switch-datasets` skill changes it mid-session (config value is informational-only) |
 | `session_id` | `COGNEE_SESSION_ID` | auto-generated per launch | Override to resume a named session |
 | `session_strategy` | `COGNEE_SESSION_STRATEGY` | `per-directory` | `per-directory`, `git-branch`, `static` |
 | `session_prefix` | `COGNEE_SESSION_PREFIX` | `codex` | Prefix for auto-generated session IDs |
@@ -402,7 +425,7 @@ Keys are letters, digits, and underscores. Values are taken literally — no `$V
 - If a mode seems stuck, check for a forgotten `COGNEE_BACKEND` / `COGNEE_CODEX_BACKEND` export in the shell or in `~/.cognee/.env` — the plugin-specific name silently beats the shared one.
 
 **Recall returns empty but data was ingested**
-- Recall is scoped to the active dataset (`COGNEE_PLUGIN_DATASET` / `agent_sessions`).
+- Recall is scoped to the active dataset (the one in the status line — `COGNEE_PLUGIN_DATASET` / `agent_sessions` at launch, or whatever you switched to).
 - Data written via the Python SDK or `client.py` goes to `default_dataset` by default, if dataset not otherwise specified.
 - To verify, call the recall API directly without a dataset filter: `curl -X POST "$COGNEE_BASE_URL/api/v1/recall" -d '{"query":"..."}'`
 

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,6 +10,35 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.0]
+
+### Added
+- **Switch datasets mid-session: `the `cognee-switch-datasets` skill`.** Lists the
+  datasets you can write to (owned by the principal behind your API key — `GET
+  /api/v1/datasets` returns everything readable, so read-only ones are filtered out
+  and counted), presents them as a numbered list (Codex has no picker outside plan mode), and moves the launch: the current session is
+  synced into its dataset first (`sync-session-to-graph.py --strict`; the switch
+  aborts if that fails, `--force` to proceed anyway), a **new** Cognee session is
+  registered on the target dataset under a fresh connection handle, and only then
+  is the old handle released — so a local agent-mode server never drops to zero
+  connections. Backed by `scripts/switch-dataset.py` (`--list [--json]`, `<name>
+  [--force] [--json]`, `--session-key`).
+
+### Changed
+- **The active dataset now lives in the launch record**
+  (`~/.cognee-plugin/codex/sessions/<host id>.json`), seeded at SessionStart
+  from `COGNEE_PLUGIN_DATASET`/default. `config.get_dataset`, `load_resolved`, the
+  `cognee-search.sh`/`cognee-remember.sh` wrappers, the idle and exit watchers and
+  the status line all read it, so a switch is followed everywhere and survives
+  a resume. A switched record beats an exported `COGNEE_SESSION_ID`.
+- **In-context status line** shows the launch's recorded dataset and a plain `· switched` tag
+  once it differs from the launch-time one.
+- **Final sync covers every session the launch touched.** The record keeps a
+  `touched` list of `{session_id, dataset, conn_uuid}` triples; the SessionEnd /
+  exit-watcher sync bridges each pair (current last) and releases every handle, so a
+  write that raced a switch is never lost.
+- `sync-session-to-graph.py --strict` exits non-zero on an incomplete bridge.
+
 ## [1.4.3]
 
 ### Fixed

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -172,9 +172,18 @@ def _session_map_path(host_key: str) -> Path:
 def _read_map_record(host_key: str) -> dict:
     """Return the launch record for a host session id, or {}.
 
-    Record shape: ``{conn_uuid, session_id, host_key, created_at, touched: [...]}``.
-    ``session_id`` = current Cognee session (switchable); ``conn_uuid`` = the
-    per-launch liveness handle used for registration/counting (never switched).
+    Record shape::
+
+        {conn_uuid, session_id, dataset, host_key, host_pid, cwd, created_at,
+         switched_at, touched: [{session_id, dataset, conn_uuid, from, to}, ...]}
+
+    ``session_id`` / ``dataset`` / ``conn_uuid`` describe the CURRENT Cognee
+    session of this launch. A dataset switch (``switch-dataset.py``) replaces all
+    three at once — a Cognee session never spans two datasets, and each session
+    is registered under its own connection handle — and appends the retired
+    triple to ``touched`` so the final sync/unregister still covers it.
+    Legacy records store ``touched`` as a list of session-id strings; see
+    ``touched_pairs``.
     """
     if not host_key:
         return {}
@@ -225,17 +234,23 @@ def resolve_cognee_session_id(host_key: str = "", cwd: str = "") -> str:
     """Resolve the Cognee session id that scopes all saves/recalls this launch.
 
     Precedence:
-      1. ``COGNEE_SESSION_ID`` env — explicit launch-time override.
-      2. host-keyed map record — the current session for this launch (stable
-         across the launch's separate hook processes; updated by the picker).
-      3. freshly generated id (new launch), persisted to the map.
+      1. host-keyed map record AFTER a dataset switch (``switched_at`` set) —
+         the user explicitly moved this launch, which beats a shell export
+         that would otherwise pin every hook to the pre-switch session.
+      2. ``COGNEE_SESSION_ID`` env — explicit launch-time override.
+      3. host-keyed map record — the current session for this launch (stable
+         across the launch's separate hook processes).
+      4. freshly generated id (new launch), persisted to the map.
     """
+    host_key = _sanitize_session_key(host_key) or get_session_key()
+    rec = _read_map_record(host_key)
+    if rec.get("switched_at") and rec.get("session_id"):
+        return _sanitize_session_key(str(rec["session_id"]))
+
     explicit = _sanitize_session_key(str(os.environ.get("COGNEE_SESSION_ID", "") or "").strip())
     if explicit:
         return explicit
 
-    host_key = _sanitize_session_key(host_key) or get_session_key()
-    rec = _read_map_record(host_key)
     if rec.get("session_id"):
         return _sanitize_session_key(str(rec["session_id"]))
 
@@ -254,15 +269,29 @@ def resolve_cognee_session_id(host_key: str = "", cwd: str = "") -> str:
     return str(winner.get("session_id") or new_id)
 
 
-def ensure_launch_record(host_key: str = "", cwd: str = "") -> tuple[str, str]:
+def ensure_launch_record(
+    host_key: str = "",
+    cwd: str = "",
+    *,
+    dataset: str = "",
+    host_pid: int = 0,
+) -> tuple[str, str]:
     """Create (first-writer-wins) and return this launch's (session_id, conn_uuid).
 
     Called by SessionStart. The session id honors an explicit ``COGNEE_SESSION_ID``
     override, else the existing/generated id; the conn_uuid is minted once.
+
+    ``dataset`` seeds the record's active dataset (from the env/default at launch)
+    the first time it is seen; a record that already carries one — a resume, or
+    a launch that was switched — keeps it, so the switch survives hook restarts
+    and is not undone by the shell's ``COGNEE_PLUGIN_DATASET``. ``cwd`` and
+    ``host_pid`` are stored so a process that has no hook payload (the switch
+    command running under the host's shell tool) can find its own record.
     """
     host_key = _sanitize_session_key(host_key) or get_session_key()
     rec = _read_map_record(host_key)
     if rec.get("session_id") and rec.get("conn_uuid"):
+        _backfill_launch_record(host_key, rec, dataset=dataset, cwd=cwd, host_pid=host_pid)
         return str(rec["session_id"]), str(rec["conn_uuid"])
 
     explicit = _sanitize_session_key(str(os.environ.get("COGNEE_SESSION_ID", "") or "").strip())
@@ -276,6 +305,12 @@ def ensure_launch_record(host_key: str = "", cwd: str = "") -> tuple[str, str]:
         or datetime.now(timezone.utc).isoformat(timespec="seconds"),
         "touched": rec.get("touched") or [session_id],
     }
+    if dataset:
+        record["dataset"] = str(rec.get("dataset") or dataset)
+    if cwd:
+        record["cwd"] = str(rec.get("cwd") or cwd)
+    if host_pid:
+        record["host_pid"] = int(rec.get("host_pid") or host_pid)
     if not host_key:
         return session_id, conn_uuid
     winner = _create_map_record_if_absent(host_key, record)
@@ -288,7 +323,306 @@ def ensure_launch_record(host_key: str = "", cwd: str = "") -> tuple[str, str]:
         merged.setdefault("host_key", host_key)
         _write_map_record(host_key, merged)
         winner = _read_map_record(host_key) or merged
+    _backfill_launch_record(host_key, winner, dataset=dataset, cwd=cwd, host_pid=host_pid)
     return str(winner.get("session_id") or session_id), str(winner.get("conn_uuid") or conn_uuid)
+
+
+def _backfill_launch_record(
+    host_key: str, rec: dict, *, dataset: str = "", cwd: str = "", host_pid: int = 0
+) -> None:
+    """Add launch metadata a pre-existing record lacks (never overwrites)."""
+    if not host_key or not isinstance(rec, dict):
+        return
+    updates = {}
+    if dataset and not rec.get("dataset"):
+        updates["dataset"] = dataset
+    if cwd and not rec.get("cwd"):
+        updates["cwd"] = cwd
+    if host_pid and not rec.get("host_pid"):
+        updates["host_pid"] = int(host_pid)
+    if not updates:
+        return
+    merged = dict(_read_map_record(host_key) or rec)
+    for key, value in updates.items():
+        merged.setdefault(key, value)
+    _write_map_record(host_key, merged)
+
+
+# ── Dataset switching ──────────────────────────────────────────────────────
+#
+# A launch's active dataset lives in its launch record. Every hook reads it from
+# there (via config.get_dataset -> resolve_active_dataset); the shell's
+# COGNEE_PLUGIN_DATASET only seeds the record at SessionStart. The switch command
+# (switch-dataset.py) rewrites session_id + dataset + conn_uuid atomically and
+# retires the previous triple into ``touched``.
+
+_DEFAULT_DATASET_NAME = "agent_sessions"
+
+
+def resolve_active_dataset(host_key: str = "") -> str:
+    """The dataset this launch writes to: launch record → env → default.
+
+    Without a host key (a process outside any launch, e.g. a bare CLI call) the
+    env/default rule applies unchanged.
+    """
+    host_key = _sanitize_session_key(host_key) or get_session_key()
+    if host_key:
+        rec = _read_map_record(host_key)
+        ds = str(rec.get("dataset") or "").strip()
+        if ds:
+            return ds
+    return str(os.environ.get("COGNEE_PLUGIN_DATASET", "") or "").strip() or _DEFAULT_DATASET_NAME
+
+
+def touched_pairs(host_key: str = "") -> list[dict]:
+    """Every (session_id, dataset, conn_uuid) this launch has used, oldest first.
+
+    The current triple is always last. Legacy records hold ``touched`` as plain
+    session-id strings — those are paired with the record's current dataset (a
+    pre-switch record only ever had one).
+    """
+    host_key = _sanitize_session_key(host_key) or get_session_key()
+    rec = _read_map_record(host_key)
+    if not rec:
+        return []
+    current = {
+        "session_id": str(rec.get("session_id") or ""),
+        "dataset": str(rec.get("dataset") or "") or resolve_active_dataset(host_key),
+        "conn_uuid": str(rec.get("conn_uuid") or ""),
+    }
+    out: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+    for item in rec.get("touched") or []:
+        if isinstance(item, dict):
+            entry = {
+                "session_id": str(item.get("session_id") or ""),
+                "dataset": str(item.get("dataset") or current["dataset"]),
+                "conn_uuid": str(item.get("conn_uuid") or ""),
+            }
+        else:
+            entry = {
+                "session_id": str(item or ""),
+                "dataset": current["dataset"],
+                "conn_uuid": "",
+            }
+        key = (entry["session_id"], entry["dataset"])
+        if (
+            not entry["session_id"]
+            or key in seen
+            or key == (current["session_id"], current["dataset"])
+        ):
+            continue
+        seen.add(key)
+        out.append(entry)
+    if current["session_id"]:
+        out.append(current)
+    return out
+
+
+def mint_switch_session_id(host_key: str = "") -> str:
+    """A new, self-describing Cognee session id for a switched launch.
+
+    ``_generate_session_id`` is deterministic per host session (``{agent}_{host}``),
+    so a switch appends an ordinal: ``{agent}_{host}__2``, ``__3``, ... — never
+    colliding with the pre-switch id while staying readable in the dashboard.
+    """
+    host_key = _sanitize_session_key(host_key) or get_session_key()
+    base = _generate_session_id("", host_key)
+    used = {p["session_id"] for p in touched_pairs(host_key)}
+    n = max(2, len(used) + 1)
+    candidate = f"{base}__{n}"
+    while candidate in used:
+        n += 1
+        candidate = f"{base}__{n}"
+    return candidate
+
+
+def switch_launch_record(
+    host_key: str,
+    *,
+    session_id: str,
+    dataset: str,
+    conn_uuid: str,
+) -> dict:
+    """Atomically point the launch at a new (session, dataset, connection).
+
+    The previous triple is appended to ``touched`` (with ``to`` stamped) so the
+    final sync and unregister still cover it; ``switched_at`` marks the record as
+    user-moved (see ``resolve_cognee_session_id`` precedence). Returns the record
+    now on disk.
+    """
+    host_key = _sanitize_session_key(host_key) or get_session_key()
+    if not host_key:
+        raise ValueError("switch_launch_record: no host session key")
+    rec = _read_map_record(host_key)
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    touched = touched_pairs(host_key)
+    # touched_pairs() returns the current triple last; stamp it as retired.
+    if touched:
+        touched[-1] = {**touched[-1], "to": now}
+        touched[-1].setdefault("from", str(rec.get("switched_at") or rec.get("created_at") or ""))
+    touched.append(
+        {"session_id": session_id, "dataset": dataset, "conn_uuid": conn_uuid, "from": now}
+    )
+    merged = dict(rec)
+    merged.update(
+        {
+            "host_key": host_key,
+            "session_id": _sanitize_session_key(session_id),
+            "dataset": str(dataset).strip(),
+            "conn_uuid": str(conn_uuid),
+            "switched_at": now,
+            "touched": touched,
+        }
+    )
+    merged.setdefault("created_at", now)
+    _write_map_record(host_key, merged)
+    hook_log(
+        "dataset_switched",
+        {
+            "host_key": host_key,
+            "session_id": merged["session_id"],
+            "dataset": merged["dataset"],
+            "conn_uuid": conn_uuid,
+            "touched": len(touched),
+        },
+    )
+    return _read_map_record(host_key) or merged
+
+
+def resolve_host_key_outside_hook(cwd: str = "") -> tuple[str, str]:
+    """Find this launch's host session key from a process that got no hook payload.
+
+    The switch command runs under the host's shell tool, which has no hook stdin.
+    Resolution, in order — returns ``(host_key, source)``, ``("", reason)`` when
+    nothing matched:
+      1. ``COGNEE_SESSION_KEY`` — already inside a hook.
+      2. The host's own session-id export (Claude Code: ``CLAUDE_CODE_SESSION_ID``).
+      3. The host's pid export or our process ancestry, matched against the
+         ``host_pid`` each SessionStart stores in its record.
+      4. A single live record whose ``cwd`` equals ours.
+    """
+    key = get_session_key()
+    if key:
+        return key, "env_session_key"
+
+    for var in ("CLAUDE_CODE_SESSION_ID", "CODEX_SESSION_ID", "CODEX_THREAD_ID"):
+        val = _sanitize_session_key(str(os.environ.get(var, "") or "").strip())
+        if val and _session_map_path(val).exists():
+            return val, var
+
+    records = _live_launch_records()
+    pids = _candidate_host_pids()
+    if pids:
+        by_pid = [r for r in records if int(r.get("host_pid") or 0) in pids]
+        if len(by_pid) == 1:
+            return str(by_pid[0].get("host_key") or ""), "host_pid"
+
+    cwd = str(cwd or os.getcwd())
+    by_cwd = [r for r in records if str(r.get("cwd") or "") == cwd]
+    if len(by_cwd) == 1:
+        return str(by_cwd[0].get("host_key") or ""), "cwd"
+    if len(by_cwd) > 1:
+        return "", "ambiguous_cwd"
+    return "", "not_found"
+
+
+def _live_launch_records() -> list[dict]:
+    """Launch records whose host process is still alive (or whose pid is unknown)."""
+    from _proc import pid_alive
+
+    out: list[dict] = []
+    try:
+        paths = sorted(_SESSIONS_MAP_DIR.glob("*.json"), key=lambda p: p.stat().st_mtime)
+    except Exception:
+        return out
+    for path in paths:
+        rec = _load_json_file(path)
+        if not rec or not rec.get("session_id"):
+            continue
+        rec.setdefault("host_key", path.stem)
+        pid = int(rec.get("host_pid") or 0)
+        if pid and not pid_alive(pid):
+            continue
+        out.append(rec)
+    return out
+
+
+def _candidate_host_pids() -> set[int]:
+    """Pids that could be this process's host: the host's pid export + ancestry."""
+    pids: set[int] = set()
+    for var in ("CLAUDE_PID", "CODEX_PID"):
+        try:
+            v = int(str(os.environ.get(var, "") or "0").strip() or 0)
+        except ValueError:
+            v = 0
+        if v > 1:
+            pids.add(v)
+    if sys.platform != "win32":
+        try:
+            raw = subprocess.check_output(
+                ["ps", "-axo", "pid=,ppid="], text=True, stderr=subprocess.DEVNULL
+            )
+            table: dict[int, int] = {}
+            for line in raw.splitlines():
+                parts = line.split()
+                if len(parts) == 2:
+                    try:
+                        table[int(parts[0])] = int(parts[1])
+                    except ValueError:
+                        continue
+            pid = os.getppid()
+            seen: set[int] = set()
+            while pid > 1 and pid not in seen:
+                seen.add(pid)
+                pids.add(pid)
+                pid = table.get(pid, 0)
+        except Exception:
+            pass
+    return pids
+
+
+def list_writable_datasets(user_id: str = "", *, timeout: float = 15.0) -> dict:
+    """Datasets this principal can switch to, from ``GET /api/v1/datasets``.
+
+    The endpoint lists datasets the caller can READ; only those it OWNS are
+    guaranteed writable (creation grants read/write/share/delete). Returns::
+
+        {"datasets": [{"name", "id", "owner_id", "writable": True|None}],
+         "hidden_readonly": N, "filtered": bool}
+
+    A dataset owned by someone else is dropped (counted in ``hidden_readonly``).
+    ``writable`` is None — and the row kept — when ownership cannot be judged:
+    no ``user_id`` to compare against, or a server whose DTO carries no owner
+    (pre-1.6 releases). ``filtered`` is True only when every row was judged, so
+    the caller can say whether the list is proven-writable or merely readable;
+    the switch itself still rejects a non-writable dataset loudly.
+    """
+    raw = _json_http_request("/api/v1/datasets", method="GET", timeout=timeout)
+    items = raw if isinstance(raw, list) else []
+    rows = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "").strip()
+        if not name:
+            continue
+        # OutDTO serialises camelCase on the wire (ownerId); accept both spellings.
+        owner = str(item.get("owner_id") or item.get("ownerId") or "").strip()
+        writable = None
+        if owner and user_id:
+            writable = owner == str(user_id)
+        rows.append(
+            {"name": name, "id": str(item.get("id") or ""), "owner_id": owner, "writable": writable}
+        )
+    rows.sort(key=lambda r: r["name"].lower())
+    kept = [r for r in rows if r["writable"] is not False]
+    return {
+        "datasets": kept,
+        "readonly": [r["name"] for r in rows if r["writable"] is False],
+        "hidden_readonly": len(rows) - len(kept),
+        "filtered": bool(rows) and all(r["writable"] is not None for r in rows),
+    }
 
 
 def resolve_conn_uuid(host_key: str = "") -> str:
@@ -383,6 +717,9 @@ def load_resolved(session_key: str = "") -> dict:
     cognee_session_id = resolve_cognee_session_id(active_session_key)
     if cognee_session_id:
         resolved["session_id"] = cognee_session_id
+    # The launch's active dataset (switchable) — read from the record so every
+    # hook and worker follows a switch, not the shell it was launched from.
+    resolved["dataset"] = resolve_active_dataset(active_session_key)
     conn_uuid = resolve_conn_uuid(active_session_key)
     if conn_uuid:
         resolved["agent_session_name"] = conn_uuid

--- a/integrations/codex/plugins/cognee/scripts/cognee-remember.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-remember.sh
@@ -6,11 +6,12 @@
 #
 # --node-set: node set for categorization (default: user_context)
 #             user_context | project_docs | agent_actions
-# --dataset:  dataset name (default: COGNEE_PLUGIN_DATASET or agent_sessions)
+# --dataset:  dataset name (default: this launch's active dataset)
 #
 # Configuration:
 #   Resolves auth from env/api_key.json.
-#   Dataset is env-driven: COGNEE_PLUGIN_DATASET, then agent_sessions.
+#   Dataset comes from this launch's record (follows a dataset switch), then
+#   COGNEE_PLUGIN_DATASET, then agent_sessions.
 #   Falls back to cognee-cli only if the server is unreachable.
 
 set -euo pipefail
@@ -48,6 +49,15 @@ if not api_key:
             pass
 
 dataset = (os.environ.get("COGNEE_PLUGIN_DATASET") or "").strip()
+# The launch record wins: it carries the dataset chosen with switch-dataset.py.
+try:
+    from _plugin_common import _read_map_record, resolve_host_key_outside_hook
+    _host_key, _ = resolve_host_key_outside_hook()
+    _rec = _read_map_record(_host_key) if _host_key else {}
+    if str(_rec.get("dataset") or "").strip():
+        dataset = str(_rec["dataset"]).strip()
+except Exception:
+    pass
 
 print(json.dumps({"service_url": service_url, "api_key": api_key, "dataset": dataset}))
 PY

--- a/integrations/codex/plugins/cognee/scripts/cognee-search.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-search.sh
@@ -9,8 +9,9 @@
 # No flag:   search session first, then graph if empty
 #
 # Configuration:
-#   Resolves session ID from Cognee endpoints using API auth.
-#   Dataset is env-driven: COGNEE_PLUGIN_DATASET, then agent_sessions.
+#   Session ID and dataset come from this launch's record (~/.cognee-plugin/
+#   codex/sessions/<host id>.json — follows a dataset switch), falling
+#   back to the Cognee connection endpoint and COGNEE_PLUGIN_DATASET / agent_sessions.
 
 set -euo pipefail
 
@@ -50,7 +51,19 @@ if not api_key:
 
 session_id = ""
 dataset = (os.environ.get("COGNEE_PLUGIN_DATASET") or "").strip()
-if service_url and api_key:
+# The launch record wins: it carries the dataset + session chosen with
+# switch-dataset.py, which the shell env and a first-connection lookup lack.
+try:
+    from _plugin_common import _read_map_record, resolve_host_key_outside_hook
+    _host_key, _ = resolve_host_key_outside_hook()
+    _rec = _read_map_record(_host_key) if _host_key else {}
+    if str(_rec.get("dataset") or "").strip():
+        dataset = str(_rec["dataset"]).strip()
+    if str(_rec.get("session_id") or "").strip():
+        session_id = str(_rec["session_id"]).strip()
+except Exception:
+    pass
+if not session_id and service_url and api_key:
     try:
         import ssl
         try:

--- a/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
@@ -66,13 +66,40 @@ _DEFAULT_DATASET = "agent_sessions"
 _DEFAULT_LOCAL_BASE_URL = "http://localhost:8011"
 
 
-def _active_dataset() -> str:
-    # 1. env var (inherited from the shell that launched Codex)
+_SESSIONS_DIR = _SHARED_ROOT / "codex" / "sessions"
+
+
+def _launch_record(host_id: str) -> dict:
+    """This launch's record (``sessions/<host id>.json``), or {}.
+
+    The host session key handed to the renderer is the same key SessionStart
+    files the record under, so the bar reads the dataset the launch is actually
+    writing to — including one chosen with the ``cognee-switch-datasets`` skill.
+    """
+    if not _path_safe(host_id):
+        return {}
+    return _read_json(_SESSIONS_DIR / f"{host_id}.json")
+
+
+def _active_dataset(host_id: str = "") -> str:
+    # 1. the launch record (authoritative once SessionStart has run; switchable)
+    recorded = str(_launch_record(host_id).get("dataset") or "").strip()
+    if recorded:
+        return recorded
+    # 2. env var (inherited from the shell that launched Codex)
     v = os.environ.get("COGNEE_PLUGIN_DATASET", "").strip()
     if v:
         return v
-    # 2. default
+    # 3. default
     return _DEFAULT_DATASET
+
+
+def _switched_marker(host_id: str = "") -> str:
+    """A plain ``· switched`` tag once the launch left its launch-time dataset
+    (this bar goes into the model's context, so no styling)."""
+    if _launch_record(host_id).get("switched_at"):
+        return " · switched"
+    return ""
 
 
 _LOOPBACK = {"localhost", "127.0.0.1", "::1", ""}
@@ -520,7 +547,8 @@ def render_status_for_host(host_id: str) -> str:
     LLM-key verdicts written by this session (the marker is machine-wide)."""
     return (
         f"{_pipeline_health_glyph()}{_status_prefix(str(host_id or ''))}"
-        f"cognee: {_active_dataset()} · {_active_mode()}"
+        f"cognee: {_active_dataset(str(host_id or ''))} · {_active_mode()}"
+        f"{_switched_marker(str(host_id or ''))}"
         f"{_credits_segment()}{_update_segment()}"
     )
 
@@ -540,13 +568,19 @@ def main() -> None:
         except Exception:
             pass
 
+    ctx: dict = {}
     try:
-        json.load(sys.stdin)  # consume stdin as required by the host
+        ctx = json.load(sys.stdin)  # consume stdin as required by the host
     except Exception:
-        pass
+        ctx = {}
+    if not isinstance(ctx, dict):
+        ctx = {}
+    # The host session id (when the context carries one) selects this launch's
+    # record, so the dataset shown follows a switch.
+    host_id = str(ctx.get("session_id") or ctx.get("thread_id") or "")
     sys.stdout.write(
         f"{_pipeline_health_glyph()}{_status_prefix()}"
-        f"cognee: {_active_dataset()} · {_active_mode()}"
+        f"cognee: {_active_dataset(host_id)} · {_active_mode()}{_switched_marker(host_id)}"
         f"{_credits_segment()}{_update_segment()}"
     )
 

--- a/integrations/codex/plugins/cognee/scripts/config.py
+++ b/integrations/codex/plugins/cognee/scripts/config.py
@@ -194,7 +194,7 @@ def get_session_id(config: dict, cwd: Optional[str] = None) -> str:
 
     Hooks call this after setting the host session key from their payload, so the
     resolver finds the launch's id in the map. An explicit ``COGNEE_SESSION_ID``
-    env (or ``.cognee/session-config.json`` picker) overrides.
+    env overrides, unless the launch was moved with ``switch-dataset.py``.
     """
     from _plugin_common import get_session_key, resolve_cognee_session_id
 
@@ -204,7 +204,23 @@ def get_session_id(config: dict, cwd: Optional[str] = None) -> str:
 
 
 def get_dataset(config: dict) -> str:
-    """Get the dataset name from config."""
+    """The dataset this launch writes to.
+
+    Inside a launch (host session key set) the launch record is authoritative —
+    it carries the dataset chosen with ``switch-dataset.py``, seeded at
+    SessionStart from the env/default. Outside a launch, the config value
+    (``COGNEE_PLUGIN_DATASET`` → default) applies as before.
+    """
+    try:
+        from _plugin_common import _read_map_record, get_session_key
+
+        host_key = get_session_key()
+        if host_key:
+            recorded = str(_read_map_record(host_key).get("dataset") or "").strip()
+            if recorded:
+                return recorded
+    except Exception:
+        pass
     return config.get("dataset", "agent_sessions")
 
 

--- a/integrations/codex/plugins/cognee/scripts/exit-watcher.py
+++ b/integrations/codex/plugins/cognee/scripts/exit-watcher.py
@@ -180,6 +180,23 @@ def main() -> None:
         _log("pidfile_replaced", parent_pid=parent_pid, pidfile=str(pidfile))
         return
 
+    # A dataset switch mid-session replaced the session, dataset and connection
+    # handle this watcher was spawned with. Re-read the launch record so the
+    # final sync targets the live triple (the sync worker itself also covers the
+    # retired sessions in the record's ``touched`` list).
+    if session_key:
+        try:
+            from _plugin_common import _read_map_record
+
+            rec = _read_map_record(session_key)
+            if rec.get("switched_at"):
+                session_id = str(rec.get("session_id") or session_id)
+                dataset = str(rec.get("dataset") or dataset)
+                agent_session_name = str(rec.get("conn_uuid") or agent_session_name)
+                _log("exit_target_switched", session=session_id, dataset=dataset)
+        except Exception as exc:
+            _log("exit_target_resolve_failed", error=str(exc)[:200])
+
     _log("parent_exited", parent_pid=parent_pid, session=session_id, dataset=dataset)
     _spawn_sync(
         session_id,

--- a/integrations/codex/plugins/cognee/scripts/idle-watcher.py
+++ b/integrations/codex/plugins/cognee/scripts/idle-watcher.py
@@ -288,6 +288,26 @@ async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
     exit_reason = "loop_complete"
     bridge_disabled = False
 
+    def _current_pair() -> tuple[str, str]:
+        """The launch's live (session_id, dataset), re-read before every bridge.
+
+        A dataset switch rewrites the launch record mid-session; the bootstrap
+        values this watcher was spawned with would otherwise bridge the retired
+        session into the old dataset. Falls back to the bootstrap pair when the
+        record is unavailable.
+        """
+        try:
+            from _plugin_common import resolve_active_dataset, resolve_cognee_session_id
+
+            sid = resolve_cognee_session_id() or session_id
+            ds = resolve_active_dataset() or dataset
+            if (sid, ds) != (session_id, dataset):
+                _log("bridge_target_switched", session=sid, dataset=ds)
+            return sid, ds
+        except Exception as exc:
+            _log("bridge_target_resolve_failed", error=str(exc)[:200])
+            return session_id, dataset
+
     while not _should_stop:
         if _STOPFILE.exists():
             _log("stop_sentinel_seen")
@@ -312,7 +332,7 @@ async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
             and time_since_improve >= IMPROVE_COOLDOWN
         ):
             _log("idle_trigger", idle_for=round(idle_for, 1))
-            ok = await _improve_once(session_id, dataset, config)
+            ok = await _improve_once(*_current_pair(), config)
             if ok:
                 last_improved_at = time.time()
                 _log("bridge_done")
@@ -334,7 +354,7 @@ async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
         and ts > last_improved_at
     ):
         _log("shutdown_trigger", reason=exit_reason, activity_age=round(time.time() - ts, 1))
-        ok = await _improve_once(session_id, dataset, config)
+        ok = await _improve_once(*_current_pair(), config)
         if ok:
             last_improved_at = time.time()
             _log("shutdown_bridge_done")

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -1260,9 +1260,22 @@ async def _start(payload: dict | None = None) -> dict:
     # Resolve (and persist) this launch's record: session_id (data scoping, unique
     # per launch) + conn_uuid (liveness handle for registration/counting). Written
     # synchronously here so prompt hooks read back the identical ids before any run.
-    session_id, conn_uuid = ensure_launch_record(session_key, cwd)
+    # The record also seeds the launch's active dataset (env/default) and stores
+    # the host pid + cwd so switch-dataset.py, which runs under the shell tool
+    # with no hook payload, can find this launch. A resumed record keeps the
+    # dataset it already has — including one chosen by a switch.
+    session_id, conn_uuid = ensure_launch_record(
+        session_key,
+        cwd,
+        dataset=str(config.get("dataset", "") or "").strip(),
+        host_pid=_find_codex_parent_pid(),
+    )
     os.environ["COGNEE_SESSION_ID"] = session_id
     agent_session_name = conn_uuid
+    dataset = get_dataset(config)
+    # Registration and the bootstrap worker read the dataset off config: keep it
+    # in step with the record so a resumed, switched launch re-binds correctly.
+    config["dataset"] = dataset
     hook_log(
         "session_resolved",
         {
@@ -1270,9 +1283,9 @@ async def _start(payload: dict | None = None) -> dict:
             "session_key": session_key,
             "session_id": session_id,
             "conn_uuid": conn_uuid,
+            "dataset": dataset,
         },
     )
-    dataset = get_dataset(config)
 
     # Boot-vs-connect is decided purely by whether the server is already up:
     #   * up                -> connect (we don't boot, so agent mode is left as-is)

--- a/integrations/codex/plugins/cognee/scripts/switch-dataset.py
+++ b/integrations/codex/plugins/cognee/scripts/switch-dataset.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Move this launch to another Cognee dataset (``cognee-switch-datasets`` skill).
+
+A Cognee session never spans two datasets, so a switch is: sync the current
+session into its dataset, register a NEW session bound to the new dataset,
+retire the old one, and repoint every hook at the new triple.
+
+Usage:
+    switch-dataset.py --list [--json]          # datasets you can switch to
+    switch-dataset.py <dataset-name> [--force] [--json]
+
+Runs under the host's shell tool (no hook payload), so it finds its own launch
+record via ``resolve_host_key_outside_hook``; pass ``--session-key <host id>``
+to pin one when several launches share a directory.
+
+Exit codes:
+    0  switched / listed            3  sync of the current session failed (use --force)
+    1  unexpected error              4  registering the new session failed (nothing changed)
+    2  launch record not found       5  dataset not writable / not found for this principal
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _plugin_common import (  # noqa: E402
+    _new_conn_uuid,
+    _read_map_record,
+    hook_log,
+    list_writable_datasets,
+    load_resolved,
+    mint_switch_session_id,
+    register_agent_via_http,
+    resolve_host_key_outside_hook,
+    resolved_http_endpoint_auth,
+    set_session_key,
+    switch_launch_record,
+    touch_activity,
+    unregister_agent_via_http,
+)
+from _proc import pid_alive  # noqa: E402
+from config import ensure_dataset_ready_via_api, load_config  # noqa: E402
+
+_STATE_DIR = Path.home() / ".cognee-plugin" / "codex"
+_WATCHER_PID = _STATE_DIR / "watcher.pid"
+_WATCHER_STOP = _STATE_DIR / "watcher.stop"
+_HERE = Path(__file__).resolve().parent
+_SYNC_SCRIPT = _HERE / "sync-session-to-graph.py"
+_WATCHER_SCRIPT = _HERE / "idle-watcher.py"
+
+EXIT_OK, EXIT_ERROR, EXIT_NO_RECORD, EXIT_SYNC_FAILED, EXIT_REGISTER_FAILED, EXIT_NOT_WRITABLE = (
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+)
+
+
+class SwitchError(Exception):
+    def __init__(self, code: int, message: str, **detail):
+        super().__init__(message)
+        self.code = code
+        self.detail = detail
+
+
+# ── launch resolution ──────────────────────────────────────────────────────
+
+
+def _resolve_launch(explicit_key: str) -> tuple[str, dict]:
+    host_key = explicit_key.strip()
+    source = "flag"
+    if not host_key:
+        host_key, source = resolve_host_key_outside_hook()
+    rec = _read_map_record(host_key) if host_key else {}
+    if not rec.get("session_id"):
+        hint = (
+            "several Cognee launches share this directory — rerun with "
+            "--session-key <host session id>"
+            if source == "ambiguous_cwd"
+            else "start a Codex session with the Cognee plugin active first"
+        )
+        raise SwitchError(EXIT_NO_RECORD, f"no launch record found ({source}); {hint}")
+    set_session_key(host_key)
+    return host_key, rec
+
+
+# ── listing ────────────────────────────────────────────────────────────────
+
+
+def _list(host_key: str, rec: dict) -> dict:
+    resolved = load_resolved(session_key=host_key)
+    user_id = str(resolved.get("user_id") or "")
+    try:
+        listing = list_writable_datasets(user_id)
+    except urllib.error.HTTPError as exc:
+        raise SwitchError(EXIT_ERROR, f"GET /api/v1/datasets failed (HTTP {exc.code})")
+    except Exception as exc:
+        raise SwitchError(EXIT_ERROR, f"GET /api/v1/datasets failed ({exc})")
+    current = str(rec.get("dataset") or resolved.get("dataset") or "")
+    rows = [{**row, "current": row["name"] == current} for row in listing["datasets"]]
+    return {
+        "current": current,
+        "session_id": str(rec.get("session_id") or ""),
+        "datasets": rows,
+        "hidden_readonly": listing["hidden_readonly"],
+        "filtered": listing["filtered"],
+    }
+
+
+# ── the switch ─────────────────────────────────────────────────────────────
+
+
+def _sync_current(host_key: str, session_id: str, dataset: str) -> None:
+    """Bridge the session we are about to retire, strictly (non-zero = failure)."""
+    env = os.environ.copy()
+    env["COGNEE_SESSION_KEY"] = host_key
+    env["COGNEE_SYNC_SESSION_ID"] = session_id
+    env["COGNEE_SYNC_DATASET"] = dataset
+    started = time.monotonic()
+    proc = subprocess.run(
+        [sys.executable, str(_SYNC_SCRIPT), "--strict"],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=float(os.environ.get("COGNEE_SWITCH_SYNC_TIMEOUT", "") or 900),
+    )
+    hook_log(
+        "switch_sync_result",
+        {
+            "session": session_id,
+            "dataset": dataset,
+            "returncode": proc.returncode,
+            "elapsed_ms": int((time.monotonic() - started) * 1000),
+            "stderr": (proc.stderr or "")[-400:],
+        },
+    )
+    if proc.returncode != 0:
+        tail = (proc.stderr or "").strip().splitlines()[-1:] or ["no detail"]
+        raise SwitchError(
+            EXIT_SYNC_FAILED,
+            f"sync of session {session_id} (dataset {dataset}) failed: {tail[0]}",
+        )
+
+
+def _register_new(session_id: str, dataset: str) -> str:
+    """Register the new session under a fresh connection handle; returns the handle.
+
+    Fresh handle first, old one released after: the server's agent-mode count
+    goes 1→2→1 and never touches 0, which would shut a local server down.
+    """
+    conn_uuid = _new_conn_uuid()
+    ok, _ = register_agent_via_http(
+        agent_session_name=conn_uuid, session_id=session_id, dataset_names=[dataset]
+    )
+    if not ok:
+        raise SwitchError(
+            EXIT_REGISTER_FAILED,
+            f"registering session {session_id} on dataset {dataset} failed; nothing was changed",
+        )
+    return conn_uuid
+
+
+def _ensure_dataset(dataset: str) -> None:
+    service_url, api_key = resolved_http_endpoint_auth()
+    try:
+        asyncio.run(ensure_dataset_ready_via_api(service_url, api_key, dataset))
+    except Exception as exc:
+        text = str(exc)
+        code = EXIT_NOT_WRITABLE if any(s in text for s in ("401", "403", "404")) else EXIT_ERROR
+        raise SwitchError(code, f"dataset {dataset!r} is not available to this principal ({text})")
+
+
+def _restart_idle_watcher(host_key: str, session_id: str, dataset: str, user_id: str) -> None:
+    """Replace the idle watcher so its bootstrap names the new triple.
+
+    The watcher re-reads the record before each bridge anyway; this keeps its
+    log/bootstrap honest and clears a pending bridge aimed at the old session.
+    """
+    if os.environ.get("COGNEE_IDLE_DISABLED", "").lower() in ("1", "true", "yes"):
+        return
+    try:
+        if _WATCHER_PID.exists():
+            pid = int(_WATCHER_PID.read_text(encoding="utf-8").strip() or 0)
+            if pid and pid_alive(pid):
+                _WATCHER_STOP.write_text("stop", encoding="utf-8")
+                os.kill(pid, signal.SIGTERM)
+                deadline = time.monotonic() + 5.0
+                while pid_alive(pid) and time.monotonic() < deadline:
+                    time.sleep(0.1)
+        if _WATCHER_STOP.exists():
+            _WATCHER_STOP.unlink()
+    except Exception as exc:
+        hook_log("switch_watcher_stop_failed", {"error": str(exc)[:200]})
+
+    config = load_config()
+    bootstrap = {
+        "session_id": session_id,
+        "dataset": dataset,
+        "user_id": user_id,
+        "session_key": host_key,
+        "config": {
+            "base_url": config.get("base_url", ""),
+            "llm_model": config.get("llm_model", ""),
+            "dataset": dataset,
+        },
+    }
+    try:
+        log_fh = (_STATE_DIR / "watcher.log").open("a", encoding="utf-8")
+    except Exception:
+        log_fh = subprocess.DEVNULL
+    try:
+        env = os.environ.copy()
+        env["COGNEE_SESSION_KEY"] = host_key
+        subprocess.Popen(
+            [sys.executable, str(_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            env=env,
+            start_new_session=True,
+            close_fds=True,
+        )
+        hook_log("switch_watcher_restarted", {"session": session_id, "dataset": dataset})
+    except Exception as exc:
+        hook_log("switch_watcher_restart_failed", {"error": str(exc)[:200]})
+
+
+def _switch(host_key: str, rec: dict, target: str, *, force: bool) -> dict:
+    target = target.strip()
+    if not target:
+        raise SwitchError(EXIT_ERROR, "dataset name is empty")
+    old_session = str(rec.get("session_id") or "")
+    old_dataset = str(
+        rec.get("dataset") or load_resolved(session_key=host_key).get("dataset") or ""
+    )
+    old_conn = str(rec.get("conn_uuid") or "")
+    if target == old_dataset:
+        return {
+            "switched": False,
+            "reason": "already_active",
+            "dataset": target,
+            "session_id": old_session,
+        }
+
+    resolved = load_resolved(session_key=host_key)
+    user_id = str(resolved.get("user_id") or "")
+
+    # The target must be one this principal can write to. Owned datasets are
+    # guaranteed writable; anything else is refused up front rather than failing
+    # half-way through.
+    listing = list_writable_datasets(user_id)
+    if target in listing["readonly"]:
+        raise SwitchError(
+            EXIT_NOT_WRITABLE,
+            f"dataset {target!r} is readable but owned by someone else (not writable); "
+            "run --list to see the options",
+            hidden_readonly=listing["hidden_readonly"],
+        )
+    # A name that is not listed at all is created for this principal by the
+    # ensure step below (owner = us, hence writable).
+
+    # 1. Sync the session we are leaving. Abort on failure unless forced — the
+    #    retired triple stays in `touched`, so the final sync retries it.
+    sync_ok = True
+    sync_error = ""
+    try:
+        _sync_current(host_key, old_session, old_dataset)
+    except SwitchError as exc:
+        if not force:
+            raise
+        sync_ok, sync_error = False, str(exc)
+        hook_log("switch_sync_forced_past_failure", {"error": sync_error[:300]})
+
+    # 2. Make sure the dataset exists for this principal (idempotent).
+    _ensure_dataset(target)
+
+    # 3. Register the new session first (fresh handle) ...
+    new_session = mint_switch_session_id(host_key)
+    new_conn = _register_new(new_session, target)
+
+    # 4. ... repoint the launch record (atomic) ...
+    switch_launch_record(host_key, session_id=new_session, dataset=target, conn_uuid=new_conn)
+
+    # 5. ... then release the old handle. Best-effort: a lingering active
+    #    connection is harmless and the final unregister sweeps `touched`.
+    old_released = False
+    if old_conn:
+        old_released, _ = unregister_agent_via_http(agent_session_name=old_conn)
+        hook_log("switch_old_handle_released", {"conn_uuid": old_conn, "ok": old_released})
+
+    # 6. Fresh watcher + reset the idle clock for the new session.
+    _restart_idle_watcher(host_key, new_session, target, user_id)
+    touch_activity()
+
+    return {
+        "switched": True,
+        "dataset": target,
+        "session_id": new_session,
+        "conn_uuid": new_conn,
+        "previous": {
+            "dataset": old_dataset,
+            "session_id": old_session,
+            "synced": sync_ok,
+            **({"sync_error": sync_error} if sync_error else {}),
+            "unregistered": old_released,
+        },
+    }
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+
+def _print_listing(result: dict, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(result))
+        return
+    print(f"Current dataset: {result['current']}  (session {result['session_id']})")
+    if not result["datasets"]:
+        print("No other writable datasets found.")
+    for row in result["datasets"]:
+        mark = "*" if row["current"] else " "
+        print(f" {mark} {row['name']}")
+    if result["hidden_readonly"]:
+        print(f"({result['hidden_readonly']} read-only dataset(s) not shown)")
+    if not result["filtered"]:
+        print("(write access could not be verified — showing every readable dataset)")
+
+
+def _print_switch(result: dict, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(result))
+        return
+    if not result.get("switched"):
+        print(f"Already on dataset {result['dataset']!r} (session {result['session_id']}).")
+        return
+    prev = result["previous"]
+    synced = "synced" if prev["synced"] else f"NOT synced ({prev.get('sync_error', '')})"
+    print(
+        f"Switched to dataset {result['dataset']!r} — new session {result['session_id']}. "
+        f"Previous session {prev['session_id']} ({prev['dataset']}) {synced}."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    as_json = "--json" in args
+    force = "--force" in args
+    do_list = "--list" in args
+    explicit_key = ""
+    if "--session-key" in args:
+        i = args.index("--session-key")
+        explicit_key = args[i + 1] if i + 1 < len(args) else ""
+        del args[i : i + 2]
+    positional = [a for a in args if not a.startswith("--")]
+
+    try:
+        host_key, rec = _resolve_launch(explicit_key)
+        if do_list or not positional:
+            _print_listing(_list(host_key, rec), as_json)
+            return EXIT_OK
+        result = _switch(host_key, rec, positional[0], force=force)
+        _print_switch(result, as_json)
+        return EXIT_OK
+    except SwitchError as exc:
+        hook_log("switch_failed", {"code": exc.code, "error": str(exc)[:300], **exc.detail})
+        if as_json:
+            print(json.dumps({"error": str(exc), "code": exc.code, **exc.detail}))
+        else:
+            print(f"cognee-switch-datasets: {exc}", file=sys.stderr)
+        return exc.code
+    except Exception as exc:  # pragma: no cover - defensive
+        hook_log("switch_crashed", {"error": str(exc)[:300]})
+        if as_json:
+            print(json.dumps({"error": str(exc), "code": EXIT_ERROR}))
+        else:
+            print(f"cognee-switch-datasets: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/codex/plugins/cognee/scripts/sync-session-to-graph.py
+++ b/integrations/codex/plugins/cognee/scripts/sync-session-to-graph.py
@@ -49,6 +49,7 @@ _WATCHER_PID = _STATE_DIR / "watcher.pid"
 _WATCHER_STOP = _STATE_DIR / "watcher.stop"
 _DETACHED_ARG = "--detached-final"
 _SESSION_END_ARG = "--session-end"
+_STRICT_ARG = "--strict"
 _FINAL_SYNC_ONCE_DIR = _STATE_DIR / "final-sync-once"
 _FINAL_SYNC_ONCE_TTL_SECONDS = 3600
 _DETACHED_RETRIES_DEFAULT = 3
@@ -242,16 +243,69 @@ def _load_resolved() -> tuple:
     )
 
 
-async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: bool = False):
+def _sync_targets(
+    session_id: str, dataset: str, session_key: str, include_touched: bool
+) -> list[tuple[str, str]]:
+    """(session_id, dataset) pairs to bridge, current pair last.
+
+    A launch that switched datasets has retired sessions in its record's
+    ``touched`` list. The final sync covers them too — a write that raced the
+    switch (landing in the old session after its switch-time sync) is otherwise
+    lost. Re-bridging an already-synced pair is cheap: the bridge state is keyed
+    by (dataset, session) and the server's improve is idempotent per session.
+    """
+    pairs: list[tuple[str, str]] = []
+    if include_touched and session_key:
+        try:
+            from _plugin_common import touched_pairs
+
+            for entry in touched_pairs(session_key):
+                pair = (str(entry.get("session_id") or ""), str(entry.get("dataset") or ""))
+                if pair[0] and pair[1] and pair not in pairs:
+                    pairs.append(pair)
+        except Exception as exc:
+            hook_log("sync_touched_pairs_failed", {"error": str(exc)[:200]})
+    current = (session_id, dataset)
+    if session_id:
+        pairs = [p for p in pairs if p != current] + [current]
+    return pairs
+
+
+def _unregister_handles(session_key: str, agent_session_name: str) -> list[str]:
+    """Connection handles to release at the end: the live one plus any retired
+    by a switch (the switch unregisters those itself; this is the safety net)."""
+    handles: list[str] = []
+    if session_key:
+        try:
+            from _plugin_common import touched_pairs
+
+            for entry in touched_pairs(session_key):
+                cu = str(entry.get("conn_uuid") or "").strip()
+                if cu and cu not in handles:
+                    handles.append(cu)
+        except Exception as exc:
+            hook_log("sync_touched_handles_failed", {"error": str(exc)[:200]})
+    live = str(agent_session_name or "").strip()
+    if live:
+        handles = [h for h in handles if h != live] + [live]
+    return handles
+
+
+async def _sync(
+    stop_watcher: bool,
+    unregister_on_finish: bool = False,
+    strict: bool = False,
+    include_touched: bool = False,
+):
     session_id, dataset, user_id, agent_session_name, was_registered, has_api_key, session_key = (
         _load_resolved()
     )
-    target_sessions = [session_id] if session_id else []
+    targets = _sync_targets(session_id, dataset, session_key, include_touched)
     hook_log(
         "sync_start",
         {
             "session": session_id,
-            "targets": target_sessions,
+            "targets": [f"{ds}:{sid}" for sid, ds in targets],
             "dataset": dataset,
             "user_id": user_id,
             "stop_watcher": stop_watcher,
@@ -270,30 +324,31 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: 
             if not acquired:
                 hook_log("sync_skipped_lock_busy", {"session": session_id, "dataset": dataset})
                 print("cognee-sync: skipped, another sync is running", file=sys.stderr)
+                if strict:
+                    raise RuntimeError("another sync is running")
                 return
 
-            if not target_sessions:
+            if not targets:
                 hook_log("sync_no_target_sessions", {"dataset": dataset})
                 return
 
             incomplete: list[str] = []
             if api_mode:
-                for sid in target_sessions:
-                    wrote = run_session_improve(dataset, sid)
+                for sid, ds in targets:
+                    wrote = run_session_improve(ds, sid)
                     if not wrote:
-                        incomplete.append(sid)
+                        incomplete.append(f"{ds}:{sid}")
                     hook_log(
                         "sync_bridge_done",
                         {
                             "session": sid,
-                            "dataset": dataset,
+                            "dataset": ds,
                             "via": "http_improve",
                             "wrote": wrote,
                         },
                     )
                     print(
-                        f"cognee-sync: dataset={dataset} session={sid} "
-                        f"via=http_improve wrote={wrote}",
+                        f"cognee-sync: dataset={ds} session={sid} via=http_improve wrote={wrote}",
                         file=sys.stderr,
                     )
                 if strict and incomplete:
@@ -308,23 +363,23 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: 
 
             await ensure_cognee_ready(config)
             user = await resolve_user(user_id)
-            await ensure_dataset_ready(dataset, user)
-            for sid in target_sessions:
-                result = await improve_session_local(dataset, sid, user)
+            for sid, ds in targets:
+                await ensure_dataset_ready(ds, user)
+                result = await improve_session_local(ds, sid, user)
                 if not result.get("ok"):
-                    incomplete.append(sid)
+                    incomplete.append(f"{ds}:{sid}")
                 hook_log(
                     "sync_bridge_done",
                     {
                         "session": sid,
-                        "dataset": dataset,
+                        "dataset": ds,
                         "user_id": str(getattr(user, "id", "")),
                         "via": "local_improve",
                         "ok": bool(result.get("ok")),
                     },
                 )
                 print(
-                    f"cognee-sync: dataset={dataset} session={sid} "
+                    f"cognee-sync: dataset={ds} session={sid} "
                     f"via=local_improve ok={result.get('ok')}",
                     file=sys.stderr,
                 )
@@ -338,13 +393,15 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: 
                     {"session": session_id, "dataset": dataset},
                 )
             else:
-                unregister_name = str(agent_session_name or session_key or "").strip()
-                if not unregister_name:
+                handles = _unregister_handles(
+                    session_key, str(agent_session_name or session_key or "").strip()
+                )
+                if not handles:
                     hook_log(
                         "agent_unregister_skipped_no_session_name",
                         {"session": session_id, "dataset": dataset},
                     )
-                else:
+                for unregister_name in handles:
                     ok, active = unregister_agent_via_http(agent_session_name=unregister_name)
                     hook_log(
                         "agent_unregister_result",
@@ -417,6 +474,12 @@ def main():
             os.environ.get("COGNEE_SYNC_RETRY_DELAY", str(_DETACHED_RETRY_DELAY_DEFAULT))
         )
 
+    # --strict: the caller (switch-dataset.py, syncing the session it is about
+    # to retire) needs a verdict — exit non-zero when the bridge is incomplete
+    # instead of the hook-friendly swallow below.
+    strict_cli = _STRICT_ARG in sys.argv
+
+    last_error: Exception | None = None
     for attempt in range(1, max(1, attempts) + 1):
         try:
             asyncio.run(
@@ -425,11 +488,15 @@ def main():
                     unregister_on_finish=unregister_on_finish,
                     # The detached-final run is the session's last sync: an
                     # incomplete result raises so this loop retries it.
-                    strict=detached_final,
+                    strict=detached_final or strict_cli,
+                    # ...and it covers every session this launch touched (a
+                    # dataset switch retires sessions mid-launch).
+                    include_touched=detached_final,
                 )
             )
             return
         except Exception as exc:
+            last_error = exc
             # Non-fatal: session sync failure should not crash Codex.
             hook_log(
                 "sync_failed",
@@ -439,6 +506,8 @@ def main():
             if attempt < attempts:
                 hook_log("sync_retry_scheduled", {"attempt": attempt + 1, "delay": retry_delay})
                 time.sleep(retry_delay)
+    if strict_cli and last_error is not None:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/integrations/codex/plugins/cognee/skills/cognee-switch-datasets/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/cognee-switch-datasets/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: cognee-switch-datasets
+description: Use when the user wants to switch this Codex session to another Cognee dataset, see which datasets are available, or move memory capture to a different dataset. Syncs the current session first, then starts a fresh Cognee session bound to the chosen dataset.
+---
+
+# Switch Datasets
+
+Move this Codex session to a different Cognee dataset. A Cognee session never
+spans two datasets, so the switch retires the current session (after syncing
+it into the graph) and starts a new one on the chosen dataset. All later saves
+and recalls target the new dataset; the in-context status line shows it.
+
+## Rules
+
+- Never guess a dataset name: list first unless the user named one.
+- Only offer datasets the listing returns — read-only ones are already filtered out.
+- Do not pass `--force` unless the user explicitly accepts that unsynced entries of the current session are retried at session end instead.
+
+## Instructions
+
+### 1. If the user named a dataset, switch directly
+
+```bash
+python3 "${CODEX_PLUGIN_ROOT}/scripts/switch-dataset.py" "<name>" --json
+```
+
+### 2. Otherwise, list and let the user choose
+
+```bash
+python3 "${CODEX_PLUGIN_ROOT}/scripts/switch-dataset.py" --list --json
+```
+
+The JSON has `current`, `datasets` (`[{name, id, writable, current}]`),
+`hidden_readonly` (datasets you can read but not write — never offered) and
+`filtered` (`true` when write access was verified for every row).
+
+Codex has no interactive picker outside plan mode, so present a **numbered
+list** of the dataset names (mark the current one) and ask the user to reply
+with a number or a name. If `filtered` is `false`, say that write access could
+not be verified. When the user answers, run the switch with the chosen name:
+
+```bash
+python3 "${CODEX_PLUGIN_ROOT}/scripts/switch-dataset.py" "<chosen name>" --json
+```
+
+A name that is not in the list is created for the user on switch.
+
+### 3. Report the result
+
+On success the JSON is
+`{"switched": true, "dataset", "session_id", "previous": {"dataset", "session_id", "synced": true|false}}`.
+Tell the user in one line which dataset and Cognee session are now active and
+that the previous session was synced. The status line updates on the next
+prompt. If `"switched": false` with `"reason": "already_active"`, say the
+session is already on that dataset.
+
+On failure the JSON is `{"error", "code"}`:
+
+| code | meaning | what to do |
+|------|---------|------------|
+| 2 | launch record not found | the plugin did not initialise this session; run `cognee-cli.sh doctor`. If several Codex sessions share this directory, rerun with `--session-key <host session id>` |
+| 3 | syncing the current session failed | nothing was changed; show the error and ask before retrying with `--force` |
+| 4 | registering the new session failed | nothing was changed; the server rejected the registration — check the connection |
+| 5 | dataset not writable | the name is readable but owned by another principal; pick from the list |
+
+## What the switch does
+
+1. Syncs the current session into its dataset (`sync-session-to-graph.py --strict`) — aborts if this fails.
+2. Ensures the target dataset exists for this principal.
+3. Registers a **new** Cognee session on the target dataset under a fresh connection handle, then releases the old handle (register-then-unregister, so a local agent-mode server never sees zero connections).
+4. Repoints this launch's record: every hook, the shell wrappers, the idle/exit watchers and the status line follow it.
+5. Retired sessions stay in the record's `touched` list; the session-end sync covers them again as a safety net.
+
+## Notes
+
+- `COGNEE_PLUGIN_DATASET` only seeds the dataset at launch; a switch overrides it for the rest of the session and survives a resume.
+- Recall is scoped to the active dataset, so after a switch earlier context from the previous dataset is no longer injected — switch back to see it again.

--- a/integrations/tests/tests/integration/test_switch_dataset.py
+++ b/integrations/tests/tests/integration/test_switch_dataset.py
@@ -1,0 +1,223 @@
+"""switch-dataset.py against the mock server: listing, ordering, and the abort paths.
+
+The switch is a sequence with a strict order — sync the retiring session, ensure
+the target dataset, REGISTER the new session under a fresh handle, repoint the
+record, then UNREGISTER the old handle — because a local agent-mode server shuts
+down when its connection count reaches zero. These tests pin that order over
+real HTTP and check that every failure leaves the launch record untouched.
+
+The sync step spawns ``sync-session-to-graph.py`` as a subprocess; here it is
+replaced with a recorder (its own strict behaviour is covered in
+test_sync_strict.py), and the idle-watcher restart is a no-op.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+HOST = "host-switch-1"
+REGISTER, UNREGISTER, DATASETS = (
+    "/api/v1/agents/register",
+    "/api/v1/agents/unregister",
+    "/api/v1/datasets",
+)
+
+
+@pytest.fixture
+def env(suite, hook_module, isolated_modules, mock_server, monkeypatch):
+    switch = hook_module(suite, "switch-dataset.py")
+    pc = isolated_modules(suite, "_plugin_common")
+    monkeypatch.setenv("COGNEE_BASE_URL", mock_server.url)
+    monkeypatch.delenv("COGNEE_SESSION_KEY", raising=False)
+    monkeypatch.delenv("COGNEE_SESSION_ID", raising=False)
+    monkeypatch.setattr(pc, "hook_log", lambda *a, **k: None)
+    monkeypatch.setattr(switch, "hook_log", lambda *a, **k: None)
+    monkeypatch.setattr(switch, "_restart_idle_watcher", lambda *a, **k: None)
+    monkeypatch.setattr(switch, "touch_activity", lambda: None)
+
+    synced: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        switch, "_sync_current", lambda hk, sid, ds: synced.append((sid, ds)) or None
+    )
+
+    ident = mock_server.identity
+    ident.seed_user("owner@example.com")
+    # ensure_dataset_ready_via_api only POSTs when it has a key to send.
+    monkeypatch.setenv("COGNEE_API_KEY", ident.seed_owner_key("owner@example.com"))
+    # The launch as SessionStart left it: registered under conn_uuid on dataset "a".
+    sid, conn = pc.ensure_launch_record(HOST, "/w", dataset="a")
+    ident.agents_register({"agent_session_name": conn, "session_id": sid})
+    ident.seed_dataset("a")
+    ident.seed_dataset("b")
+    ident.seed_dataset("shared-ro", owner_id="someone-else")
+
+    class Env:
+        pass
+
+    e = Env()
+    e.switch, e.pc, e.server, e.synced = switch, pc, mock_server, synced
+    e.host, e.session_id, e.conn = HOST, sid, conn
+    e.rec = lambda: pc._read_map_record(HOST)
+    return e
+
+
+def _calls(server, path):
+    return [c for c in server.calls if c["path"] == path]
+
+
+# ── listing ────────────────────────────────────────────────────────────────
+
+
+def test_list_hides_foreign_datasets_and_marks_current(env):
+    out = env.switch._list(env.host, env.rec())
+    assert out["current"] == "a" and out["session_id"] == env.session_id
+    names = {r["name"]: r for r in out["datasets"]}
+    assert set(names) == {"a", "b"}
+    assert names["a"]["current"] is True and names["b"]["current"] is False
+    assert out["hidden_readonly"] == 1 and out["filtered"] is True
+
+
+# ── the switch ─────────────────────────────────────────────────────────────
+
+
+def test_switch_order_register_new_then_unregister_old(env):
+    result = env.switch._switch(env.host, env.rec(), "b", force=False)
+    assert result["switched"] is True and result["dataset"] == "b"
+
+    # 1. the retiring session was synced into ITS dataset
+    assert env.synced == [(env.session_id, "a")]
+
+    # 2. register(new) happened before unregister(old), and named the new dataset
+    order = [c for c in env.server.calls if c["path"] in (REGISTER, UNREGISTER)]
+    assert [c["path"] for c in order] == [REGISTER, UNREGISTER]
+    reg, unreg = order
+    assert reg["json"]["dataset_names"] == ["b"]
+    assert reg["json"]["session_id"] == result["session_id"]
+    assert reg["json"]["agent_session_name"] == result["conn_uuid"] != env.conn
+    assert unreg["json"]["agent_session_name"] == env.conn
+
+    # 3. the record now points at the new triple, the old one is retired
+    rec = env.rec()
+    assert (rec["session_id"], rec["dataset"], rec["conn_uuid"]) == (
+        result["session_id"],
+        "b",
+        result["conn_uuid"],
+    )
+    assert rec["switched_at"]
+    pairs = env.pc.touched_pairs(env.host)
+    assert [(p["session_id"], p["dataset"]) for p in pairs] == [
+        (env.session_id, "a"),
+        (result["session_id"], "b"),
+    ]
+    assert result["previous"] == {
+        "dataset": "a",
+        "session_id": env.session_id,
+        "synced": True,
+        "unregistered": True,
+    }
+    # the server's view: only the new handle is active
+    assert set(env.server.identity.registered_agents) == {result["conn_uuid"]}
+
+
+def test_switch_to_current_dataset_is_a_noop(env):
+    result = env.switch._switch(env.host, env.rec(), "a", force=False)
+    assert result == {
+        "switched": False,
+        "reason": "already_active",
+        "dataset": "a",
+        "session_id": env.session_id,
+    }
+    assert env.synced == [] and not _calls(env.server, REGISTER)
+
+
+def test_switch_refuses_readonly_dataset_before_touching_anything(env):
+    before = env.rec()
+    with pytest.raises(env.switch.SwitchError) as exc:
+        env.switch._switch(env.host, env.rec(), "shared-ro", force=False)
+    assert exc.value.code == env.switch.EXIT_NOT_WRITABLE
+    assert env.synced == [] and not _calls(env.server, REGISTER)
+    assert env.rec() == before
+
+
+def test_switch_creates_an_unlisted_dataset_for_the_principal(env):
+    result = env.switch._switch(env.host, env.rec(), "brand-new", force=False)
+    assert result["switched"] is True
+    created = [c for c in env.server.calls if c["path"] == DATASETS and c["method"] == "POST"]
+    assert created and created[0]["json"]["name"] == "brand-new"
+    assert env.server.identity.datasets["brand-new"]["ownerId"] == env.server.identity.principal_id
+
+
+def test_sync_failure_aborts_with_record_untouched(env, monkeypatch):
+    def boom(hk, sid, ds):
+        raise env.switch.SwitchError(env.switch.EXIT_SYNC_FAILED, "improve failed")
+
+    monkeypatch.setattr(env.switch, "_sync_current", boom)
+    before = env.rec()
+    with pytest.raises(env.switch.SwitchError) as exc:
+        env.switch._switch(env.host, env.rec(), "b", force=False)
+    assert exc.value.code == env.switch.EXIT_SYNC_FAILED
+    assert env.rec() == before
+    assert not _calls(env.server, REGISTER) and not _calls(env.server, UNREGISTER)
+
+
+def test_force_switches_past_sync_failure_and_reports_it(env, monkeypatch):
+    def boom(hk, sid, ds):
+        raise env.switch.SwitchError(env.switch.EXIT_SYNC_FAILED, "improve failed")
+
+    monkeypatch.setattr(env.switch, "_sync_current", boom)
+    result = env.switch._switch(env.host, env.rec(), "b", force=True)
+    assert result["switched"] is True
+    assert result["previous"]["synced"] is False
+    assert "improve failed" in result["previous"]["sync_error"]
+    # the retired pair is still in `touched`, so the final sync retries it
+    assert (env.session_id, "a") in {
+        (p["session_id"], p["dataset"]) for p in env.pc.touched_pairs(env.host)
+    }
+
+
+def test_register_failure_changes_nothing(env):
+    env.server.force_response("POST", REGISTER, 500, {"detail": "boom"})
+    before = env.rec()
+    with pytest.raises(env.switch.SwitchError) as exc:
+        env.switch._switch(env.host, env.rec(), "b", force=False)
+    assert exc.value.code == env.switch.EXIT_REGISTER_FAILED
+    assert env.synced == [(env.session_id, "a")]  # sync ran first, by design
+    assert env.rec() == before
+    assert not _calls(env.server, UNREGISTER)
+    assert set(env.server.identity.registered_agents) == {env.conn}
+
+
+# ── CLI surface ────────────────────────────────────────────────────────────
+
+
+def test_main_list_json_and_missing_record(env, capsys, monkeypatch):
+    import json
+
+    assert env.switch.main(["--list", "--json", "--session-key", env.host]) == env.switch.EXIT_OK
+    out = json.loads(capsys.readouterr().out)
+    assert out["current"] == "a" and {r["name"] for r in out["datasets"]} == {"a", "b"}
+
+    # No flag, no hook env, and discovery finds nothing: a clear "no record" exit.
+    monkeypatch.delenv("COGNEE_SESSION_KEY", raising=False)
+    monkeypatch.setattr(
+        env.switch, "resolve_host_key_outside_hook", lambda cwd="": ("", "not_found")
+    )
+    assert env.switch.main(["--list", "--json"]) == env.switch.EXIT_NO_RECORD
+    assert json.loads(capsys.readouterr().out)["code"] == env.switch.EXIT_NO_RECORD
+
+
+# ── final sync covers retired sessions ─────────────────────────────────────
+
+
+def test_final_sync_targets_include_touched_pairs(suite, hook_module, env, monkeypatch):
+    env.switch._switch(env.host, env.rec(), "b", force=False)
+    sync = hook_module(suite, "sync-session-to-graph.py")
+    rec = env.rec()
+    targets = sync._sync_targets(rec["session_id"], "b", env.host, include_touched=True)
+    assert targets == [(env.session_id, "a"), (rec["session_id"], "b")]
+    # a mid-session manual sync stays scoped to the live pair
+    assert sync._sync_targets(rec["session_id"], "b", env.host, include_touched=False) == [
+        (rec["session_id"], "b")
+    ]
+    handles = sync._unregister_handles(env.host, rec["conn_uuid"])
+    assert handles == [env.conn, rec["conn_uuid"]]

--- a/integrations/tests/tests/unit/test_dataset_switch.py
+++ b/integrations/tests/tests/unit/test_dataset_switch.py
@@ -1,0 +1,236 @@
+"""Dataset switching: the launch record as the single source of the active dataset.
+
+A launch's dataset used to be process-local (COGNEE_PLUGIN_DATASET or the
+default, read by every hook independently). ``switch-dataset.py`` moves a launch
+to another dataset mid-session, so the dataset now lives in the host-keyed launch
+record and every reader — hooks via ``config.get_dataset``, the shell wrappers,
+the watchers, the status line — follows the record.
+
+Covers, for both suites:
+  * record seeding at SessionStart and the env/default fallback outside a launch
+  * a switched record beating an exported COGNEE_SESSION_ID
+  * ``touched`` history (legacy string list and the new triple list)
+  * switch session-id minting (``{agent}_{host}__N``, never colliding)
+  * ``switch_launch_record`` atomically replacing the live triple
+  * the writable-dataset filter (owner match, camelCase wire key, unknown owner)
+  * launch-record discovery from a process with no hook payload
+  * the status line reading the record's dataset
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+HOST = "host-abc-123"
+
+
+@pytest.fixture
+def pc(suite, isolated_modules, monkeypatch):
+    common = isolated_modules(suite, "_plugin_common")
+    monkeypatch.setattr(common, "hook_log", lambda *a, **k: None)
+    monkeypatch.delenv("COGNEE_SESSION_KEY", raising=False)
+    monkeypatch.delenv("COGNEE_SESSION_ID", raising=False)
+    monkeypatch.delenv("COGNEE_PLUGIN_DATASET", raising=False)
+    return common
+
+
+# ── record seeding + resolution ─────────────────────────────────────────────
+
+
+def test_launch_record_seeds_dataset_cwd_and_pid(pc):
+    sid, conn = pc.ensure_launch_record(HOST, "/work/proj", dataset="seeded", host_pid=4242)
+    rec = pc._read_map_record(HOST)
+    assert rec["session_id"] == sid and rec["conn_uuid"] == conn
+    assert rec["dataset"] == "seeded"
+    assert rec["cwd"] == "/work/proj"
+    assert rec["host_pid"] == 4242
+    assert "switched_at" not in rec
+
+
+def test_resume_keeps_recorded_dataset_over_new_seed(pc):
+    """A resumed launch (record exists) keeps its dataset — incl. a switched one —
+    even when the shell now exports a different COGNEE_PLUGIN_DATASET."""
+    pc.ensure_launch_record(HOST, "/w", dataset="first")
+    pc.ensure_launch_record(HOST, "/w", dataset="from-new-shell")
+    assert pc._read_map_record(HOST)["dataset"] == "first"
+
+
+def test_backfill_adds_missing_metadata_only(pc):
+    pc.ensure_launch_record(HOST, "/w")  # legacy-shaped: no dataset/cwd/pid
+    assert "dataset" not in pc._read_map_record(HOST)
+    pc.ensure_launch_record(HOST, "/w", dataset="later", host_pid=7)
+    rec = pc._read_map_record(HOST)
+    assert rec["dataset"] == "later" and rec["host_pid"] == 7
+
+
+def test_resolve_active_dataset_precedence(pc, monkeypatch):
+    monkeypatch.setenv("COGNEE_PLUGIN_DATASET", "from-env")
+    # outside a launch: env
+    assert pc.resolve_active_dataset("") == "from-env"
+    # inside a launch without a recorded dataset: env
+    pc.ensure_launch_record(HOST, "/w")
+    assert pc.resolve_active_dataset(HOST) == "from-env"
+    # recorded: record wins
+    pc.ensure_launch_record(HOST, "/w", dataset="recorded")
+    assert pc.resolve_active_dataset(HOST) == "recorded"
+    # no env, no record: default
+    monkeypatch.delenv("COGNEE_PLUGIN_DATASET")
+    assert pc.resolve_active_dataset("nope") == "agent_sessions"
+
+
+def test_config_get_dataset_follows_record(suite, pc, isolated_modules, monkeypatch):
+    config = isolated_modules(suite, "config")
+    cfg = {"dataset": "from-config"}
+    assert config.get_dataset(cfg) == "from-config"  # no launch → config value
+    pc.ensure_launch_record(HOST, "/w", dataset="from-config")
+    pc.switch_launch_record(HOST, session_id="s2", dataset="switched", conn_uuid="c2")
+    monkeypatch.setenv("COGNEE_SESSION_KEY", HOST)
+    assert config.get_dataset(cfg) == "switched"
+
+
+def test_load_resolved_carries_dataset(pc, monkeypatch):
+    pc.ensure_launch_record(HOST, "/w", dataset="ds-a")
+    monkeypatch.setattr(pc, "_json_http_request", lambda *a, **k: (_ for _ in ()).throw(OSError()))
+    assert pc.load_resolved(HOST)["dataset"] == "ds-a"
+
+
+# ── session id precedence after a switch ───────────────────────────────────
+
+
+def test_switched_record_beats_exported_session_id(pc, monkeypatch):
+    pc.ensure_launch_record(HOST, "/w", dataset="a")
+    monkeypatch.setenv("COGNEE_SESSION_ID", "pinned_by_shell")
+    assert pc.resolve_cognee_session_id(HOST) == "pinned_by_shell"  # unchanged before
+    pc.switch_launch_record(HOST, session_id="moved", dataset="b", conn_uuid="c")
+    assert pc.resolve_cognee_session_id(HOST) == "moved"
+
+
+# ── touched history + id minting ───────────────────────────────────────────
+
+
+def test_touched_pairs_legacy_string_list(pc):
+    pc._write_map_record(
+        HOST,
+        {"session_id": "cur", "conn_uuid": "c1", "dataset": "d", "touched": ["old", "cur"]},
+    )
+    pairs = pc.touched_pairs(HOST)
+    assert [p["session_id"] for p in pairs] == ["old", "cur"]
+    assert all(p["dataset"] == "d" for p in pairs)
+    assert pairs[-1]["conn_uuid"] == "c1"
+
+
+def test_switch_record_replaces_live_triple_and_retires_old(pc):
+    sid, conn = pc.ensure_launch_record(HOST, "/w", dataset="a")
+    rec = pc.switch_launch_record(HOST, session_id="s2", dataset="b", conn_uuid="c2")
+    assert (rec["session_id"], rec["dataset"], rec["conn_uuid"]) == ("s2", "b", "c2")
+    assert rec["switched_at"]
+    pairs = pc.touched_pairs(HOST)
+    assert [(p["session_id"], p["dataset"], p["conn_uuid"]) for p in pairs] == [
+        (sid, "a", conn),
+        ("s2", "b", "c2"),
+    ]
+    assert rec["touched"][0]["to"] and rec["touched"][1]["from"]
+
+
+def test_mint_switch_session_id_never_collides(suite, pc):
+    pc.ensure_launch_record(HOST, "/w", dataset="a")
+    base = f"{suite.session_prefix}_{HOST}"
+    first = pc.mint_switch_session_id(HOST)
+    assert first == f"{base}__2"
+    pc.switch_launch_record(HOST, session_id=first, dataset="b", conn_uuid="c2")
+    second = pc.mint_switch_session_id(HOST)
+    assert second == f"{base}__3"
+    assert second not in {p["session_id"] for p in pc.touched_pairs(HOST)}
+
+
+# ── writable-dataset filter ────────────────────────────────────────────────
+
+
+def _serve(pc, monkeypatch, rows):
+    monkeypatch.setattr(pc, "_json_http_request", lambda *a, **k: rows)
+
+
+def test_list_writable_filters_by_owner_camelcase(pc, monkeypatch):
+    _serve(
+        pc,
+        monkeypatch,
+        [
+            {"name": "mine", "id": "1", "ownerId": "me"},
+            {"name": "theirs", "id": "2", "ownerId": "someone"},
+            {"name": "also-mine", "id": "3", "owner_id": "me"},
+        ],
+    )
+    out = pc.list_writable_datasets("me")
+    assert [r["name"] for r in out["datasets"]] == ["also-mine", "mine"]
+    assert out["readonly"] == ["theirs"]
+    assert out["hidden_readonly"] == 1 and out["filtered"] is True
+
+
+def test_list_writable_unknown_owner_is_kept_not_verified(pc, monkeypatch):
+    """A pre-1.6 server has no owner in the DTO: show everything, say so."""
+    _serve(pc, monkeypatch, [{"name": "x", "id": "1"}, {"name": "y", "id": "2"}])
+    out = pc.list_writable_datasets("me")
+    assert [r["name"] for r in out["datasets"]] == ["x", "y"]
+    assert all(r["writable"] is None for r in out["datasets"])
+    assert out["filtered"] is False and out["hidden_readonly"] == 0
+
+
+def test_list_writable_without_user_id_is_unfiltered(pc, monkeypatch):
+    _serve(pc, monkeypatch, [{"name": "x", "id": "1", "ownerId": "someone"}])
+    out = pc.list_writable_datasets("")
+    assert [r["name"] for r in out["datasets"]] == ["x"] and out["filtered"] is False
+
+
+# ── launch discovery without a hook payload ────────────────────────────────
+
+
+def test_host_key_from_env_session_key(pc, monkeypatch):
+    pc.ensure_launch_record(HOST, "/w", dataset="a")
+    monkeypatch.setenv("COGNEE_SESSION_KEY", HOST)
+    assert pc.resolve_host_key_outside_hook() == (HOST, "env_session_key")
+
+
+def test_host_key_from_claude_session_export(pc, monkeypatch):
+    pc.ensure_launch_record(HOST, "/w", dataset="a")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", HOST)
+    assert pc.resolve_host_key_outside_hook() == (HOST, "CLAUDE_CODE_SESSION_ID")
+
+
+def test_host_key_from_unique_cwd(pc, monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+    monkeypatch.setattr(pc, "_candidate_host_pids", lambda: set())
+    pc.ensure_launch_record(HOST, str(tmp_path), dataset="a")
+    assert pc.resolve_host_key_outside_hook(str(tmp_path)) == (HOST, "cwd")
+    pc.ensure_launch_record("other-host", str(tmp_path), dataset="a")
+    assert pc.resolve_host_key_outside_hook(str(tmp_path)) == ("", "ambiguous_cwd")
+
+
+def test_host_key_from_host_pid(pc, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+    pc.ensure_launch_record(HOST, "/w", dataset="a", host_pid=999_999)
+    monkeypatch.setattr(pc._proc, "pid_alive", lambda pid: True)
+    import _proc
+
+    monkeypatch.setattr(_proc, "pid_alive", lambda pid: True)
+    monkeypatch.setattr(pc, "_candidate_host_pids", lambda: {999_999})
+    assert pc.resolve_host_key_outside_hook("/elsewhere") == (HOST, "host_pid")
+
+
+# ── status line ────────────────────────────────────────────────────────────
+
+
+def test_statusline_reads_record_dataset(suite, statusline, temp_home, monkeypatch):
+    sessions = temp_home / ".cognee-plugin" / suite.state_subdir / "sessions"
+    sessions.mkdir(parents=True)
+    (sessions / f"{HOST}.json").write_text(
+        json.dumps({"session_id": "s", "dataset": "from-record", "switched_at": "2026-01-01"})
+    )
+    monkeypatch.setenv("COGNEE_PLUGIN_DATASET", "from-env")
+    assert statusline._active_dataset(HOST) == "from-record"
+    assert "switched" in statusline._switched_marker(HOST)
+    # another launch, or no host id: env still rules and no marker
+    assert statusline._active_dataset("unknown-host") == "from-env"
+    assert statusline._switched_marker("unknown-host") == ""
+    assert statusline._active_dataset("../evil") == "from-env"  # path-unsafe id ignored

--- a/integrations/tests/utils/identity_fake.py
+++ b/integrations/tests/utils/identity_fake.py
@@ -170,8 +170,28 @@ class IdentityFake:
         }
         return 200, {"agent": agent}
 
+    @property
+    def principal_id(self) -> str:
+        """The user id the authenticated key resolves to (mirrors connections/me)."""
+        owner = next(iter(self.users), "")
+        return str(self.users.get(owner, {}).get("id", "user"))
+
+    def seed_dataset(self, name: str, owner_id: str | None = None) -> dict[str, str]:
+        """Pre-create a dataset; ``owner_id`` other than the principal makes it
+        readable-but-not-writable for the plugin (the switch must hide it)."""
+        self.datasets[name] = {
+            "id": self._new_id("ds"),
+            "name": name,
+            "ownerId": owner_id if owner_id is not None else self.principal_id,
+        }
+        return self.datasets[name]
+
     def datasets_create(self, name: str) -> tuple[int, dict[str, Any]]:
         new = name not in self.datasets
         if new:
-            self.datasets[name] = {"id": self._new_id("ds"), "name": name}
+            self.seed_dataset(name)
         return (201 if new else 200), self.datasets[name]
+
+    def datasets_list(self) -> tuple[int, list[dict[str, Any]]]:
+        """GET /datasets: every seeded dataset, camelCase like the real OutDTO."""
+        return 200, [dict(d) for d in self.datasets.values()]

--- a/integrations/tests/utils/mock_cognee.py
+++ b/integrations/tests/utils/mock_cognee.py
@@ -201,6 +201,7 @@ class MockCogneeServer:
         route("/api/v1/recall", "POST", self._recall)
         route("/api/v1/improve", "POST", self._improve)
         route("/api/v1/datasets", "POST", self._datasets)
+        route("/api/v1/datasets", "GET", self._datasets_list)
         route("/api/v1/datasets/status", "GET", self._datasets_status)
 
         # cloud platform (billing)
@@ -286,6 +287,13 @@ class MockCogneeServer:
         self._record(req)
         body_in = req.get_json(silent=True) or {}
         status, body = self.identity.datasets_create(body_in.get("name", "default"))
+        return _json(status, body)
+
+    def _datasets_list(self, req: Request) -> Response:
+        """GET /api/v1/datasets — every dataset the principal can read, camelCase
+        on the wire like the real OutDTO (``ownerId``)."""
+        self._record(req)
+        status, body = self.identity.datasets_list()
         return _json(status, body)
 
     def _datasets_status(self, req: Request) -> Response:


### PR DESCRIPTION
## Switch datasets mid-session (`cognee-switch-datasets`) — Claude Code + Codex

Adds a way to move a running session to another Cognee dataset without restarting the host.

### What
- **New skill + script** `switch-dataset.py` (both plugins):
  - `--list` shows datasets the principal can *write* to (owned by the API-key user, from `GET /api/v1/datasets`); read-only ones are counted, never offered. Claude picks via `AskUserQuestion`, Codex via a numbered list.
  - `<name>` runs the switch: sync the current session (`sync-session-to-graph.py --strict`, aborts on failure; `--force` to override) → ensure target dataset → **register a new Cognee session under a fresh connection handle → unregister the old one** (this order keeps a local agent-mode server from ever seeing zero connections) → repoint the launch record → restart the idle watcher.
- **Launch record is now the source of truth for the active dataset** (`sessions/<host id>.json`: `dataset`, per-session `conn_uuid`, `switched_at`, `touched` triples). `get_dataset`, `load_resolved`, the shell wrappers, idle/exit watchers and both status lines read it; a switch survives resume and beats an exported `COGNEE_SESSION_ID`.
- **Final sync covers every touched session/dataset pair** and releases every handle, so writes racing a switch aren't lost.
- Status line shows the recorded dataset plus `· switched`.

### Notes
- Dataset owner comes over the wire as `ownerId` (camelCase); servers without an owner field fall back to "unverified — show all readable".
- Versions: `cognee-memory` 1.3.3 → 1.4.0, Codex plugin 1.4.3 → 1.5.0. READMEs and CHANGELOGs updated.

### Testing
- New unit + integration tests (record schema/precedence, writable filter, register→unregister ordering, abort/rollback paths, final-sync targets); mock server gained `GET /api/v1/datasets`.
- Full hermetic suite: 1020 passed. Verified live against a local server: switch, second switch, status line, cleanup.