### PR TITLE
fix: exit-watcher re-probes to check server status

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "author": {
         "name": "Cognee"
       },

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": {
     "name": "Cognee"
   },

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -12,6 +12,20 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.4.1]
 
+### Fixed
+- **Status line: a stale red ✕ now heals itself while you are idle.** Recovery
+  from a recorded failure verdict (`unreachable`, `server_error`,
+  `not_responding`, `auth_failed`) was prompt-driven: nothing re-checked the
+  shared marker until a hook ran, so a server that came back while the terminal
+  sat idle kept a red glyph on the bar for up to the 30-minute fade — long
+  enough to tempt a needless restart. The session-long exit watcher now
+  re-probes about once a minute (`COGNEE_CONN_REPROBE_INTERVAL`) while, and
+  only while, the marker holds a failure state for this session's own
+  `base_url`, and writes `ready` on success. Only a positive verdict is ever
+  written — timeouts stay no-verdict, so this can clear a wrong red but never
+  paint one — and `auth_failed` clears only on an authenticated success, since
+  `/health` answering 200 says nothing about the key.
+
 ### Changed
 - **Status line: memory hits in plain words, plus a per-session total.** The
   `recall 4s/5t/0g/1a · saved 2p/41t/2a` strip is replaced by

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -13,6 +13,12 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ## [1.4.1]
 
 ### Fixed
+- **Cloud: creating a dataset through the API no longer fails on a redirect.**
+  Cloud tenants answer `POST /api/v1/datasets` with a 307 to the trailing-slash
+  path, and the stdlib HTTP client will not replay a POST body across a 307, so
+  ensuring the target dataset (setup, and switching datasets mid-session) failed
+  against cloud with a redirect status. The client now posts to
+  `/api/v1/datasets/` directly.
 - **Status line: a stale red ✕ now heals itself while you are idle.** Recovery
   from a recorded failure verdict (`unreachable`, `server_error`,
   `not_responding`, `auth_failed`) was prompt-driven: nothing re-checked the

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,9 +10,21 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.4.1]
+## [1.4.2]
 
 ### Fixed
+- **Recall no longer reports an error for a graph that simply doesn't exist yet.**
+  A dataset nobody has cognified yet has no graph, and the server answers the
+  graph recall scope with 404 until the first sync lands — on a fresh install
+  that is every prompt of the first session. That expected answer was logged as
+  `recall_error` and counted against connection health alongside real failures.
+  It is now logged as `recall_graph_not_built` (debug, not error) and kept out
+  of the health accounting, so genuine failures stay visible.
+- **The pending-prompt buffer no longer leaves an empty file behind per session.**
+  Consuming the last buffered prompt wrote `{}` back instead of removing the
+  file, so `pending/` collected one 2-byte husk per session forever. The buffer
+  file is now deleted when its last entry is consumed, and the session-start
+  sweep clears the husks older versions already left.
 - **Cloud: creating a dataset through the API no longer fails on a redirect.**
   Cloud tenants answer `POST /api/v1/datasets` with a 307 to the trailing-slash
   path, and the stdlib HTTP client will not replay a POST body across a 307, so
@@ -31,6 +43,8 @@ project adheres to [Semantic Versioning](https://semver.org/).
   written — timeouts stay no-verdict, so this can clear a wrong red but never
   paint one — and `auth_failed` clears only on an authenticated success, since
   `/health` answering 200 says nothing about the key.
+
+## [1.4.1]
 
 ### Changed
 - **Status line: memory hits in plain words, plus a per-session total.** The

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -313,7 +313,7 @@ async def ensure_dataset_ready_via_api(service_url: str, api_key: str, dataset: 
 
     base = service_url.rstrip("/")
     status, text = _cloud_http_request(
-        f"{base}/api/v1/datasets",
+        f"{base}/api/v1/datasets/",  # trailing slash: cloud tenants 307-redirect the bare path
         method="POST",
         api_key=api_key,
         json_body={"name": dataset},

--- a/integrations/claude-code/scripts/exit-watcher.py
+++ b/integrations/claude-code/scripts/exit-watcher.py
@@ -115,6 +115,85 @@ def _refresh_credits_marker(service_url: str) -> None:
         _log("credits_check_error", error=str(exc)[:200])
 
 
+# Connection self-heal. Recovery of a red status-line verdict is
+# otherwise prompt-driven: once the shared marker says unreachable /
+# server_error / not_responding / auth_failed, nothing re-checks it until a
+# hook runs, so a server that recovers while the user is idle leaves a stale
+# ✕ on the bar for up to the renderer's 30-minute fade. This process lives as
+# long as the host session (see _refresh_credits_marker), so it is the right
+# place for a slow background re-probe.
+_CONN_REPROBE_STATES = ("unreachable", "server_error", "not_responding", "auth_failed")
+_last_conn_reprobe_at = 0.0
+
+
+def _conn_reprobe_interval() -> float:
+    try:
+        return float(os.environ.get("COGNEE_CONN_REPROBE_INTERVAL", "") or 60.0)
+    except ValueError:
+        return 60.0
+
+
+def _reprobe_connection(service_url: str, api_key: str = "") -> None:
+    """Re-probe a recorded failure state and mark ready if the server is back.
+
+    Contract, in order:
+      * Only acts while the shared marker holds a failure state — a healthy or
+        absent marker costs one file read and nothing else.
+      * Same-base_url guard: the marker is machine-wide (Claude and Codex, local
+        and cloud, share it), so a verdict about a different server than this
+        session's is not ours to overwrite.
+      * Throttled to one probe per interval (default 60s) per watcher process.
+      * ONLY a positive "ready" is ever written. Timeouts / unknown are no
+        verdict and leave the marker untouched — the re-probe can heal a wrong
+        red but can never paint one.
+      * auth_failed heals only on an AUTHENTICATED success: /health answering
+        200 says nothing about the key. Other failure states heal on either
+        probe, with the authed one preferred because it is the stronger signal.
+    """
+    global _last_conn_reprobe_at
+    try:
+        from _plugin_common import (
+            _local_api_url,
+            _normalize_service_url,
+            authed_liveness,
+            mark_server_ready,
+            probe_health,
+            read_connection_state,
+        )
+
+        marker = read_connection_state()
+        state = str(marker.get("state") or "")
+        if state not in _CONN_REPROBE_STATES:
+            return
+        base_url = _normalize_service_url(str(service_url or "") or _local_api_url())
+        if not base_url:
+            return
+        marker_url = _normalize_service_url(str(marker.get("base_url") or ""))
+        if marker_url and marker_url != base_url:
+            return  # someone else's server
+        now = time.time()
+        last_seen = max(_last_conn_reprobe_at, float(marker.get("checked_at", 0) or 0))
+        if now - last_seen < _conn_reprobe_interval():
+            return
+        _last_conn_reprobe_at = now
+
+        verdict = authed_liveness(base_url, api_key, timeout=2.0)
+        authed = verdict != "unknown"
+        if not authed:
+            verdict = probe_health(base_url, timeout=2.0)
+        if verdict != "ready":
+            _log("connection_reprobe_no_heal", state=state, verdict=verdict, base_url=base_url)
+            return
+        if state == "auth_failed" and not authed:
+            # /health is unauthenticated: a 200 cannot clear an auth verdict.
+            _log("connection_reprobe_no_heal", state=state, verdict="ready_unauthed")
+            return
+        mark_server_ready(base_url)
+        _log("connection_self_healed", prior=state, base_url=base_url, authed=authed)
+    except Exception as exc:
+        _log("connection_reprobe_error", error=str(exc)[:200])
+
+
 def main() -> None:
     if len(sys.argv) < 2:
         _log("fatal_missing_args")
@@ -173,6 +252,8 @@ def main() -> None:
     while _owns_pidfile(pidfile) and _pid_alive(parent_pid):
         # Session-long steady-state credits refresh (throttled internally).
         _refresh_credits_marker(service_url)
+        # Self-heal a stale red connection verdict (throttled internally).
+        _reprobe_connection(service_url, api_key)
         time.sleep(_POLL_SECONDS)
 
     if not _owns_pidfile(pidfile):

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -13,6 +13,12 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ## [1.5.1]
 
 ### Fixed
+- **Cloud: creating a dataset through the API no longer fails on a redirect.**
+  Cloud tenants answer `POST /api/v1/datasets` with a 307 to the trailing-slash
+  path, and the stdlib HTTP client will not replay a POST body across a 307, so
+  ensuring the target dataset (setup, and switching datasets mid-session) failed
+  against cloud with a redirect status. The client now posts to
+  `/api/v1/datasets/` directly.
 - **Status line: a stale red ✕ now heals itself while you are idle.** Recovery
   from a recorded failure verdict (`unreachable`, `server_error`,
   `not_responding`, `auth_failed`) was prompt-driven: nothing re-checked the

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,9 +10,21 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.5.1]
+## [1.5.2]
 
 ### Fixed
+- **Recall no longer reports an error for a graph that simply doesn't exist yet.**
+  A dataset nobody has cognified yet has no graph, and the server answers the
+  graph recall scope with 404 until the first sync lands — on a fresh install
+  that is every prompt of the first session. That expected answer was logged as
+  `recall_error` and counted against connection health alongside real failures.
+  It is now logged as `recall_graph_not_built` (debug, not error) and kept out
+  of the health accounting, so genuine failures stay visible.
+- **The pending-prompt buffer no longer leaves an empty file behind per session.**
+  Consuming the last buffered prompt wrote `{}` back instead of removing the
+  file, so `pending/` collected one 2-byte husk per session forever. The buffer
+  file is now deleted when its last entry is consumed, and the session-start
+  sweep clears the husks older versions already left.
 - **Cloud: creating a dataset through the API no longer fails on a redirect.**
   Cloud tenants answer `POST /api/v1/datasets` with a 307 to the trailing-slash
   path, and the stdlib HTTP client will not replay a POST body across a 307, so
@@ -31,6 +43,8 @@ project adheres to [Semantic Versioning](https://semver.org/).
   written — timeouts stay no-verdict, so this can clear a wrong red but never
   paint one — and `auth_failed` clears only on an authenticated success, since
   `/health` answering 200 says nothing about the key.
+
+## [1.5.1]
 
 ### Changed
 - **Memory header in plain words, plus a per-session total.** The

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -12,6 +12,20 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.5.1]
 
+### Fixed
+- **Status line: a stale red ✕ now heals itself while you are idle.** Recovery
+  from a recorded failure verdict (`unreachable`, `server_error`,
+  `not_responding`, `auth_failed`) was prompt-driven: nothing re-checked the
+  shared marker until a hook ran, so a server that came back while the terminal
+  sat idle kept a red glyph on the bar for up to the 30-minute fade — long
+  enough to tempt a needless restart. The session-long exit watcher now
+  re-probes about once a minute (`COGNEE_CONN_REPROBE_INTERVAL`) while, and
+  only while, the marker holds a failure state for this session's own
+  `base_url`, and writes `ready` on success. Only a positive verdict is ever
+  written — timeouts stay no-verdict, so this can clear a wrong red but never
+  paint one — and `auth_failed` clears only on an authenticated success, since
+  `/health` answering 200 says nothing about the key.
+
 ### Changed
 - **Memory header in plain words, plus a per-session total.** The
   `Cognee memory: recall 4 session / 5 trace / 0 graph / 1 agent; saved …` line

--- a/integrations/codex/plugins/cognee/scripts/config.py
+++ b/integrations/codex/plugins/cognee/scripts/config.py
@@ -301,7 +301,7 @@ async def ensure_dataset_ready_via_api(service_url: str, api_key: str, dataset: 
 
     base = service_url.rstrip("/")
     status, text = _cloud_http_request(
-        f"{base}/api/v1/datasets",
+        f"{base}/api/v1/datasets/",  # trailing slash: cloud tenants 307-redirect the bare path
         method="POST",
         api_key=api_key,
         json_body={"name": dataset},

--- a/integrations/codex/plugins/cognee/scripts/exit-watcher.py
+++ b/integrations/codex/plugins/cognee/scripts/exit-watcher.py
@@ -115,6 +115,85 @@ def _refresh_credits_marker(service_url: str) -> None:
         _log("credits_check_error", error=str(exc)[:200])
 
 
+# Connection self-heal. Recovery of a red status-line verdict is
+# otherwise prompt-driven: once the shared marker says unreachable /
+# server_error / not_responding / auth_failed, nothing re-checks it until a
+# hook runs, so a server that recovers while the user is idle leaves a stale
+# ✕ on the bar for up to the renderer's 30-minute fade. This process lives as
+# long as the host session (see _refresh_credits_marker), so it is the right
+# place for a slow background re-probe.
+_CONN_REPROBE_STATES = ("unreachable", "server_error", "not_responding", "auth_failed")
+_last_conn_reprobe_at = 0.0
+
+
+def _conn_reprobe_interval() -> float:
+    try:
+        return float(os.environ.get("COGNEE_CONN_REPROBE_INTERVAL", "") or 60.0)
+    except ValueError:
+        return 60.0
+
+
+def _reprobe_connection(service_url: str, api_key: str = "") -> None:
+    """Re-probe a recorded failure state and mark ready if the server is back.
+
+    Contract, in order:
+      * Only acts while the shared marker holds a failure state — a healthy or
+        absent marker costs one file read and nothing else.
+      * Same-base_url guard: the marker is machine-wide (Claude and Codex, local
+        and cloud, share it), so a verdict about a different server than this
+        session's is not ours to overwrite.
+      * Throttled to one probe per interval (default 60s) per watcher process.
+      * ONLY a positive "ready" is ever written. Timeouts / unknown are no
+        verdict and leave the marker untouched — the re-probe can heal a wrong
+        red but can never paint one.
+      * auth_failed heals only on an AUTHENTICATED success: /health answering
+        200 says nothing about the key. Other failure states heal on either
+        probe, with the authed one preferred because it is the stronger signal.
+    """
+    global _last_conn_reprobe_at
+    try:
+        from _plugin_common import (
+            _local_api_url,
+            _normalize_service_url,
+            authed_liveness,
+            mark_server_ready,
+            probe_health,
+            read_connection_state,
+        )
+
+        marker = read_connection_state()
+        state = str(marker.get("state") or "")
+        if state not in _CONN_REPROBE_STATES:
+            return
+        base_url = _normalize_service_url(str(service_url or "") or _local_api_url())
+        if not base_url:
+            return
+        marker_url = _normalize_service_url(str(marker.get("base_url") or ""))
+        if marker_url and marker_url != base_url:
+            return  # someone else's server
+        now = time.time()
+        last_seen = max(_last_conn_reprobe_at, float(marker.get("checked_at", 0) or 0))
+        if now - last_seen < _conn_reprobe_interval():
+            return
+        _last_conn_reprobe_at = now
+
+        verdict = authed_liveness(base_url, api_key, timeout=2.0)
+        authed = verdict != "unknown"
+        if not authed:
+            verdict = probe_health(base_url, timeout=2.0)
+        if verdict != "ready":
+            _log("connection_reprobe_no_heal", state=state, verdict=verdict, base_url=base_url)
+            return
+        if state == "auth_failed" and not authed:
+            # /health is unauthenticated: a 200 cannot clear an auth verdict.
+            _log("connection_reprobe_no_heal", state=state, verdict="ready_unauthed")
+            return
+        mark_server_ready(base_url)
+        _log("connection_self_healed", prior=state, base_url=base_url, authed=authed)
+    except Exception as exc:
+        _log("connection_reprobe_error", error=str(exc)[:200])
+
+
 def main() -> None:
     if len(sys.argv) < 2:
         _log("fatal_missing_args")
@@ -173,6 +252,8 @@ def main() -> None:
     while _owns_pidfile(pidfile) and _pid_alive(parent_pid):
         # Session-long steady-state credits refresh (throttled internally).
         _refresh_credits_marker(service_url)
+        # Self-heal a stale red connection verdict (throttled internally).
+        _reprobe_connection(service_url, api_key)
         time.sleep(_POLL_SECONDS)
 
     if not _owns_pidfile(pidfile):

--- a/integrations/tests/tests/unit/test_exit_watcher_connection_reprobe.py
+++ b/integrations/tests/tests/unit/test_exit_watcher_connection_reprobe.py
@@ -1,0 +1,143 @@
+"""Regression tests for the exit-watcher's connection self-heal.
+
+Status-line recovery from a failure verdict is otherwise prompt-driven: once
+``server-ready.json`` says unreachable / server_error / not_responding /
+auth_failed, nothing re-checks it until a hook runs, so a server that recovers
+while the user is idle leaves a stale red ✕ for up to the renderer's 30-minute
+fade. The exit-watcher is the only plugin process whose lifetime matches the
+host session, so it hosts a throttled background re-probe. These pin the
+contract: only failure states are probed; only this session's base_url; only a
+positive "ready" is ever written; auth_failed heals only on an authenticated
+success; timeouts are no verdict.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+_URL = "http://localhost:8011"
+_OTHER_URL = "https://tenant-f8c21da4-6674-4cc5-bc56-de5e93db881d.aws.cognee.ai"
+
+
+@pytest.fixture
+def drive(suite, hook_module, isolated_modules, monkeypatch):
+    """Run _reprobe_connection with patched seams; return what it did.
+
+    Same load-order caveat as the credits tests: the watcher imports
+    _plugin_common function-locally, so load the watcher first and then a fresh
+    _plugin_common — the late import binds to that same sys.modules entry.
+    """
+
+    def _drive(*, marker, authed="unknown", health="unknown", service_url=_URL, api_key="k"):
+        watcher = hook_module(suite, "exit-watcher.py")
+        pc = isolated_modules(suite, "_plugin_common")
+        monkeypatch.setattr(watcher, "_log", lambda *a, **k: None)
+        monkeypatch.setattr(watcher, "_last_conn_reprobe_at", 0.0)
+
+        calls = {"authed": 0, "health": 0, "ready": []}
+
+        def _authed(url, key, timeout=0):
+            calls["authed"] += 1
+            return authed
+
+        def _health(url, timeout=0):
+            calls["health"] += 1
+            return health
+
+        monkeypatch.setattr(pc, "read_connection_state", lambda: dict(marker))
+        monkeypatch.setattr(pc, "authed_liveness", _authed)
+        monkeypatch.setattr(pc, "probe_health", _health)
+        monkeypatch.setattr(
+            pc, "mark_server_ready", lambda url, version="": calls["ready"].append(url)
+        )
+        watcher._reprobe_connection(service_url, api_key)
+        return calls
+
+    return _drive
+
+
+def _stale(state, url=_URL):
+    return {"state": state, "base_url": url, "checked_at": time.time() - 120}
+
+
+def test_ready_marker_is_not_probed(drive):
+    calls = drive(marker=_stale("ready"), authed="ready")
+    assert calls["authed"] == 0 and calls["health"] == 0 and calls["ready"] == []
+
+
+def test_empty_marker_is_not_probed(drive):
+    calls = drive(marker={}, authed="ready")
+    assert calls["authed"] == 0 and calls["ready"] == []
+
+
+@pytest.mark.parametrize("state", ["unreachable", "server_error", "not_responding"])
+def test_failure_state_heals_on_authed_ready(drive, state):
+    calls = drive(marker=_stale(state), authed="ready")
+    assert calls["ready"] == [_URL]
+    assert calls["health"] == 0  # authed verdict was conclusive; no fallback
+
+
+@pytest.mark.parametrize("state", ["unreachable", "server_error", "not_responding"])
+def test_failure_state_heals_on_unauthed_health_when_no_key(drive, state):
+    # authed_liveness returns "unknown" without a key → fall back to /health.
+    calls = drive(marker=_stale(state), authed="unknown", health="ready", api_key="")
+    assert calls["ready"] == [_URL]
+
+
+def test_auth_failed_heals_only_on_authenticated_success(drive):
+    healed = drive(marker=_stale("auth_failed"), authed="ready")
+    assert healed["ready"] == [_URL]
+    unauthed = drive(marker=_stale("auth_failed"), authed="unknown", health="ready")
+    assert unauthed["ready"] == []  # /health 200 says nothing about the key
+
+
+@pytest.mark.parametrize(
+    "verdict", ["slow", "unknown", "unreachable", "server_error", "auth_failed"]
+)
+def test_non_ready_verdict_writes_nothing(drive, verdict):
+    # The re-probe may heal a red, never paint or re-stamp one.
+    calls = drive(marker=_stale("unreachable"), authed=verdict, health="slow")
+    assert calls["ready"] == []
+
+
+def test_other_base_url_is_left_alone(drive):
+    # The marker is machine-wide; a cloud session must not clear a local verdict.
+    calls = drive(marker=_stale("unreachable", url=_OTHER_URL), authed="ready")
+    assert calls["authed"] == 0 and calls["ready"] == []
+
+
+def test_trailing_slash_does_not_defeat_url_guard(drive):
+    calls = drive(marker=_stale("unreachable", url=_URL + "/"), authed="ready")
+    assert calls["ready"] == [_URL]
+
+
+def test_fresh_marker_is_throttled(drive):
+    fresh = {"state": "unreachable", "base_url": _URL, "checked_at": time.time()}
+    calls = drive(marker=fresh, authed="ready")
+    assert calls["authed"] == 0 and calls["ready"] == []
+
+
+def test_recent_probe_is_throttled(suite, hook_module, isolated_modules, monkeypatch):
+    watcher = hook_module(suite, "exit-watcher.py")
+    pc = isolated_modules(suite, "_plugin_common")
+    monkeypatch.setattr(watcher, "_log", lambda *a, **k: None)
+    monkeypatch.setattr(watcher, "_last_conn_reprobe_at", time.time() - 5)
+    monkeypatch.setattr(pc, "read_connection_state", lambda: _stale("unreachable"))
+    probed = []
+    monkeypatch.setattr(pc, "authed_liveness", lambda *a, **k: probed.append(1) or "ready")
+    monkeypatch.setattr(pc, "mark_server_ready", lambda *a, **k: probed.append("ready"))
+    watcher._reprobe_connection(_URL, "k")
+    assert probed == []
+
+
+def test_empty_bootstrap_falls_back_to_local_default(drive, isolated_modules, suite):
+    # No bootstrap URL → the plugin's local default; the marker must match it.
+    pc = isolated_modules(suite, "_plugin_common")
+    local = pc._normalize_service_url(pc._local_api_url())
+    assert local
+    healed = drive(marker=_stale("unreachable", url=local), authed="ready", service_url="")
+    assert healed["ready"] == [local]
+    other = drive(marker=_stale("unreachable", url=_OTHER_URL), authed="ready", service_url="")
+    assert other["ready"] == []

--- a/integrations/tests/utils/mock_cognee.py
+++ b/integrations/tests/utils/mock_cognee.py
@@ -33,6 +33,11 @@ def _json(status: int, body: Any) -> Response:
     return Response(json.dumps(body), status=status, content_type="application/json")
 
 
+def _norm_path(path: str) -> str:
+    """Canonical request path: trailing slash dropped (except for the root)."""
+    return path.rstrip("/") or "/"
+
+
 class MockCogneeServer:
     """Registers Cognee routes on a pytest-httpserver ``HTTPServer``.
 
@@ -140,14 +145,14 @@ class MockCogneeServer:
         JSON-encoded. The request is still recorded. Clear with
         ``clear_forced``.
         """
-        self._forced[(method, path)] = (status, body if body is not None else {})
+        self._forced[(method, _norm_path(path))] = (status, body if body is not None else {})
 
     def clear_forced(self, method: str | None = None, path: str | None = None) -> None:
         """Drop forced responses (all of them, or one method+path pair)."""
         if method is None and path is None:
             self._forced.clear()
         else:
-            self._forced.pop((method, path), None)
+            self._forced.pop((method, _norm_path(path)), None)
 
     def assert_called(self, method: str, path: str, **json_fields: Any) -> dict[str, Any]:
         """Assert a matching request was recorded; return the call entry.
@@ -176,7 +181,9 @@ class MockCogneeServer:
     def _record(self, req: Request) -> None:
         entry: dict[str, Any] = {
             "method": req.method,
-            "path": req.path,
+            # Trailing slash normalized: clients may send either spelling (see the
+            # POST /api/v1/datasets route), tests key on the bare path.
+            "path": _norm_path(req.path),
             "query": dict(req.args),
             "headers": dict(req.headers),
         }
@@ -199,7 +206,7 @@ class MockCogneeServer:
 
         def route(uri, method, handler):
             def dispatch(req: Request, _handler=handler) -> Response:
-                forced = self._forced.get((req.method, req.path))
+                forced = self._forced.get((req.method, _norm_path(req.path)))
                 if forced is not None:
                     self._record(req)
                     status, body = forced
@@ -231,7 +238,10 @@ class MockCogneeServer:
         route("/api/v1/remember/entry", "POST", self._remember_entry)
         route("/api/v1/recall", "POST", self._recall)
         route("/api/v1/improve", "POST", self._improve)
-        route("/api/v1/datasets", "POST", self._datasets)
+        # POST accepts both spellings: the clients send the trailing slash because
+        # cloud tenants 307-redirect the bare path, and urllib will not replay a
+        # POST across a 307.
+        route(re.compile(r"^/api/v1/datasets/?$"), "POST", self._datasets)
         route("/api/v1/datasets", "GET", self._datasets_list)
         route("/api/v1/datasets/status", "GET", self._datasets_status)
 


### PR DESCRIPTION
Server health wasn't re-probed correctly, so a failed server state was in the statusline even when the server became healthy, since the next probe always came at prompt time. This PR makes the exit-watcher probe the server, which fixes the issue.