### PR TITLE
feat: update hermes to 1.5.3; add dataset-switch, forget, recall scopes, code graph

### DIFF
--- a/integrations/hermes-agent/CHANGELOG.md
+++ b/integrations/hermes-agent/CHANGELOG.md
@@ -10,6 +10,109 @@ The version must match the `version` field in both `pyproject.toml` and
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.0]
+
+Parity release: brings the Hermes plugin up to the claude-code/codex
+integrations (and the OpenClaw 2026.8.27 parity release) on every user-facing
+memory operation, expressed the way Hermes consumes capabilities — as memory
+provider tools plus `hermes cognee` CLI commands.
+
+### Added
+
+- **Recall session layers.** The per-prompt recall used a single
+  `scope: auto` call, and with `datasets` + an explicit `search_type` in the
+  request the server resolves that to graph-only — so cached Q&A turns,
+  tool-call trace lessons and distilled agent guidance never reached the
+  prompt. Recall now fans out one bounded call per scope, cheap lanes first
+  (`session → trace → session_context → graph`, the graph lane on
+  `HYBRID_COMPLETION` with `only_context`), each rendered as its own block
+  (`<session_memory>`, `<trace_lessons>`, `<agent_guidance>`,
+  `<graph_memory>`), under a shared budget (`COGNEE_RECALL_BUDGET`, 20s) so a
+  slow graph search can never starve the cheap lanes. A failure in one lane
+  never discards the others; a 404 on the graph lane (dataset not yet
+  cognified — routine on a fresh install) is benign, not a breaker failure.
+  The `cognee_recall` tool's `scope=session` now covers all three session
+  layers. Opt out with `COGNEE_RECALL_LAYERS=false`.
+- **Per-document forget.** `cognee_forget` is now two-phase and user-directed
+  ("forget what we said about tennis"): `action=find` lists candidate
+  documents with raw-text previews and matched terms; `action=forget` deletes
+  only the listed `data_ids`, one `POST /forget` (`datasetId`/`dataId`) each,
+  and only with `confirm=true`. Ids are validated as UUIDs before they touch a
+  request; whole-dataset deletion requires an explicit
+  `everything_in_dataset=true`, and the all-datasets wipe is not expressible
+  from the tool by construction. Targeted session-cache invalidation on delete
+  needs cognee >= 1.5.3.
+- **`cognee_switch_dataset` tool** — move one conversation to another dataset:
+  `list` / `current` / `switch` / `reset`. A switch flushes the pending turn,
+  bridges the current session into its old dataset (`improve` on the server's
+  background pipeline — strict: it aborts on failure unless `force=true`, in
+  which case the un-bridged session is recorded and re-submitted at session
+  end), ensures the target, then re-points capture, recall and the session-end
+  improve (and the crash-safe exit watcher) under a fresh cognee session id
+  (`hermes_<id>__N`). Overrides persist per conversation in
+  `~/.cognee-plugin/hermes/dataset-overrides.json` and are re-applied when the
+  same Hermes session initializes again. `COGNEE_DATASET_SWITCH_TOOL=false`
+  removes the tool.
+- **Code graph.** `hermes cognee index-repo <path|url> [--dataset]
+  [--index-vectors] [--wait <s>]` indexes a repository into cognee's
+  deterministic code graph (enola pipeline, no LLM/embedding calls, one
+  `codebase-<repo>-<digest>` dataset per repo — the path digest keeps
+  same-basename checkouts from sharing a graph); `cognee_code_search` answers
+  structural questions exactly (`query_facts`, `explore`, `traverse`,
+  `find_path`, `impact_analysis`, `delta`); an additive `code` recall lane
+  fires only when a prompt names an identifier-shaped token AND the launch
+  directory sits inside an indexed repo (or `COGNEE_CODE_DATASETS` names one).
+  Autoindex and per-turn re-ingest are deliberately not ported — Hermes is
+  rarely launched inside a checkout (the OpenClaw plugin made the same call).
+  Indexed repos are recorded under `~/.cognee-plugin/hermes/code-graph/`.
+  Requires cognee >= 1.5.3. `COGNEE_CODE_SEARCH_TOOL` / `COGNEE_CODE_GRAPH_RECALL`
+  opt out.
+- **Memory steer.** The system-prompt block now asserts Cognee as the
+  preferred, authoritative long-term memory over Hermes' built-in memory — the
+  counterpart of claude-code's `COGNEE_PREFER_MEMORY` and openclaw's
+  `memorySteer`. `COGNEE_MEMORY_STEER=false` disables it,
+  `COGNEE_MEMORY_STEER_TEXT` replaces the wording.
+- **Memory-hit visibility.** The injected recall block opens with plain words
+  on what memory just did — `4 memory hits this turn (2 beyond this session) ·
+  3/7 turns had hits this session` — with per-session totals that reset when a
+  conversation resets. `COGNEE_MEMORY_HITS=false` hides it.
+- **Version display + update check.** `hermes cognee version`, and both it and
+  `hermes cognee status` now carry an "update available" hint from a
+  rate-limited, fail-silent PyPI check (cached in
+  `~/.cognee-plugin/hermes/update-check.json`; `COGNEE_UPDATE_CHECK`,
+  `COGNEE_UPDATE_CHECK_INTERVAL`, `--check-updates` forces a live check).
+  CLI-only — the session path never checks. The nudge stays two-step on
+  purpose: `pip install -U` then `cognee-hermes-install`, because Hermes runs
+  the installed copy.
+
+### Changed
+
+- **Breaking — cognee is now pinned to exactly 1.5.3** (`cognee==1.5.3`; the
+  repo's pin checker accepts exact pins as bounding both sides). The installed
+  package doubles as the local server this plugin spawns, and this release's
+  features set a hard floor there: `content_type="code"` repo indexing, the
+  `code` recall scope, and targeted session invalidation on document delete
+  all first shipped in 1.5.3, so a 1.4.x resolve would silently strip the code
+  graph and let a later sync re-persist forgotten content. The claude-code,
+  codex and openclaw plugins pin their server to exactly 1.5.3 for the same
+  reason; a *remote* server (`COGNEE_BASE_URL`) is unaffected by the pin but
+  needs >= 1.5.3 for the same features, and an older one now gets clear
+  errors on the code paths instead of quiet degradation.
+- The HTTP transport grew the endpoints the new features stand on:
+  `GET /datasets`, `GET /datasets/{id}/data`, `GET /datasets/{id}/data/{id}/raw`,
+  single-document `POST /forget`, code indexing via `POST /remember`
+  (`content_type=code`), `GET /datasets/status`, and `recall` now carries
+  `scope` lists, `context_profile`, `code_query` and `only_context`. The SDK
+  transport reports these operations as HTTP-only instead of failing obscurely.
+
+### Known limitations
+
+- Turns from the live conversation become deletable documents only after the
+  session is bridged to the graph; `cognee_forget` says so in its envelope.
+- The dataset listing in `cognee_switch_dataset` cannot tell read-only
+  datasets apart client-side; a switch to one fails at the ensure step with a
+  clear error instead.
+
 ## [1.1.0]
 
 Hardens the plugin against silently corrupted search indexes with local Ollama

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -26,11 +26,22 @@ Python package with the `hermes_agent.plugins` entry point.
 ## Features
 
 - Stores each completed Hermes turn in Cognee session memory.
-- Uses `cognee_recall` for session-first recall with graph fallback.
-- Exposes `cognee_remember` for durable graph memory.
-- Exposes `cognee_forget` for deletion requests.
+- Recalls memory per prompt in layers — the session cache, tool-call trace
+  lessons, distilled agent guidance and the permanent graph — each injected as
+  its own labelled block, with a plain-words hit counter on top.
+- Uses `cognee_recall` for explicit search, `cognee_remember` for durable
+  graph memory.
+- Exposes `cognee_forget` for user-directed, per-document deletion ("forget
+  what we said about tennis"): find candidates with previews, then delete only
+  what the user confirms.
+- Exposes `cognee_switch_dataset` to move a conversation to another dataset
+  mid-session, bridging the session it leaves behind.
+- Indexes repositories into a deterministic code graph (`hermes cognee
+  index-repo`) and answers structural code questions exactly via
+  `cognee_code_search`, plus an identifier-gated code recall lane.
 - Runs `cognee.improve()` at Hermes session end to bridge session memory into the graph.
-- Mirrors explicit Hermes memory writes through `on_memory_write`.
+- Mirrors explicit Hermes memory writes through `on_memory_write`, and steers
+  the agent to prefer Cognee over Hermes' built-in memory files.
 - Supports local embedded Cognee and remote Cognee service mode.
 - Closes every session out of process, the way the other cognee plugins do: a
   detached worker bridges the session into the graph and only then unregisters
@@ -282,6 +293,17 @@ LLM_API_KEY=sk-...
 | `recall_timeout` | `COGNEE_RECALL_TIMEOUT` | `120` (seconds) |
 | `write_timeout` | `COGNEE_WRITE_TIMEOUT` | `120` (seconds) |
 | `improve_timeout` | `COGNEE_IMPROVE_TIMEOUT` | `300` (seconds) |
+| `recall_session_layers` | `COGNEE_RECALL_LAYERS` | `true` |
+| `recall_budget` | `COGNEE_RECALL_BUDGET` | `20` (seconds, bounds the per-prompt fan-out) |
+| `memory_steer` | `COGNEE_MEMORY_STEER` | `true` |
+| `memory_steer_text` | `COGNEE_MEMORY_STEER_TEXT` | built-in wording |
+| `memory_hits` | `COGNEE_MEMORY_HITS` | `true` |
+| `dataset_switch_tool` | `COGNEE_DATASET_SWITCH_TOOL` | `true` |
+| `code_search_tool` | `COGNEE_CODE_SEARCH_TOOL` | `true` |
+| `code_graph_recall` | `COGNEE_CODE_GRAPH_RECALL` | `true` |
+| `code_datasets` | `COGNEE_CODE_DATASETS` | empty (comma-separated extra code datasets) |
+| `update_check` | `COGNEE_UPDATE_CHECK` | `true` (CLI-only PyPI check) |
+| `update_check_interval` | `COGNEE_UPDATE_CHECK_INTERVAL` | `3600` (seconds) |
 
 > **Storage is shared, and a server is per port.** The roots above are the ones
 > every cognee agent plugin pins, so the store is the same no matter which plugin
@@ -362,16 +384,51 @@ an LLM per query, which local models make slow. `search_type=CHUNKS` returns
 matching stored text directly with no LLM in the loop; `COGNEE_RECALL_TIMEOUT`
 raises the deadline.
 
+## Code graph: index a repository
+
+Repositories are indexed explicitly (Hermes is rarely launched inside a
+checkout, so there is no auto-indexing):
+
+```bash
+hermes cognee index-repo ~/work/my-service            # local path
+hermes cognee index-repo https://github.com/o/repo    # URL (the server clones it)
+hermes cognee index-repo ~/work/my-service --wait 120 # block until queryable
+```
+
+Each repository gets its own `codebase-<repo>-<digest>` dataset. Indexing is
+deterministic — no LLM or embedding calls on either side (add semantic search
+over code entities with `--index-vectors`). Requires a cognee server >= 1.5.3.
+
+Once indexed, two things light up in a Hermes session:
+
+- the **`cognee_code_search` tool** — exact structural answers: `query_facts`,
+  `explore`, `traverse`, `find_path`, `impact_analysis`, `delta`;
+- the **code recall lane** — a prompt naming an identifier-shaped token
+  (`process_payment`, `UserService`, `billing/api.py`) while Hermes runs inside
+  an indexed repo gets code-graph facts injected alongside the memory layers.
+  For repos indexed elsewhere, list their datasets in `COGNEE_CODE_DATASETS`.
+
+A locally indexed path reflects the working tree at index time; a URL-indexed
+repo reflects the last pushed commit. Re-run `index-repo` after significant
+changes — the server's content hashes make re-runs cheap.
+
 ## Hermes Commands
 
 When Cognee is the active memory provider:
 
 ```bash
-hermes cognee status
+hermes cognee status [--check-updates]
+hermes cognee version [--check-updates]
 hermes cognee setup
 hermes cognee config
 hermes cognee install
+hermes cognee index-repo <path-or-url> [--dataset D] [--index-vectors] [--wait SECONDS]
 ```
+
+`status` and `version` include an update hint when PyPI has a newer release
+(checked at most once per `COGNEE_UPDATE_CHECK_INTERVAL`, never from a live
+session): update with `pip install -U cognee-integration-hermes-agent` and then
+`cognee-hermes-install`, since Hermes runs the installed copy.
 
 ## Development
 

--- a/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/plugin.yaml
+++ b/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/plugin.yaml
@@ -1,14 +1,14 @@
 name: cognee
 kind: exclusive
-version: 1.1.0
+version: 1.2.0
 description: "Cognee memory provider for Hermes Agent: session-aware graph memory, recall, forget, and session-end improvement."
 pip_dependencies:
-  # Floor 1.2.1: the HTTP wire contract this plugin depends on
-  # (/api/v1/remember/entry, improve(session_ids)) first shipped there.
-  # Cap 1.4.0: the newest version verified against the test suite and a live
-  # server boot. Repo policy (scripts/check_version_pins.py) requires a bounded
-  # range rather than an exact pin; the lockfile resolves to 1.4.0.
-  - cognee>=1.2.1,<=1.4.0
+  # Exact pin: the installed package doubles as the local server this plugin
+  # spawns, and 1.5.3 is both the floor — content_type="code" repo indexing,
+  # the "code" recall scope, and targeted session invalidation on document
+  # delete all first shipped there — and the newest version verified against
+  # the test suite and a live server.
+  - cognee==1.5.3
 hooks:
   - on_session_end
   - on_memory_write

--- a/integrations/hermes-agent/cognee_integration_hermes/backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/backend.py
@@ -95,11 +95,16 @@ class MemoryBackend:
         top_k: int,
         auto_route: bool,
         query_type: Optional[str],
-        scope: Optional[str] = None,
+        scope: Any = None,
+        context_profile: Optional[str] = None,
+        code_query: Optional[dict[str, Any]] = None,
+        only_context: bool = False,
         timeout: float,
     ) -> list[Any]:
         """Search memory. ``scope`` is the provider's routing decision by name —
-        ``session``, ``graph`` or ``auto`` — alongside the targets it implies.
+        ``session``, ``graph`` or ``auto``, or an explicit list of server scopes
+        (e.g. ``["session", "trace", "session_context"]``) — alongside the
+        targets it implies.
 
         A transport that can state the scope outright should say it rather than
         leave the server to infer it from which targets happen to be set: that
@@ -133,6 +138,48 @@ class MemoryBackend:
     ) -> Any:
         """Bridge session-cache content into the permanent graph."""
         raise NotImplementedError
+
+    # -- inspection / targeted deletion / code graph -------------------------
+    #
+    # These operations exist only on the server's REST API — the SDK's client
+    # objects have no equivalents — so only the HTTP transport implements them.
+    # The shared default raises a uniform, actionable error instead of
+    # NotImplementedError so a tool envelope can carry it verbatim.
+
+    def _http_only(self, operation: str) -> RuntimeError:
+        return RuntimeError(
+            f"{operation} requires the HTTP transport to a cognee server. "
+            "Unset COGNEE_TRANSPORT/COGNEE_EMBEDDED (local-server mode is the "
+            "default) or set COGNEE_TRANSPORT=http."
+        )
+
+    def list_datasets(self, *, timeout: float) -> list[dict[str, Any]]:
+        raise self._http_only("listing datasets")
+
+    def list_dataset_data(self, *, dataset_id: str, timeout: float) -> list[dict[str, Any]]:
+        raise self._http_only("listing dataset documents")
+
+    def read_raw_data(self, *, dataset_id: str, data_id: str, timeout: float) -> str:
+        raise self._http_only("reading a stored document")
+
+    def forget_document(self, *, dataset_id: str, data_id: str, timeout: float) -> dict[str, Any]:
+        raise self._http_only("per-document deletion")
+
+    def index_repository(
+        self,
+        *,
+        repo: str,
+        dataset: str,
+        index_vectors: bool = False,
+        run_in_background: bool = True,
+        timeout: float,
+    ) -> dict[str, Any]:
+        raise self._http_only("code-graph indexing")
+
+    def dataset_pipeline_status(
+        self, *, dataset_id: str, pipeline: str = "code_graph_pipeline", timeout: float
+    ) -> str:
+        raise self._http_only("pipeline status polling")
 
     # -- diagnostics -------------------------------------------------------
 
@@ -278,16 +325,23 @@ class SdkBackend(MemoryBackend):
         auto_route,
         query_type,
         scope=None,
+        context_profile=None,
+        code_query=None,
+        only_context=False,
         timeout,
     ) -> list[Any]:
         # ``scope`` is accepted but not forwarded. ``cognee.recall`` grew a
-        # ``scope`` parameter after this plugin's 1.2.1 floor, and passing an
-        # unknown keyword to the older SDK is a TypeError, not a degraded search.
-        # Nothing is lost by leaving it out: the in-process path passes
-        # ``auto_route`` and ``query_type`` natively, so cognee resolves the same
-        # sources from them. Only the HTTP transport needs to say it explicitly,
-        # because the endpoint defaults ``search_type`` where the SDK does not.
-        del scope
+        # ``scope`` parameter only after this plugin's original 1.2.1 floor, and
+        # passing an unknown keyword to an older SDK is a TypeError, not a
+        # degraded search. Nothing is lost by leaving it out: the in-process
+        # path passes ``auto_route`` and ``query_type`` natively, so cognee
+        # resolves the same sources from them. Only the HTTP transport needs to
+        # say it explicitly, because the endpoint defaults ``search_type`` where
+        # the SDK does not.
+        # ``context_profile`` / ``code_query`` / ``only_context`` are dropped for
+        # the same reason: they are HTTP-endpoint fields, and every feature that
+        # sets them is HTTP-only anyway.
+        del scope, context_profile, code_query, only_context
         return self._bridge.run(
             self._do_recall(query, session_id, datasets, top_k, auto_route, query_type),
             timeout=timeout,

--- a/integrations/hermes-agent/cognee_integration_hermes/cli.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/cli.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import time
 from pathlib import Path
 
-from .config import config_path, load_config
+from . import code_graph, update_check
+from .config import DEFAULT_LOCAL_PORT, config_path, load_config, resolve_local_roots
 
 
 def _provider_active() -> bool:
@@ -42,6 +44,24 @@ def _pip_package_version() -> str:
         return ""
 
 
+def _update_hint(cfg, *, force: bool = False) -> str:
+    """A one-line nudge when PyPI has a newer release, else "". Never raises."""
+    if not cfg.get("update_check", True):
+        return ""
+    pip_version = _pip_package_version()
+    if not pip_version:
+        return ""
+    latest = update_check.latest_published_version(
+        interval=float(cfg.get("update_check_interval") or 3600), force=force
+    )
+    if not update_check.is_newer(latest, pip_version):
+        return ""
+    return (
+        f"update available: {pip_version} → {latest} — run "
+        f"`pip install -U {update_check.PYPI_PACKAGE}` then `cognee-hermes-install`"
+    )
+
+
 def _print_status(args) -> None:
     cfg = load_config()
     path = config_path()
@@ -66,7 +86,119 @@ def _print_status(args) -> None:
             f"  Update:          pip package is {pip_version} but this installed copy "
             f"is {plugin_version} — run `cognee-hermes-install` to update"
         )
+    else:
+        hint = _update_hint(cfg, force=getattr(args, "check_updates", False))
+        if hint:
+            print(f"  Update:          {hint}")
     print()
+
+
+def _print_version(args) -> None:
+    cfg = load_config()
+    plugin_version = _installed_plugin_version()
+    pip_version = _pip_package_version()
+    print(f"cognee-integration-hermes-agent {pip_version or plugin_version or '(unknown)'}")
+    if plugin_version and pip_version and plugin_version != pip_version:
+        print(
+            f"  installed plugin copy is {plugin_version} — run `cognee-hermes-install` "
+            "to refresh it from the pip package"
+        )
+    hint = _update_hint(cfg, force=getattr(args, "check_updates", False))
+    if hint:
+        print(f"  {hint}")
+
+
+def _connect_backend():
+    """A connected HttpBackend for one-shot CLI operations.
+
+    Mirrors the provider's connection modes minus embedded (these operations
+    are HTTP-only): a set service_url is used as-is, otherwise the shared
+    local server is ensured — booted if nobody has yet — exactly as a session
+    would. Registration keeps the server's idle watchdog honest for the
+    duration; the caller must close().
+    """
+    from .http_backend import HttpBackend
+    from .server_bootstrap import ensure_local_server
+
+    cfg = load_config()
+    backend = HttpBackend(agent_session_name="hermes-cli")
+    service_url = str(cfg.get("service_url") or "")
+    if service_url:
+        backend.connect(url=service_url, api_key=str(cfg.get("api_key") or ""), timeout=30)
+        return backend
+    data_root, system_root = resolve_local_roots(cfg)
+    local_url = ensure_local_server(
+        int(cfg.get("local_port") or DEFAULT_LOCAL_PORT),
+        data_root=data_root,
+        system_root=system_root,
+        boot_timeout=float(cfg.get("server_boot_timeout") or 600),
+    )
+    backend.connect(url=local_url, api_key="", timeout=30)
+    return backend
+
+
+def _run_index_repo(args) -> int:
+    """Index one repository into a deterministic code graph (cognee >= 1.5.3)."""
+    spec = code_graph.canonical_spec(str(args.repo))
+    if not code_graph.is_remote_repo(spec) and not Path(spec).is_dir():
+        print(f"Error: {args.repo!r} is not a directory or a recognized git URL.")
+        return 1
+    dataset = str(getattr(args, "dataset", "") or "") or code_graph.default_code_dataset(spec)
+    index_vectors = bool(getattr(args, "index_vectors", False))
+    wait_seconds = float(getattr(args, "wait", 0.0) or 0.0)
+
+    try:
+        backend = _connect_backend()
+    except Exception as exc:
+        print(f"Error: could not reach a cognee server: {exc}")
+        return 1
+    try:
+        result = backend.index_repository(
+            repo=spec, dataset=dataset, index_vectors=index_vectors, timeout=120
+        )
+        status = str(result.get("status") or "submitted")
+        print(f"Indexing {spec}")
+        print(f"  dataset: {dataset}")
+        print(f"  status:  {status}")
+        dataset_id = str(result.get("dataset_id") or "")
+        if wait_seconds > 0 and dataset_id:
+            outcome = _poll_code_graph(backend, dataset_id, wait_seconds)
+            print(f"  outcome: {outcome}")
+            status = outcome
+        elif wait_seconds > 0:
+            print("  outcome: unknown (the server returned no dataset_id to poll)")
+        code_graph.record_index(spec, dataset, index_vectors=index_vectors, status=status)
+        print(
+            "Registered for code recall. Query it with the cognee_code_search tool "
+            "in a Hermes session."
+        )
+        return 0
+    except Exception as exc:
+        print(f"Error: indexing failed: {exc}")
+        return 1
+    finally:
+        try:
+            backend.close(timeout=5)
+        except Exception:
+            pass
+
+
+def _poll_code_graph(backend, dataset_id: str, deadline_seconds: float) -> str:
+    """Poll the code_graph_pipeline until completed/errored/timeout."""
+    deadline = time.monotonic() + max(0.0, deadline_seconds)
+    while True:
+        status = ""
+        try:
+            status = backend.dataset_pipeline_status(dataset_id=dataset_id, timeout=10)
+        except Exception:
+            pass
+        if status.endswith("COMPLETED"):
+            return "completed"
+        if status.endswith("ERRORED"):
+            return "errored"
+        if time.monotonic() >= deadline:
+            return "timeout"
+        time.sleep(3.0)
 
 
 def _print_config(args) -> None:
@@ -107,6 +239,10 @@ def cognee_command(args) -> None:
         _print_config(args)
     elif sub == "install":
         _print_install(args)
+    elif sub == "version":
+        _print_version(args)
+    elif sub == "index-repo":
+        raise SystemExit(_run_index_repo(args))
     else:
         _print_status(args)
 
@@ -114,8 +250,35 @@ def cognee_command(args) -> None:
 def register_cli(subparser) -> None:
     """Build the `hermes cognee` command tree."""
     subs = subparser.add_subparsers(dest="cognee_command")
-    subs.add_parser("status", help="Show Cognee memory status")
+    status = subs.add_parser("status", help="Show Cognee memory status")
+    status.add_argument(
+        "--check-updates", action="store_true", help="Force a live PyPI update check"
+    )
     subs.add_parser("setup", help="Run Hermes memory setup for Cognee")
     subs.add_parser("config", help="Print Cognee plugin config with secrets redacted")
     subs.add_parser("install", help="Print installation commands")
+    version = subs.add_parser("version", help="Show plugin version and update availability")
+    version.add_argument(
+        "--check-updates", action="store_true", help="Force a live PyPI update check"
+    )
+    index = subs.add_parser(
+        "index-repo",
+        help="Index a repository into a deterministic Cognee code graph (cognee >= 1.5.3)",
+    )
+    index.add_argument("repo", help="Local path or git URL of the repository")
+    index.add_argument(
+        "--dataset", default="", help="Dataset name (default: codebase-<repo>-<digest>)"
+    )
+    index.add_argument(
+        "--index-vectors",
+        action="store_true",
+        help="Also embed code entities for semantic search (needs an embedding provider)",
+    )
+    index.add_argument(
+        "--wait",
+        type=float,
+        default=0.0,
+        metavar="SECONDS",
+        help="Wait up to SECONDS for the indexing pipeline to finish",
+    )
     subparser.set_defaults(func=cognee_command)

--- a/integrations/hermes-agent/cognee_integration_hermes/code_graph.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/code_graph.py
@@ -1,0 +1,311 @@
+"""Code-graph (enola) helpers: repo identity, the recall gate, per-repo state.
+
+Ported from the claude-code/codex plugins' ``_code_graph.py``, minus transport
+(the :class:`~.backend.MemoryBackend` owns that) and minus the freshness /
+auto-index machinery: Hermes sessions are rarely launched inside a checkout,
+so repositories are indexed explicitly — ``hermes cognee index-repo`` — the
+way the OpenClaw plugin chose too. Requires a cognee server >= 1.5.3 (the
+release that opened ``content_type="code"`` on /api/v1/remember and the
+``code`` recall scope).
+
+Two responsibilities:
+
+1. **Repo identity + state.** One dataset per indexed repository,
+   ``codebase-<repo>-<digest>`` — the path digest is load-bearing (two
+   checkouts sharing a basename would otherwise share a graph database, where
+   cognee's stale-node sweep lets each re-index delete the other's nodes).
+   State lives under ``~/.cognee-plugin/hermes/code-graph/<slug>.json``; a
+   repo has a state file once it has been indexed, and only such repos are
+   ever matched by the recall lane.
+
+2. **Recall gating** (:func:`auto_code_lane`): the per-prompt recall adds a
+   ``code`` scope lane ONLY when (a) the prompt contains an identifier-shaped
+   token and (b) the cwd sits inside a repo this plugin has indexed. The lane
+   is additive — it never replaces the semantic scopes — and a seed the code
+   graph cannot resolve contributes nothing server-side, so misfires are
+   cheap by design.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+from .config import SHARED_PLUGIN_STATE_DIR
+
+_STATE_DIR = SHARED_PLUGIN_STATE_DIR / "hermes" / "code-graph"
+
+# Mirrors cognee's CodeLoader SUPPORTED_CODE_EXTENSIONS (v1.5.3) — the
+# extensions the per-file CODE route claims. Used by the identifier
+# extractor's filename pattern.
+CODE_EXTENSIONS = frozenset(
+    {
+        "c", "cc", "cpp", "cs", "cxx", "dart", "fs", "go", "h", "hcl", "hh",
+        "hpp", "java", "js", "jsx", "kt", "kts", "php", "proto", "py", "rake",
+        "rb", "rs", "scala", "svelte", "swift", "tf", "ts", "tsx", "vb", "vue",
+    }
+)  # fmt: skip
+
+# CamelCase words that are common prose, product names, or agent vocabulary —
+# not symbols worth seeding a code-graph query with. Misfires are cheap
+# (seed-not-found returns an empty lane), so this list stays small and only
+# covers the words that would fire on nearly every prompt in this ecosystem.
+_CAMEL_STOPLIST = frozenset(
+    {
+        "Claude",
+        "ClaudeCode",
+        "Codex",
+        "Cognee",
+        "Hermes",
+        "HermesAgent",
+        "GitHub",
+        "GitLab",
+        "JavaScript",
+        "TypeScript",
+        "PostgreSQL",
+        "MongoDB",
+        "OpenAI",
+        "MacOS",
+        "ReadMe",
+        "WiFi",
+        "OAuth",
+        "TODOs",
+    }
+)
+
+# Ordered by confidence: backticked wins, then file paths, dotted paths,
+# snake_case, CamelCase. Each pattern is deliberately conservative — the gate
+# exists to keep the code lane OFF conversational prompts, not to catch every
+# possible symbol.
+_BACKTICK_RE = re.compile(r"`([^`\n]{2,120})`")
+_FILEPATH_RE = re.compile(r"\b[\w./-]{1,120}\.(?:%s)\b" % "|".join(sorted(CODE_EXTENSIONS)))
+_DOTTED_RE = re.compile(r"\b[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+\b")
+_SNAKE_RE = re.compile(r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b")
+_CAMEL_RE = re.compile(r"\b[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]*)+\b")
+
+_IDENTIFIER_CHARS_RE = re.compile(r"^[\w./:-]+$")
+
+# The structured operations cognee's deterministic code route accepts.
+CODE_OPERATIONS = (
+    "query_facts",
+    "explore",
+    "traverse",
+    "find_path",
+    "impact_analysis",
+    "delta",
+)
+
+
+def extract_identifiers(prompt: str, limit: int = 2) -> list[str]:
+    """Identifier-shaped tokens from a prompt, best first, at most ``limit``.
+
+    An empty list means the syntactic gate did not fire and the code lane
+    should be skipped for this prompt.
+    """
+    if not prompt:
+        return []
+    found: list[str] = []
+    seen: set[str] = set()
+
+    def _add(token: str) -> None:
+        token = token.strip().strip(".,:;()[]{}")
+        if len(token) < 3 or len(token) > 120:
+            return
+        if token in _CAMEL_STOPLIST:
+            return
+        key = token.casefold()
+        if key in seen:
+            return
+        seen.add(key)
+        found.append(token)
+
+    for match in _BACKTICK_RE.finditer(prompt):
+        inner = match.group(1).strip()
+        # Backticks quote commands and prose too; only take single
+        # identifier-shaped tokens (no spaces, identifier charset).
+        if " " not in inner and _IDENTIFIER_CHARS_RE.match(inner):
+            _add(inner)
+    for pattern in (_FILEPATH_RE, _DOTTED_RE, _SNAKE_RE, _CAMEL_RE):
+        for match in pattern.finditer(prompt):
+            token = match.group(0)
+            if pattern is _DOTTED_RE:
+                # Drop prose artifacts like "e.g" / "i.e": require some meat.
+                parts = token.split(".")
+                if len(token) < 5 or not any(len(p) >= 3 for p in parts):
+                    continue
+                # Domain-ish tokens ("example.com") are not symbols.
+                if len(parts) == 2 and parts[1].lower() in ("com", "org", "net", "io", "ai", "dev"):
+                    continue
+            _add(token)
+
+    return found[:limit]
+
+
+def build_code_query(identifier: str, limit: int = 5) -> dict[str, Any]:
+    """The auto-recall code_query: a bounded substring fact lookup.
+
+    query_facts (not explore) on purpose: explore needs a resolvable seed and
+    errors on ambiguity, while query_facts degrades to an empty page — the
+    right failure mode for a lane that must never disturb the prompt path.
+    """
+    return {"operation": "query_facts", "name": identifier, "limit": limit}
+
+
+# ---------------------------------------------------------------------------
+# Repo identity + per-repo state
+# ---------------------------------------------------------------------------
+
+
+def is_remote_repo(spec: str) -> bool:
+    return isinstance(spec, str) and spec.startswith(("https://", "http://", "git@", "ssh://"))
+
+
+def canonical_spec(spec: str) -> str:
+    """The stable identity of an indexed repository.
+
+    Local paths resolve through symlinks so the same checkout reached by two
+    routes is one repository; remote URLs drop a trailing slash and the ``.git``
+    suffix so ``…/repo`` and ``…/repo.git`` do not index twice.
+    """
+    spec = str(spec).strip()
+    if is_remote_repo(spec):
+        canonical = spec.rstrip("/")
+        if canonical.endswith(".git"):
+            canonical = canonical[: -len(".git")]
+        return canonical
+    return os.path.realpath(os.path.expanduser(spec))
+
+
+def _readable_tail(canonical: str) -> str:
+    tail = os.path.basename(canonical.rstrip("/")) or "repo"
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", tail).strip("-.") or "repo"
+
+
+def _repo_slug(root_or_spec: str) -> str:
+    canonical = canonical_spec(root_or_spec)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:12]
+    return f"{_readable_tail(canonical)}-{digest}"
+
+
+def default_code_dataset(spec: str) -> str:
+    """A stable, readable, collision-free per-repo dataset name.
+
+    Narrow datasets keep the CODE snapshot cache and the delta pre-read small,
+    so one dataset per indexed repository is the default. The basename alone
+    cannot be that identity: checkouts routinely share one (``~/work/a/service``
+    and ``~/work/b/service``), and two repos landing in one dataset share a
+    graph database — where cognee's stale-node sweep, scoped by repo name,
+    would let each ingestion delete the other's nodes. The path digest makes
+    the name unique per checkout while the readable tail keeps it recognizable
+    in a dataset listing.
+    """
+    canonical = canonical_spec(spec)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:8]
+    return f"codebase-{_readable_tail(canonical).lower()}-{digest}"
+
+
+def _state_path(key: str) -> Path:
+    return _STATE_DIR / f"{_repo_slug(key)}.json"
+
+
+def save_repo_state(state: dict[str, Any]) -> None:
+    """Persist one repo's index state. ``state`` must carry ``spec``."""
+    key = state.get("repo_root") or state.get("spec") or ""
+    if not key:
+        return
+    _STATE_DIR.mkdir(parents=True, exist_ok=True)
+    _state_path(key).write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
+
+
+def load_repo_states() -> list[dict[str, Any]]:
+    """All recorded repo states (invalid files are skipped, never raised)."""
+    states: list[dict[str, Any]] = []
+    try:
+        entries = sorted(_STATE_DIR.glob("*.json"))
+    except OSError:
+        return states
+    for path in entries:
+        try:
+            state = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if isinstance(state, dict):
+            states.append(state)
+    return states
+
+
+def find_indexed_repo(cwd: str) -> dict[str, Any]:
+    """The index state whose repo_root contains ``cwd``, or {}.
+
+    Only locally-indexed repos (spec = path) are matched by cwd; a repo
+    indexed by URL has no local root to match. Longest matching root wins so
+    nested checkouts resolve to the innermost indexed repo.
+    """
+    real = os.path.realpath(cwd) if cwd else ""
+    if not real:
+        return {}
+    best: dict[str, Any] = {}
+    for state in load_repo_states():
+        root = str(state.get("repo_root") or "")
+        if not root:
+            continue
+        if real == root or real.startswith(root.rstrip(os.sep) + os.sep):
+            if len(root) > len(str(best.get("repo_root") or "")):
+                best = state
+    return best
+
+
+def find_repo_state(spec_or_dataset: str) -> dict[str, Any]:
+    """The index state matching a repo spec or a code dataset name, or {}."""
+    wanted = str(spec_or_dataset or "").strip()
+    if not wanted:
+        return {}
+    canonical = canonical_spec(wanted)
+    for state in load_repo_states():
+        if state.get("dataset") == wanted or state.get("spec") == canonical:
+            return state
+    return {}
+
+
+def auto_code_lane(prompt: str, cwd: str) -> dict[str, Any]:
+    """The per-prompt recall gate. Returns {} when the lane must not fire.
+
+    Fires only when the prompt carries an identifier-shaped token AND the
+    cwd sits inside a repo this plugin indexed — never on conversational
+    prompts, never on repos nobody asked to index.
+    """
+    identifiers = extract_identifiers(prompt)
+    if not identifiers:
+        return {}
+    state = find_indexed_repo(cwd)
+    if not state or not state.get("dataset"):
+        return {}
+    return {
+        "dataset": str(state["dataset"]),
+        "identifier": identifiers[0],
+        "code_query": build_code_query(identifiers[0]),
+    }
+
+
+def record_index(
+    spec: str, dataset: str, *, index_vectors: bool, status: str = "submitted"
+) -> dict[str, Any]:
+    """Record a successful index submission so the recall lane and re-runs see it."""
+    canonical = canonical_spec(spec)
+    remote = is_remote_repo(canonical)
+    state = {
+        "spec": canonical,
+        "spec_kind": "url" if remote else "path",
+        "repo_root": "" if remote else canonical,
+        "dataset": dataset,
+        "index_vectors": bool(index_vectors),
+        "last_index_at": time.time(),
+        "last_status": status,
+    }
+    save_repo_state(state)
+    return state

--- a/integrations/hermes-agent/cognee_integration_hermes/config.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/config.py
@@ -221,6 +221,28 @@ def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
         "recall_timeout": str_to_int(os.environ.get("COGNEE_RECALL_TIMEOUT"), 120),
         "write_timeout": str_to_int(os.environ.get("COGNEE_WRITE_TIMEOUT"), 120),
         "improve_timeout": str_to_int(os.environ.get("COGNEE_IMPROVE_TIMEOUT"), 300),
+        # Layered recall (parity with the claude-code/codex per-prompt lookup and
+        # openclaw's recallSessionLayers): fan recall out over the session cache,
+        # trace lessons, distilled agent guidance and the graph, each rendered as
+        # its own block. The budget bounds the whole fan-out, cheap scopes first.
+        "recall_session_layers": str_to_bool(os.environ.get("COGNEE_RECALL_LAYERS"), True),
+        "recall_budget": str_to_int(os.environ.get("COGNEE_RECALL_BUDGET"), 20),
+        # Memory steer: one system-prompt line asserting Cognee as the preferred,
+        # authoritative long-term memory (the COGNEE_PREFER_MEMORY counterpart).
+        "memory_steer": str_to_bool(os.environ.get("COGNEE_MEMORY_STEER"), True),
+        "memory_steer_text": os.environ.get("COGNEE_MEMORY_STEER_TEXT", ""),
+        # Per-turn memory-hit visibility in the injected recall block.
+        "memory_hits": str_to_bool(os.environ.get("COGNEE_MEMORY_HITS"), True),
+        # Agent tools beyond the recall/remember/forget trio.
+        "dataset_switch_tool": str_to_bool(os.environ.get("COGNEE_DATASET_SWITCH_TOOL"), True),
+        "code_search_tool": str_to_bool(os.environ.get("COGNEE_CODE_SEARCH_TOOL"), True),
+        # The identifier-gated code recall lane, plus extra always-on code
+        # datasets (comma-separated) for repos indexed from another machine.
+        "code_graph_recall": str_to_bool(os.environ.get("COGNEE_CODE_GRAPH_RECALL"), True),
+        "code_datasets": os.environ.get("COGNEE_CODE_DATASETS", ""),
+        # PyPI update check (CLI only, never on the session path).
+        "update_check": str_to_bool(os.environ.get("COGNEE_UPDATE_CHECK"), True),
+        "update_check_interval": str_to_int(os.environ.get("COGNEE_UPDATE_CHECK_INTERVAL"), 3600),
     }
 
     path = config_path(hermes_home)
@@ -247,6 +269,15 @@ def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
     config["auto_route"] = str_to_bool(config.get("auto_route"), True)
     config["improve_on_end"] = str_to_bool(config.get("improve_on_end"), True)
     config["embedded"] = str_to_bool(config.get("embedded"), False)
+    config["recall_session_layers"] = str_to_bool(config.get("recall_session_layers"), True)
+    config["recall_budget"] = max(1, str_to_int(config.get("recall_budget"), 20))
+    config["memory_steer"] = str_to_bool(config.get("memory_steer"), True)
+    config["memory_hits"] = str_to_bool(config.get("memory_hits"), True)
+    config["dataset_switch_tool"] = str_to_bool(config.get("dataset_switch_tool"), True)
+    config["code_search_tool"] = str_to_bool(config.get("code_search_tool"), True)
+    config["code_graph_recall"] = str_to_bool(config.get("code_graph_recall"), True)
+    config["update_check"] = str_to_bool(config.get("update_check"), True)
+    config["update_check_interval"] = max(60, str_to_int(config.get("update_check_interval"), 3600))
     return config
 
 

--- a/integrations/hermes-agent/cognee_integration_hermes/dataset_overrides.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/dataset_overrides.py
@@ -1,0 +1,81 @@
+"""Per-conversation dataset overrides, persisted across process restarts.
+
+A ``cognee_switch_dataset`` switch must survive the Hermes process: the same
+Hermes session resumed later should keep writing where the user moved it, not
+silently fall back to the configured default. The claude-code/codex plugins
+keep this in their launch records and openclaw in ``dataset-overrides.json``;
+this is the hermes counterpart of the latter — one JSON map keyed by the
+*hermes* session id::
+
+    { "<hermes session id>": {"dataset": "...", "counter": 2}, ... }
+
+``counter`` feeds the switched cognee session id (``hermes_<id>__N``): a
+cognee session never spans two datasets, so every switch mints a fresh one.
+Everything here is best-effort — an unreadable file means "no overrides",
+never a failed session.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from .config import SHARED_PLUGIN_STATE_DIR
+
+logger = logging.getLogger(__name__)
+
+_OVERRIDES_PATH = SHARED_PLUGIN_STATE_DIR / "hermes" / "dataset-overrides.json"
+
+# Overrides for conversations nobody resumes must not accumulate forever.
+_MAX_ENTRIES = 200
+
+
+def _load(path: Optional[Path] = None) -> dict[str, Any]:
+    target = path or _OVERRIDES_PATH
+    try:
+        data = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save(data: dict[str, Any], path: Optional[Path] = None) -> None:
+    target = path or _OVERRIDES_PATH
+    try:
+        if len(data) > _MAX_ENTRIES:
+            # Oldest first by recorded time; unstamped entries drop first.
+            ordered = sorted(data.items(), key=lambda kv: kv[1].get("updated_at", 0))
+            data = dict(ordered[-_MAX_ENTRIES:])
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+    except OSError as exc:
+        logger.debug("could not persist dataset overrides: %s", exc)
+
+
+def load_override(session_id: str, *, path: Optional[Path] = None) -> dict[str, Any]:
+    """The stored override for one hermes session id, or {}."""
+    if not session_id:
+        return {}
+    entry = _load(path).get(session_id)
+    return entry if isinstance(entry, dict) else {}
+
+
+def save_override(
+    session_id: str, dataset: str, counter: int, *, path: Optional[Path] = None
+) -> None:
+    if not session_id:
+        return
+    import time
+
+    data = _load(path)
+    data[session_id] = {"dataset": dataset, "counter": counter, "updated_at": time.time()}
+    _save(data, path)
+
+
+def clear_override(session_id: str, *, path: Optional[Path] = None) -> None:
+    data = _load(path)
+    if session_id in data:
+        del data[session_id]
+        _save(data, path)

--- a/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
@@ -7,12 +7,13 @@ own REST API and own the request bodies. The alternative, routing through
 most importantly ``session_ids`` on ``improve()``, which is what bridges session
 memory into the permanent graph.
 
-**Wire contract** (verified against cognee 1.2.1's routers, live-checked on the
-pinned 1.4.0):
+**Wire contract** (first verified against cognee 1.2.1's routers, live-checked
+on the pinned 1.5.3):
 
 ===================  =========================================================
 ``recall``           ``POST /api/v1/recall``   JSON: ``query``, ``search_type``,
-                     ``scope``, ``datasets``, ``top_k``, ``session_id``
+                     ``scope``, ``datasets``, ``top_k``, ``session_id``,
+                     ``context_profile``, ``code_query``, ``only_context``
 ``remember_session`` ``POST /api/v1/remember`` multipart: ``data``,
                      ``datasetName``, ``session_id``
 ``remember_permanent`` ``POST /api/v1/remember`` multipart: ``data``,
@@ -21,6 +22,16 @@ pinned 1.4.0):
                      ``session_ids``, ``run_in_background``
 ``forget``           ``POST /api/v1/forget``   JSON: ``dataset``, ``everything``,
                      ``memory_only``
+``forget_document``  ``POST /api/v1/forget``   JSON: ``datasetId``, ``dataId``
+                     (single-document delete; cognee >= 1.5.3 for targeted
+                     session invalidation)
+``list_datasets``    ``GET /api/v1/datasets``
+``list_dataset_data`` ``GET /api/v1/datasets/{id}/data``
+``read_raw_data``    ``GET /api/v1/datasets/{id}/data/{id}/raw``
+``index_repository`` ``POST /api/v1/remember`` multipart: ``datasetName``,
+                     ``content_type=code``, ``repositories``,
+                     ``run_in_background``, ``index_vectors`` (cognee >= 1.5.3)
+``dataset_pipeline_status`` ``GET /api/v1/datasets/status?dataset=&pipeline=``
 ===================  =========================================================
 
 Note the field-name differences from the SDK: the endpoint calls them ``query``
@@ -121,6 +132,19 @@ def _is_local_url(url: str) -> bool:
     return host in {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
 
 
+def _require_uuid(value: str, label: str) -> str:
+    """Refuse anything that is not a canonical UUID before it is used.
+
+    Dataset and data ids travel in the request URL and the JSON body; the
+    claude-code forget helper validates them for the same reason — a crafted
+    value could otherwise redirect the request to a different endpoint.
+    """
+    try:
+        return str(uuid.UUID(str(value)))
+    except (ValueError, AttributeError, TypeError):
+        raise ValueError(f"invalid {label} (expected a UUID): {str(value)[:80]!r}") from None
+
+
 class RememberResponse:
     """A remember result that exposes ``.status`` like the SDK's ``RememberResult``.
 
@@ -213,8 +237,14 @@ class HttpBackend(MemoryBackend):
         multipart: Optional[tuple[str, bytes]] = None,
         cookies: Optional[dict[str, str]] = None,
         base_url: str = "",
+        parse_json: bool = True,
     ) -> Any:
-        """Make one request and return its parsed JSON body (``None`` if empty)."""
+        """Make one request and return its parsed JSON body (``None`` if empty).
+
+        With ``parse_json=False`` the raw text body is returned instead — for
+        endpoints like ``/raw`` whose response is the stored document itself,
+        not JSON.
+        """
         url = (base_url or self.url).rstrip("/") + path
         headers: dict[str, str] = {}
         data: Optional[bytes] = None
@@ -251,6 +281,8 @@ class HttpBackend(MemoryBackend):
         except Exception as exc:  # URLError / timeout / OSError
             raise CogneeUnreachable(f"cognee unreachable at {url}: {str(exc)[:200]}") from exc
 
+        if not parse_json:
+            return raw
         if not raw:
             return None
         try:
@@ -532,6 +564,9 @@ class HttpBackend(MemoryBackend):
         auto_route,
         query_type,
         scope=None,
+        context_profile=None,
+        code_query=None,
+        only_context=False,
         timeout,
     ) -> list[Any]:
         if not auto_route and not query_type:
@@ -552,8 +587,23 @@ class HttpBackend(MemoryBackend):
             # State the scope outright. Without it the server infers sources from
             # the other fields, and that inference requires a null search_type —
             # so a caller who set COGNEE_AUTO_ROUTE=false would lose the session
-            # cache as a side effect of choosing a search strategy.
+            # cache as a side effect of choosing a search strategy. A list scope
+            # (e.g. ["session", "trace", "session_context"]) travels as-is: the
+            # endpoint accepts a name or a list of names.
             body["scope"] = scope
+        if context_profile:
+            # "agent" selects the distilled agent-guidance rendering for the
+            # session_context scope, matching the claude-code/codex recall.
+            body["context_profile"] = context_profile
+        if code_query is not None:
+            # Deterministic code-graph lane (cognee >= 1.5.3): only meaningful
+            # when the scope includes "code" — the server rejects it otherwise.
+            body["code_query"] = code_query
+        if only_context:
+            # Skip the server-side LLM completion and return raw context. The
+            # layered per-scope recall uses this: it renders results itself, so
+            # paying an LLM call per scope would only add latency.
+            body["only_context"] = True
         # Always sent, null included: the endpoint defaults a *missing*
         # search_type to GRAPH_COMPLETION for backward compatibility, and only an
         # explicit null opts into the query classifier. Omitting the key would
@@ -637,3 +687,110 @@ class HttpBackend(MemoryBackend):
         if session_ids:
             body["session_ids"] = session_ids
         return self._request("POST", "/api/v1/improve", timeout=timeout, json_body=body)
+
+    # -- inspection / targeted deletion (cognee-forget parity) ---------------
+
+    def list_datasets(self, *, timeout: float) -> list[dict[str, Any]]:
+        """Every dataset visible to this principal (server-side RBAC applies)."""
+        result = self._request("GET", "/api/v1/datasets", timeout=timeout)
+        return [row for row in result if isinstance(row, dict)] if isinstance(result, list) else []
+
+    def list_dataset_data(self, *, dataset_id: str, timeout: float) -> list[dict[str, Any]]:
+        """The data items (documents) stored in one dataset."""
+        dataset_id = _require_uuid(dataset_id, "dataset id")
+        result = self._request("GET", f"/api/v1/datasets/{dataset_id}/data", timeout=timeout)
+        return [row for row in result if isinstance(row, dict)] if isinstance(result, list) else []
+
+    def read_raw_data(self, *, dataset_id: str, data_id: str, timeout: float) -> str:
+        """One data item's raw stored content, as text."""
+        dataset_id = _require_uuid(dataset_id, "dataset id")
+        data_id = _require_uuid(data_id, "data id")
+        raw = self._request(
+            "GET",
+            f"/api/v1/datasets/{dataset_id}/data/{data_id}/raw",
+            timeout=timeout,
+            parse_json=False,
+        )
+        text = str(raw or "")
+        # The endpoint may answer with a JSON-encoded string; unwrap that one
+        # shape so previews read as the document, not as an escaped literal.
+        if text.startswith('"') and text.endswith('"'):
+            try:
+                decoded = json.loads(text)
+                if isinstance(decoded, str):
+                    return decoded
+            except (json.JSONDecodeError, ValueError):
+                pass
+        return text
+
+    def forget_document(self, *, dataset_id: str, data_id: str, timeout: float) -> dict[str, Any]:
+        """Delete exactly one data item — the only deletion shape this method
+        can express, by construction (both ids must be UUIDs; there is no
+        ``everything`` field in the body it builds). Dataset-wide deletion
+        stays on :meth:`forget`. Requires cognee >= 1.5.3 for the targeted
+        session-cache invalidation that keeps a later sync from re-persisting
+        the deleted content."""
+        body = {
+            "datasetId": _require_uuid(dataset_id, "dataset id"),
+            "dataId": _require_uuid(data_id, "data id"),
+        }
+        result = self._request("POST", "/api/v1/forget", timeout=timeout, json_body=body)
+        return result if isinstance(result, dict) else {}
+
+    # -- code graph (cognee >= 1.5.3) ----------------------------------------
+
+    def index_repository(
+        self,
+        *,
+        repo: str,
+        dataset: str,
+        index_vectors: bool = False,
+        run_in_background: bool = True,
+        timeout: float,
+    ) -> dict[str, Any]:
+        """Submit one repository for deterministic code-graph indexing."""
+        multipart = _multipart_body(
+            {
+                "datasetName": dataset,
+                "content_type": "code",
+                "repositories": str(repo),
+                "run_in_background": "true" if run_in_background else "false",
+                "index_vectors": "true" if index_vectors else "false",
+            },
+            {},
+        )
+        try:
+            payload = self._request(
+                "POST", "/api/v1/remember", timeout=timeout, multipart=multipart
+            )
+        except CogneeHttpError as exc:
+            if exc.status == 400 and "content_type" in str(exc):
+                # An older server (< 1.5.3) rejects content_type='code' outright.
+                raise CogneeHttpError(
+                    exc.status,
+                    "the cognee server rejected content_type='code' — repo indexing "
+                    "requires cognee >= 1.5.3; upgrade the server and retry. "
+                    f"Detail: {exc}",
+                ) from exc
+            raise
+        return payload if isinstance(payload, dict) else {}
+
+    def dataset_pipeline_status(
+        self, *, dataset_id: str, pipeline: str = "code_graph_pipeline", timeout: float
+    ) -> str:
+        """The named pipeline's status for one dataset, uppercased ("" if unknown).
+
+        The plugins' cognify poll targets ``cognify_pipeline``, which never sees
+        code runs — this variant exists for the code route.
+        """
+        dataset_id = _require_uuid(dataset_id, "dataset id")
+        query = urllib.parse.urlencode({"dataset": dataset_id, "pipeline": pipeline})
+        parsed = self._request("GET", f"/api/v1/datasets/status?{query}", timeout=timeout)
+        if not isinstance(parsed, dict) or not parsed:
+            return ""
+        value = parsed.get(dataset_id)
+        if value is None and len(parsed) == 1:
+            value = next(iter(parsed.values()))
+        if isinstance(value, dict):
+            value = value.get(pipeline)
+        return str(value or "").upper()

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -11,7 +11,7 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
-from . import exit_watcher
+from . import code_graph, dataset_overrides, exit_watcher
 from .backend import MemoryBackend, build_backend, default_backend, has_cognee
 from .config import (
     DEFAULT_DATASET,
@@ -29,7 +29,13 @@ from .config import (
 from .config import (
     save_config as save_plugin_config,
 )
-from .schemas import FORGET_SCHEMA, RECALL_SCHEMA, REMEMBER_SCHEMA
+from .schemas import (
+    CODE_SEARCH_SCHEMA,
+    FORGET_SCHEMA,
+    RECALL_SCHEMA,
+    REMEMBER_SCHEMA,
+    SWITCH_DATASET_SCHEMA,
+)
 from .server_bootstrap import ensure_local_server
 
 try:
@@ -147,6 +153,21 @@ class CogneeMemoryProvider(MemoryProvider):
         self._breaker_open_until = 0.0
         # Set when a crash-safe exit watcher is armed (server modes only).
         self._watcher_state_path: Optional[Path] = None
+        # Dataset switching: the configured default, the per-conversation switch
+        # counter (feeds hermes_<id>__N cognee session ids), and sessions retired
+        # by a forced switch whose bridge failed — re-submitted at session end so
+        # the escape hatch defers the sync instead of dropping turns.
+        self._default_dataset = DEFAULT_DATASET
+        self._switch_counter = 0
+        self._retired_sessions: list[tuple[str, str]] = []
+        # Where Hermes was launched; gates the identifier-based code recall lane.
+        self._cwd = ""
+        # Per-session memory-hit totals for the visibility header (guarded by
+        # _prefetch_lock: written by prefetch workers, read on consumption).
+        self._turns_seen = 0
+        self._turns_with_hits = 0
+        self._hits_total = 0
+        self._cross_hits_total = 0
 
     @property
     def name(self) -> str:
@@ -287,12 +308,18 @@ class CogneeMemoryProvider(MemoryProvider):
         self._hermes_home = kwargs.get("hermes_home")
         self._config = load_config(self._hermes_home)
         self._session_id = session_id
-        self._dataset = str(self._config.get("dataset") or DEFAULT_DATASET)
+        self._default_dataset = str(self._config.get("dataset") or DEFAULT_DATASET)
+        self._dataset = self._default_dataset
         self._top_k = int(self._config.get("top_k") or 5)
         self._auto_route = str_to_bool(self._config.get("auto_route"), True)
         self._improve_on_end = str_to_bool(self._config.get("improve_on_end"), True)
         self._writes_enabled = kwargs.get("agent_context", "primary") in {"", "primary", None}
         self._session_cognee_id = self._build_cognee_session_id(session_id, **kwargs)
+        self._apply_dataset_override()
+        try:
+            self._cwd = os.getcwd()
+        except OSError:
+            self._cwd = ""
 
         # Now that config is loaded, choose the transport (unless one was injected).
         if self._injected_backend is None:
@@ -455,12 +482,25 @@ class CogneeMemoryProvider(MemoryProvider):
         if not self._is_usable():
             return ""
         mode = "remote" if self._remote_mode else "local"
-        return (
-            "# Cognee Memory\n"
-            f"Active ({mode}). Dataset: {self._dataset}.\n"
+        lines = [
+            "# Cognee Memory",
+            f"Active ({mode}). Dataset: {self._dataset}.",
             "Use cognee_recall for prior context, cognee_remember for durable facts, "
-            "and cognee_forget when the user asks to remove Cognee memory."
-        )
+            "cognee_forget when the user asks to remove Cognee memory, "
+            "cognee_switch_dataset to move this conversation to another dataset, and "
+            "cognee_code_search for structural questions about an indexed repository.",
+        ]
+        # The memory steer — the counterpart of claude-code's COGNEE_PREFER_MEMORY
+        # and openclaw's memorySteer: without it the agent reaches for the host's
+        # native memory files by habit and the graph never hears about it.
+        if str_to_bool(self._config.get("memory_steer"), True):
+            steer = str(self._config.get("memory_steer_text") or "").strip() or (
+                "Cognee is the preferred, authoritative long-term memory. Consult "
+                "recalled Cognee context first, and store durable knowledge through "
+                "the cognee tools rather than Hermes' built-in memory."
+            )
+            lines.append(steer)
+        return "\n".join(lines)
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if not self._is_usable():
@@ -487,6 +527,9 @@ class CogneeMemoryProvider(MemoryProvider):
         generation = self._prefetch_generation
 
         def _run() -> None:
+            if str_to_bool(self._config.get("recall_session_layers"), True):
+                self._run_layered_prefetch(query, cognee_session_id, generation)
+                return
             try:
                 results = self._recall(
                     query,
@@ -496,11 +539,16 @@ class CogneeMemoryProvider(MemoryProvider):
                     session_id=cognee_session_id,
                 )
                 lines = self._format_recall_lines(results, limit=5)
-                if lines:
-                    with self._prefetch_lock:
+                rendered = "\n".join(lines)
+                with self._prefetch_lock:
+                    self._turns_seen += 1
+                    if lines:
+                        self._hits_total += len(lines)
+                        self._turns_with_hits += 1
+                        rendered = self._hit_header(len(lines), 0) + rendered
                         # Drop the result if a reset invalidated it mid-recall.
                         if generation == self._prefetch_generation:
-                            self._prefetch_result = "\n".join(lines)
+                            self._prefetch_result = rendered
                 # The backend answered, so this is a success either way.
                 self._record_success()
             except Exception as exc:
@@ -545,7 +593,14 @@ class CogneeMemoryProvider(MemoryProvider):
         self._sync_thread.start()
 
     def get_tool_schemas(self) -> list[dict[str, Any]]:
-        return [RECALL_SCHEMA, REMEMBER_SCHEMA, FORGET_SCHEMA]
+        schemas = [RECALL_SCHEMA, REMEMBER_SCHEMA, FORGET_SCHEMA]
+        # Config may not be loaded yet when Hermes collects schemas; the
+        # defaults (on) match load_config's, so both paths agree.
+        if str_to_bool(self._config.get("dataset_switch_tool"), True):
+            schemas.append(SWITCH_DATASET_SCHEMA)
+        if str_to_bool(self._config.get("code_search_tool"), True):
+            schemas.append(CODE_SEARCH_SCHEMA)
+        return schemas
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if not self._is_usable():
@@ -565,6 +620,10 @@ class CogneeMemoryProvider(MemoryProvider):
             return self._handle_remember(args)
         if tool_name == "cognee_forget":
             return self._handle_forget(args)
+        if tool_name == "cognee_switch_dataset":
+            return self._handle_switch_dataset(args)
+        if tool_name == "cognee_code_search":
+            return self._handle_code_search(args)
         return json.dumps({"error": f"Unknown Cognee tool: {tool_name}"})
 
     def on_session_end(self, messages: list[dict[str, Any]]) -> None:
@@ -577,6 +636,9 @@ class CogneeMemoryProvider(MemoryProvider):
             or self._is_breaker_open()
         ):
             return
+        # Sessions retired by a forced dataset switch get their deferred bridge
+        # before the current session's own close.
+        self._bridge_retired_sessions()
         if self._hand_off_session_close():
             return
         self._improve_inline()
@@ -649,7 +711,12 @@ class CogneeMemoryProvider(MemoryProvider):
         if self._sync_thread and self._sync_thread.is_alive():
             self._sync_thread.join(timeout=5.0)
         self._session_id = new_session_id
+        # A different conversation means its own dataset override (or none) and
+        # its own switch counter — never the previous conversation's.
+        self._dataset = self._default_dataset
+        self._switch_counter = 0
         self._session_cognee_id = self._build_cognee_session_id(new_session_id, **kwargs)
+        self._apply_dataset_override()
         if self._watcher_state_path is not None and not self._close_handed_off:
             # Re-point the crash insurance at the new session (and re-enable the
             # improve half in case a previous session end disabled it). Skipped
@@ -658,6 +725,7 @@ class CogneeMemoryProvider(MemoryProvider):
             exit_watcher.update(
                 self._watcher_state_path,
                 session_id=self._session_cognee_id,
+                dataset=self._dataset,
                 improve=bool(self._writes_enabled and self._improve_on_end),
             )
         if reset:
@@ -667,6 +735,11 @@ class CogneeMemoryProvider(MemoryProvider):
                 # Only on reset: /resume, /branch and compression continue the same
                 # logical conversation, so a prefetch issued for it stays valid.
                 self._prefetch_generation += 1
+                # The hit totals describe one conversation; a fresh one starts at 0.
+                self._turns_seen = 0
+                self._turns_with_hits = 0
+                self._hits_total = 0
+                self._cross_hits_total = 0
 
     def on_memory_write(
         self,
@@ -793,6 +866,11 @@ class CogneeMemoryProvider(MemoryProvider):
         """
         normalized = (scope or "auto").lower()
         if normalized == "session":
+            if str_to_bool(self._config.get("recall_session_layers"), True):
+                # The session corpus is three server scopes, not one: cached Q&A
+                # turns, tool-call trace lessons, and distilled agent guidance.
+                # Same scope list openclaw's memory_search corpus=sessions sends.
+                return session_id, [self._dataset], None, ["session", "trace", "session_context"]
             return session_id, None, None, normalized
         query_type = search_type or None
         if normalized == "graph":
@@ -829,6 +907,158 @@ class CogneeMemoryProvider(MemoryProvider):
             session_ids=[self._session_cognee_id],
             timeout=self._timeout("write_timeout", 120),
         )
+
+    # -- layered per-prompt recall -------------------------------------------
+
+    def _hit_header(self, hits: int, cross: int) -> str:
+        """One plain-words line on what memory just contributed, or "".
+
+        Must be called under ``_prefetch_lock`` after the counters were updated:
+        the per-session totals it renders are the ones this turn just advanced.
+        """
+        if not str_to_bool(self._config.get("memory_hits"), True):
+            return ""
+        line = f"{hits} memory hit{'s' if hits != 1 else ''} this turn"
+        if cross:
+            line += f" ({cross} beyond this session)"
+        line += f" · {self._turns_with_hits}/{self._turns_seen} turns had hits this session"
+        return line + "\n"
+
+    def _code_lane(self, query: str) -> dict[str, Any]:
+        """The additive code-graph lane for this prompt, or {}.
+
+        Syntactically gated: fires only when the prompt names an
+        identifier-shaped token AND either the cwd sits inside a repo indexed
+        via ``hermes cognee index-repo`` or ``code_datasets`` names one.
+        """
+        if not str_to_bool(self._config.get("code_graph_recall"), True):
+            return {}
+        try:
+            lane = code_graph.auto_code_lane(query, self._cwd)
+        except Exception as exc:
+            logger.debug("code lane gate failed: %s", exc)
+            lane = {}
+        if lane:
+            return lane
+        extra = [
+            name.strip()
+            for name in str(self._config.get("code_datasets") or "").split(",")
+            if name.strip()
+        ]
+        if not extra:
+            return {}
+        identifiers = code_graph.extract_identifiers(query)
+        if not identifiers:
+            return {}
+        return {
+            "dataset": extra[0],
+            "identifier": identifiers[0],
+            "code_query": code_graph.build_code_query(identifiers[0]),
+        }
+
+    @staticmethod
+    def _is_graph_not_built(exc: Exception, scope: Any) -> bool:
+        """A 404 on the graph scope means nobody has cognified the dataset yet —
+        routine on a fresh install, so it must not read as a recall failure."""
+        return scope == ["graph"] and getattr(exc, "status", None) == 404
+
+    def _run_layered_prefetch(self, query: str, session_id: str, generation: int) -> None:
+        """Fan recall out over the memory layers, cheap scopes first.
+
+        With ``dataset_ids`` + ``search_type`` in a single request the server's
+        ``auto`` scope resolves graph-only, so cached Q&A turns, trace lessons
+        and distilled agent guidance never reached the prompt. One bounded call
+        per scope instead, each rendered as its own labelled block; a failure in
+        one lane never discards the others. The graph lane runs last — it is the
+        only call that can consume a full per-call timeout, and running it
+        earlier starves the cheap lanes out of the budget.
+        """
+        budget = self._config.get("recall_budget")
+        deadline = time.monotonic() + (20.0 if budget is None else float(budget))
+        recall_timeout = self._timeout("recall_timeout", 120)
+        top_k = min(self._top_k, 5)
+
+        lanes: list[tuple[str, dict[str, Any], bool]] = [
+            ("session_memory", {"scope": ["session"]}, False),
+            ("trace_lessons", {"scope": ["trace"]}, False),
+            ("agent_guidance", {"scope": ["session_context"], "context_profile": "agent"}, True),
+        ]
+        code_lane = self._code_lane(query)
+        if code_lane:
+            lanes.append(
+                (
+                    "code_graph",
+                    {
+                        "scope": ["code"],
+                        "datasets": [code_lane["dataset"]],
+                        "code_query": code_lane["code_query"],
+                    },
+                    True,
+                )
+            )
+        # HYBRID_COMPLETION combines BM25 + vector + graph retrieval; with
+        # only_context the LLM completion is skipped server-side either way.
+        lanes.append(
+            ("graph_memory", {"scope": ["graph"], "query_type": "HYBRID_COMPLETION"}, True)
+        )
+
+        blocks: list[str] = []
+        hits = 0
+        cross = 0
+        answered = False
+        hard_failures = 0
+        for label, spec, is_cross in lanes:
+            remaining = deadline - time.monotonic()
+            if remaining < 0.2:
+                # Not enough budget left for an honest attempt; skipping beats
+                # firing a request with a doomed deadline.
+                break
+            try:
+                results = self._backend.recall(
+                    query=query,
+                    session_id=session_id,
+                    datasets=spec.get("datasets") or [self._dataset],
+                    top_k=top_k,
+                    auto_route=True,
+                    query_type=spec.get("query_type"),
+                    scope=spec["scope"],
+                    context_profile=spec.get("context_profile"),
+                    code_query=spec.get("code_query"),
+                    only_context=True,
+                    timeout=min(recall_timeout, remaining),
+                )
+                answered = True
+            except Exception as exc:
+                if self._is_graph_not_built(exc, spec["scope"]):
+                    answered = True
+                    continue
+                hard_failures += 1
+                logger.debug("Cognee recall lane %s failed: %s", label, exc)
+                continue
+            lines = self._format_recall_lines(results, limit=top_k)
+            if not lines:
+                continue
+            hits += len(lines)
+            if is_cross:
+                cross += len(lines)
+            blocks.append(f"<{label}>\n" + "\n".join(lines) + f"\n</{label}>")
+
+        # One verdict per turn, not per lane: a single dead server must not
+        # feed the breaker five failures every prompt, and one healthy lane is
+        # proof the backend is up.
+        if answered:
+            self._record_success()
+        elif hard_failures:
+            self._record_failure()
+
+        with self._prefetch_lock:
+            self._turns_seen += 1
+            if blocks:
+                self._turns_with_hits += 1
+                self._hits_total += hits
+                self._cross_hits_total += cross
+                if generation == self._prefetch_generation:
+                    self._prefetch_result = self._hit_header(hits, cross) + "\n\n".join(blocks)
 
     def _handle_recall(self, args: dict[str, Any]) -> str:
         query = str(args.get("query") or "").strip()
@@ -895,25 +1125,417 @@ class CogneeMemoryProvider(MemoryProvider):
             self._record_failure()
             return json.dumps({"error": f"Cognee remember failed: {exc}"})
 
+    _FORGET_MAX_SCANNED = 100
+    _FORGET_MAX_CANDIDATES = 8
+    _FORGET_PREVIEW_CHARS = 240
+
+    def _resolve_dataset_id(self, name: str, *, timeout: float = 30.0) -> str:
+        """The UUID of the named dataset, or "" when this principal cannot see it."""
+        for row in self._backend.list_datasets(timeout=timeout):
+            if str(row.get("name") or "") == name:
+                return str(row.get("id") or "")
+        return ""
+
+    @staticmethod
+    def _forget_terms(raw_terms: str) -> list[str]:
+        return [token for token in raw_terms.lower().replace(",", " ").split() if len(token) >= 2]
+
     def _handle_forget(self, args: dict[str, Any]) -> str:
-        dataset = args.get("dataset")
-        everything = bool(args.get("everything", False))
-        memory_only = bool(args.get("memory_only", False))
-        if not dataset and not everything:
-            return json.dumps({"error": "Specify dataset or set everything=true."})
+        action = str(args.get("action") or "").strip().lower()
+        if action == "find":
+            return self._forget_find(args)
+        if action == "forget":
+            return self._forget_delete(args)
+        return json.dumps(
+            {
+                "error": (
+                    "Specify action='find' (list candidate documents by terms) or "
+                    "action='forget' (delete confirmed data_ids)."
+                )
+            }
+        )
+
+    def _forget_find(self, args: dict[str, Any]) -> str:
+        terms = self._forget_terms(str(args.get("terms") or ""))
+        if not terms:
+            return json.dumps({"error": "action='find' requires terms describing the content."})
+        dataset = str(args.get("dataset") or self._dataset)
+        # Flush the turn currently being written so it is at least in the cache;
+        # note that unbridged session turns are not documents yet either way.
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
 
         try:
-            result = self._backend.forget(
-                dataset=dataset,
-                everything=everything,
-                memory_only=memory_only,
-                timeout=self._timeout("write_timeout", 120),
-            )
+            dataset_id = self._resolve_dataset_id(dataset)
+            if not dataset_id:
+                return json.dumps({"error": f"Dataset {dataset!r} was not found."})
+            items = self._backend.list_dataset_data(dataset_id=dataset_id, timeout=30.0)
+            candidates: list[dict[str, Any]] = []
+            scanned = 0
+            # The doc cap alone is not a time bound — 100 raw reads at the
+            # per-read timeout could hold the tool call for minutes. One overall
+            # deadline; a partial scan is reported as such via `scanned`.
+            scan_deadline = time.monotonic() + self._timeout("write_timeout", 120)
+            for item in items[: self._FORGET_MAX_SCANNED]:
+                data_id = str(item.get("id") or "")
+                if not data_id:
+                    continue
+                if time.monotonic() >= scan_deadline:
+                    break
+                scanned += 1
+                try:
+                    raw = self._backend.read_raw_data(
+                        dataset_id=dataset_id,
+                        data_id=data_id,
+                        timeout=min(30.0, max(1.0, scan_deadline - time.monotonic())),
+                    )
+                except Exception as exc:
+                    logger.debug("raw read of %s failed during forget find: %s", data_id, exc)
+                    continue
+                lowered = raw.lower()
+                matched = [term for term in terms if term in lowered]
+                if not matched:
+                    continue
+                first = lowered.find(matched[0])
+                start = max(0, first - self._FORGET_PREVIEW_CHARS // 3)
+                preview = raw[start : start + self._FORGET_PREVIEW_CHARS].strip()
+                candidates.append(
+                    {
+                        "data_id": data_id,
+                        "name": str(item.get("name") or ""),
+                        "matched_terms": matched,
+                        "preview": preview,
+                    }
+                )
             self._record_success()
-            return json.dumps({"result": "Cognee memory deleted.", "details": result})
+            candidates.sort(key=lambda c: len(c["matched_terms"]), reverse=True)
+            envelope: dict[str, Any] = {
+                "action": "find",
+                "dataset": dataset,
+                "dataset_id": dataset_id,
+                "candidates": candidates[: self._FORGET_MAX_CANDIDATES],
+                "scanned": scanned,
+                "total_items": len(items),
+                "note": (
+                    "Show these candidates to the user; delete only what they confirm, "
+                    "via action='forget' with data_ids and confirm=true. Turns from the "
+                    "current conversation become deletable documents only after the "
+                    "session is bridged to the graph."
+                ),
+            }
+            if not candidates:
+                envelope["result"] = "No stored documents matched those terms."
+            return json.dumps(envelope)
+        except Exception as exc:
+            self._record_failure()
+            return json.dumps({"error": f"Cognee forget find failed: {exc}"})
+
+    def _forget_delete(self, args: dict[str, Any]) -> str:
+        if not bool(args.get("confirm", False)):
+            return json.dumps(
+                {"error": "Deletion requires confirm=true, after the user has confirmed."}
+            )
+        dataset = str(args.get("dataset") or self._dataset)
+        if bool(args.get("everything_in_dataset", False)):
+            # Whole-dataset deletion stays on the coarse endpoint; the everything
+            # (all datasets) wipe is deliberately not expressible from this tool.
+            try:
+                result = self._backend.forget(
+                    dataset=dataset,
+                    everything=False,
+                    memory_only=False,
+                    timeout=self._timeout("write_timeout", 120),
+                )
+                self._record_success()
+                return json.dumps({"result": f"Dataset {dataset!r} deleted.", "details": result})
+            except Exception as exc:
+                self._record_failure()
+                return json.dumps({"error": f"Cognee forget failed: {exc}"})
+
+        data_ids = [str(value) for value in (args.get("data_ids") or []) if str(value).strip()]
+        if not data_ids:
+            return json.dumps({"error": "action='forget' requires data_ids (from action='find')."})
+        try:
+            dataset_id = self._resolve_dataset_id(dataset)
+            if not dataset_id:
+                return json.dumps({"error": f"Dataset {dataset!r} was not found."})
         except Exception as exc:
             self._record_failure()
             return json.dumps({"error": f"Cognee forget failed: {exc}"})
+
+        deleted: list[str] = []
+        errors: list[dict[str, str]] = []
+        for data_id in data_ids:
+            try:
+                self._backend.forget_document(
+                    dataset_id=dataset_id,
+                    data_id=data_id,
+                    timeout=self._timeout("write_timeout", 120),
+                )
+                deleted.append(data_id)
+            except Exception as exc:
+                if getattr(exc, "status", None) == 404:
+                    errors.append({"data_id": data_id, "error": "not found (already deleted?)"})
+                else:
+                    errors.append({"data_id": data_id, "error": str(exc)[:200]})
+        if deleted:
+            self._record_success()
+        elif errors:
+            self._record_failure()
+        envelope: dict[str, Any] = {
+            "action": "forget",
+            "dataset": dataset,
+            "deleted": deleted,
+            "count": len(deleted),
+        }
+        if errors:
+            envelope["errors"] = errors
+        return json.dumps(envelope)
+
+    # -- dataset switching -----------------------------------------------------
+
+    def _apply_dataset_override(self) -> None:
+        """Re-apply a persisted per-conversation dataset switch, if any."""
+        override = dataset_overrides.load_override(self._session_id)
+        if not override:
+            return
+        try:
+            dataset = str(override.get("dataset") or "")
+            counter = int(override.get("counter") or 0)
+        except (TypeError, ValueError):
+            return
+        if not dataset or counter <= 0:
+            return
+        self._dataset = dataset
+        self._switch_counter = counter
+        self._session_cognee_id = f"{self._session_cognee_id}__{counter}"
+
+    def _handle_switch_dataset(self, args: dict[str, Any]) -> str:
+        action = str(args.get("action") or "").strip().lower()
+        force = bool(args.get("force", False))
+        if action == "current":
+            return json.dumps(
+                {
+                    "dataset": self._dataset,
+                    "default": self._default_dataset,
+                    "switched": self._dataset != self._default_dataset,
+                    "cognee_session_id": self._session_cognee_id,
+                }
+            )
+        if action == "list":
+            try:
+                rows = self._backend.list_datasets(timeout=30.0)
+                self._record_success()
+            except Exception as exc:
+                self._record_failure()
+                return json.dumps({"error": f"Listing datasets failed: {exc}"})
+            names = sorted({str(row.get("name") or "") for row in rows} - {""})
+            return json.dumps(
+                {
+                    "current": self._dataset,
+                    "default": self._default_dataset,
+                    "datasets": [
+                        {"name": name, "current": name == self._dataset} for name in names
+                    ],
+                    "note": (
+                        "A name not listed is created on switch. Code-graph datasets "
+                        "(codebase-*) belong to indexed repositories — do not move "
+                        "conversations into them."
+                    ),
+                }
+            )
+        if action == "switch":
+            target = str(args.get("dataset") or "").strip()
+            if not target:
+                return json.dumps({"error": "action='switch' requires a dataset name."})
+            return self._switch_dataset(target, force=force)
+        if action == "reset":
+            return self._switch_dataset(self._default_dataset, force=force)
+        return json.dumps({"error": "Specify action: list, current, switch, or reset."})
+
+    def _switch_dataset(self, target: str, *, force: bool) -> str:
+        if target == self._dataset:
+            return json.dumps({"switched": False, "reason": "already_active", "dataset": target})
+        old_dataset, old_session = self._dataset, self._session_cognee_id
+
+        # 1. Flush the turn currently being written, then bridge the session we
+        #    are leaving into its dataset. A cognee session never spans two
+        #    datasets, so this is the last chance its cached turns have of
+        #    reaching the old dataset's graph. run_in_background: the server owns
+        #    the promotion; the tool call must not stall on a graph build.
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=10.0)
+        bridged = True
+        bridge_error = ""
+        if self._writes_enabled and self._improve_on_end:
+            try:
+                self._backend.improve(
+                    dataset=old_dataset,
+                    session_ids=[old_session],
+                    background=True,
+                    timeout=self._timeout("improve_timeout", 300),
+                )
+            except Exception as exc:
+                bridged, bridge_error = False, str(exc)[:300]
+                if not force:
+                    self._record_failure()
+                    return json.dumps(
+                        {
+                            "error": (
+                                f"Bridging the current session into {old_dataset!r} failed, "
+                                "so nothing was switched. Retry, or pass force=true to "
+                                "switch anyway (the session is then re-bridged at session "
+                                f"end). Cause: {bridge_error}"
+                            )
+                        }
+                    )
+                # Forced past the failure: defer the bridge instead of dropping it.
+                self._retired_sessions.append((old_dataset, old_session))
+
+        # 2. Make sure the target exists for this principal (idempotent).
+        try:
+            self._backend.ensure_dataset(dataset=target, timeout=30.0)
+        except Exception as exc:
+            self._record_failure()
+            return json.dumps(
+                {"error": f"Dataset {target!r} is not available to this principal: {exc}"}
+            )
+
+        # 3. Re-point capture, recall and the session-end improve under a fresh
+        #    cognee session id.
+        self._switch_counter += 1
+        base = self._build_cognee_session_id(self._session_id)
+        self._session_cognee_id = f"{base}__{self._switch_counter}"
+        self._dataset = target
+        dataset_overrides.save_override(self._session_id, target, self._switch_counter)
+        with self._prefetch_lock:
+            self._prefetch_result = ""
+            self._prefetch_generation += 1
+        if self._watcher_state_path is not None and not self._close_handed_off:
+            exit_watcher.update(
+                self._watcher_state_path,
+                session_id=self._session_cognee_id,
+                dataset=target,
+                improve=bool(self._writes_enabled and self._improve_on_end),
+            )
+        self._record_success()
+        envelope: dict[str, Any] = {
+            "switched": True,
+            "dataset": target,
+            "cognee_session_id": self._session_cognee_id,
+            "previous": {"dataset": old_dataset, "session_id": old_session, "bridged": bridged},
+        }
+        if bridge_error:
+            envelope["previous"]["bridge_error"] = bridge_error
+        return json.dumps(envelope)
+
+    def _bridge_retired_sessions(self) -> None:
+        """Re-submit the bridge for sessions retired by a forced switch."""
+        if not self._retired_sessions:
+            return
+        remaining: list[tuple[str, str]] = []
+        for dataset, session_id in self._retired_sessions:
+            try:
+                self._backend.improve(
+                    dataset=dataset,
+                    session_ids=[session_id],
+                    background=True,
+                    timeout=self._timeout("improve_timeout", 300),
+                )
+            except Exception as exc:
+                logger.warning(
+                    "re-bridging retired session %s into %s failed: %s", session_id, dataset, exc
+                )
+                remaining.append((dataset, session_id))
+        self._retired_sessions = remaining
+
+    # -- code graph --------------------------------------------------------------
+
+    def _resolve_code_dataset(self, repo: str) -> str:
+        """Map a repo path/URL/dataset name — or the cwd — to a code dataset."""
+        repo = repo.strip()
+        configured = [
+            name.strip()
+            for name in str(self._config.get("code_datasets") or "").split(",")
+            if name.strip()
+        ]
+        if repo:
+            if repo.startswith("codebase-") or repo in configured:
+                return repo
+            state = code_graph.find_repo_state(repo)
+            return str(state.get("dataset") or "")
+        state = code_graph.find_indexed_repo(self._cwd)
+        if state.get("dataset"):
+            return str(state["dataset"])
+        return configured[0] if configured else ""
+
+    def _handle_code_search(self, args: dict[str, Any]) -> str:
+        operation = str(args.get("operation") or "").strip().lower()
+        if operation not in code_graph.CODE_OPERATIONS:
+            return json.dumps(
+                {
+                    "error": f"Unknown operation {operation!r}. One of: "
+                    + ", ".join(code_graph.CODE_OPERATIONS)
+                }
+            )
+        name = str(args.get("name") or "").strip()
+        target = str(args.get("target") or "").strip()
+        limit = min(max(1, int(args.get("limit") or 10)), 50)
+
+        dataset = self._resolve_code_dataset(str(args.get("repo") or ""))
+        if not dataset:
+            return json.dumps(
+                {
+                    "error": (
+                        "No indexed repository found. Index one first with "
+                        "`hermes cognee index-repo <path-or-url>`, or name an indexed "
+                        "repo/dataset via the repo parameter."
+                    )
+                }
+            )
+
+        code_query: dict[str, Any] = {"operation": operation}
+        if operation == "query_facts":
+            if name:
+                code_query["name"] = name
+            code_query["limit"] = limit
+        elif operation == "explore":
+            if not name:
+                return json.dumps({"error": "explore requires name (the symbol to explore)."})
+            code_query["name"] = name
+        elif operation == "traverse":
+            if not name:
+                return json.dumps({"error": "traverse requires name (the seed symbol)."})
+            code_query["start"] = name
+        elif operation == "find_path":
+            if not name or not target:
+                return json.dumps({"error": "find_path requires name (source) and target."})
+            code_query["source"] = name
+            code_query["target"] = target
+        elif operation == "impact_analysis":
+            if not name:
+                return json.dumps({"error": "impact_analysis requires name (the symbol)."})
+            code_query["targets"] = [name]
+
+        try:
+            results = self._backend.recall(
+                query=name or operation,
+                session_id=None,
+                datasets=[dataset],
+                top_k=limit,
+                auto_route=True,
+                query_type=None,
+                scope=["code"],
+                code_query=code_query,
+                only_context=True,
+                timeout=self._timeout("recall_timeout", 120),
+            )
+            self._record_success()
+        except Exception as exc:
+            self._record_failure()
+            return json.dumps({"error": f"Cognee code search failed: {exc}"})
+        items = [_coerce_result_dict(item) for item in results]
+        return json.dumps({"dataset": dataset, "results": items, "count": len(items)})
 
     def _normalize_recall_item(self, item: Any) -> dict[str, Any]:
         data = _coerce_result_dict(item)

--- a/integrations/hermes-agent/cognee_integration_hermes/schemas.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/schemas.py
@@ -64,25 +64,144 @@ REMEMBER_SCHEMA = {
 FORGET_SCHEMA = {
     "name": "cognee_forget",
     "description": (
-        "Delete Cognee memory. Use only when the user asks to remove or clear stored "
-        "information. Requires either a dataset or everything=true."
+        "Delete specific content from Cognee memory when the user asks to forget "
+        "something (e.g. 'forget what we said about tennis'). Two-phase: call with "
+        "action='find' and terms describing what to forget — it lists candidate "
+        "documents with previews; show them to the user, then call with "
+        "action='forget', the confirmed data_ids, and confirm=true to delete "
+        "exactly those documents (irreversible). Dataset-wide deletion requires "
+        "an explicit user request: action='forget' with everything_in_dataset "
+        "plus confirm=true."
     ),
     "parameters": {
         "type": "object",
         "properties": {
+            "action": {
+                "type": "string",
+                "description": "find: list matching documents. forget: delete listed ids.",
+                "enum": ["find", "forget"],
+            },
+            "terms": {
+                "type": "string",
+                "description": (
+                    "For action='find': words or phrases describing the content to "
+                    "forget; candidates are matched against their raw stored text."
+                ),
+            },
+            "data_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "For action='forget': the data ids to delete, exactly as returned "
+                    "by action='find'."
+                ),
+            },
+            "confirm": {
+                "type": "boolean",
+                "description": (
+                    "Required true for action='forget'. Only set after the user has "
+                    "seen the candidates and confirmed the deletion."
+                ),
+            },
             "dataset": {
                 "type": "string",
-                "description": "Dataset to delete.",
+                "description": "Optional dataset name. Defaults to the provider dataset.",
             },
-            "everything": {
+            "everything_in_dataset": {
                 "type": "boolean",
-                "description": "Delete all Cognee data visible to this integration.",
-            },
-            "memory_only": {
-                "type": "boolean",
-                "description": "Delete only memory-layer records when supported by Cognee.",
+                "description": (
+                    "Delete the whole dataset instead of individual documents. Only "
+                    "when the user explicitly asked to clear the entire dataset."
+                ),
             },
         },
-        "required": [],
+        "required": ["action"],
+    },
+}
+
+SWITCH_DATASET_SCHEMA = {
+    "name": "cognee_switch_dataset",
+    "description": (
+        "Move this conversation to another Cognee dataset. action='list' shows the "
+        "datasets visible to this principal, 'current' reports the active one, "
+        "'switch' bridges the current session into its dataset and re-points "
+        "capture, recall and the session-end improve at the target (creating it "
+        "if needed), 'reset' returns to the configured default dataset."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "description": "list, current, switch, or reset.",
+                "enum": ["list", "current", "switch", "reset"],
+            },
+            "dataset": {
+                "type": "string",
+                "description": "For action='switch': the target dataset name.",
+            },
+            "force": {
+                "type": "boolean",
+                "description": (
+                    "Proceed with a switch/reset even when bridging the current "
+                    "session into its old dataset fails (the un-bridged session is "
+                    "recorded and retried at session end)."
+                ),
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+CODE_SEARCH_SCHEMA = {
+    "name": "cognee_code_search",
+    "description": (
+        "Query an indexed repository's deterministic code graph (symbols, calls, "
+        "imports, endpoints) — exact answers, no LLM in the loop. Repositories are "
+        "indexed with `hermes cognee index-repo <path-or-url>`. Operations: "
+        "query_facts (substring fact lookup by name), explore (a symbol's "
+        "neighborhood), traverse (walk relations from a seed), find_path (between "
+        "two symbols), impact_analysis (what depends on a symbol), delta (what "
+        "changed between indexings)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "operation": {
+                "type": "string",
+                "description": "The structured code-graph operation to run.",
+                "enum": [
+                    "query_facts",
+                    "explore",
+                    "traverse",
+                    "find_path",
+                    "impact_analysis",
+                    "delta",
+                ],
+            },
+            "name": {
+                "type": "string",
+                "description": (
+                    "The symbol / identifier the operation starts from (for "
+                    "find_path, the source symbol)."
+                ),
+            },
+            "target": {
+                "type": "string",
+                "description": "For find_path: the destination symbol.",
+            },
+            "repo": {
+                "type": "string",
+                "description": (
+                    "Repository path/URL or code dataset name. Defaults to the repo "
+                    "containing the current working directory, if indexed."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum results to return. Default 10.",
+            },
+        },
+        "required": ["operation"],
     },
 }

--- a/integrations/hermes-agent/cognee_integration_hermes/update_check.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/update_check.py
@@ -1,0 +1,106 @@
+"""PyPI update check — rate-limited, cached, fail-silent.
+
+The counterpart of the other plugins' registry checks (claude-code/codex poll
+the marketplace manifest, openclaw the npm registry; same env names:
+``COGNEE_UPDATE_CHECK``, ``COGNEE_UPDATE_CHECK_INTERVAL``). Deliberately
+CLI-only: ``hermes cognee status`` / ``version`` may reach for the network
+once per interval, the session path never does.
+
+The verdict is cached in ``~/.cognee-plugin/hermes/update-check.json``::
+
+    {"checked_at": <epoch>, "latest": "1.2.0"}
+
+Every failure mode returns the best answer available (the cached one, else "")
+— an update nudge must never break a status command.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from .config import SHARED_PLUGIN_STATE_DIR
+
+PYPI_PACKAGE = "cognee-integration-hermes-agent"
+_PYPI_URL = f"https://pypi.org/pypi/{PYPI_PACKAGE}/json"
+
+_CACHE_PATH = SHARED_PLUGIN_STATE_DIR / "hermes" / "update-check.json"
+
+
+def _read_cache(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_cache(path: Path, latest: str, now: float) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"checked_at": now, "latest": latest}), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _fetch_latest(timeout: float, opener: Optional[Callable[..., Any]]) -> str:
+    request = urllib.request.Request(_PYPI_URL, headers={"Accept": "application/json"})
+    open_fn = opener or urllib.request.urlopen
+    with open_fn(request, timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    return str(((payload or {}).get("info") or {}).get("version") or "")
+
+
+def latest_published_version(
+    *,
+    interval: float = 3600.0,
+    force: bool = False,
+    timeout: float = 3.0,
+    now: Optional[float] = None,
+    cache_path: Optional[Path] = None,
+    opener: Optional[Callable[..., Any]] = None,
+) -> str:
+    """The newest version on PyPI, or "" when it cannot be determined.
+
+    Within ``interval`` of the last check the cached answer is returned without
+    touching the network; ``force`` skips that gate. Never raises.
+    """
+    path = cache_path or _CACHE_PATH
+    current_time = time.time() if now is None else now
+    cache = _read_cache(path)
+    cached_latest = str(cache.get("latest") or "")
+    try:
+        checked_at = float(cache.get("checked_at") or 0.0)
+    except (TypeError, ValueError):
+        checked_at = 0.0
+    if not force and cached_latest and current_time - checked_at < interval:
+        return cached_latest
+    try:
+        latest = _fetch_latest(timeout, opener)
+    except Exception:
+        return cached_latest
+    if latest:
+        _write_cache(path, latest, current_time)
+    return latest or cached_latest
+
+
+def _version_tuple(version: str) -> tuple:
+    parts: list[Any] = []
+    for token in version.split("."):
+        digits = "".join(ch for ch in token if ch.isdigit())
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts)
+
+
+def is_newer(candidate: str, current: str) -> bool:
+    """True when ``candidate`` is a strictly newer release than ``current``.
+
+    Numeric best-effort comparison — good enough for the X.Y.Z scheme this
+    package publishes; anything unparseable compares as 0 and never nags.
+    """
+    if not candidate or not current:
+        return False
+    return _version_tuple(candidate) > _version_tuple(current)

--- a/integrations/hermes-agent/plugin.yaml
+++ b/integrations/hermes-agent/plugin.yaml
@@ -1,14 +1,14 @@
 name: cognee
 kind: exclusive
-version: 1.1.0
+version: 1.2.0
 description: "Cognee memory provider for Hermes Agent: session-aware graph memory, recall, forget, and session-end improvement."
 pip_dependencies:
-  # Floor 1.2.1: the HTTP wire contract this plugin depends on
-  # (/api/v1/remember/entry, improve(session_ids)) first shipped there.
-  # Cap 1.4.0: the newest version verified against the test suite and a live
-  # server boot. Repo policy (scripts/check_version_pins.py) requires a bounded
-  # range rather than an exact pin; the lockfile resolves to 1.4.0.
-  - cognee>=1.2.1,<=1.4.0
+  # Exact pin: the installed package doubles as the local server this plugin
+  # spawns, and 1.5.3 is both the floor — content_type="code" repo indexing,
+  # the "code" recall scope, and targeted session invalidation on document
+  # delete all first shipped there — and the newest version verified against
+  # the test suite and a live server.
+  - cognee==1.5.3
 hooks:
   - on_session_end
   - on_memory_write

--- a/integrations/hermes-agent/pyproject.toml
+++ b/integrations/hermes-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cognee-integration-hermes-agent"
-version = "1.1.0"
+version = "1.2.0"
 description = "Standalone Cognee memory provider plugin for Hermes Agent."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -12,7 +12,11 @@ authors = [
     {name = "Cognee team"}
 ]
 dependencies = [
-    "cognee>=1.2.1,<=1.4.0",
+    # Exact pin: the installed package doubles as the local server this plugin
+    # spawns, and 1.5.3 is both the floor (code graph, per-document forget
+    # invalidation) and the newest version verified against the test suite and
+    # a live server.
+    "cognee==1.5.3",
 ]
 
 [project.entry-points."hermes_agent.plugins"]

--- a/integrations/hermes-agent/tests/_char_helpers.py
+++ b/integrations/hermes-agent/tests/_char_helpers.py
@@ -228,9 +228,15 @@ class FakeBackend(MemoryBackend):
             "remember_session": None,
             "remember_permanent": RememberResultStub(),
             "forget": {"deleted": True},
+            "forget_document": {"deleted": True},
             "improve": {},
             "connect": None,
             "resolve_identity": "USER",
+            "list_datasets": [],
+            "list_dataset_data": [],
+            "read_raw_data": "",
+            "index_repository": {},
+            "dataset_pipeline_status": "",
         }
         self.empty_recall_hint_value = None
         self.overflow_hint_value = None
@@ -300,6 +306,24 @@ class FakeBackend(MemoryBackend):
     def improve(self, **kwargs):
         return self._recorder.record("improve", kwargs)
 
+    def list_datasets(self, **kwargs):
+        return self._recorder.record("list_datasets", kwargs)
+
+    def list_dataset_data(self, **kwargs):
+        return self._recorder.record("list_dataset_data", kwargs)
+
+    def read_raw_data(self, **kwargs):
+        return self._recorder.record("read_raw_data", kwargs)
+
+    def forget_document(self, **kwargs):
+        return self._recorder.record("forget_document", kwargs)
+
+    def index_repository(self, **kwargs):
+        return self._recorder.record("index_repository", kwargs)
+
+    def dataset_pipeline_status(self, **kwargs):
+        return self._recorder.record("dataset_pipeline_status", kwargs)
+
     def empty_recall_hint(self, **kwargs):
         self._recorder.record("empty_recall_hint", kwargs)
         return self.empty_recall_hint_value
@@ -365,11 +389,16 @@ def make_provider(
     provider._improve_on_end = improve_on_end
     provider._session_id = session_id
     provider._session_cognee_id = session_cognee_id or f"hermes_{session_id}"
+    provider._default_dataset = dataset
     provider._config = {
         "recall_timeout": 5,
         "write_timeout": 5,
         "improve_timeout": 5,
         "improve_background": "",
+        # The layered fan-out and the hit header have their own tests; the
+        # legacy single-call prefetch path stays characterized with both off.
+        "recall_session_layers": False,
+        "memory_hits": False,
         **(config or {}),
     }
     return provider

--- a/integrations/hermes-agent/tests/conftest.py
+++ b/integrations/hermes-agent/tests/conftest.py
@@ -64,10 +64,23 @@ def pytest_collection_modifyitems(items):
 
 
 @pytest.fixture(autouse=True)
-def hermetic_env(request, monkeypatch):
-    """Drop every ambient cognee variable, for every test but the live ones."""
+def hermetic_env(request, monkeypatch, tmp_path):
+    """Drop every ambient cognee variable, for every test but the live ones.
+
+    The shared state files under ``~/.cognee-plugin/hermes/`` are re-pointed at
+    the test's tmp dir for the same reason the env is scrubbed: the dataset
+    overrides a developer switched, the repos they indexed for code recall and
+    their cached update check would otherwise leak into (and be written by)
+    the hermetic suite.
+    """
     if request.module.__name__.rsplit(".", 1)[-1] in _LIVE_MODULES:
         return
     for name in list(os.environ):
         if name.startswith(_SCRUBBED_PREFIXES):
             monkeypatch.delenv(name, raising=False)
+
+    from cognee_integration_hermes import code_graph, dataset_overrides, update_check
+
+    monkeypatch.setattr(code_graph, "_STATE_DIR", tmp_path / "code-graph")
+    monkeypatch.setattr(dataset_overrides, "_OVERRIDES_PATH", tmp_path / "dataset-overrides.json")
+    monkeypatch.setattr(update_check, "_CACHE_PATH", tmp_path / "update-check.json")

--- a/integrations/hermes-agent/tests/test_code_graph.py
+++ b/integrations/hermes-agent/tests/test_code_graph.py
@@ -1,0 +1,155 @@
+"""The code-graph helpers: identifier gate, repo identity, state registry.
+
+Run standalone with ``python3 tests/test_code_graph.py``.
+"""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from cognee_integration_hermes import code_graph  # noqa: E402
+
+
+class TestExtractIdentifiers(unittest.TestCase):
+    """The syntactic gate that keeps the code lane off conversational prompts."""
+
+    def test_conversational_prompts_yield_nothing(self):
+        for prompt in (
+            "how are you today",
+            "summarize what we discussed yesterday",
+            "what's the weather like",
+            "",
+        ):
+            self.assertEqual(code_graph.extract_identifiers(prompt), [], prompt)
+
+    def test_snake_case_fires(self):
+        self.assertEqual(
+            code_graph.extract_identifiers("what calls process_payment?"),
+            ["process_payment"],
+        )
+
+    def test_camel_case_fires(self):
+        self.assertIn("UserService", code_graph.extract_identifiers("explain UserService"))
+
+    def test_file_paths_fire(self):
+        self.assertIn(
+            "billing/api.py", code_graph.extract_identifiers("look at billing/api.py please")
+        )
+
+    def test_backticked_identifiers_win(self):
+        found = code_graph.extract_identifiers("check `resolve_config` and process_payment")
+        self.assertEqual(found[0], "resolve_config")
+
+    def test_backticked_prose_is_ignored(self):
+        self.assertEqual(code_graph.extract_identifiers("run `git status now` for me"), [])
+
+    def test_stoplist_words_do_not_fire(self):
+        self.assertEqual(code_graph.extract_identifiers("ask Cognee about GitHub"), [])
+        self.assertEqual(code_graph.extract_identifiers("Hermes and OpenAI teamed up"), [])
+
+    def test_domains_and_prose_dots_do_not_fire(self):
+        self.assertEqual(code_graph.extract_identifiers("see example.com e.g. today"), [])
+
+    def test_at_most_limit_tokens(self):
+        found = code_graph.extract_identifiers("a_b c_d e_f g_h", limit=2)
+        self.assertEqual(len(found), 2)
+
+
+class TestRepoIdentity(unittest.TestCase):
+    def test_remote_specs_are_canonicalized(self):
+        self.assertEqual(
+            code_graph.canonical_spec("https://github.com/a/repo.git"),
+            "https://github.com/a/repo",
+        )
+        self.assertEqual(
+            code_graph.canonical_spec("https://github.com/a/repo/"),
+            "https://github.com/a/repo",
+        )
+
+    def test_dataset_name_is_stable_and_prefixed(self):
+        name = code_graph.default_code_dataset("https://github.com/a/repo")
+        self.assertTrue(name.startswith("codebase-repo-"))
+        self.assertEqual(name, code_graph.default_code_dataset("https://github.com/a/repo.git"))
+
+    def test_same_basename_different_paths_get_different_datasets(self):
+        # The path digest is load-bearing: two checkouts sharing a basename in
+        # one dataset would let each re-index's stale-node sweep delete the
+        # other's nodes.
+        a = code_graph.default_code_dataset("https://github.com/a/service")
+        b = code_graph.default_code_dataset("https://github.com/b/service")
+        self.assertNotEqual(a, b)
+
+
+class TestRepoStateRegistry(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.tmp = Path(tmp.name).resolve()
+        patcher = mock.patch.object(code_graph, "_STATE_DIR", self.tmp / "state")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_record_and_find_by_cwd(self):
+        repo = self.tmp / "repo"
+        (repo / "src").mkdir(parents=True)
+        state = code_graph.record_index(str(repo), "codebase-repo-x", index_vectors=False)
+        self.assertEqual(state["spec_kind"], "path")
+        found = code_graph.find_indexed_repo(str(repo / "src"))
+        self.assertEqual(found["dataset"], "codebase-repo-x")
+        # Outside the repo: no match.
+        self.assertEqual(code_graph.find_indexed_repo(str(self.tmp)), {})
+
+    def test_nested_checkouts_resolve_to_the_innermost_repo(self):
+        outer = self.tmp / "outer"
+        inner = outer / "vendor" / "inner"
+        inner.mkdir(parents=True)
+        code_graph.record_index(str(outer), "codebase-outer-1", index_vectors=False)
+        code_graph.record_index(str(inner), "codebase-inner-1", index_vectors=False)
+        self.assertEqual(code_graph.find_indexed_repo(str(inner))["dataset"], "codebase-inner-1")
+        self.assertEqual(code_graph.find_indexed_repo(str(outer))["dataset"], "codebase-outer-1")
+
+    def test_url_indexed_repos_have_no_local_root(self):
+        state = code_graph.record_index(
+            "https://github.com/a/repo", "codebase-repo-y", index_vectors=True
+        )
+        self.assertEqual(state["spec_kind"], "url")
+        self.assertEqual(state["repo_root"], "")
+        self.assertEqual(code_graph.find_indexed_repo(str(self.tmp)), {})
+        # But it is findable by spec and by dataset name.
+        self.assertEqual(
+            code_graph.find_repo_state("https://github.com/a/repo.git")["dataset"],
+            "codebase-repo-y",
+        )
+        self.assertEqual(
+            code_graph.find_repo_state("codebase-repo-y")["dataset"], "codebase-repo-y"
+        )
+
+    def test_auto_code_lane_needs_both_gates(self):
+        repo = self.tmp / "repo"
+        repo.mkdir()
+        # Identifier without an indexed repo: no lane.
+        self.assertEqual(code_graph.auto_code_lane("what calls foo_bar", str(repo)), {})
+        code_graph.record_index(str(repo), "codebase-repo-z", index_vectors=False)
+        # Indexed repo without an identifier: no lane.
+        self.assertEqual(code_graph.auto_code_lane("how are you", str(repo)), {})
+        # Both: the lane fires with a bounded query_facts seed.
+        lane = code_graph.auto_code_lane("what calls foo_bar", str(repo))
+        self.assertEqual(lane["dataset"], "codebase-repo-z")
+        self.assertEqual(lane["identifier"], "foo_bar")
+        self.assertEqual(lane["code_query"]["operation"], "query_facts")
+
+    def test_invalid_state_files_are_skipped(self):
+        state_dir = self.tmp / "state"
+        state_dir.mkdir(parents=True)
+        (state_dir / "broken.json").write_text("{not json", encoding="utf-8")
+        self.assertEqual(code_graph.load_repo_states(), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/integrations/hermes-agent/tests/test_http_backend.py
+++ b/integrations/hermes-agent/tests/test_http_backend.py
@@ -724,11 +724,28 @@ class TestProviderOverHttp(unittest.TestCase):
         self.assertTrue(provider._is_breaker_open())
 
     def test_forget_reaches_the_endpoint_and_reports_details(self):
-        opener = FakeOpener({"/api/v1/forget": {"deleted": 2}})
-        out = json.loads(
-            self._provider(opener).handle_tool_call("cognee_forget", {"dataset": "hermes"})
+        dataset_id = "11111111-1111-1111-1111-111111111111"
+        data_id = "22222222-2222-2222-2222-222222222222"
+        opener = FakeOpener(
+            {
+                "/api/v1/datasets": [{"id": dataset_id, "name": "hermes"}],
+                "/api/v1/forget": {"deleted": 1},
+            }
         )
-        self.assertEqual(out, {"result": "Cognee memory deleted.", "details": {"deleted": 2}})
+        out = json.loads(
+            self._provider(opener).handle_tool_call(
+                "cognee_forget",
+                {"action": "forget", "data_ids": [data_id], "confirm": True},
+            )
+        )
+        self.assertEqual(out["deleted"], [data_id])
+        self.assertEqual(out["count"], 1)
+        # The wire body is the single-document shape — the only deletion this
+        # tool path can express.
+        self.assertEqual(
+            opener.json_body("/api/v1/forget"),
+            {"datasetId": dataset_id, "dataId": data_id},
+        )
 
 
 if __name__ == "__main__":

--- a/integrations/hermes-agent/tests/test_integration_roundtrip.py
+++ b/integrations/hermes-agent/tests/test_integration_roundtrip.py
@@ -204,16 +204,29 @@ class TestHttpRoundTrip(unittest.TestCase):
         finally:
             provider.shutdown()
 
-    def test_forget_clears_the_dataset(self):
+    def test_forget_finds_and_deletes_the_stored_document(self):
         import json
 
         provider = self._provider()
         try:
-            provider.handle_tool_call("cognee_remember", {"content": "Disposable fact."})
+            provider.handle_tool_call(
+                "cognee_remember", {"content": "Disposable fact about zebras."}
+            )
+            found = json.loads(
+                provider.handle_tool_call("cognee_forget", {"action": "find", "terms": "zebras"})
+            )
+            self.assertNotIn("error", found, found)
+            candidates = found.get("candidates") or []
+            self.assertTrue(candidates, f"the stored document was not listed: {found}")
+            data_ids = [candidate["data_id"] for candidate in candidates]
             result = json.loads(
-                provider.handle_tool_call("cognee_forget", {"dataset": self.dataset})
+                provider.handle_tool_call(
+                    "cognee_forget",
+                    {"action": "forget", "data_ids": data_ids, "confirm": True},
+                )
             )
             self.assertNotIn("error", result, result)
+            self.assertEqual(result["count"], len(data_ids), result)
         finally:
             provider.shutdown()
 

--- a/integrations/hermes-agent/tests/test_layered_recall.py
+++ b/integrations/hermes-agent/tests/test_layered_recall.py
@@ -1,0 +1,224 @@
+"""The layered per-prompt recall and the memory-hit header.
+
+With ``dataset_ids`` + ``search_type`` in a single request the server's
+``auto`` scope resolves graph-only, so cached Q&A turns, trace lessons and
+distilled agent guidance never reached the prompt. The layered fan-out runs
+one bounded call per scope, cheap lanes first, and renders each layer as its
+own labelled block. Run standalone with ``python3 tests/test_layered_recall.py``.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from _char_helpers import fake_backend, make_provider  # noqa: E402
+
+_LAYERED = {"recall_session_layers": True, "recall_budget": 20}
+
+
+def _settle(provider, timeout=5.0):
+    thread = provider._prefetch_thread
+    if thread is not None:
+        thread.join(timeout=timeout)
+
+
+def _prefetch(provider, query="q"):
+    provider.queue_prefetch(query)
+    _settle(provider)
+    return provider.prefetch(query)
+
+
+class TestLayeredFanOut(unittest.TestCase):
+    def test_one_call_per_scope_cheap_lanes_first(self):
+        with fake_backend() as fake:
+            provider = make_provider(config=_LAYERED)
+            _prefetch(provider)
+            scopes = [kwargs["scope"] for kwargs in fake.kwargs_for("recall")]
+        self.assertEqual(scopes, [["session"], ["trace"], ["session_context"], ["graph"]])
+
+    def test_graph_lane_uses_hybrid_completion_and_only_context(self):
+        with fake_backend() as fake:
+            provider = make_provider(config=_LAYERED)
+            _prefetch(provider)
+            calls = fake.kwargs_for("recall")
+        by_scope = {tuple(kwargs["scope"]): kwargs for kwargs in calls}
+        self.assertEqual(by_scope[("graph",)]["query_type"], "HYBRID_COMPLETION")
+        self.assertTrue(all(kwargs["only_context"] for kwargs in calls))
+        # The session_context lane asks for the distilled agent rendering.
+        self.assertEqual(by_scope[("session_context",)]["context_profile"], "agent")
+        self.assertIsNone(by_scope[("session",)]["context_profile"])
+
+    def test_every_lane_targets_the_plugin_dataset_and_session(self):
+        with fake_backend() as fake:
+            provider = make_provider(config=_LAYERED)
+            _prefetch(provider)
+            for kwargs in fake.kwargs_for("recall"):
+                self.assertEqual(kwargs["datasets"], ["hermes"])
+                self.assertEqual(kwargs["session_id"], "hermes_s-1")
+
+    def test_results_are_rendered_as_labelled_blocks(self):
+        with fake_backend() as fake:
+            fake.results["recall"] = [{"text": "remembered", "source": "x"}]
+            provider = make_provider(config={**_LAYERED, "memory_hits": False})
+            out = _prefetch(provider)
+        for label in ("<session_memory>", "<trace_lessons>", "<agent_guidance>", "<graph_memory>"):
+            self.assertIn(label, out)
+        self.assertIn("</session_memory>", out)
+
+    def test_a_failing_lane_does_not_discard_the_others(self):
+        with fake_backend() as fake:
+            calls = {"n": 0}
+            original = fake.recall
+
+            def flaky(**kwargs):
+                calls["n"] += 1
+                if kwargs["scope"] == ["trace"]:
+                    raise RuntimeError("trace lane down")
+                original(**kwargs)
+                return [{"text": "kept"}]
+
+            fake.recall = flaky
+            provider = make_provider(config={**_LAYERED, "memory_hits": False})
+            out = _prefetch(provider)
+        self.assertIn("<session_memory>", out)
+        self.assertIn("<graph_memory>", out)
+        self.assertNotIn("<trace_lessons>", out)
+
+    def test_empty_lanes_leave_nothing_cached(self):
+        with fake_backend() as fake:
+            fake.results["recall"] = []
+            provider = make_provider(config=_LAYERED)
+            self.assertEqual(_prefetch(provider), "")
+
+    def test_a_graph_404_is_benign_not_a_breaker_failure(self):
+        # A dataset nobody has cognified answers the graph scope with 404 on
+        # every prompt of a fresh install; that must not feed the breaker.
+        class _Http404(RuntimeError):
+            status = 404
+
+        with fake_backend() as fake:
+            original = fake.recall
+
+            def not_built(**kwargs):
+                original(**kwargs)
+                if kwargs["scope"] == ["graph"]:
+                    raise _Http404("graph not built")
+                return []
+
+            fake.recall = not_built
+            provider = make_provider(config=_LAYERED)
+            _prefetch(provider)
+        self.assertEqual(provider._consecutive_failures, 0)
+
+    def test_all_lanes_failing_counts_one_breaker_failure(self):
+        with fake_backend() as fake:
+            fake.errors["recall"] = RuntimeError("down")
+            provider = make_provider(config=_LAYERED)
+            _prefetch(provider)
+        self.assertEqual(provider._consecutive_failures, 1)
+
+    def test_zero_budget_skips_every_lane(self):
+        with fake_backend() as fake:
+            provider = make_provider(config={**_LAYERED, "recall_budget": 0})
+            _prefetch(provider)
+            self.assertEqual(fake.kwargs_for("recall"), [])
+
+
+class TestCodeLane(unittest.TestCase):
+    def test_configured_code_dataset_arms_the_lane_on_identifiers(self):
+        with fake_backend() as fake:
+            provider = make_provider(config={**_LAYERED, "code_datasets": "codebase-svc-abc123"})
+            provider.queue_prefetch("what calls process_payment?")
+            _settle(provider)
+            scopes = [tuple(kwargs["scope"]) for kwargs in fake.kwargs_for("recall")]
+            self.assertIn(("code",), scopes)
+            code_call = next(
+                kwargs for kwargs in fake.kwargs_for("recall") if kwargs["scope"] == ["code"]
+            )
+        self.assertEqual(code_call["datasets"], ["codebase-svc-abc123"])
+        self.assertEqual(code_call["code_query"]["operation"], "query_facts")
+        self.assertEqual(code_call["code_query"]["name"], "process_payment")
+
+    def test_conversational_prompts_never_arm_the_code_lane(self):
+        with fake_backend() as fake:
+            provider = make_provider(config={**_LAYERED, "code_datasets": "codebase-svc-abc123"})
+            provider.queue_prefetch("how are you today")
+            _settle(provider)
+            scopes = [tuple(kwargs["scope"]) for kwargs in fake.kwargs_for("recall")]
+        self.assertNotIn(("code",), scopes)
+
+    def test_code_graph_recall_off_disables_the_lane(self):
+        with fake_backend() as fake:
+            provider = make_provider(
+                config={
+                    **_LAYERED,
+                    "code_datasets": "codebase-svc-abc123",
+                    "code_graph_recall": False,
+                }
+            )
+            provider.queue_prefetch("what calls process_payment?")
+            _settle(provider)
+            scopes = [tuple(kwargs["scope"]) for kwargs in fake.kwargs_for("recall")]
+        self.assertNotIn(("code",), scopes)
+
+
+class TestMemoryHitHeader(unittest.TestCase):
+    def test_header_reports_hits_and_per_session_totals(self):
+        with fake_backend() as fake:
+            fake.results["recall"] = [{"text": "remembered"}]
+            provider = make_provider(config={**_LAYERED, "memory_hits": True})
+            out = _prefetch(provider)
+        self.assertIn("4 memory hits this turn", out)
+        self.assertIn("(2 beyond this session)", out)  # agent_guidance + graph
+        self.assertIn("1/1 turns had hits this session", out)
+
+    def test_totals_accumulate_across_turns(self):
+        with fake_backend() as fake:
+            fake.results["recall"] = []
+            provider = make_provider(config={**_LAYERED, "memory_hits": True})
+            self.assertEqual(_prefetch(provider), "")  # turn 1: no hits
+            fake.results["recall"] = [{"text": "remembered"}]
+            out = _prefetch(provider)  # turn 2: hits
+        self.assertIn("1/2 turns had hits this session", out)
+
+    def test_reset_session_switch_clears_the_totals(self):
+        with fake_backend() as fake:
+            fake.results["recall"] = [{"text": "remembered"}]
+            provider = make_provider(config={**_LAYERED, "memory_hits": True})
+            _prefetch(provider)
+            provider.on_session_switch("s-2", reset=True)
+        self.assertEqual(provider._turns_seen, 0)
+        self.assertEqual(provider._hits_total, 0)
+
+    def test_header_is_absent_when_disabled(self):
+        with fake_backend() as fake:
+            fake.results["recall"] = [{"text": "remembered"}]
+            provider = make_provider(config={**_LAYERED, "memory_hits": False})
+            out = _prefetch(provider)
+        self.assertNotIn("memory hit", out)
+
+
+class TestSessionScopeMapping(unittest.TestCase):
+    def test_tool_session_scope_covers_the_three_session_layers(self):
+        with fake_backend() as fake:
+            provider = make_provider(config={"recall_session_layers": True})
+            provider.handle_tool_call("cognee_recall", {"query": "q", "scope": "session"})
+            kwargs = fake.only_call("recall")
+        self.assertEqual(kwargs["scope"], ["session", "trace", "session_context"])
+        self.assertEqual(kwargs["datasets"], ["hermes"])
+
+    def test_legacy_session_scope_with_layers_off(self):
+        with fake_backend() as fake:
+            provider = make_provider(config={"recall_session_layers": False})
+            provider.handle_tool_call("cognee_recall", {"query": "q", "scope": "session"})
+            kwargs = fake.only_call("recall")
+        self.assertEqual(kwargs["scope"], "session")
+        self.assertIsNone(kwargs["datasets"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/integrations/hermes-agent/tests/test_recall_wire_contract.py
+++ b/integrations/hermes-agent/tests/test_recall_wire_contract.py
@@ -88,10 +88,14 @@ class TestRecallBodyMeansWhatWeIntend(unittest.TestCase):
 
     def test_omitting_search_type_is_what_broke_auto_routing(self):
         # Characterizes the old wire format: same request minus the key, parsed
-        # by the same DTO, silently means GRAPH_COMPLETION.
+        # by the same DTO, silently means a *pinned* search type instead of the
+        # query classifier. Which type the DTO defaults to has itself moved
+        # (GRAPH_COMPLETION on 1.4, HYBRID_COMPLETION on 1.5.3); the harm this
+        # test pins is that it is not None — auto-routing and the session fold
+        # are conditional on an explicit null.
         body = _sent_body()
         body.pop("search_type")
-        self.assertEqual(str(self._parse(body).search_type), "SearchType.GRAPH_COMPLETION")
+        self.assertIsNotNone(self._parse(body).search_type)
 
     def test_auto_route_false_still_pins_graph_completion(self):
         dto = self._parse(_sent_body(auto_route=False))

--- a/integrations/hermes-agent/tests/test_smoke.py
+++ b/integrations/hermes-agent/tests/test_smoke.py
@@ -16,6 +16,8 @@ def test_provider_imports():
         "cognee_recall",
         "cognee_remember",
         "cognee_forget",
+        "cognee_switch_dataset",
+        "cognee_code_search",
     }
 
 

--- a/integrations/hermes-agent/tests/test_switch_and_code_tools.py
+++ b/integrations/hermes-agent/tests/test_switch_and_code_tools.py
@@ -1,0 +1,230 @@
+"""The cognee_switch_dataset and cognee_code_search tool contracts.
+
+Run standalone with ``python3 tests/test_switch_and_code_tools.py``.
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from _char_helpers import fake_backend, make_provider  # noqa: E402
+from cognee_integration_hermes import code_graph, dataset_overrides  # noqa: E402
+
+
+def _call(provider, tool, args):
+    return json.loads(provider.handle_tool_call(tool, args))
+
+
+class TestSwitchDataset(unittest.TestCase):
+    def test_current_reports_the_active_and_default_dataset(self):
+        with fake_backend():
+            provider = make_provider()
+            out = _call(provider, "cognee_switch_dataset", {"action": "current"})
+        self.assertEqual(out["dataset"], "hermes")
+        self.assertEqual(out["default"], "hermes")
+        self.assertFalse(out["switched"])
+
+    def test_list_marks_the_current_dataset(self):
+        with fake_backend() as fake:
+            fake.results["list_datasets"] = [
+                {"id": "x", "name": "hermes"},
+                {"id": "y", "name": "work"},
+            ]
+            provider = make_provider()
+            out = _call(provider, "cognee_switch_dataset", {"action": "list"})
+        rows = {row["name"]: row["current"] for row in out["datasets"]}
+        self.assertEqual(rows, {"hermes": True, "work": False})
+
+    def test_switch_bridges_ensures_and_repoints(self):
+        with fake_backend() as fake:
+            provider = make_provider()
+            out = _call(provider, "cognee_switch_dataset", {"action": "switch", "dataset": "work"})
+        self.assertTrue(out["switched"])
+        self.assertEqual(out["dataset"], "work")
+        self.assertTrue(out["previous"]["bridged"])
+        # 1. The session being left was bridged into its OLD dataset, on the
+        #    server's own background pipeline.
+        improve = fake.only_call("improve")
+        self.assertEqual(improve["dataset"], "hermes")
+        self.assertEqual(improve["session_ids"], ["hermes_s-1"])
+        self.assertTrue(improve["background"])
+        # 2. The target was ensured.
+        self.assertEqual(fake.only_call("ensure_dataset")["dataset"], "work")
+        # 3. Capture and recall now target the new dataset under a fresh cognee
+        #    session id (a cognee session never spans two datasets).
+        self.assertEqual(provider._dataset, "work")
+        self.assertEqual(provider._session_cognee_id, "hermes_s-1__1")
+        # 4. The override is persisted for a later resume of this conversation.
+        override = dataset_overrides.load_override("s-1")
+        self.assertEqual(override["dataset"], "work")
+        self.assertEqual(override["counter"], 1)
+
+    def test_switch_to_the_active_dataset_is_a_noop(self):
+        with fake_backend() as fake:
+            provider = make_provider()
+            out = _call(
+                provider, "cognee_switch_dataset", {"action": "switch", "dataset": "hermes"}
+            )
+        self.assertFalse(out["switched"])
+        self.assertEqual(out["reason"], "already_active")
+        self.assertEqual(fake.calls, [])
+
+    def test_a_failed_bridge_aborts_without_force(self):
+        with fake_backend() as fake:
+            fake.errors["improve"] = RuntimeError("server busy")
+            provider = make_provider()
+            out = _call(provider, "cognee_switch_dataset", {"action": "switch", "dataset": "work"})
+        self.assertIn("force=true", out["error"])
+        # Nothing changed: same dataset, same session id, target never ensured.
+        self.assertEqual(provider._dataset, "hermes")
+        self.assertEqual(provider._session_cognee_id, "hermes_s-1")
+        self.assertEqual(fake.kwargs_for("ensure_dataset"), [])
+
+    def test_force_defers_the_failed_bridge_to_session_end(self):
+        with fake_backend() as fake:
+            fake.errors["improve"] = RuntimeError("server busy")
+            provider = make_provider()
+            out = _call(
+                provider,
+                "cognee_switch_dataset",
+                {"action": "switch", "dataset": "work", "force": True},
+            )
+            self.assertTrue(out["switched"])
+            self.assertFalse(out["previous"]["bridged"])
+            self.assertEqual(provider._retired_sessions, [("hermes", "hermes_s-1")])
+            # At session end the retired session is re-submitted (and the
+            # current one closed as usual).
+            del fake.errors["improve"]
+            provider.on_session_end([])
+            improves = fake.kwargs_for("improve")
+        self.assertEqual(improves[0]["dataset"], "hermes")
+        self.assertEqual(improves[0]["session_ids"], ["hermes_s-1"])
+        self.assertEqual(provider._retired_sessions, [])
+
+    def test_an_unavailable_target_dataset_is_an_error(self):
+        with fake_backend() as fake:
+            fake.errors["ensure_dataset"] = RuntimeError("403")
+            provider = make_provider()
+            out = _call(provider, "cognee_switch_dataset", {"action": "switch", "dataset": "work"})
+        self.assertIn("not available", out["error"])
+        self.assertEqual(provider._dataset, "hermes")
+
+    def test_reset_returns_to_the_default_dataset(self):
+        with fake_backend():
+            provider = make_provider()
+            _call(provider, "cognee_switch_dataset", {"action": "switch", "dataset": "work"})
+            out = _call(provider, "cognee_switch_dataset", {"action": "reset"})
+        self.assertTrue(out["switched"])
+        self.assertEqual(out["dataset"], "hermes")
+        # Every switch mints a fresh session id — the counter never reuses one.
+        self.assertEqual(provider._session_cognee_id, "hermes_s-1__2")
+
+    def test_a_persisted_override_is_reapplied_on_initialize(self):
+        dataset_overrides.save_override("sess-9", "work", 3)
+        with fake_backend():
+            provider = make_provider(session_id="sess-9")
+            provider._session_cognee_id = "hermes_sess-9"
+            provider._apply_dataset_override()
+        self.assertEqual(provider._dataset, "work")
+        self.assertEqual(provider._session_cognee_id, "hermes_sess-9__3")
+        self.assertEqual(provider._switch_counter, 3)
+
+
+class TestCodeSearch(unittest.TestCase):
+    def _provider(self, **kwargs):
+        provider = make_provider(**kwargs)
+        provider._cwd = ""  # no ambient repo unless a test sets one
+        return provider
+
+    def test_unknown_operation_is_an_error(self):
+        with fake_backend():
+            out = _call(self._provider(), "cognee_code_search", {"operation": "drop_tables"})
+        self.assertIn("Unknown operation", out["error"])
+
+    def test_without_an_indexed_repo_the_error_names_the_cli(self):
+        with fake_backend():
+            out = _call(
+                self._provider(),
+                "cognee_code_search",
+                {"operation": "query_facts", "name": "foo"},
+            )
+        self.assertIn("hermes cognee index-repo", out["error"])
+
+    def test_query_facts_builds_the_bounded_code_query(self):
+        with fake_backend() as fake:
+            fake.results["recall"] = [{"operation": "query_facts", "facts": []}]
+            provider = self._provider(config={"code_datasets": "codebase-svc-abc"})
+            out = _call(
+                provider,
+                "cognee_code_search",
+                {"operation": "query_facts", "name": "process_payment", "limit": 7},
+            )
+            kwargs = fake.only_call("recall")
+        self.assertEqual(out["dataset"], "codebase-svc-abc")
+        self.assertEqual(kwargs["scope"], ["code"])
+        self.assertEqual(kwargs["datasets"], ["codebase-svc-abc"])
+        self.assertEqual(
+            kwargs["code_query"],
+            {"operation": "query_facts", "name": "process_payment", "limit": 7},
+        )
+
+    def test_operation_specific_shapes(self):
+        cases = [
+            ({"operation": "explore", "name": "A"}, {"operation": "explore", "name": "A"}),
+            ({"operation": "traverse", "name": "A"}, {"operation": "traverse", "start": "A"}),
+            (
+                {"operation": "find_path", "name": "A", "target": "B"},
+                {"operation": "find_path", "source": "A", "target": "B"},
+            ),
+            (
+                {"operation": "impact_analysis", "name": "A"},
+                {"operation": "impact_analysis", "targets": ["A"]},
+            ),
+            ({"operation": "delta"}, {"operation": "delta"}),
+        ]
+        for args, expected in cases:
+            with fake_backend() as fake:
+                provider = self._provider(config={"code_datasets": "codebase-svc-abc"})
+                _call(provider, "cognee_code_search", args)
+                self.assertEqual(
+                    fake.only_call("recall")["code_query"], expected, args["operation"]
+                )
+
+    def test_seed_requiring_operations_demand_a_name(self):
+        for operation in ("explore", "traverse", "impact_analysis"):
+            with fake_backend() as fake:
+                provider = self._provider(config={"code_datasets": "codebase-svc-abc"})
+                out = _call(provider, "cognee_code_search", {"operation": operation})
+                self.assertIn("requires name", out["error"], operation)
+                self.assertEqual(fake.kwargs_for("recall"), [])
+
+    def test_repo_argument_resolves_via_the_registry(self):
+        with fake_backend() as fake:
+            code_graph.record_index(
+                "https://github.com/a/svc", "codebase-svc-def", index_vectors=False
+            )
+            provider = self._provider()
+            out = _call(
+                provider,
+                "cognee_code_search",
+                {"operation": "delta", "repo": "https://github.com/a/svc"},
+            )
+        self.assertEqual(out["dataset"], "codebase-svc-def")
+        self.assertEqual(fake.only_call("recall")["datasets"], ["codebase-svc-def"])
+
+    def test_results_pass_through_as_structured_dicts(self):
+        with fake_backend() as fake:
+            fake.results["recall"] = [{"operation": "delta", "added": 3, "removed": 1}]
+            provider = self._provider(config={"code_datasets": "codebase-svc-abc"})
+            out = _call(provider, "cognee_code_search", {"operation": "delta"})
+        self.assertEqual(out["count"], 1)
+        self.assertEqual(out["results"][0]["added"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/integrations/hermes-agent/tests/test_tool_contract.py
+++ b/integrations/hermes-agent/tests/test_tool_contract.py
@@ -204,27 +204,122 @@ class TestRememberEnvelope(unittest.TestCase):
         self.assertTrue(out["error"].startswith("Cognee remember failed:"))
 
 
+_DATASET_ID = "11111111-1111-1111-1111-111111111111"
+_DATA_ID_A = "22222222-2222-2222-2222-222222222222"
+_DATA_ID_B = "33333333-3333-3333-3333-333333333333"
+
+
 class TestForgetEnvelope(unittest.TestCase):
-    def test_requires_dataset_or_everything(self):
+    """The two-phase forget: find lists candidates, forget deletes confirmed ids."""
+
+    def test_missing_action_is_an_error_and_touches_nothing(self):
         with fake_backend() as fake:
             provider = make_provider()
             out = _call(provider, "cognee_forget", {})
-        self.assertEqual(out, {"error": "Specify dataset or set everything=true."})
+        self.assertIn("action='find'", out["error"])
+        self.assertEqual(fake.calls, [])
+
+    def test_find_requires_terms(self):
+        with fake_backend() as fake:
+            provider = make_provider()
+            out = _call(provider, "cognee_forget", {"action": "find"})
+        self.assertIn("terms", out["error"])
+        self.assertEqual(fake.calls, [])
+
+    def test_find_lists_matching_documents_with_previews(self):
+        with fake_backend() as fake:
+            fake.results["list_datasets"] = [{"id": _DATASET_ID, "name": "hermes"}]
+            fake.results["list_dataset_data"] = [
+                {"id": _DATA_ID_A, "name": "doc-a"},
+                {"id": _DATA_ID_B, "name": "doc-b"},
+            ]
+            raw = {
+                _DATA_ID_A: "we talked about tennis and rackets",
+                _DATA_ID_B: "grocery list: milk, eggs",
+            }
+            original = fake.read_raw_data
+
+            def read_raw_data(**kwargs):
+                original(**kwargs)
+                return raw[kwargs["data_id"]]
+
+            fake.read_raw_data = read_raw_data
+            provider = make_provider()
+            out = _call(provider, "cognee_forget", {"action": "find", "terms": "tennis"})
+        self.assertEqual(out["action"], "find")
+        self.assertEqual(len(out["candidates"]), 1)
+        candidate = out["candidates"][0]
+        self.assertEqual(candidate["data_id"], _DATA_ID_A)
+        self.assertEqual(candidate["matched_terms"], ["tennis"])
+        self.assertIn("tennis", candidate["preview"])
+        # Nothing was deleted during a find.
+        self.assertEqual(fake.kwargs_for("forget_document"), [])
         self.assertEqual(fake.kwargs_for("forget"), [])
 
-    def test_success_envelope_passes_backend_details_through(self):
+    def test_find_with_no_matches_says_so(self):
+        with fake_backend() as fake:
+            fake.results["list_datasets"] = [{"id": _DATASET_ID, "name": "hermes"}]
+            fake.results["list_dataset_data"] = []
+            provider = make_provider()
+            out = _call(provider, "cognee_forget", {"action": "find", "terms": "tennis"})
+        self.assertEqual(out["candidates"], [])
+        self.assertIn("No stored documents matched", out["result"])
+
+    def test_forget_requires_confirm(self):
+        with fake_backend() as fake:
+            provider = make_provider()
+            out = _call(provider, "cognee_forget", {"action": "forget", "data_ids": [_DATA_ID_A]})
+        self.assertIn("confirm=true", out["error"])
+        self.assertEqual(fake.calls, [])
+
+    def test_forget_requires_data_ids(self):
+        with fake_backend() as fake:
+            provider = make_provider()
+            out = _call(provider, "cognee_forget", {"action": "forget", "confirm": True})
+        self.assertIn("data_ids", out["error"])
+        self.assertEqual(fake.kwargs_for("forget_document"), [])
+
+    def test_forget_deletes_exactly_the_listed_ids(self):
+        with fake_backend() as fake:
+            fake.results["list_datasets"] = [{"id": _DATASET_ID, "name": "hermes"}]
+            provider = make_provider()
+            out = _call(
+                provider,
+                "cognee_forget",
+                {"action": "forget", "data_ids": [_DATA_ID_A, _DATA_ID_B], "confirm": True},
+            )
+        self.assertEqual(out["deleted"], [_DATA_ID_A, _DATA_ID_B])
+        deletes = fake.kwargs_for("forget_document")
+        self.assertEqual([d["data_id"] for d in deletes], [_DATA_ID_A, _DATA_ID_B])
+        self.assertTrue(all(d["dataset_id"] == _DATASET_ID for d in deletes))
+
+    def test_a_failed_delete_is_reported_per_id_not_thrown(self):
+        with fake_backend() as fake:
+            fake.results["list_datasets"] = [{"id": _DATASET_ID, "name": "hermes"}]
+            fake.errors["forget_document"] = RuntimeError("denied")
+            provider = make_provider()
+            out = _call(
+                provider,
+                "cognee_forget",
+                {"action": "forget", "data_ids": [_DATA_ID_A], "confirm": True},
+            )
+        self.assertEqual(out["deleted"], [])
+        self.assertEqual(out["errors"][0]["data_id"], _DATA_ID_A)
+
+    def test_everything_in_dataset_uses_the_coarse_endpoint(self):
         with fake_backend() as fake:
             fake.results["forget"] = {"deleted": 3}
             provider = make_provider()
-            out = _call(provider, "cognee_forget", {"dataset": "hermes"})
-        self.assertEqual(out, {"result": "Cognee memory deleted.", "details": {"deleted": 3}})
-
-    def test_backend_failure_is_reported_as_error_text(self):
-        with fake_backend() as fake:
-            fake.errors["forget"] = RuntimeError("denied")
-            provider = make_provider()
-            out = _call(provider, "cognee_forget", {"everything": True})
-        self.assertTrue(out["error"].startswith("Cognee forget failed:"))
+            out = _call(
+                provider,
+                "cognee_forget",
+                {"action": "forget", "everything_in_dataset": True, "confirm": True},
+            )
+            kwargs = fake.only_call("forget")
+        self.assertIn("deleted", out["result"].lower() + str(out))
+        self.assertEqual(kwargs["dataset"], "hermes")
+        # The all-datasets wipe is not expressible from the tool, by construction.
+        self.assertIs(kwargs["everything"], False)
 
 
 class TestDispatch(unittest.TestCase):
@@ -247,20 +342,33 @@ class TestDispatch(unittest.TestCase):
                 self.assertIn("temporarily unavailable", out["error"])
         self.assertEqual(fake.calls, [])
 
-    def test_tool_schemas_are_the_three_declared_tools_with_required_params(self):
+    def test_tool_schemas_are_the_five_declared_tools_with_required_params(self):
         provider = make_provider()
         schemas = {schema["name"]: schema for schema in provider.get_tool_schemas()}
         self.assertEqual(
             set(schemas),
-            {"cognee_recall", "cognee_remember", "cognee_forget"},
+            {
+                "cognee_recall",
+                "cognee_remember",
+                "cognee_forget",
+                "cognee_switch_dataset",
+                "cognee_code_search",
+            },
         )
         self.assertEqual(schemas["cognee_recall"]["parameters"]["required"], ["query"])
         self.assertEqual(schemas["cognee_remember"]["parameters"]["required"], ["content"])
-        self.assertEqual(schemas["cognee_forget"]["parameters"]["required"], [])
+        self.assertEqual(schemas["cognee_forget"]["parameters"]["required"], ["action"])
+        self.assertEqual(schemas["cognee_switch_dataset"]["parameters"]["required"], ["action"])
+        self.assertEqual(schemas["cognee_code_search"]["parameters"]["required"], ["operation"])
         self.assertEqual(
             set(schemas["cognee_recall"]["parameters"]["properties"]),
             {"query", "scope", "search_type", "top_k"},
         )
+
+    def test_optional_tools_can_be_disabled_by_config(self):
+        provider = make_provider(config={"dataset_switch_tool": False, "code_search_tool": False})
+        names = {schema["name"] for schema in provider.get_tool_schemas()}
+        self.assertEqual(names, {"cognee_recall", "cognee_remember", "cognee_forget"})
 
 
 # --------------------------------------------------------------------------
@@ -443,28 +551,48 @@ class TestRememberPayload(unittest.TestCase):
 
 
 class TestForgetPayload(unittest.TestCase):
-    def test_dataset_scoped_delete(self):
+    def test_document_delete_resolves_the_dataset_id_by_name(self):
         with fake_backend() as fake:
+            fake.results["list_datasets"] = [
+                {"id": _DATASET_ID, "name": "hermes"},
+                {"id": _DATA_ID_B, "name": "other"},
+            ]
             provider = make_provider()
-            provider.handle_tool_call("cognee_forget", {"dataset": "hermes"})
-            kwargs = fake.only_call("forget")
-        self.assertEqual(kwargs["dataset"], "hermes")
-        self.assertIs(kwargs["everything"], False)
-        self.assertIs(kwargs["memory_only"], False)
+            provider.handle_tool_call(
+                "cognee_forget",
+                {"action": "forget", "data_ids": [_DATA_ID_A], "confirm": True},
+            )
+            kwargs = fake.only_call("forget_document")
+        self.assertEqual(kwargs["dataset_id"], _DATASET_ID)
+        self.assertEqual(kwargs["data_id"], _DATA_ID_A)
 
-    def test_everything_is_forwarded(self):
-        # Whether a wipe-everything request also carries the dataset is a wire
-        # detail of each transport — see test_sdk_backend.
+    def test_an_explicit_dataset_argument_wins_over_the_provider_default(self):
         with fake_backend() as fake:
+            fake.results["list_datasets"] = [{"id": _DATASET_ID, "name": "special"}]
             provider = make_provider()
-            provider.handle_tool_call("cognee_forget", {"dataset": "hermes", "everything": True})
-            self.assertIs(fake.only_call("forget")["everything"], True)
+            provider.handle_tool_call(
+                "cognee_forget",
+                {
+                    "action": "forget",
+                    "dataset": "special",
+                    "data_ids": [_DATA_ID_A],
+                    "confirm": True,
+                },
+            )
+            self.assertEqual(fake.only_call("forget_document")["dataset_id"], _DATASET_ID)
 
-    def test_memory_only_is_forwarded(self):
+    def test_an_unknown_dataset_is_an_error_before_any_delete(self):
         with fake_backend() as fake:
+            fake.results["list_datasets"] = []
             provider = make_provider()
-            provider.handle_tool_call("cognee_forget", {"dataset": "hermes", "memory_only": True})
-            self.assertIs(fake.only_call("forget")["memory_only"], True)
+            out = json.loads(
+                provider.handle_tool_call(
+                    "cognee_forget",
+                    {"action": "forget", "data_ids": [_DATA_ID_A], "confirm": True},
+                )
+            )
+        self.assertIn("not found", out["error"])
+        self.assertEqual(fake.kwargs_for("forget_document"), [])
 
 
 if __name__ == "__main__":

--- a/integrations/hermes-agent/tests/test_update_check.py
+++ b/integrations/hermes-agent/tests/test_update_check.py
@@ -1,0 +1,122 @@
+"""The PyPI update check: cached, rate-limited, fail-silent.
+
+Run standalone with ``python3 tests/test_update_check.py``.
+"""
+
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from cognee_integration_hermes import update_check  # noqa: E402
+
+
+class _Response(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _opener_returning(version, calls=None):
+    def opener(request, timeout=None):
+        if calls is not None:
+            calls.append(request.full_url)
+        return _Response(json.dumps({"info": {"version": version}}).encode("utf-8"))
+
+    return opener
+
+
+class TestLatestPublishedVersion(unittest.TestCase):
+    def _cache(self, tmp_name="update-check.json"):
+        import tempfile
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        return Path(tmp.name) / tmp_name
+
+    def test_fetches_and_caches(self):
+        cache = self._cache()
+        calls = []
+        latest = update_check.latest_published_version(
+            cache_path=cache, opener=_opener_returning("2.0.0", calls), now=1000.0
+        )
+        self.assertEqual(latest, "2.0.0")
+        self.assertEqual(len(calls), 1)
+        stored = json.loads(cache.read_text())
+        self.assertEqual(stored["latest"], "2.0.0")
+        self.assertEqual(stored["checked_at"], 1000.0)
+
+    def test_a_fresh_cache_skips_the_network(self):
+        cache = self._cache()
+        calls = []
+        opener = _opener_returning("2.0.0", calls)
+        update_check.latest_published_version(cache_path=cache, opener=opener, now=1000.0)
+        latest = update_check.latest_published_version(
+            cache_path=cache, opener=opener, now=1000.0 + 100, interval=3600
+        )
+        self.assertEqual(latest, "2.0.0")
+        self.assertEqual(len(calls), 1)
+
+    def test_an_expired_cache_rechecks(self):
+        cache = self._cache()
+        calls = []
+        opener = _opener_returning("2.0.0", calls)
+        update_check.latest_published_version(cache_path=cache, opener=opener, now=1000.0)
+        update_check.latest_published_version(
+            cache_path=cache, opener=opener, now=1000.0 + 7200, interval=3600
+        )
+        self.assertEqual(len(calls), 2)
+
+    def test_force_skips_the_rate_limit(self):
+        cache = self._cache()
+        calls = []
+        opener = _opener_returning("2.0.0", calls)
+        update_check.latest_published_version(cache_path=cache, opener=opener, now=1000.0)
+        update_check.latest_published_version(
+            cache_path=cache, opener=opener, now=1000.0 + 1, force=True
+        )
+        self.assertEqual(len(calls), 2)
+
+    def test_a_network_failure_returns_the_cached_answer(self):
+        cache = self._cache()
+        update_check.latest_published_version(
+            cache_path=cache, opener=_opener_returning("2.0.0"), now=1000.0
+        )
+
+        def broken(request, timeout=None):
+            raise OSError("offline")
+
+        latest = update_check.latest_published_version(
+            cache_path=cache, opener=broken, now=1000.0 + 7200, interval=3600
+        )
+        self.assertEqual(latest, "2.0.0")
+
+    def test_a_network_failure_with_no_cache_returns_empty(self):
+        def broken(request, timeout=None):
+            raise OSError("offline")
+
+        latest = update_check.latest_published_version(cache_path=self._cache(), opener=broken)
+        self.assertEqual(latest, "")
+
+
+class TestIsNewer(unittest.TestCase):
+    def test_ordering(self):
+        self.assertTrue(update_check.is_newer("1.2.0", "1.1.0"))
+        self.assertTrue(update_check.is_newer("1.10.0", "1.9.9"))
+        self.assertFalse(update_check.is_newer("1.1.0", "1.1.0"))
+        self.assertFalse(update_check.is_newer("1.0.9", "1.1.0"))
+
+    def test_blank_sides_never_nag(self):
+        self.assertFalse(update_check.is_newer("", "1.0.0"))
+        self.assertFalse(update_check.is_newer("1.0.0", ""))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/integrations/hermes-agent/uv.lock
+++ b/integrations/hermes-agent/uv.lock
@@ -2,10 +2,14 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version >= '3.14' and sys_platform != 'darwin')",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version >= '3.12' and python_full_version < '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin')",
+    "(python_full_version >= '3.12' and python_full_version < '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.12' and python_full_version < '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.11.*' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version == '3.11.*' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version < '3.11' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version < '3.11' and sys_platform != 'darwin')",
+    "(python_full_version < '3.11' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version < '3.11' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
 ]
 
 [[package]]
@@ -696,7 +700,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.4.0"
+version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -705,6 +709,7 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "alembic" },
     { name = "cbor2" },
+    { name = "cryptography" },
     { name = "datamodel-code-generator" },
     { name = "diskcache" },
     { name = "fakeredis", extra = ["lua"] },
@@ -715,7 +720,8 @@ dependencies = [
     { name = "gunicorn" },
     { name = "instructor" },
     { name = "jinja2" },
-    { name = "ladybug" },
+    { name = "ladybug", version = "0.17.1", source = { registry = "https://pypi.org/simple" }, marker = "('Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or ('Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')" },
+    { name = "ladybug", version = "0.19.0", source = { registry = "https://pypi.org/simple" }, marker = "('Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or sys_platform != 'darwin'" },
     { name = "lancedb" },
     { name = "langdetect" },
     { name = "limits" },
@@ -746,14 +752,14 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/21/68e640d10ea9445b55b01715a8ae87a9d469e443614a87261c18c3e507e8/cognee-1.4.0.tar.gz", hash = "sha256:e783dd802ea25471b2c6feec317e8628fa99d67ed9223f22ca339add8fb7da1a", size = 23166925, upload-time = "2026-07-17T15:39:36.9Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/6c/d59798a299dd7f28c18a3b14d0e711036e7f12941feb1e1666a539418870/cognee-1.5.3.tar.gz", hash = "sha256:49c4799c313990a0905cfcc90a0e0ba3e1521d1726134dd8bcca47e2f19c36ad", size = 27624449, upload-time = "2026-08-23T18:30:38.484Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/f7/2388c4307fb1c5a20e02dad9188fad96f62f28d46f930e12fa402462732a/cognee-1.4.0-py3-none-any.whl", hash = "sha256:51ed9f1f8ca5b5caf215b00f10522e6291e6f3e82f19aaf2864e21ec8176ee0d", size = 3555996, upload-time = "2026-07-17T15:39:33.348Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/44/71d7f7fd0245ecbf6032b6dc3fb37d41e715b55d8c5477851c0f43d28ee5/cognee-1.5.3-py3-none-any.whl", hash = "sha256:575c2791a911edecfa70321c81e984a7ebbc16746f41562361f43636be76308f", size = 8194900, upload-time = "2026-08-23T18:30:35.031Z" },
 ]
 
 [[package]]
 name = "cognee-integration-hermes-agent"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },
@@ -767,7 +773,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "cognee", specifier = ">=1.2.1,<=1.4.0" }]
+requires-dist = [{ name = "cognee", specifier = "==1.5.3" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1670,48 +1676,78 @@ wheels = [
 name = "ladybug"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version >= '3.12' and python_full_version < '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.12' and python_full_version < '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version == '3.11.*' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version < '3.11' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version < '3.11' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/f6/1511d2ab4391af8a4133c556ccaf79b613d79c6120e3fcced02c8d438982/ladybug-0.17.1.tar.gz", hash = "sha256:82efea498713c7da7f6f94f80252574599252d26ee10fb11e62ae932b5d8f2ba", size = 10160802, upload-time = "2026-06-02T20:08:43.241Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/60/b87c4d017caf35b50c839299b6698a1bf79ab1a6486e4e935a73332bffd2/ladybug-0.17.1-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:faf616d55f8a1269346c66913cabb32a88f9459878adadd7befb5e7adb206ea2", size = 4183667, upload-time = "2026-06-02T20:07:20.659Z" },
     { url = "https://files.pythonhosted.org/packages/a5/fb/7e2c6bc3950a60250cfa87fb20146f26df3888049490168f4b1d8924bab6/ladybug-0.17.1-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:6b93d3dc7eb3827bfec82368d1196f78aa529dcddab848a06015a51d05ec622d", size = 4666415, upload-time = "2026-06-02T20:07:22.826Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/03/4489ab0d7a65d82fe945c31abe5c0007f396b4040c1fabed512800ecad84/ladybug-0.17.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0624025078a120b4e397d0e84a4de2a931a8a40434fa0594c49da5beee093ce", size = 7066895, upload-time = "2026-06-02T20:07:24.537Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/b8/f84cd5c39ad471c332272ae54df83b533df208305d28857dc70bb9eee526/ladybug-0.17.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b69c79fafd7fbd2eaa2fa5ee7b891aa5ddf91f913b1d252a983175c1b8c4563", size = 7922849, upload-time = "2026-06-02T20:07:26.465Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/6a/37856a75d1ff1d7f0a6bfb15fe4fea30aed037c31c852bab77300915d91b/ladybug-0.17.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0ed7445e6bf200cc585f7e71e0d3a79b4a78718c1bf3fdcdee99dfadc0ce73c1", size = 7898267, upload-time = "2026-06-02T20:07:28.554Z" },
-    { url = "https://files.pythonhosted.org/packages/20/2e/26ce9528a96911ca11d875013504287d722b46aebacd25626ac107579c5f/ladybug-0.17.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:99a76128828245e39996c44ba693a754132b785c5db5e70f0e469e73ec24d103", size = 8783469, upload-time = "2026-06-02T20:07:30.652Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/8e/ead3989595cf2e2df0829b3064b073f379a0bcdcba99bcd620d175e8ff1f/ladybug-0.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:2748b1bb9e13c6af465f8089eb20e72fb4f1871603b1031eeb3390ab5b9f9baa", size = 5289323, upload-time = "2026-06-02T20:07:33.089Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/4c/585f3b98ebf50a9fb5ad090e4deb04ad5a0080fc91c54da4ce1aad741fa0/ladybug-0.17.1-cp310-cp310-win_arm64.whl", hash = "sha256:0a7cea07905e7bdfb8a45bd80f3491ff6624ec34d0395d1887be0e4e0e2259d3", size = 5257509, upload-time = "2026-06-02T20:07:34.904Z" },
     { url = "https://files.pythonhosted.org/packages/df/9d/d2993494ecd3a6aa2d12a027a9f6adf365a702c720d99cd1fa8a9d9142bf/ladybug-0.17.1-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:b21e9101855a852c8f810e591d078adc0d28639c45bfaae4f20c20ad07164162", size = 4185136, upload-time = "2026-06-02T20:07:36.714Z" },
     { url = "https://files.pythonhosted.org/packages/62/00/a42fdb3eef04e60819525f8bcccd785d7ea8d8bdcc0336b587e8742a2c8f/ladybug-0.17.1-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:d6ed21cc33d636d9e69c9126a0e55142000faa3f402cc8f30a79f03f9c9c997b", size = 4667711, upload-time = "2026-06-02T20:07:38.573Z" },
-    { url = "https://files.pythonhosted.org/packages/28/fa/f27d01ea2a14fbf03a8d38d254ac39e36954f1ee6dfd0cf2f0f0aa34bbe6/ladybug-0.17.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:afbf3096d18ab6300a29df15c2a77c936434d11bf9ef2b370076e13450592907", size = 7069633, upload-time = "2026-06-02T20:07:40.586Z" },
-    { url = "https://files.pythonhosted.org/packages/58/97/6eac02e95ed5cf31eb3336ac2f95b4db3a98c775593a91f183a291f4a9e1/ladybug-0.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3cffc7023414c890f8be7841df8f41a9b3d489715ada9ab7426f943701e64eb6", size = 7923999, upload-time = "2026-06-02T20:07:42.631Z" },
-    { url = "https://files.pythonhosted.org/packages/75/0f/0887c7e6fe74245569f572a9a8d1011dead4367e9fce72b318acff544930/ladybug-0.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7eb77583aee8618bcb8d174ec834950b821f44feb21655d502fda415d51e1194", size = 7900586, upload-time = "2026-06-02T20:07:44.716Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/88/151439e993103788c112f7dc547596329ddd9e89abc439a629f79475d953/ladybug-0.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8eb26cb7508541facc38e4d4282583469ef3927fbb99900eb4ae66632a55e215", size = 8784396, upload-time = "2026-06-02T20:07:46.941Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/9f/f35cd80041209f93f47b6a60bc17d0fa73fa1b2c80467c788a10a6188bab/ladybug-0.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:b2fd0e4e8948e15e567e8dcdfa38709906f6f1a66552cd44eea873a8ff664df9", size = 5289990, upload-time = "2026-06-02T20:07:49.211Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/82/f66966cebb674dd9f995cb981c9d79284d84259dc482453edbd963a53a00/ladybug-0.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:e1b881433e6623daa5c84eb80a9c1d6d5b4a16618c022fa028aa16b9de7a7dd8", size = 5258334, upload-time = "2026-06-02T20:07:51.145Z" },
     { url = "https://files.pythonhosted.org/packages/75/0b/76ba668df9fe004c80bc2ee0cd46e76924467fa4d96853125962947d9c33/ladybug-0.17.1-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:1a5fd5f324df8c5659a8cd6a0c08c58b2f6efbf0319cde6ec7cdcc3480343129", size = 4185245, upload-time = "2026-06-02T20:07:52.826Z" },
     { url = "https://files.pythonhosted.org/packages/25/54/11855f62e55a9b47e64c3c45c9d312e9830e5fc253c1f1b6d860f12faf74/ladybug-0.17.1-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:17e540cedd30816fad248e4d3cc6444bbc139a4b79e43af5f471acbe790a707a", size = 4668570, upload-time = "2026-06-02T20:07:55.132Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/94/1e8796e91ec8d741a2bcd10bfa99cd96f0a30f26fe55ca910a993e6bcb9f/ladybug-0.17.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:067e183bd3fb2094a040cc4e69269fdcc5a770579a89f2d9f5dd8c93da6c08bc", size = 7065841, upload-time = "2026-06-02T20:07:57.147Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/1a/12796133dd933b59a441eb39145ff604a36d1fa3b9c08deb90048233b38b/ladybug-0.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c11887032a14ca49941cbb5e9ac94adcba804c17fc7f823f598c8cceb5438612", size = 7921694, upload-time = "2026-06-02T20:07:59.278Z" },
-    { url = "https://files.pythonhosted.org/packages/11/59/24f4dfbebc4298ca05ace1755abda6fe096e37db19a019239ca08828ee4c/ladybug-0.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5a3e906981abb4a92f3c2add315ae44419b1c5487bbedfa50eb03a0e2040dc38", size = 7897206, upload-time = "2026-06-02T20:08:01.334Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/4b/5dbe3d4193866ae54b210f75552a11a9c0f5fd6408ea78e01332347d7422/ladybug-0.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bc0d0276b6181c26434f33eb675a304d33ce183fe6f90d04c91e7c001468b407", size = 8781956, upload-time = "2026-06-02T20:08:03.322Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/77/c71612d69c41c4813a7687ee547145d1787bea96cd5530a23cc67eb8d5d8/ladybug-0.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:4efc3f1117c16d7e9728afe9a0a87b89d4d3fb98c480d16d7f22c64be963a43b", size = 5290750, upload-time = "2026-06-02T20:08:05.597Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/78/a6c1d9fe146216fb92dc6dfc8c289a818db0d8563333aca751679329ad26/ladybug-0.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:4c50a9e3e288cb57ede865b16e84bb4fd0471c572a641481e548cd70c4e82973", size = 5258304, upload-time = "2026-06-02T20:08:07.441Z" },
     { url = "https://files.pythonhosted.org/packages/13/4a/8a5a208b5a53384c576870c49a940a178083b1740f1b20332f2433f9a846/ladybug-0.17.1-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:785c95d595754be8d16b2e35defc44a906ccbef329c180e97e47ac7df17776bf", size = 4185250, upload-time = "2026-06-02T20:08:09.137Z" },
     { url = "https://files.pythonhosted.org/packages/8c/1d/c4c2815475571c9eb32f44ae435957049e20ce7474fa5fc04aa74ac2b12e/ladybug-0.17.1-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:a168cdeea1f239b698ca222d680faa9b9b01b5ff96a1087b6235be23533d05e0", size = 4668500, upload-time = "2026-06-02T20:08:11.013Z" },
-    { url = "https://files.pythonhosted.org/packages/92/64/6233cb455e327f752b7938cdcbbc693cd9584a154723be429272b9fa694c/ladybug-0.17.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb2d88b4852689d73437c7c31057345fc95540e242c25e71999d541ad104f390", size = 7065427, upload-time = "2026-06-02T20:08:12.979Z" },
-    { url = "https://files.pythonhosted.org/packages/37/31/18875d6e46e29081d7c0b0072c60df3e20090d46de00d481eaecf71cf0ab/ladybug-0.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf0ec0e0c0cb06be60ef83e3d95a3f5c02e3df6fe0270fee576b5688d0e70d28", size = 7921542, upload-time = "2026-06-02T20:08:15.167Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/ce/89eeaf428595146c790d7ebf982bdb53fa51b678daded5f09152a1454435/ladybug-0.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8fd79f020c5b2db9d2b2b689ac2616f86d43ebc5d36063a001ee1ce158f50bf8", size = 7898139, upload-time = "2026-06-02T20:08:17.308Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/44/b4c80147c547c380d35b9904245de01def0224342254b4fa36d8815210de/ladybug-0.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a9706c6a65365955ac3b18688a582c82ac3388362fdccab13a18e66b2c864e6b", size = 8782280, upload-time = "2026-06-02T20:08:19.49Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/39/f09366d5fe6d2f2c75a22d368e7c09f2e0194d1d80a4dfa7ece5b2deaa83/ladybug-0.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:616d5017ee21ac99c4e1251f75c569053b709f73e207bd2d97f7742169680286", size = 5291337, upload-time = "2026-06-02T20:08:21.538Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/d4/e64ae350b011c0cacde3df87e47cc6ec59564366cd364fc13698d6d774ca/ladybug-0.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5e84e5329f74e833828eeddd468ac881323fbfdb54a8610ae9f2bbe7bc02f952", size = 5258364, upload-time = "2026-06-02T20:08:23.504Z" },
     { url = "https://files.pythonhosted.org/packages/a9/e6/94dff21a9ef485fba3a933d76735197e8ced13184edd862361319ee2e253/ladybug-0.17.1-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:c8a71f90f2fe16396c98380aadd5519ed72346aed4d7872b06e2450e9470ac77", size = 4186197, upload-time = "2026-06-02T20:08:25.443Z" },
     { url = "https://files.pythonhosted.org/packages/c6/7c/a9fd639408629e8a33d014d482355eab272edfe525aea1c7a5305d32662e/ladybug-0.17.1-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:08934e417214ca03836934ed7bd1f6ebedf6959db3b4405541aa4389f60800a6", size = 4668982, upload-time = "2026-06-02T20:08:27.451Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/aa/ccd37c07d38e7305212ddd8d05dbfadd61a07ad5e56aebaf92fe4c6c23cb/ladybug-0.17.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2dbca5d77c309b6c992f5ab9f5d18b2a8002d4766f09ab7fa6ff9510df304b74", size = 7066952, upload-time = "2026-06-02T20:08:29.43Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/a1/e9e987fdf72ec8c67bf57223295abba78489c7629bc126e851249cd4c24e/ladybug-0.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f206b635840a26dd76e0b2f74e00e25e33fad1eb4e913bcce98cd5e5cf0146d", size = 7921609, upload-time = "2026-06-02T20:08:31.751Z" },
-    { url = "https://files.pythonhosted.org/packages/56/0b/8267a09d1589e9f19756c1118d406da88d9370fb04ede0285ae75b9b0d04/ladybug-0.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4c6701f0abce984e7820f8242754682b7e6ed82787b1316b614c192458bac99", size = 7898765, upload-time = "2026-06-02T20:08:33.864Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/06/5214d7ed85e3a302a855af067475234d44d45dbf220f5773bd9f476c7ee8/ladybug-0.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c53cf98ae5b414af6f6f2025ccbb06dcd368eb1142e9a675ab24ccc4b936ed5", size = 8782260, upload-time = "2026-06-02T20:08:36.309Z" },
-    { url = "https://files.pythonhosted.org/packages/45/d7/5ad430ad61b7db1b409fd3086f32fb1b64300c9a2f1d455dd0ca7b39adf0/ladybug-0.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:48efb95673096a7524a1f16943a1885ad016944ea8a5a000746d9939cf2a039b", size = 5455451, upload-time = "2026-06-02T20:08:39.118Z" },
-    { url = "https://files.pythonhosted.org/packages/af/da/75ca2ef8911bd554e997793c767f6e77892c8cb4761939f3abd225532ebc/ladybug-0.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:2ad869f14b0307c7eb2f91639da7ab887c666c2f93260c46a055c7969e082a09", size = 5400801, upload-time = "2026-06-02T20:08:41.114Z" },
+]
+
+[[package]]
+name = "ladybug"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version >= '3.14' and sys_platform != 'darwin')",
+    "(python_full_version >= '3.12' and python_full_version < '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin')",
+    "(python_full_version == '3.11.*' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
+    "(python_full_version < '3.11' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version < '3.11' and sys_platform != 'darwin')",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/f7/0ef0a9616d622c790c7fd559d10eb0fdd320c5880e79da035d0b23d2ab8d/ladybug-0.19.0.tar.gz", hash = "sha256:02a0725d29b36fd0de469dab14928c3bc8c5dfee4019acfd60ca504caffc4cd7", size = 10301849, upload-time = "2026-07-30T00:36:34.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/05/b8cb867e212ca835a4bd56ac34784022d897cd93a466f023c02183ea6ce9/ladybug-0.19.0-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:5adf17c61155d8687f8b0a999a227549edf4473ae1ced897e0d6ac9937550b0a", size = 4561242, upload-time = "2026-07-30T00:35:23.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e5/44e625653cf4999111c87e28fb975fc4c0874a3d82c172acb73b84bfeb31/ladybug-0.19.0-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:8aca1fdf33f02508f0679ed49c90a154051c01640be1f44d5d93fb9e32635d36", size = 4901666, upload-time = "2026-07-30T00:35:25.34Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f3/b6e06c39af47785b77a69570a9862cc4b42e3423505dddb509b3bbf2baa8/ladybug-0.19.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85647a6359186c39936c905f5f78714ab4be020ae734c4ac834fcfbf78f9caa6", size = 7362271, upload-time = "2026-07-30T00:35:26.927Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/22/4b5a40c96b1c6135c6d323340b5fdbc03cfa9c3dff0a165927c8edd8377c/ladybug-0.19.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:71d8cfdb2200295d294f10cbda5554fd86299b751ec997cfec74d0c1eef24556", size = 8255191, upload-time = "2026-07-30T00:35:28.64Z" },
+    { url = "https://files.pythonhosted.org/packages/19/db/7b1583b708de405a6a0de9a828b17d04237ab03ff799a662c53300ed49b8/ladybug-0.19.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:507fd8a2da1970b2bfdf84f85bba3f62482864416e7f8178661331938a98d1a5", size = 8190663, upload-time = "2026-07-30T00:35:30.389Z" },
+    { url = "https://files.pythonhosted.org/packages/79/01/dd997ba5f0a7397c5e396b684d1d927ba14fa7c32513b604b49b41888920/ladybug-0.19.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:290ef1a03e88debb5039f218e7d842f7ea15861be8e716d015dbc472da4187cc", size = 9116091, upload-time = "2026-07-30T00:35:32.213Z" },
+    { url = "https://files.pythonhosted.org/packages/21/9e/3fdf6c563795d3b1eacfebdd4f61a15fe4149573fd8f6ffe9024b16dcccb/ladybug-0.19.0-cp310-cp310-win_amd64.whl", hash = "sha256:4791f27194fdda740a0debaa9e1ad7f1294ec7e3080a57eaccd6278b2aa893fd", size = 5719695, upload-time = "2026-07-30T00:35:34.362Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/5c/5bbcd04079bc0e4f4177c1bcef8566e0ca46c8d00bb32cab24770f908ace/ladybug-0.19.0-cp310-cp310-win_arm64.whl", hash = "sha256:1c26b9aae154a3dd7e9222c5e4f57e9a8309627657d143f82ff1b0edb7613c36", size = 8204490, upload-time = "2026-07-30T00:35:36.056Z" },
+    { url = "https://files.pythonhosted.org/packages/db/80/8ca473a19195fab63af64f15a0f1a31011aebe8ed09db13462f17cecfe63/ladybug-0.19.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:d1a434f02723072a6ea4407b928f458d3e3ada28eb1f5406f0f18b1d261c9457", size = 4561786, upload-time = "2026-07-30T00:35:37.731Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cf/0ef7f0e89cc169167a81025dd26e8a65145b7ce6e736e651d22f5c9bcef1/ladybug-0.19.0-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:f64b1de331d21e24240eee4c62c18a45f51903c75cfe6db7dd660deddab0dfda", size = 4903599, upload-time = "2026-07-30T00:35:39.539Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/00/5230c1f6f574fd88f747edc4d3118973242c363b47d4fab3f52992219a6b/ladybug-0.19.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f04b1557052e62802007fb40d5216c0548bb02863ba1295bbbf28b796fd8978", size = 7363410, upload-time = "2026-07-30T00:35:41.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/bb/428b1a0722aa476f03f75188f65b9a097644dec6a08830a88abf4c3f3881/ladybug-0.19.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54867877c723f3be76a32e060e948ccec95187ad2e4086563c42ef34c35a03b7", size = 8256219, upload-time = "2026-07-30T00:35:42.948Z" },
+    { url = "https://files.pythonhosted.org/packages/18/fb/95fd9ebe0841a3b2241d2570048051920f207393bf9b6ab2806451022595/ladybug-0.19.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:09f6052dd8b0f9e8985457e7d40287726e199234934678db28d0b27e98104da2", size = 8191751, upload-time = "2026-07-30T00:35:44.73Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/68/fc6264a9e4a4f1d64ffd7653d3862a72c88f6b9b20372f07e0b9be79d0d5/ladybug-0.19.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:38d798d62001ceb976d9b7107e5e3d916305deb5d131f92789ccbfcda51f0fdc", size = 9117419, upload-time = "2026-07-30T00:35:46.494Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/89/ac7106173442b73fca95812e286a901b41db35ce6fa711ddb43794a50dbf/ladybug-0.19.0-cp311-cp311-win_amd64.whl", hash = "sha256:a8367c2bd473e4361f80e50d24186542f12af4004eb548cb1854736fdd352b3c", size = 5720052, upload-time = "2026-07-30T00:35:48.437Z" },
+    { url = "https://files.pythonhosted.org/packages/79/15/f196ca72426c6e4ab05be543afda3a8738f64db205c83f870999381f6c15/ladybug-0.19.0-cp311-cp311-win_arm64.whl", hash = "sha256:66fe4fcd4113f2adfa15ae9b195e43e450fc52de71b612d65c64ada65d597157", size = 8205756, upload-time = "2026-07-30T00:35:50.18Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9c/62ebf8ff99509bcb6a274b18688f4690e300afe400156f04258a464e2f27/ladybug-0.19.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:2189d4baccd8518bd37cb86212105f06b1033b8b711f0328fecb306159c0acca", size = 4561997, upload-time = "2026-07-30T00:35:51.77Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ab/013769e2a63c61e92d6c6aab5ef149e5959dad552f0402b188f7eefb15da/ladybug-0.19.0-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:a232e0eb484647f6573be2eec71a862d9a1c953353a954e0774b6d83e075b488", size = 4907061, upload-time = "2026-07-30T00:35:53.317Z" },
+    { url = "https://files.pythonhosted.org/packages/17/35/0a4ea3eef8d951820a8ea3bc5bc693afef2354be38b613cc83b415401835/ladybug-0.19.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f5333857dbfd871b6fc611ff9e08b98c9b2f09d6ddcf1ae53061de85837bd65", size = 7360691, upload-time = "2026-07-30T00:35:54.864Z" },
+    { url = "https://files.pythonhosted.org/packages/63/40/b5c9c84fd6adb544d559510cc7c0d69a1ba4e7fff4b04d9cd31ef59cc1d1/ladybug-0.19.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8c4d00d5cc55e13524eff56e3295732a3c1b8d272d001b30748c2cc348581827", size = 8255273, upload-time = "2026-07-30T00:35:56.687Z" },
+    { url = "https://files.pythonhosted.org/packages/57/5e/d4da91d8a5718ef1ec145cf7f178383a698f61b375820ec59e34b5d2bc3e/ladybug-0.19.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1dfb149912cc960e24a19f83688df5857d0679cc688f8553a896d10f4e8dd8f3", size = 8189623, upload-time = "2026-07-30T00:35:58.42Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/94/e787d51eae4e9d5d0f3188b35f5d1de191cc17a3d04ac1e12c3ac501e4be/ladybug-0.19.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aacd9f3c8f50b0ee1cbcb6a8ef8cb522b288784482ef13eda2ef1ead6e645cea", size = 9113674, upload-time = "2026-07-30T00:36:00.039Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/863742a52f79570b561564efb3fc4957fdb921af20f352fef74df56b89db/ladybug-0.19.0-cp312-cp312-win_amd64.whl", hash = "sha256:42d15b5e090f3600a47efd4697b1809547fbb0a637f593024e906aa960e7c92b", size = 5720735, upload-time = "2026-07-30T00:36:02.014Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/4c/bee1ac2816aecc5fa5671599a36cefac9de37c24ce43bd32418079599494/ladybug-0.19.0-cp312-cp312-win_arm64.whl", hash = "sha256:e07c17db7834f95bb7f0003a8b0476390908549c91d93865465da60700565425", size = 8205067, upload-time = "2026-07-30T00:36:03.595Z" },
+    { url = "https://files.pythonhosted.org/packages/11/a1/4a79481cdaacbbff5225414aa6f9e565640687918fa875d0b3ccb18442ed/ladybug-0.19.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:5470bbc0e3b3b544e16d91d33784aeba64e39a7e0f0ae3a04cc2d28e53b8f965", size = 4562061, upload-time = "2026-07-30T00:36:05.273Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/27/df981d8c273f98ef6b3b29130a23a952b204cd57783b648752658b3b257e/ladybug-0.19.0-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:e98bfbf891fb8cbcc345760124dae86d236621ef945d0993fed1fce6ef50ff7e", size = 4907180, upload-time = "2026-07-30T00:36:06.739Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/10/0ec2a931d858d0d510b15be5af9cdb226d3ca8735e5d92101abb48187f23/ladybug-0.19.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6116f000eaf7346ca242cf5ae9ee51b2536165a88d43d760e2e746cc8b67be58", size = 7360435, upload-time = "2026-07-30T00:36:08.504Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f8/9d13303b41f21c22c03918d3b87c785b5688a8a0edc2617f139eb50215ed/ladybug-0.19.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86c352593983e399ad4b43b1e7d7fe04591f763167ec7acf40e6c57f39005c7f", size = 8254852, upload-time = "2026-07-30T00:36:10.194Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/50/9a8e4733e7bcd6da90bfe8e9107fe7c36a7138cede8420d15dc6c812a851/ladybug-0.19.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a329b267bcad79cc9ea56bcd982d5d0c5ed91934219116ecb85910475f82d3f9", size = 8189088, upload-time = "2026-07-30T00:36:12.122Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fc/1d6d714e000c010a8dc762149e58003e3ef316cd57883a725ae92f6abde0/ladybug-0.19.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c035c4f00d97c6e1c89f166c43547a753e6a6e22ec3188a762770cecfb21c7e7", size = 9114190, upload-time = "2026-07-30T00:36:13.841Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/35/a9850cd10087fbece8ed5ecbecbeafdd9384b4c78deef466fd89564d2d4c/ladybug-0.19.0-cp313-cp313-win_amd64.whl", hash = "sha256:c32273d33360dcc89798ee6a4ae711614c95f18d65b0fc1082653ec55f2530f5", size = 5720836, upload-time = "2026-07-30T00:36:15.759Z" },
+    { url = "https://files.pythonhosted.org/packages/63/a2/2872a3caf7d9a8cc45cc5736a265ab956c1286cb63d0826854cc8e6c1f3f/ladybug-0.19.0-cp313-cp313-win_arm64.whl", hash = "sha256:0b0e88b49ed63f6a19a143d688b9e4c052ac09e1d11b92583d862d0512ee6bb2", size = 8205353, upload-time = "2026-07-30T00:36:17.477Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/96/b47d5c67f67002df8c4cdb9bfffadc3968f8ef4f7c4baece73e7ad2212cf/ladybug-0.19.0-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:4c2cdf36b2f904709b22518938e7828eec9718795b8b562512e3592af4b8466d", size = 4562927, upload-time = "2026-07-30T00:36:19.278Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/25/10a3f7fb496b2f9e5a26b55433970b2fa493f2f1765ac04651d4c8bfbcca/ladybug-0.19.0-cp314-cp314-macosx_15_0_x86_64.whl", hash = "sha256:088c5f79bd843ac15aee0bb44c417d70dce833a5295252569dcd139d348700dc", size = 4907779, upload-time = "2026-07-30T00:36:20.976Z" },
+    { url = "https://files.pythonhosted.org/packages/59/c5/f632c6f0a1a4a7c53c15c642d4e28c51809b920e831fdac53e6450c4f5de/ladybug-0.19.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ea03d4388dd024c5fa4629d607765c9c2c6f4fa4350aceabecee8d37b54289bb", size = 7361226, upload-time = "2026-07-30T00:36:22.46Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/30/2e42725df3c002b16204f44c055afc50cedd80ca93c0180656741493c575/ladybug-0.19.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f880a6d5329461088d25854a8cd77aec17ffbf00b2f3642ed32f94b5d001f452", size = 8255330, upload-time = "2026-07-30T00:36:24.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e7/a08b5179cbc07fc35f01dd3cfdbf523410cd6ca0a9a6fb5828b1e27da1ea/ladybug-0.19.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:be3035c3e9232d5c50f399a85fd39713f6b31574d2b198d696117e2f21f96d1b", size = 8190323, upload-time = "2026-07-30T00:36:25.825Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f0/060e015ce0384acfbfe19fb4bd1c54bd7da52de6a61f34da066a17f4e572/ladybug-0.19.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b3b2227e10d2004691b3fca755ec050da317eb9a7e1411f5358a395c2eaf19bb", size = 9113582, upload-time = "2026-07-30T00:36:27.522Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/58/0b8c6b7c73d3c3b86f1b646b7ea7fbd0055476e582ad12911f491733da28/ladybug-0.19.0-cp314-cp314-win_amd64.whl", hash = "sha256:1051bf29963eb73d35910f60256fb0649057cd1d0993237bdaf193654071507c", size = 5895460, upload-time = "2026-07-30T00:36:29.643Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b4/f74b3049cc049a04700dbdafb91b299fec6f804759c56e173dd907cbd768/ladybug-0.19.0-cp314-cp314-win_arm64.whl", hash = "sha256:69b8a3d05f04dbadde0f111e03a82e387675032232d3f8ccc91921b749fa8306", size = 8462283, upload-time = "2026-07-30T00:36:31.646Z" },
 ]
 
 [[package]]
@@ -2178,7 +2214,8 @@ name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "(python_full_version < '3.11' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version < '3.11' and sys_platform != 'darwin')",
+    "(python_full_version < '3.11' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version < '3.11' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
@@ -2190,9 +2227,12 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
-    "python_full_version == '3.11.*'",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version >= '3.14' and sys_platform != 'darwin')",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version >= '3.12' and python_full_version < '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin')",
+    "(python_full_version >= '3.12' and python_full_version < '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.12' and python_full_version < '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.11.*' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version == '3.11.*' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
@@ -2204,7 +2244,8 @@ name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "(python_full_version < '3.11' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version < '3.11' and sys_platform != 'darwin')",
+    "(python_full_version < '3.11' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version < '3.11' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -2269,7 +2310,8 @@ name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.11.*'",
+    "(python_full_version == '3.11.*' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.11.*' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version == '3.11.*' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
@@ -2351,8 +2393,10 @@ name = "numpy"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version >= '3.14' and sys_platform != 'darwin')",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version >= '3.12' and python_full_version < '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin')",
+    "(python_full_version >= '3.12' and python_full_version < '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.12' and python_full_version < '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e7/05/3d27272d30698dc0ecb7fdfaa41ad70303b444f81722bb99bce1d818638a/numpy-2.5.0.tar.gz", hash = "sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c", size = 20652461, upload-time = "2026-06-21T20:57:51.95Z" }
 wheels = [
@@ -3291,7 +3335,8 @@ name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "(python_full_version < '3.11' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version < '3.11' and sys_platform != 'darwin')",
+    "(python_full_version < '3.11' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version < '3.11' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
 wheels = [
@@ -3416,9 +3461,12 @@ name = "rpds-py"
 version = "2026.5.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
-    "python_full_version == '3.11.*'",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version >= '3.14' and sys_platform != 'darwin')",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version >= '3.12' and python_full_version < '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin')",
+    "(python_full_version >= '3.12' and python_full_version < '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.12' and python_full_version < '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.11.*' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version == '3.11.*' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
 wheels = [

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -67,7 +67,7 @@ integrations:
     registry: pypi
     package_name: "cognee-integration-hermes-agent"
     cognee_dependency: http-api
-    current_version: "1.1.0"
+    current_version: "1.2.0"
     migration_status: done
     source_repo: https://github.com/NousResearch/hermes-agent/pull/7418
     notes: >-

--- a/scripts/check_version_pins.py
+++ b/scripts/check_version_pins.py
@@ -2,7 +2,8 @@
 """Check that all Python integrations pin the cognee dependency with a bounded range.
 
 Policy: Every Python integration that depends on cognee must declare it with both
-a lower bound (>=) and an upper bound (< or <=). For example: cognee>=0.5.1,<0.6.0
+a lower bound (>=) and an upper bound (< or <=), e.g. cognee>=0.5.1,<0.6.0 — or
+an exact pin (==), which bounds both sides by definition, e.g. cognee==1.5.3.
 
 Handles:
   - Simple deps:        "cognee>=0.5.1,<0.6.0"
@@ -36,6 +37,10 @@ LOWER_BOUND_PATTERN = re.compile(r">=?\s*\d")
 # Check for upper bound (< or <=, but not !=)
 UPPER_BOUND_PATTERN = re.compile(r"(?<!=)<=?\s*\d")
 
+# Exact pin (==): bounds both sides by definition. (`!=` has a single `=`,
+# so it can never match this.)
+EXACT_PIN_PATTERN = re.compile(r"==\s*\d")
+
 
 def check_pyproject(pyproject_path: Path) -> list[str]:
     """Check a single integration's pyproject.toml for proper cognee pinning."""
@@ -65,6 +70,10 @@ def check_pyproject(pyproject_path: Path) -> list[str]:
                 f"{integration_name}: cognee dependency has no version constraint. "
                 f"Found: {dep_name} (unpinned)"
             )
+            continue
+
+        if EXACT_PIN_PATTERN.search(version_spec):
+            # An exact pin is the tightest bound there is.
             continue
 
         if not LOWER_BOUND_PATTERN.search(version_spec):


### PR DESCRIPTION
## hermes-agent 1.2.0 — parity with the claude-code/codex/openclaw plugins

Brings the Hermes plugin up to the other cognee agent plugins on every
user-facing memory operation:

- **Layered recall**: per-prompt fan-out over session cache, trace lessons,
  agent guidance and graph (was one graph-only `auto` call), with a budget,
  labelled blocks, and a plain-words memory-hit header.
- **Per-document forget**: two-phase find → confirm → delete; dataset-wide
  deletion gated, all-datasets wipe not expressible from the tool.
- **`cognee_switch_dataset`**: move a conversation to another dataset;
  bridges the old session, persists the override across resumes.
- **Code graph**: `hermes cognee index-repo` CLI, `cognee_code_search` tool,
  identifier-gated code recall lane (explicit indexing only, like openclaw).
- **Memory steer**, and a `version` command + rate-limited PyPI update check.
- **cognee pinned to exactly 1.5.3** (`==`), required for code indexing and
  targeted forget invalidation; `check_version_pins.py` now accepts exact
  pins (repo-level tooling change, no effect on other integrations).