### PR TITLE
fix(hermes-agent): make pip installs actually activate the memory provider

### DIFF
--- a/integrations/hermes-agent/CHANGELOG.md
+++ b/integrations/hermes-agent/CHANGELOG.md
@@ -10,6 +10,47 @@ The version must match the `version` field in both `pyproject.toml` and
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.1]
+
+Fixes [#382](https://github.com/topoteretes/cognee-integrations/issues/382):
+**every pip install of 1.0.0–1.2.0 produced a plugin Hermes silently ignored.**
+`pip install` + `cognee-hermes-install` reported success, `hermes plugins show
+cognee` said "enabled", but the memory provider — recall, remember, forget,
+the session-end bridge — was never wired up; `hermes memory status` ("Plugin:
+NOT installed") was the only symptom. Installs copied from a repo checkout
+(the path the plugin was developed and live-tested through) were unaffected,
+which is how this shipped three times.
+
+### Fixed
+
+- **`cognee-hermes-install` now lays down the plugin root's `__init__.py`.**
+  Hermes' memory-provider loader (`plugins.memory._is_memory_provider_dir`)
+  skips — silently — any plugin directory without an `__init__.py` naming
+  `MemoryProvider` or `register_memory_provider`. The repo always had the
+  right file (it is what made checkout installs work); the installer's file
+  list simply never included it. It ships in the wheel as
+  `_plugin_root/plugin_init.py` (an `__init__.py` inside `_plugin_root/`
+  would make it an importable subpackage) and is installed under its real
+  name. After `pip install -U`, re-run `cognee-hermes-install` — that now
+  also repairs an existing broken install in place.
+- **The pip entry point is now in the group Hermes actually reads.** The
+  memory loader scans `hermes_agent.memory_providers`; the package declared
+  only the generic `hermes_agent.plugins` group (kept for compatibility),
+  which is why Hermes reported the plugin "enabled" with nothing registered.
+  With the correct group, a plain `pip install` activates the provider via
+  `register(ctx)` even before `cognee-hermes-install` runs — the installer
+  remains recommended (the directory install carries the `hermes cognee` CLI
+  and the dashboard config panel at full fidelity).
+- Regression tests: the installer's output directory must pass Hermes'
+  discovery heuristic verbatim, and the pyproject must declare the
+  `hermes_agent.memory_providers` entry point.
+
+### Corrections to earlier notes
+
+- 1.0.0's known-limitations claim that "Hermes discovers memory providers by
+  directory scan only" was wrong: Hermes has always had a pip entry-point
+  path for memory providers — this package was registered in the wrong group.
+
 ## [1.2.0]
 
 Parity release: brings the Hermes plugin up to the claude-code/codex

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -133,21 +133,21 @@ tenant, authenticated with your API key via `X-Api-Key`.
 
 ## How the pip install works
 
-Hermes has no entry-point plugin discovery (yet) — it scans
-`$HERMES_HOME/plugins/` for directories with a `plugin.yaml`. The wheel
-therefore ships the plugin-root files as package data and provides the
-`cognee-hermes-install` console script, which materializes the exact directory
-shape the scanner expects. Because Hermes runs that *copy*, upgrading is always
-two steps: `pip install -U cognee-integration-hermes-agent`, then
-`cognee-hermes-install` again.
+Hermes discovers memory providers two ways, and the package serves both:
 
-The package also declares the entry point Hermes would use if it grows native
-discovery, at which point the copy step becomes unnecessary:
+- **Pip entry point** — the wheel declares
+  `[project.entry-points."hermes_agent.memory_providers"]`, the group Hermes'
+  memory loader scans, so the provider activates from a plain `pip install`.
+- **Directory install** — `cognee-hermes-install` copies the plugin into
+  `$HERMES_HOME/plugins/cognee/` in the exact shape the directory scanner
+  expects; the load-bearing file is the root `__init__.py` (Hermes silently
+  skips a plugin directory without one). The directory install is the
+  recommended path: it carries the `hermes cognee` subcommands and the
+  dashboard config panel at full fidelity.
 
-```toml
-[project.entry-points."hermes_agent.plugins"]
-cognee = "cognee_integration_hermes"
-```
+Because Hermes runs the directory *copy*, upgrading it is always two steps:
+`pip install -U cognee-integration-hermes-agent`, then `cognee-hermes-install`
+again (`hermes cognee status` reminds you when the copy is stale).
 
 Releases are published from CI on `hermes-agent-v*` tags
 (`.github/workflows/hermes-agent-publish.yml`).

--- a/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/plugin.yaml
+++ b/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/plugin.yaml
@@ -1,6 +1,6 @@
 name: cognee
 kind: exclusive
-version: 1.2.0
+version: 1.2.1
 description: "Cognee memory provider for Hermes Agent: session-aware graph memory, recall, forget, and session-end improvement."
 pip_dependencies:
   # Exact pin: the installed package doubles as the local server this plugin

--- a/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/plugin_init.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/plugin_init.py
@@ -1,0 +1,17 @@
+"""Directory-plugin entry point for Hermes Agent."""
+
+try:
+    from .cognee_integration_hermes import CogneeMemoryProvider
+except ImportError:  # pragma: no cover - supports direct pytest/path imports.
+    import sys
+    from pathlib import Path
+
+    plugin_dir = Path(__file__).resolve().parent
+    if str(plugin_dir) not in sys.path:
+        sys.path.insert(0, str(plugin_dir))
+    from cognee_integration_hermes import CogneeMemoryProvider
+
+
+def register(ctx) -> None:
+    """Register Cognee as the active Hermes memory provider."""
+    ctx.register_memory_provider(CogneeMemoryProvider())

--- a/integrations/hermes-agent/cognee_integration_hermes/installer.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/installer.py
@@ -3,13 +3,22 @@
 Hermes discovers memory providers by scanning ``$HERMES_HOME/plugins/`` — a pip
 install alone puts this package in site-packages, where Hermes never looks. The
 ``cognee-hermes-install`` console script bridges that gap: it lays down the
-exact directory shape the scanner expects (``plugin.yaml`` and the ``cli.py``
-shim at the plugin root, this package beside them), copied from the installed
-wheel. The full flow:
+exact directory shape the scanner expects, copied from the installed wheel.
+The full flow:
 
     pip install cognee-integration-hermes-agent
     cognee-hermes-install
     hermes memory setup
+
+The one file the scanner actually keys on is the plugin root's ``__init__.py``:
+Hermes' ``plugins.memory._is_memory_provider_dir`` skips — silently — any
+directory without one (it must mention ``MemoryProvider`` or
+``register_memory_provider`` in its first 8KB). Versions 1.0.0–1.2.0 of this
+installer never laid that file down, so a pip install produced a plugin Hermes
+ignored while everything reported success (issue #382). It ships in the wheel
+as ``_plugin_root/plugin_init.py`` — naming it ``__init__.py`` in place would
+turn ``_plugin_root`` into an importable subpackage and change how setuptools
+treats its data files — and is written to the target under its real name.
 
 Because Hermes runs the *copy*, ``pip install -U`` alone changes nothing —
 re-run ``cognee-hermes-install`` after upgrading. ``hermes cognee status``
@@ -28,7 +37,14 @@ from pathlib import Path
 
 from .config import resolve_hermes_home
 
-_ROOT_FILES = ("plugin.yaml", "cli.py", "after-install.md")
+# Packaged name -> name at the plugin root. plugin_init.py becomes the
+# __init__.py that makes the directory discoverable as a memory provider.
+_ROOT_FILES = {
+    "plugin.yaml": "plugin.yaml",
+    "cli.py": "cli.py",
+    "after-install.md": "after-install.md",
+    "plugin_init.py": "__init__.py",
+}
 
 
 def install(hermes_home: str | Path | None = None) -> Path:
@@ -48,8 +64,8 @@ def install(hermes_home: str | Path | None = None) -> Path:
 
     target = home / "plugins" / "cognee"
     target.mkdir(parents=True, exist_ok=True)
-    for name in _ROOT_FILES:
-        shutil.copyfile(root_src / name, target / name)
+    for source_name, target_name in _ROOT_FILES.items():
+        shutil.copyfile(root_src / source_name, target / target_name)
 
     # Replace the package wholesale so removed modules never linger.
     dest_package = target / package_src.name

--- a/integrations/hermes-agent/plugin.yaml
+++ b/integrations/hermes-agent/plugin.yaml
@@ -1,6 +1,6 @@
 name: cognee
 kind: exclusive
-version: 1.2.0
+version: 1.2.1
 description: "Cognee memory provider for Hermes Agent: session-aware graph memory, recall, forget, and session-end improvement."
 pip_dependencies:
   # Exact pin: the installed package doubles as the local server this plugin

--- a/integrations/hermes-agent/pyproject.toml
+++ b/integrations/hermes-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cognee-integration-hermes-agent"
-version = "1.2.0"
+version = "1.2.1"
 description = "Standalone Cognee memory provider plugin for Hermes Agent."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -19,12 +19,23 @@ dependencies = [
     "cognee==1.5.3",
 ]
 
+# The group Hermes' memory-provider loader actually scans
+# (plugins/memory ENTRY_POINTS_GROUP): with this, a plain pip install activates
+# the provider via `register(ctx)` even before cognee-hermes-install runs.
+# 1.0.0–1.2.0 declared only the generic group below, which the memory loader
+# never reads (issue #382).
+[project.entry-points."hermes_agent.memory_providers"]
+cognee = "cognee_integration_hermes"
+
+# Hermes' generic plugin system; kept so existing `plugins.enabled` entries
+# keep resolving.
 [project.entry-points."hermes_agent.plugins"]
 cognee = "cognee_integration_hermes"
 
 [project.scripts]
-# Hermes discovers plugins by directory scan, not entry points — this copies
-# the installed package into $HERMES_HOME/plugins/cognee. See installer.py.
+# Copies the installed package into $HERMES_HOME/plugins/cognee, which gets the
+# directory-scan discovery path plus the plugin-root cli.py/plugin.yaml
+# (dashboard config panel, `hermes cognee` subcommands). See installer.py.
 cognee-hermes-install = "cognee_integration_hermes.installer:main"
 
 [tool.setuptools.packages.find]
@@ -32,7 +43,8 @@ where = ["."]
 include = ["cognee_integration_hermes*"]
 
 [tool.setuptools.package-data]
-# The plugin-root files (plugin.yaml, cli.py shim, after-install.md) that the
+# The plugin-root files (plugin.yaml, cli.py shim, after-install.md, and
+# plugin_init.py — installed as the plugin root's __init__.py) that the
 # installer lays down next to the package. Kept byte-identical to the repo-root
 # canonical copies by tests/test_installer.py.
 cognee_integration_hermes = ["_plugin_root/*"]

--- a/integrations/hermes-agent/tests/test_installer.py
+++ b/integrations/hermes-agent/tests/test_installer.py
@@ -1,10 +1,13 @@
 """Tests for the pip-install bridge (``cognee-hermes-install``).
 
-Hermes discovers plugins by directory scan, so the installer must materialize
-the exact plugin shape from the wheel: the root files at the plugin root and
-the package beside them. The drift tests are the load-bearing ones — the wheel
-ships *copies* of the repo-root plugin files, and a stale copy would publish a
-plugin.yaml that disagrees with the repository.
+Hermes discovers memory providers by directory scan and by the
+``hermes_agent.memory_providers`` entry-point group; the installer must
+materialize the exact plugin shape the scanner expects — including the root
+``__init__.py`` the scanner keys on (issue #382: three releases shipped
+without it, so pip installs were silently ignored). The drift tests are the
+load-bearing ones — the wheel ships *copies* of the repo-root plugin files,
+and a stale copy would publish a plugin.yaml that disagrees with the
+repository.
 
 Runs under pytest or standalone (``python3 tests/test_installer.py``); touches
 nothing outside temporary directories.
@@ -30,9 +33,9 @@ _PACKAGE = ROOT / "cognee_integration_hermes"
 class TestPackagedCopiesMatchTheRepo(unittest.TestCase):
     """The wheel's _plugin_root/* must be byte-identical to the repo root files."""
 
-    def _assert_same(self, name):
+    def _assert_same(self, name, canonical_name=None):
         packaged = (_PACKAGE / "_plugin_root" / name).read_bytes()
-        canonical = (ROOT / name).read_bytes()
+        canonical = (ROOT / (canonical_name or name)).read_bytes()
         self.assertEqual(
             packaged,
             canonical,
@@ -48,6 +51,11 @@ class TestPackagedCopiesMatchTheRepo(unittest.TestCase):
 
     def test_after_install(self):
         self._assert_same("after-install.md")
+
+    def test_plugin_init(self):
+        # Packaged as plugin_init.py (an __init__.py inside _plugin_root/ would
+        # make it an importable subpackage); installed as __init__.py.
+        self._assert_same("plugin_init.py", canonical_name="__init__.py")
 
     def test_plugin_yaml_version_matches_pyproject(self):
         # The CHANGELOG contract: one version across plugin.yaml and pyproject.
@@ -70,11 +78,38 @@ class TestInstall(unittest.TestCase):
     def test_lays_down_the_plugin_shape_hermes_scans_for(self):
         target = installer.install(self.home)
         self.assertEqual(target, self.home / "plugins" / "cognee")
-        for name in ("plugin.yaml", "cli.py", "after-install.md"):
+        for name in ("plugin.yaml", "cli.py", "after-install.md", "__init__.py"):
             self.assertTrue((target / name).is_file(), f"missing root file {name}")
         # The package itself, importable next to the root files.
         self.assertTrue((target / "cognee_integration_hermes" / "provider.py").is_file())
         self.assertTrue((target / "cognee_integration_hermes" / "exit_watcher.py").is_file())
+
+    def test_installed_dir_passes_hermes_discovery_heuristic(self):
+        # Regression for issue #382: 1.0.0–1.2.0 laid down no root __init__.py,
+        # and Hermes' plugins.memory._is_memory_provider_dir silently skips any
+        # directory without one — every pip install produced a plugin Hermes
+        # ignored. This mirrors that heuristic exactly: __init__.py must exist
+        # and mention MemoryProvider or register_memory_provider in its first
+        # 8KB.
+        target = installer.install(self.home)
+        init_file = target / "__init__.py"
+        self.assertTrue(init_file.exists(), "plugin root has no __init__.py")
+        source = init_file.read_text(errors="replace", encoding="utf-8")[:8192]
+        self.assertTrue(
+            "register_memory_provider" in source or "MemoryProvider" in source,
+            "__init__.py would fail Hermes' memory-provider text heuristic",
+        )
+
+    def test_pyproject_declares_the_memory_providers_entry_point(self):
+        # The other half of issue #382: the memory loader scans the
+        # hermes_agent.memory_providers group; 1.0.0–1.2.0 declared only the
+        # generic hermes_agent.plugins group, which it never reads. Parsed by
+        # section-splitting rather than tomllib, which 3.10 (our floor) lacks.
+        text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        header = '[project.entry-points."hermes_agent.memory_providers"]'
+        self.assertIn(header, text)
+        section = text.split(header, 1)[1].split("\n[", 1)[0]
+        self.assertIn('cognee = "cognee_integration_hermes"', section)
 
     def test_bytecode_caches_are_not_shipped(self):
         target = installer.install(self.home)
@@ -93,7 +128,7 @@ class TestInstall(unittest.TestCase):
         )
 
     def test_missing_packaged_files_fail_loudly(self):
-        with mock.patch.object(installer, "_ROOT_FILES", ("no-such-file.txt",)):
+        with mock.patch.object(installer, "_ROOT_FILES", {"no-such-file.txt": "no-such-file.txt"}):
             with self.assertRaisesRegex(RuntimeError, "packaged plugin files missing"):
                 installer.install(self.home)
 

--- a/integrations/hermes-agent/uv.lock
+++ b/integrations/hermes-agent/uv.lock
@@ -759,7 +759,7 @@ wheels = [
 
 [[package]]
 name = "cognee-integration-hermes-agent"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -67,7 +67,7 @@ integrations:
     registry: pypi
     package_name: "cognee-integration-hermes-agent"
     cognee_dependency: http-api
-    current_version: "1.2.0"
+    current_version: "1.2.1"
     migration_status: done
     source_repo: https://github.com/NousResearch/hermes-agent/pull/7418
     notes: >-


### PR DESCRIPTION
Fixes #382 — every pip install of 1.0.0-1.2.0 produced a plugin Hermes silently ignored; only checkout installs ever activated. Two independent bugs, both in the packaging surface:

- cognee-hermes-install never laid down the plugin root's __init__.py, the one file Hermes' directory scanner keys on (plugins.memory._is_memory_provider_dir skips a dir without it). It now ships in the wheel as _plugin_root/plugin_init.py and is installed under its real name; re-running the installer repairs broken installs in place.
- The pip entry point was declared in the generic hermes_agent.plugins group; the memory loader only reads hermes_agent.memory_providers. Both are declared now, so a plain pip install activates via register(ctx).

Regression tests mirror Hermes' discovery heuristic verbatim and pin the entry-point group; verified end-to-end from the built wheel in a scratch venv (directory heuristic, entry-point load, register(ctx), path load).

Release 1.2.1.