### PR TITLE
fix(claude-code,codex): prefer the host's exported pid for the exit watcher

### DIFF
--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -891,7 +891,22 @@ def _spawn_idle_watcher(
 
 
 def _find_claude_parent_pid() -> int:
-    """Find the nearest live Claude ancestor, skipping hook shells."""
+    """Find the live Claude host process for this hook.
+
+    Claude Code exports its own pid as ``CLAUDE_PID`` to every subprocess; when
+    that pid is alive it IS the host, so use it before walking the process tree.
+    The walk below stops at the *nearest* ``claude`` ancestor, which on the
+    Windows desktop app is the short-lived hook-runner rather than the session
+    runtime: the exit watcher then sees ``parent_exited`` within a second of
+    session start, runs the final sync early and unregisters the live connection
+    (topoteretes/cognee-integrations#391).
+    """
+    try:
+        host_pid = int(str(os.environ.get("CLAUDE_PID", "") or "0").strip() or 0)
+    except ValueError:
+        host_pid = 0
+    if host_pid > 1 and _pid_alive(host_pid):
+        return host_pid
     fallback = os.getppid()
     if sys.platform == "win32":
         return find_host_ancestor_windows(fallback, "claude")

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -890,7 +890,20 @@ def _spawn_idle_watcher(
 
 
 def _find_codex_parent_pid() -> int:
-    """Find the nearest live Codex ancestor, skipping hook shells."""
+    """Find the live Codex host process for this hook.
+
+    Codex exports its own pid as ``CODEX_PID`` to subprocesses; when that pid
+    is alive it IS the host, so use it before walking the process tree. The
+    walk stops at the *nearest* ``codex`` ancestor, which can be a short-lived
+    hook-runner rather than the session runtime (see the claude-code twin,
+    topoteretes/cognee-integrations#391).
+    """
+    try:
+        host_pid = int(str(os.environ.get("CODEX_PID", "") or "0").strip() or 0)
+    except ValueError:
+        host_pid = 0
+    if host_pid > 1 and _pid_alive(host_pid):
+        return host_pid
     fallback = os.getppid()
     if sys.platform == "win32":
         return find_host_ancestor_windows(fallback, "codex")

--- a/integrations/tests/tests/unit/test_exit_watcher_host_pid.py
+++ b/integrations/tests/tests/unit/test_exit_watcher_host_pid.py
@@ -1,0 +1,52 @@
+"""``_find_<host>_parent_pid`` picks the pid the exit watcher waits on.
+
+The ancestor walk returns the nearest host-named process; on the Claude desktop
+app (Windows) that is the hook-runner, gone within a second of SessionStart, so
+the watcher fired at once and unregistered the live connection (#391). Both
+hosts export their pid (``CLAUDE_PID`` / ``CODEX_PID``): an alive value must win,
+anything else must fall back to the walk.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+_HOST = {
+    "claude-code": ("_find_claude_parent_pid", "CLAUDE_PID"),
+    "codex": ("_find_codex_parent_pid", "CODEX_PID"),
+}
+
+
+@pytest.fixture
+def find_host_pid(suite, hook_module, monkeypatch):
+    fn_name, env_var = _HOST[suite.name]
+    module = hook_module(suite, "session-start.py")
+    fn = getattr(module, fn_name)
+    monkeypatch.delenv("CLAUDE_PID", raising=False)
+    monkeypatch.delenv("CODEX_PID", raising=False)
+    return fn, env_var, module
+
+
+def test_alive_exported_pid_wins(find_host_pid, monkeypatch):
+    fn, env_var, _ = find_host_pid
+    monkeypatch.setenv(env_var, str(os.getpid()))
+    assert fn() == os.getpid()
+
+
+@pytest.mark.parametrize("bad", ["999999999", "0", "-5", "garbage", ""])
+def test_unusable_exported_pid_falls_back(find_host_pid, monkeypatch, bad):
+    fn, env_var, module = find_host_pid
+    monkeypatch.setenv(env_var, bad)
+    pid = fn()
+    assert isinstance(pid, int) and pid > 1
+    assert str(pid) != bad
+    assert module._pid_alive(pid)
+
+
+def test_absent_exported_pid_falls_back(find_host_pid):
+    fn, _, module = find_host_pid
+    pid = fn()
+    assert isinstance(pid, int) and pid > 1
+    assert module._pid_alive(pid)


### PR DESCRIPTION
Fixes #391

## Summary
- `_find_claude_parent_pid()` / `_find_codex_parent_pid()` use the pid the host exports (`CLAUDE_PID` / `CODEX_PID`) when it is alive; the process-tree walk stays as the fallback.
- On the Claude desktop app (Windows) the walk returned the hook-runner `claude.exe`, gone within a second of `SessionStart`; the exit watcher fired at once, ran the final sync early and unregistered the live connection, so every later `/agents/connections/me?agent_session_name=…` lookup 404'd. Evidence in #391. Server side of that 404: topoteretes/cognee#4907.
- `_plugin_common._candidate_host_pids()` already reads both variables; this makes the watcher path consistent with it.
- Regression test `tests/unit/test_exit_watcher_host_pid.py`, parametrized over both suites: alive exported pid wins; dead / malformed / absent values fall back. Fails on `main` (2 of 14), passes here.

## Tests
- `cd integrations/tests && uv run pytest tests/unit/test_exit_watcher_host_pid.py -q` → 14 passed
- `cd integrations/tests && uv run pytest tests/unit -q` → 1047 passed, 90 skipped, 2 xfailed
- `ruff check` / `ruff format --check` on the three files (repo config) → clean

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

