### PR TITLE
feat(plugins): add explicit memory access management

### DIFF
--- a/integrations/claude-code/scripts/_dataset_access.py
+++ b/integrations/claude-code/scripts/_dataset_access.py
@@ -23,7 +23,16 @@ def recall_fields(value, scope):
     # Session history remains bound to ONE dataset. Federated graph recall is
     # a separate read: never send the active session's binding with it.
     if scope == ["graph"]:
-        raw = os.environ.get("COGNEE_PLUGIN_READ_DATASET_IDS", "").strip()
+        from _plugin_common import load_graph_read_scope
+
+        selected = load_graph_read_scope()
+        raw = (
+            json.dumps(selected)
+            if selected is not None
+            else os.environ.get("COGNEE_PLUGIN_READ_DATASET_IDS", "").strip()
+        )
+        if selected == []:
+            return fields, False
         if raw:
             values = json.loads(raw)
             if not isinstance(values, list) or not values or not all(dataset_id(v) for v in values):

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -3472,6 +3472,26 @@ def unregister_agent_via_http(
         return False, 0
 
 
+def graph_read_scope_path(host_key: str) -> Path:
+    digest = hashlib.sha256(host_key.encode()).hexdigest()
+    return _PLUGIN_DIR / "read-scopes" / f"{digest}.json"
+
+
+def load_graph_read_scope():
+    host_key = get_session_key()
+    if not host_key:
+        return None
+    path = graph_read_scope_path(host_key)
+    if not path.exists():
+        return None
+    record = _load_json_file(path)
+    if record.get("base_url") != _normalize_service_url(_local_api_url()) or record.get(
+        "credential_fingerprint"
+    ) != _principal_fingerprint(_api_key()):
+        raise RuntimeError("Read scope belongs to a different identity or server; select it again")
+    return record.get("dataset_ids", [])
+
+
 def recall_via_http(
     query: str,
     *,

--- a/integrations/claude-code/scripts/memory-access.py
+++ b/integrations/claude-code/scripts/memory-access.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Manage plugin memory access using explicit IDs and authenticated API calls."""
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _plugin_common as pc
+from _dataset_access import dataset_id
+
+
+def owner_credentials():
+    url = pc._local_api_url()
+    cached_agent = pc.load_cached_agent_key(url)
+    key = os.environ.get("COGNEE_API_KEY", "").strip()
+    if not key or key == cached_agent:
+        key = os.environ.get("COGNEE_PRINCIPAL_API_KEY", "").strip() or pc.load_cached_api_key(url)
+    if not key or key == cached_agent:
+        raise RuntimeError("An explicit principal credential is required to manage access")
+    me = pc._json_http_request("/api/v1/users/me", method="GET", api_key=key)
+    if me.get("parent_user_id") or me.get("parentUserId"):
+        raise RuntimeError("Access management requires the user principal, not an agent credential")
+    return key, me
+
+
+def change_permission(principal_id, dataset_ids, permission, *, revoke=False):
+    ident = dataset_id(principal_id)
+    ids = [dataset_id(value) for value in dataset_ids]
+    if not ident or not ids or not all(ids) or permission not in ("read", "write"):
+        raise ValueError("Use principal and dataset UUIDs, with read or write permission")
+    key, _ = owner_credentials()
+    return pc._json_http_request(
+        f"/api/v1/permissions/datasets/{ident}?permission_name={permission}",
+        ids,
+        method="DELETE" if revoke else "POST",
+        api_key=key,
+    )
+
+
+def set_read_scope(host_key, dataset_ids):
+    if not pc._read_map_record(host_key).get("session_id"):
+        raise RuntimeError("No active launch record; pass the host session ID")
+    ids = [dataset_id(value) for value in dataset_ids]
+    if not all(ids):
+        raise ValueError("Read datasets must be UUIDs")
+    readable = pc._json_http_request("/api/v1/datasets/", method="GET")
+    allowed = {str(row.get("id")) for row in readable}
+    if not set(ids).issubset(allowed):
+        raise RuntimeError("The plugin cannot read every selected dataset; grant access first")
+    scope = {
+        "base_url": pc._normalize_service_url(pc._local_api_url()),
+        "credential_fingerprint": pc._principal_fingerprint(pc._api_key()),
+        "dataset_ids": list(dict.fromkeys(ids)),
+    }
+    path = pc.graph_read_scope_path(host_key)
+    pc._write_json_file(path, scope)
+    if pc._load_json_file(path) != scope:
+        raise RuntimeError("Read scope was not persisted")
+    return {"read_dataset_ids": scope["dataset_ids"], "session_key": host_key}
+
+
+def connect_existing_identity(agent_key):
+    """Import a supplied key; never mint or rotate credentials implicitly."""
+    owner_key, owner = owner_credentials()
+    if not agent_key or agent_key == owner_key:
+        raise ValueError("Supply the plugin agent's key, not the principal key")
+    agent = pc._json_http_request("/api/v1/users/me", method="GET", api_key=agent_key)
+    parent = agent.get("parent_user_id") or agent.get("parentUserId")
+    if str(parent or "") != str(owner.get("id")):
+        raise RuntimeError("The supplied agent does not belong to the authenticated user")
+    status = pc._json_http_request("/api/v1/integrations/status", method="GET", api_key=owner_key)
+    plugins = status.get("plugins", [])
+    rows = [row for row in plugins if row.get("key") == pc.PLUGIN_KEY]
+    if not rows or str(rows[0].get("agentId") or rows[0].get("agent_id")) != str(agent.get("id")):
+        raise RuntimeError("The supplied key is not this plugin's registered identity")
+    with pc.plugin_identity_lock():
+        pc.save_cached_agent_key(
+            pc._local_api_url(), agent_key, str(agent["id"]), principal_key=owner_key
+        )
+    return {"connected": True, "agent_id": agent["id"], "next_step": "Start a fresh host session"}
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("status")
+    for verb in ("grant", "revoke"):
+        child = sub.add_parser(verb)
+        child.add_argument("--principal-id", required=True)
+        child.add_argument("--dataset-id", action="append", required=True)
+        child.add_argument("--permission", choices=("read", "write"), required=True)
+    child = sub.add_parser("read")
+    child.add_argument("--session-key", required=True)
+    child.add_argument("--dataset-id", action="append", default=[])
+    child = sub.add_parser("write")
+    child.add_argument("dataset_id")
+    child.add_argument("--session-key", required=True)
+    child = sub.add_parser("connect")
+    child.add_argument("--key-env", required=True, help="Name of env var holding the agent key")
+    args = parser.parse_args(argv)
+    if args.command in ("grant", "revoke"):
+        result = change_permission(
+            args.principal_id, args.dataset_id, args.permission, revoke=args.command == "revoke"
+        )
+    elif args.command == "read":
+        result = set_read_scope(args.session_key, args.dataset_id)
+    elif args.command == "connect":
+        result = connect_existing_identity(os.environ.get(args.key_env, ""))
+    elif args.command == "write":
+        if not dataset_id(args.dataset_id):
+            raise ValueError("Select a dataset UUID")
+        path = Path(__file__).with_name("switch-dataset.py")
+        spec = importlib.util.spec_from_file_location("switch_dataset", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        host, record = module._resolve_launch(args.session_key)
+        result = module._switch(host, record, args.dataset_id, force=False)
+    else:
+        me = pc._json_http_request("/api/v1/users/me", method="GET")
+        result = {
+            "plugin": pc.PLUGIN_KEY,
+            "identity": me.get("id"),
+            "datasets": pc.list_writable_datasets(str(me.get("id") or "")),
+        }
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print(json.dumps({"error": str(error)}), file=sys.stderr)
+        raise SystemExit(1) from None

--- a/integrations/claude-code/skills/cognee-manage-access/SKILL.md
+++ b/integrations/claude-code/skills/cognee-manage-access/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: cognee-manage-access
+description: Inspect plugin memory permissions, grant or revoke access, choose graph read datasets, reconnect an existing plugin identity, or switch the write dataset.
+---
+
+# Manage Cognee memory access
+
+Use the installed plugin's `scripts/memory-access.py`. Resolve that path relative
+ to this skill's plugin root. Run `python3 <script> status` first. Use dataset and
+principal UUIDs returned by the API; names can collide across owners.
+
+- Grant or revoke a specific permission with `grant` / `revoke --principal-id UUID
+  --dataset-id UUID --permission read|write`. Repeated `--dataset-id` selects
+  several datasets. These commands authenticate as the user principal, and the
+  backend must authorize sharing. Grant only the datasets and permissions the
+  user requested; do not infer team-wide sharing from a request to recall memory.
+- Select graph reads with `read --session-key HOST_ID --dataset-id UUID ...`.
+  No dataset arguments restores recall of the active write dataset. This changes
+  recall selection, not permissions. The selection is bound to the current
+  identity, backend, and host launch; account changes require re-selection.
+- Switch writes with `write UUID --session-key HOST_ID`. It syncs first, then
+  registers a fresh session and changes the launch record. A failed sync aborts.
+  Never bypass that failure automatically. Reads and writes are independent.
+- Reconnect a supplied existing plugin key with `connect --key-env ENV_VAR_NAME`.
+  Never put key values in command arguments or print them. It verifies the parent
+  and plugin identity, imports the key without rotation, and requires a fresh
+  host session. New identity creation remains an explicit SessionStart opt-in.
+
+Existing data is not moved or copied by these commands. Promotion of selected
+persisted memory from agent to user to team belongs to the SDK `cognee.promote`
+API and requires separate authorization and an explicit destination.
+
+Validate changes with status and actual authorized recall/write checks. Explain
+any permission denial; never retry using a more privileged data-plane key.

--- a/integrations/codex/plugins/cognee/scripts/_dataset_access.py
+++ b/integrations/codex/plugins/cognee/scripts/_dataset_access.py
@@ -23,7 +23,16 @@ def recall_fields(value, scope):
     # Session history remains bound to ONE dataset. Federated graph recall is
     # a separate read: never send the active session's binding with it.
     if scope == ["graph"]:
-        raw = os.environ.get("COGNEE_PLUGIN_READ_DATASET_IDS", "").strip()
+        from _plugin_common import load_graph_read_scope
+
+        selected = load_graph_read_scope()
+        raw = (
+            json.dumps(selected)
+            if selected is not None
+            else os.environ.get("COGNEE_PLUGIN_READ_DATASET_IDS", "").strip()
+        )
+        if selected == []:
+            return fields, False
         if raw:
             values = json.loads(raw)
             if not isinstance(values, list) or not values or not all(dataset_id(v) for v in values):

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -3376,6 +3376,26 @@ def unregister_agent_via_http(
         return False, 0
 
 
+def graph_read_scope_path(host_key: str) -> Path:
+    digest = hashlib.sha256(host_key.encode()).hexdigest()
+    return _PLUGIN_DIR / "read-scopes" / f"{digest}.json"
+
+
+def load_graph_read_scope():
+    host_key = get_session_key()
+    if not host_key:
+        return None
+    path = graph_read_scope_path(host_key)
+    if not path.exists():
+        return None
+    record = _load_json_file(path)
+    if record.get("base_url") != _normalize_service_url(_local_api_url()) or record.get(
+        "credential_fingerprint"
+    ) != _principal_fingerprint(_api_key()):
+        raise RuntimeError("Read scope belongs to a different identity or server; select it again")
+    return record.get("dataset_ids", [])
+
+
 def recall_via_http(
     query: str,
     *,

--- a/integrations/codex/plugins/cognee/scripts/memory-access.py
+++ b/integrations/codex/plugins/cognee/scripts/memory-access.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Manage plugin memory access using explicit IDs and authenticated API calls."""
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _plugin_common as pc
+from _dataset_access import dataset_id
+
+
+def owner_credentials():
+    url = pc._local_api_url()
+    cached_agent = pc.load_cached_agent_key(url)
+    key = os.environ.get("COGNEE_API_KEY", "").strip()
+    if not key or key == cached_agent:
+        key = os.environ.get("COGNEE_PRINCIPAL_API_KEY", "").strip() or pc.load_cached_api_key(url)
+    if not key or key == cached_agent:
+        raise RuntimeError("An explicit principal credential is required to manage access")
+    me = pc._json_http_request("/api/v1/users/me", method="GET", api_key=key)
+    if me.get("parent_user_id") or me.get("parentUserId"):
+        raise RuntimeError("Access management requires the user principal, not an agent credential")
+    return key, me
+
+
+def change_permission(principal_id, dataset_ids, permission, *, revoke=False):
+    ident = dataset_id(principal_id)
+    ids = [dataset_id(value) for value in dataset_ids]
+    if not ident or not ids or not all(ids) or permission not in ("read", "write"):
+        raise ValueError("Use principal and dataset UUIDs, with read or write permission")
+    key, _ = owner_credentials()
+    return pc._json_http_request(
+        f"/api/v1/permissions/datasets/{ident}?permission_name={permission}",
+        ids,
+        method="DELETE" if revoke else "POST",
+        api_key=key,
+    )
+
+
+def set_read_scope(host_key, dataset_ids):
+    if not pc._read_map_record(host_key).get("session_id"):
+        raise RuntimeError("No active launch record; pass the host session ID")
+    ids = [dataset_id(value) for value in dataset_ids]
+    if not all(ids):
+        raise ValueError("Read datasets must be UUIDs")
+    readable = pc._json_http_request("/api/v1/datasets/", method="GET")
+    allowed = {str(row.get("id")) for row in readable}
+    if not set(ids).issubset(allowed):
+        raise RuntimeError("The plugin cannot read every selected dataset; grant access first")
+    scope = {
+        "base_url": pc._normalize_service_url(pc._local_api_url()),
+        "credential_fingerprint": pc._principal_fingerprint(pc._api_key()),
+        "dataset_ids": list(dict.fromkeys(ids)),
+    }
+    path = pc.graph_read_scope_path(host_key)
+    pc._write_json_file(path, scope)
+    if pc._load_json_file(path) != scope:
+        raise RuntimeError("Read scope was not persisted")
+    return {"read_dataset_ids": scope["dataset_ids"], "session_key": host_key}
+
+
+def connect_existing_identity(agent_key):
+    """Import a supplied key; never mint or rotate credentials implicitly."""
+    owner_key, owner = owner_credentials()
+    if not agent_key or agent_key == owner_key:
+        raise ValueError("Supply the plugin agent's key, not the principal key")
+    agent = pc._json_http_request("/api/v1/users/me", method="GET", api_key=agent_key)
+    parent = agent.get("parent_user_id") or agent.get("parentUserId")
+    if str(parent or "") != str(owner.get("id")):
+        raise RuntimeError("The supplied agent does not belong to the authenticated user")
+    status = pc._json_http_request("/api/v1/integrations/status", method="GET", api_key=owner_key)
+    plugins = status.get("plugins", [])
+    rows = [row for row in plugins if row.get("key") == pc.PLUGIN_KEY]
+    if not rows or str(rows[0].get("agentId") or rows[0].get("agent_id")) != str(agent.get("id")):
+        raise RuntimeError("The supplied key is not this plugin's registered identity")
+    with pc.plugin_identity_lock():
+        pc.save_cached_agent_key(
+            pc._local_api_url(), agent_key, str(agent["id"]), principal_key=owner_key
+        )
+    return {"connected": True, "agent_id": agent["id"], "next_step": "Start a fresh host session"}
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("status")
+    for verb in ("grant", "revoke"):
+        child = sub.add_parser(verb)
+        child.add_argument("--principal-id", required=True)
+        child.add_argument("--dataset-id", action="append", required=True)
+        child.add_argument("--permission", choices=("read", "write"), required=True)
+    child = sub.add_parser("read")
+    child.add_argument("--session-key", required=True)
+    child.add_argument("--dataset-id", action="append", default=[])
+    child = sub.add_parser("write")
+    child.add_argument("dataset_id")
+    child.add_argument("--session-key", required=True)
+    child = sub.add_parser("connect")
+    child.add_argument("--key-env", required=True, help="Name of env var holding the agent key")
+    args = parser.parse_args(argv)
+    if args.command in ("grant", "revoke"):
+        result = change_permission(
+            args.principal_id, args.dataset_id, args.permission, revoke=args.command == "revoke"
+        )
+    elif args.command == "read":
+        result = set_read_scope(args.session_key, args.dataset_id)
+    elif args.command == "connect":
+        result = connect_existing_identity(os.environ.get(args.key_env, ""))
+    elif args.command == "write":
+        if not dataset_id(args.dataset_id):
+            raise ValueError("Select a dataset UUID")
+        path = Path(__file__).with_name("switch-dataset.py")
+        spec = importlib.util.spec_from_file_location("switch_dataset", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        host, record = module._resolve_launch(args.session_key)
+        result = module._switch(host, record, args.dataset_id, force=False)
+    else:
+        me = pc._json_http_request("/api/v1/users/me", method="GET")
+        result = {
+            "plugin": pc.PLUGIN_KEY,
+            "identity": me.get("id"),
+            "datasets": pc.list_writable_datasets(str(me.get("id") or "")),
+        }
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print(json.dumps({"error": str(error)}), file=sys.stderr)
+        raise SystemExit(1) from None

--- a/integrations/codex/plugins/cognee/skills/cognee-manage-access/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/cognee-manage-access/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: cognee-manage-access
+description: Inspect plugin memory permissions, grant or revoke access, choose graph read datasets, reconnect an existing plugin identity, or switch the write dataset.
+---
+
+# Manage Cognee memory access
+
+Use the installed plugin's `scripts/memory-access.py`. Resolve that path relative
+ to this skill's plugin root. Run `python3 <script> status` first. Use dataset and
+principal UUIDs returned by the API; names can collide across owners.
+
+- Grant or revoke a specific permission with `grant` / `revoke --principal-id UUID
+  --dataset-id UUID --permission read|write`. Repeated `--dataset-id` selects
+  several datasets. These commands authenticate as the user principal, and the
+  backend must authorize sharing. Grant only the datasets and permissions the
+  user requested; do not infer team-wide sharing from a request to recall memory.
+- Select graph reads with `read --session-key HOST_ID --dataset-id UUID ...`.
+  No dataset arguments restores recall of the active write dataset. This changes
+  recall selection, not permissions. The selection is bound to the current
+  identity, backend, and host launch; account changes require re-selection.
+- Switch writes with `write UUID --session-key HOST_ID`. It syncs first, then
+  registers a fresh session and changes the launch record. A failed sync aborts.
+  Never bypass that failure automatically. Reads and writes are independent.
+- Reconnect a supplied existing plugin key with `connect --key-env ENV_VAR_NAME`.
+  Never put key values in command arguments or print them. It verifies the parent
+  and plugin identity, imports the key without rotation, and requires a fresh
+  host session. New identity creation remains an explicit SessionStart opt-in.
+
+Existing data is not moved or copied by these commands. Promotion of selected
+persisted memory from agent to user to team belongs to the SDK `cognee.promote`
+API and requires separate authorization and an explicit destination.
+
+Validate changes with status and actual authorized recall/write checks. Explain
+any permission denial; never retry using a more privileged data-plane key.

--- a/integrations/tests/tests/unit/test_memory_access.py
+++ b/integrations/tests/tests/unit/test_memory_access.py
@@ -1,0 +1,78 @@
+"""Exercise access management without granting live permissions."""
+
+from uuid import uuid4
+
+import pytest
+
+
+@pytest.fixture
+def access(suite, hook_module, monkeypatch):
+    module = hook_module(suite, "memory-access.py")
+    pc = module.pc
+    monkeypatch.setenv("COGNEE_API_KEY", "owner-key")
+    return module, pc
+
+
+def test_grant_and_revoke_use_owner_key_and_explicit_ids(access, monkeypatch):
+    module, pc = access
+    principal, dataset = str(uuid4()), str(uuid4())
+    calls = []
+
+    def request(path, payload=None, **kwargs):
+        calls.append((path, payload, kwargs))
+        return {"id": "owner"} if path.endswith("/users/me") else {"ok": True}
+
+    monkeypatch.setattr(pc, "_json_http_request", request)
+    module.change_permission(principal, [dataset], "read")
+    assert calls[-1][0].endswith(f"{principal}?permission_name=read")
+    assert calls[-1][1] == [dataset]
+    assert calls[-1][2]["api_key"] == "owner-key"
+    module.change_permission(principal, [dataset], "write", revoke=True)
+    assert calls[-1][2]["method"] == "DELETE"
+
+
+def test_agent_credential_cannot_manage_permissions(access, monkeypatch):
+    module, pc = access
+    monkeypatch.setattr(
+        pc, "_json_http_request", lambda *a, **kw: {"id": "agent", "parent_user_id": "owner"}
+    )
+    with pytest.raises(RuntimeError, match="principal"):
+        module.change_permission(str(uuid4()), [str(uuid4())], "read")
+
+
+def test_read_scope_is_bound_to_launch_and_identity(access, monkeypatch):
+    module, pc = access
+    ident = str(uuid4())
+    pc.ensure_launch_record("host", "/tmp", dataset="write-dataset")
+    monkeypatch.setattr(pc, "_json_http_request", lambda *a, **kw: [{"id": ident}])
+    module.set_read_scope("host", [ident])
+    pc.set_session_key("host")
+    assert pc.load_graph_read_scope() == [ident]
+    monkeypatch.setenv("COGNEE_API_KEY", "different-owner")
+    with pytest.raises(RuntimeError, match="different identity"):
+        pc.load_graph_read_scope()
+
+
+def test_denied_read_selection_does_not_change_scope(access, monkeypatch):
+    module, pc = access
+    pc.ensure_launch_record("host", "/tmp", dataset="write-dataset")
+    monkeypatch.setattr(pc, "_json_http_request", lambda *a, **kw: [])
+    with pytest.raises(RuntimeError, match="grant access"):
+        module.set_read_scope("host", [str(uuid4())])
+    assert not pc.graph_read_scope_path("host").exists()
+
+
+def test_connect_refuses_another_users_agent(access, monkeypatch):
+    module, pc = access
+
+    def request(path, **kwargs):
+        return (
+            {"id": "owner"}
+            if kwargs["api_key"] == "owner-key"
+            else {"id": "agent", "parent_user_id": "other-owner"}
+        )
+
+    monkeypatch.setattr(pc, "_json_http_request", request)
+    with pytest.raises(RuntimeError, match="does not belong"):
+        module.connect_existing_identity("agent-key")
+    assert not pc._AGENT_KEY_CACHE.exists()


### PR DESCRIPTION
Stacked on #363: the base is `feature/plugin-identity-provisioning`.

Adds an explicit memory-access command and a discoverable skill to both Codex and Claude plugins. Users can inspect access, grant/revoke read or write permissions by principal and dataset UUID, select graph-read datasets independently from the write dataset, switch writes through the existing sync/register/switch flow, and reconnect an existing plugin credential without rotation.

Permission changes authenticate as the user principal and remain subject to server-side share authorization. Read selections are bound to the plugin identity, backend and host session; inaccessible selections and account mismatches fail. Reconnection verifies both the parent relationship and the plugin's registered agent ID. Key values are accepted through a named environment variable, never command-line values or output.

Validation: full shared suite passed (1,474 passed, 90 skipped, 2 expected failures); added tests cover owner-authenticated grant/revoke, denied management by an agent, identity-bound read selections, denied read selections, and wrong-parent reconnection. Both skills validated; changed code passes lint. GitHub test/lint workflows now include PRs targeting another feature branch, so this stack is checked before retargeting to main.

The identity and dataset bugs themselves are fixed in #363. This PR adds the user-facing workflow. Safe new-identity provisioning and complete effective permission queries also require https://github.com/topoteretes/cognee/pull/4942; existing installations retain principal mode until explicitly migrated.
