### PR TITLE
feat(integrations): configurable minimum prompt length for recall

### DIFF
--- a/integrations/antigravity/EVENTS.md
+++ b/integrations/antigravity/EVENTS.md
@@ -85,6 +85,7 @@ Names cover current hooks, configuration, transcript cleanup, and both watchers.
 | `hook:context_lookup_hit` | `recall.lookup_hit` |
 | `hook:context_lookup_missing_session_key` | `recall.lookup_missing_session_key` |
 | `hook:context_lookup_session_key` | `recall.lookup_session_key` |
+| `hook:context_lookup_short_prompt` | `recall.lookup_short_prompt` |
 | `hook:credits_fetch_empty` | `credits.fetch_empty` |
 | `hook:credits_fetch_failed` | `credits.fetch_failed` |
 | `hook:credits_refresh_error` | `credits.refresh_error` |

--- a/integrations/antigravity/scripts/event_names.py
+++ b/integrations/antigravity/scripts/event_names.py
@@ -88,6 +88,7 @@ EVENT_NAMES = {
     "hook:context_lookup_hit": "recall.lookup_hit",
     "hook:context_lookup_missing_session_key": "recall.lookup_missing_session_key",
     "hook:context_lookup_session_key": "recall.lookup_session_key",
+    "hook:context_lookup_short_prompt": "recall.lookup_short_prompt",
     "hook:credits_fetch_empty": "credits.fetch_empty",
     "hook:credits_fetch_failed": "credits.fetch_failed",
     "hook:credits_refresh_error": "credits.refresh_error",

--- a/integrations/antigravity/scripts/session-context-lookup.py
+++ b/integrations/antigravity/scripts/session-context-lookup.py
@@ -812,6 +812,20 @@ async def _run(prompt: str, cwd: str = "") -> dict | None:
     return output
 
 
+def _recall_min_prompt_chars() -> int:
+    """Prompts shorter than this skip recall (capture keeps its own 5-char floor).
+
+    COGNEE_RECALL_MIN_PROMPT_CHARS lets a host raise the floor so acknowledgements
+    and one-word nudges do not cost a lookup and an injected context block. The
+    default matches the stock gate, so an unset variable changes nothing.
+    """
+    raw = os.environ.get("COGNEE_RECALL_MIN_PROMPT_CHARS", "").strip()
+    try:
+        return max(5, int(raw)) if raw else 5
+    except ValueError:
+        return 5
+
+
 def main():
     payload_raw = sys.stdin.read()
     if not payload_raw.strip():
@@ -834,6 +848,10 @@ def main():
 
     prompt = payload.get("prompt", "")
     if not prompt or len(prompt) < 5:
+        return
+    min_chars = _recall_min_prompt_chars()
+    if len(prompt.strip()) < min_chars:
+        hook_log("context_lookup_short_prompt", {"chars": len(prompt.strip()), "min": min_chars})
         return
     cwd = str(payload.get("cwd") or "") or os.getcwd()
 

--- a/integrations/claude-code/EVENTS.md
+++ b/integrations/claude-code/EVENTS.md
@@ -85,6 +85,7 @@ Names cover current hooks, configuration, transcript cleanup, and both watchers.
 | `hook:context_lookup_hit` | `recall.lookup_hit` |
 | `hook:context_lookup_missing_session_key` | `recall.lookup_missing_session_key` |
 | `hook:context_lookup_session_key` | `recall.lookup_session_key` |
+| `hook:context_lookup_short_prompt` | `recall.lookup_short_prompt` |
 | `hook:credits_fetch_empty` | `credits.fetch_empty` |
 | `hook:credits_fetch_failed` | `credits.fetch_failed` |
 | `hook:credits_refresh_error` | `credits.refresh_error` |

--- a/integrations/claude-code/scripts/event_names.py
+++ b/integrations/claude-code/scripts/event_names.py
@@ -83,6 +83,7 @@ EVENT_NAMES = {
     "hook:context_lookup_hit": "recall.lookup_hit",
     "hook:context_lookup_missing_session_key": "recall.lookup_missing_session_key",
     "hook:context_lookup_session_key": "recall.lookup_session_key",
+    "hook:context_lookup_short_prompt": "recall.lookup_short_prompt",
     "hook:credits_fetch_empty": "credits.fetch_empty",
     "hook:credits_fetch_failed": "credits.fetch_failed",
     "hook:credits_refresh_error": "credits.refresh_error",

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -779,6 +779,20 @@ async def _run(prompt: str, cwd: str = "") -> dict | None:
     return output
 
 
+def _recall_min_prompt_chars() -> int:
+    """Prompts shorter than this skip recall (capture keeps its own 5-char floor).
+
+    COGNEE_RECALL_MIN_PROMPT_CHARS lets a host raise the floor so acknowledgements
+    and one-word nudges do not cost a lookup and an injected context block. The
+    default matches the stock gate, so an unset variable changes nothing.
+    """
+    raw = os.environ.get("COGNEE_RECALL_MIN_PROMPT_CHARS", "").strip()
+    try:
+        return max(5, int(raw)) if raw else 5
+    except ValueError:
+        return 5
+
+
 def main():
     payload_raw = sys.stdin.read()
     if not payload_raw.strip():
@@ -801,6 +815,10 @@ def main():
 
     prompt = payload.get("prompt", "")
     if not prompt or len(prompt) < 5:
+        return
+    min_chars = _recall_min_prompt_chars()
+    if len(prompt.strip()) < min_chars:
+        hook_log("context_lookup_short_prompt", {"chars": len(prompt.strip()), "min": min_chars})
         return
     cwd = str(payload.get("cwd") or "") or os.getcwd()
 

--- a/integrations/codex/plugins/cognee/EVENTS.md
+++ b/integrations/codex/plugins/cognee/EVENTS.md
@@ -85,6 +85,7 @@ Names cover current hooks, configuration, transcript cleanup, and both watchers.
 | `hook:context_lookup_hit` | `recall.lookup_hit` |
 | `hook:context_lookup_missing_session_key` | `recall.lookup_missing_session_key` |
 | `hook:context_lookup_session_key` | `recall.lookup_session_key` |
+| `hook:context_lookup_short_prompt` | `recall.lookup_short_prompt` |
 | `hook:credits_fetch_empty` | `credits.fetch_empty` |
 | `hook:credits_fetch_failed` | `credits.fetch_failed` |
 | `hook:credits_refresh_error` | `credits.refresh_error` |

--- a/integrations/codex/plugins/cognee/scripts/event_names.py
+++ b/integrations/codex/plugins/cognee/scripts/event_names.py
@@ -83,6 +83,7 @@ EVENT_NAMES = {
     "hook:context_lookup_hit": "recall.lookup_hit",
     "hook:context_lookup_missing_session_key": "recall.lookup_missing_session_key",
     "hook:context_lookup_session_key": "recall.lookup_session_key",
+    "hook:context_lookup_short_prompt": "recall.lookup_short_prompt",
     "hook:credits_fetch_empty": "credits.fetch_empty",
     "hook:credits_fetch_failed": "credits.fetch_failed",
     "hook:credits_refresh_error": "credits.refresh_error",

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -812,6 +812,20 @@ async def _run(prompt: str, cwd: str = "") -> dict | None:
     return output
 
 
+def _recall_min_prompt_chars() -> int:
+    """Prompts shorter than this skip recall (capture keeps its own 5-char floor).
+
+    COGNEE_RECALL_MIN_PROMPT_CHARS lets a host raise the floor so acknowledgements
+    and one-word nudges do not cost a lookup and an injected context block. The
+    default matches the stock gate, so an unset variable changes nothing.
+    """
+    raw = os.environ.get("COGNEE_RECALL_MIN_PROMPT_CHARS", "").strip()
+    try:
+        return max(5, int(raw)) if raw else 5
+    except ValueError:
+        return 5
+
+
 def main():
     payload_raw = sys.stdin.read()
     if not payload_raw.strip():
@@ -834,6 +848,10 @@ def main():
 
     prompt = payload.get("prompt", "")
     if not prompt or len(prompt) < 5:
+        return
+    min_chars = _recall_min_prompt_chars()
+    if len(prompt.strip()) < min_chars:
+        hook_log("context_lookup_short_prompt", {"chars": len(prompt.strip()), "min": min_chars})
         return
     cwd = str(payload.get("cwd") or "") or os.getcwd()
 

--- a/integrations/tests/tests/unit/test_recall_min_prompt_chars.py
+++ b/integrations/tests/tests/unit/test_recall_min_prompt_chars.py
@@ -1,0 +1,57 @@
+"""Recall skips prompts shorter than COGNEE_RECALL_MIN_PROMPT_CHARS.
+
+The lookup hook keeps the stock 5-character floor by default; a host may raise
+it so acknowledgements and one-word nudges do not cost a recall and an injected
+context block. Capture (store-user-prompt) is unaffected and keeps its own gate.
+"""
+
+import io
+import json
+
+import pytest
+
+
+def _run(hook, monkeypatch, prompt, **env):
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setattr(hook, "resolve_session_key_from_payload", lambda payload: ("key", "test"))
+    monkeypatch.setattr(hook, "set_session_key", lambda value: None)
+    monkeypatch.setattr(hook, "get_session_key", lambda: "key")
+    recalled = []
+
+    async def fake_run(prompt, cwd):
+        recalled.append(prompt)
+        return None
+
+    monkeypatch.setattr(hook, "_run", fake_run)
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"prompt": prompt, "cwd": "."})))
+    hook.main()
+    return recalled
+
+
+def test_default_floor_matches_the_stock_gate(suite, hook_module, monkeypatch):
+    hook = hook_module(suite, "session-context-lookup.py")
+    assert _run(hook, monkeypatch, "12345") == ["12345"]
+    assert _run(hook, monkeypatch, "1234") == []
+
+
+def test_raised_floor_skips_short_prompts_only(suite, hook_module, monkeypatch):
+    hook = hook_module(suite, "session-context-lookup.py")
+    env = {"COGNEE_RECALL_MIN_PROMPT_CHARS": "20"}
+    assert _run(hook, monkeypatch, "Try again", **env) == []
+    assert _run(hook, monkeypatch, "what remains outstanding?", **env) == [
+        "what remains outstanding?"
+    ]
+
+
+def test_whitespace_does_not_count_toward_the_floor(suite, hook_module, monkeypatch):
+    hook = hook_module(suite, "session-context-lookup.py")
+    padded = "go" + " " * 30
+    assert _run(hook, monkeypatch, padded, COGNEE_RECALL_MIN_PROMPT_CHARS="20") == []
+
+
+@pytest.mark.parametrize("raw", ["", "abc", "-3", "2"])
+def test_invalid_or_low_values_fall_back_to_the_stock_gate(suite, hook_module, monkeypatch, raw):
+    hook = hook_module(suite, "session-context-lookup.py")
+    assert _run(hook, monkeypatch, "12345", COGNEE_RECALL_MIN_PROMPT_CHARS=raw) == ["12345"]
+    assert _run(hook, monkeypatch, "1234", COGNEE_RECALL_MIN_PROMPT_CHARS=raw) == []


### PR DESCRIPTION
## Summary
- The context-lookup hook recalls on every prompt of five or more characters, so acknowledgements and one-word nudges ("Try again", "approved") each cost a lookup and an injected context block.
- `COGNEE_RECALL_MIN_PROMPT_CHARS` lets a host raise that floor. The default stays at the stock five characters, so an unset variable changes nothing; values below five or non-numeric values fall back to the stock gate; surrounding whitespace does not count.
- Prompt **capture** (`store-user-prompt`) keeps its own five-character floor, so short decisions still enter the session record; only recall is skipped.
- Skips are logged as `context_lookup_short_prompt` (`recall.lookup_short_prompt`), registered in `event_names.py` / `EVENTS.md`. Claude Code, Codex and Antigravity share the change. No README change; the variable is described here.

## Tests
- `cd integrations/tests && uv run pytest tests/unit/test_recall_min_prompt_chars.py tests/unit/test_event_names.py -q` -> 27 passed
- `cd integrations/tests && uv run pytest tests/unit -q` -> 3 failed, 1774 passed, 191 skipped, 2 xfailed; the same three Windows-only Antigravity adapter tests fail on a clean `main` checkout (3 failed, 1753 passed)
- `ruff check` / `ruff format --check` on the changed files (repo config) -> clean


I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
