### PR TITLE
Add Mastra integration (processors + tools over the HTTP API)

### DIFF
--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -184,6 +184,21 @@ integrations:
     source_repo: https://github.com/topoteretes/cognee-integration-crewai
     notes: "CrewAI agent tools – add, search, session management"
 
+  - slug: mastra
+    name: "Memory (Cognee) for Mastra"
+    owner: cognee
+    language: typescript
+    registry: none
+    package_name: "@cognee/cognee-mastra"
+    cognee_dependency: http-api
+    current_version: "0.1.0"
+    migration_status: done
+    notes: >-
+      Cognee memory layer for Mastra agents: input/output processors for
+      automatic recall and capture, plus cognee_search / cognee_ask /
+      cognee_remember tools. Talks to a cognee server over the HTTP API
+      (/recall, /remember, /datasets, /forget); no cognee SDK dependency.
+
   # ── Chat bots & editor (memory over the cognee HTTP API) ───────────
 
   - slug: chat-memory

--- a/integrations/mastra/CHANGELOG.md
+++ b/integrations/mastra/CHANGELOG.md
@@ -1,0 +1,117 @@
+# Changelog
+
+All notable changes to the **@cognee/cognee-mastra** package are documented here.
+
+The version here must match the `version` field in `package.json` and the
+`VERSION` constant in `src/version.ts`. This package uses semver (unlike the
+date-versioned OpenClaw/OpenCode plugins in this monorepo) because it carries
+a `@mastra/core` peer range and lives in Mastra's semver-based ecosystem. Tag
+releases as `mastra-v<version>` per the repo's tag-per-package convention.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+## [0.1.0]
+
+Initial release. A TypeScript package exposing cognee as (a) an automatic
+memory layer for Mastra agents via input/output processors and (b) explicit
+recall tools, entirely over cognee's plain HTTP API — no cognee SDK
+dependency.
+
+### Added
+
+- **`CogneeClient`** (`src/client.ts`) — the package's only network surface.
+  Implements `health`, `login`/JWT-with-cached-token, `ensureDataset`/
+  `listDatasets`/`datasetStatus`, `remember`/`add`/`cognify`, `rememberEntry`,
+  `recall` (with a normalized `RecallHit[]` result), `forget` (`everything:
+  true` hard-blocked), and `improve`. Retry (3×, exponential backoff base 3s)
+  on 5xx/429/network failures, disabled whenever a per-call `timeoutMs` is
+  set; `X-Api-Key` when configured, JWT login with one silent re-login on a
+  401 otherwise; `AbortSignal` timeouts on every call; an in-memory
+  `ensureDataset` name→id cache for the process lifetime. Ported from
+  `integrations/openclaw`'s `CogneeHttpClient` auth/retry/timeout semantics
+  rather than imported, to avoid pulling OpenClaw's plugin surface and peer
+  dependency into a Mastra package.
+- **`src/capabilities.ts`** — lazy, one-shot-per-base-URL runtime probing for
+  the four endpoint-shape questions a cognee server's exact version otherwise
+  leaves open: `/recall` vs. the legacy `/search`, `/remember` vs. `/add` +
+  `/cognify`, whether `/remember/entry` exists, and which prefix the login
+  route is mounted at. Each probe piggybacks on the first real request that
+  needs it — a 404 costs one extra round trip, once, ever, per base URL; a
+  server that supports the modern route pays nothing extra.
+- **`resolveConfig()`** (`src/config.ts`) — the single place in the package
+  that reads `process.env`, resolving every field in `CogneeMastraConfig`
+  as explicit argument → environment variable → default. Never throws for a
+  missing credential. `redactConfigForLogging()` masks `apiKey`/
+  `auth.password` for any caller that logs the resolved config.
+- **`src/scope.ts`** — Mastra thread/resource id → cognee dataset/session/tag
+  mapping, both `scope` modes (`"tagged"` default, `"dataset-per-resource"`).
+  Ids are percent-encoded (`sanitizeId`) before being embedded in a tag or
+  dataset name, so ids containing `:`, spaces, or `.` stay collision-free and
+  never produce a dataset name cognee's server-side validation rejects.
+- **`src/format.ts`** — pure, dependency-free text formatting: word-boundary
+  message truncation (`truncateAtWordBoundary`), Mastra message → cognee
+  ingestible text (`messageToText`), and recall hits → the injected
+  system-message context block (`formatContextBlock`, returns `null` — not an
+  empty block — on zero usable hits).
+- **`CircuitBreaker`** (`src/breaker.ts`) — file-backed circuit breaker for
+  the recall path (5 consecutive failures → 120s cooldown), state at
+  `~/.cognee-mastra/recall-breaker.json`. A missing, unreadable, or corrupt
+  state file degrades to closed rather than failing open.
+- **`CogneeApiError`** (`src/errors.ts`) — the one error type the client
+  throws for a non-2xx response or a network/timeout failure (`status: 0` in
+  the latter case), plus `isRetryable(status)` as the single source of truth
+  for the client's own retry loop and its tests.
+- **`CogneeInputProcessor` / `CogneeOutputProcessor` / `createCogneeProcessors()`**
+  (`src/processors.ts`) — the automatic half of the dual surface. Input
+  recalls before the model call (`search_type: CHUNKS`, `only_context:
+  true`) under a per-call `timeoutMs` and an overall `budgetMs` wall-clock
+  cap, consulting the circuit breaker first; output persists the turn via
+  `rememberEntry()` once, fire-and-forget, honouring `write.mode`. Both fail
+  open on every error path — a cognee failure never propagates to the agent
+  turn. Built on `@mastra/core`'s `Processor` interface (`id`,
+  `processInput`, `processOutputResult`) and
+  `parseMemoryRequestContext(requestContext)` for `thread`/`resourceId`
+  plumbing.
+- **`withCognee(agentConfig, config)`** (`src/with-cognee.ts`) — merges
+  cognee's processors into an existing Mastra agent config, appending to
+  whatever `inputProcessors`/`outputProcessors` (array or function form) the
+  caller already has, rather than replacing them.
+- **`createCogneeSearchTool` / `createCogneeAskTool` / `createCogneeRememberTool` /
+  `createCogneeForgetTool` / `createCogneeTools()`** (`src/tools.ts`) — the
+  explicit, model-driven half of the dual surface. `cognee_forget` is
+  destructive (`memory_only: true` always forced) and is only present in
+  `createCogneeTools()`'s returned record when `tools.enableForget === true`.
+  Every tool's `execute` returns a typed `{ error: string }` on failure
+  rather than throwing, and is wrapped in an observability span.
+- **`src/types.ts`** — the full `CogneeMastraConfig` surface plus wire DTOs
+  for every cognee endpoint this package calls, checked against the pinned
+  cognee server source (routers, response models, the `QAEntry` shape) where
+  the build spec's evidence was thin, not just against the spec text itself.
+- Unit tests (`__tests__/unit/`) for `config`, `scope`, `format`, and
+  `breaker` (fake-clocked open/half-open/close). End-to-end tests
+  (`__tests__/e2e/`) for the processors and tools against an in-process real
+  `node:http` mock cognee server (`__tests__/test-utils/mock-cognee.ts`), not
+  a fetch monkey-patch, so the client's actual retry/timeout/abort behaviour
+  is exercised.
+
+### Verified against
+
+- `cognee/cognee:main` reporting `1.5.4-local`, via the opt-in live smoke
+  test (`COGNEE_LIVE=1 npm run test:live`): health → dataset → remember →
+  cognify poll → recall → forget, all green. See the Compatibility section
+  of `README.md` for the resolved capability probes and the observed
+  write→recallable delay.
+
+### Known limitations
+
+- `scope: "tagged"` (the default) is not a tenant boundary — see the
+  Scoping section of `README.md`. Real isolation needs
+  `scope: "dataset-per-resource"` plus per-tenant cognee credentials.
+- The circuit-breaker state file is written without a lock; two processes
+  sharing one `~/.cognee-mastra/recall-breaker.json` can race each other's
+  counters. Harmless in the fail-open direction, but not a coordinated
+  breaker.
+- Capability probes are cached per base URL for the life of the process; a
+  server upgraded in place keeps the old resolution until restart.
+
+[0.1.0]: https://github.com/topoteretes/cognee-integrations/tree/main/integrations/mastra

--- a/integrations/mastra/LICENSE
+++ b/integrations/mastra/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Cognee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/integrations/mastra/README.md
+++ b/integrations/mastra/README.md
@@ -1,0 +1,297 @@
+<div align="center">
+  <a href="https://www.cognee.ai">
+    <img src="https://raw.githubusercontent.com/topoteretes/cognee-integrations/main/assets/cognee-logo.svg" alt="Cognee" width="260">
+  </a>
+  <p><strong>Cognee as a knowledge-graph memory layer for Mastra agents</strong> — automatic recall/capture processors plus explicit recall tools, over cognee's HTTP API.</p>
+  <p>
+    <a href="https://docs.cognee.ai">Docs</a> ·
+    <a href="https://discord.gg/NQPKmU5CCg">Discord</a> ·
+    <a href="https://github.com/topoteretes/cognee">Cognee core</a> ·
+    <a href="https://mastra.ai">Mastra</a>
+  </p>
+  <p>
+    <img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT license">
+    <img src="https://img.shields.io/badge/npm-not%20yet%20published-lightgrey" alt="npm: not yet published">
+  </p>
+</div>
+
+# @cognee/cognee-mastra
+
+Cognee knowledge-graph memory for [Mastra](https://mastra.ai) agents. Two surfaces, both optional and usable together:
+
+- **Processors** — `createCogneeProcessors()` / `withCognee()` recall from cognee before every turn and capture the turn afterwards, automatically.
+- **Tools** — `createCogneeTools()` gives the model `cognee_search`, `cognee_ask`, `cognee_remember`, and (opt-in) `cognee_forget` so it can query and write memory explicitly.
+
+Both talk to a cognee server over its plain HTTP API — no cognee Python SDK, no embedded server, no additional runtime dependency beyond `@mastra/core` and `zod`.
+
+> **npm package name in this document (`@cognee/cognee-mastra`) is a plan, not a live fact.** This package has not been published as of `0.1.0` — see [Compatibility](#compatibility) and the `registry` field in `integrations/inventory.yml`.
+
+## What this is / what this is not
+
+This package is **additive**. It sits *alongside* your existing Mastra `Memory` (libsql, postgres, whatever you already use as the message store of record) and adds a semantic/graph layer on top of it. It never replaces `Memory`, and it never touches the messages `Memory` stores.
+
+**It is not a `MastraMemory` or `MemoryStorage` implementation**, and that is deliberate, not an oversight. `MemoryStorage` is a message-CRUD contract: callers expect `listMessages`/`saveMessages`/`updateMessages`/`cloneThread` etc. to return messages addressed by a stable id, with ordered pagination and byte-exact round-tripping of tool-call parts. Cognee's HTTP API is an ingest-and-retrieve knowledge graph (`/remember`, `/recall`, `/datasets`, `/forget`) — there is no message-by-id endpoint, no ordered pagination, and no update-message endpoint. Implementing `MemoryStorage` on top of that would mean faking a message table inside a graph store, and a `cognify` pass can rewrite/normalize ingested text in ways that would silently corrupt the agent's own conversation history. Every other Mastra memory vendor that ships today (Mem0, Supermemory, Zep) made the same call and shipped processors and/or tools instead — including Zep, which *does* have native threads/messages and still didn't route through `MemoryStorage`.
+
+Also out of scope for `0.1.0`:
+
+- **Observational / working memory** (`getWorkingMemory` and friends) — not implemented, not stubbed.
+- **Streaming recall** — the input processor recalls once, before the model call; it does not stream partial results.
+- **A thread-end hook.** Mastra's core (as of the pinned `@mastra/core` version) exposes no `onThreadEnd`/`onSessionEnd` lifecycle event a processor can observe, so cognee's `/improve` (which promotes the session cache into the permanent graph) has no automatic trigger. `improveOnThreadEnd` therefore does not exist as a config flag — call `client.improve({ dataset_id, session_ids })` yourself if you want it, e.g. on your own app's session-close event.
+
+## Requirements
+
+- Node ≥ 20 (declared in `package.json#engines`).
+- `@mastra/core` — peer range `>=1.64.0`, the version this package was built and tested against. The true lower bound is probably older; see [Compatibility](#compatibility).
+- A reachable cognee server. No hard version floor is declared for `0.1.0` — every endpoint this package depends on is behind a one-shot runtime capability probe (see [Failure behaviour](#failure-behaviour)) that degrades to an older route shape automatically. Tested end-to-end against `cognee/cognee:main` reporting `1.5.4-local` (see [Compatibility](#compatibility)).
+
+## Install
+
+```bash
+npm install @cognee/cognee-mastra @mastra/core
+```
+
+(`@mastra/core` is a peer dependency — install it yourself, matching the version your agent already uses.)
+
+## Quick start
+
+```ts
+import { Agent, type AgentConfig } from "@mastra/core/agent";
+import { Memory } from "@mastra/memory";
+import { withCognee } from "@cognee/cognee-mastra";
+
+// Declare the config as a typed constant rather than an inline literal:
+// withCognee() is generic over the config you pass, and an inline literal
+// makes TypeScript infer the narrow constraint and reject id/name/model as
+// excess properties.
+const baseAgentConfig: AgentConfig = {
+  id: "assistant",
+  name: "assistant",
+  instructions: "You are a helpful assistant with long-term memory.",
+  model: "openai/gpt-4o-mini",
+  memory: new Memory(), // required — see the note below
+};
+
+const agent = new Agent(withCognee(baseAgentConfig, { dataset: "my-app" }));
+```
+
+**This one thing has to be true or the processors silently do nothing:** cognee's processors only run once the agent has *some* Mastra `Memory` attached (even a bare, unconfigured one is enough — it's needed purely so Mastra plumbs a `thread`/`resourceId` through), and every `generate()`/`stream()` call passes `memory: { thread, resource }`. This isn't a limitation this package adds; it's how Mastra's own `parseMemoryRequestContext(requestContext)` works — with no `Memory` and no `thread`/`resourceId` for the call, it returns `null`, and both `CogneeInputProcessor` and `CogneeOutputProcessor` no-op (fail open, not fail loud — see [Failure behaviour](#failure-behaviour)). Installing this package alone, with no `Memory` and no ids passed per call, does nothing observable.
+
+```ts
+await agent.generate("What did we decide about the launch date?", {
+  memory: { thread: "thread-123", resource: "user-42" },
+});
+```
+
+## Run cognee locally
+
+The fastest path is Docker, cognee's embedded SQLite + LanceDB + Kuzu stack, no external services:
+
+```yaml
+services:
+  cognee:
+    image: cognee/cognee:main
+    ports: ["8000:8000"]
+    environment:
+      LLM_API_KEY: ${LLM_API_KEY}
+```
+
+```bash
+LLM_API_KEY=sk-... docker compose -f examples/docker-compose.smoke.yml up
+curl http://localhost:8000/health
+```
+
+The stock image ships with a built-in user, `default_user@example.com` / `default_password`, and (as tested on `cognee/cognee:main` 1.5.4) enforces authentication on every API route regardless of `REQUIRE_AUTHENTICATION`, so point the client at those credentials for local work:
+
+```bash
+export COGNEE_USER_EMAIL=default_user@example.com
+export COGNEE_USER_PASSWORD=default_password
+```
+
+No OpenAI key handy? An offline variant works with local models — set these on the same service instead of `LLM_API_KEY`:
+
+```yaml
+    environment:
+      LLM_PROVIDER: ollama
+      LLM_MODEL: ollama_chat/llama3.1
+      EMBEDDING_PROVIDER: fastembed
+```
+
+Credentials are never optional for this client: with neither `apiKey` nor `auth.email`/`auth.password` configured, the first authenticated request fails locally (the processors then no-op and the tools return `{ error }`), so the default-user pair above is the minimum even for a throwaway local server. Past local development, switch to `COGNEE_API_KEY` or a real user's `COGNEE_USER_EMAIL`/`COGNEE_USER_PASSWORD`.
+
+## Usage
+
+### Processors — automatic recall and capture
+
+```ts
+import { createCogneeProcessors } from "@cognee/cognee-mastra";
+
+const { input, output } = createCogneeProcessors({ dataset: "my-app" });
+
+const agent = new Agent({
+  name: "assistant",
+  model: "openai/gpt-4o-mini",
+  memory: new Memory(),
+  inputProcessors: [input],
+  outputProcessors: [output],
+});
+```
+
+- **Input** (`CogneeInputProcessor.processInput`) runs before every model call. It takes the last user message (truncated to 2000 characters), skips recall entirely if it's shorter than `recall.minQueryLength` (default 8 — filters out "ok", "yes", …), and otherwise calls `recall()` with `search_type: CHUNKS`, `only_context: true`. A hit set becomes one system message, added via `messageList.addSystem(block, "cognee")`:
+
+  ```
+  Relevant memory from cognee:
+  1. The launch date was moved to March 14th. (source: chunk)
+  2. Priya owns the release checklist. (source: chunk)
+  ```
+
+  No hits, a query below the length floor, a tripped circuit breaker, or any error → the message list is returned unmodified. The turn is never blocked or failed because of cognee.
+
+- **Output** (`CogneeOutputProcessor.processOutputResult`) runs once, after the full generation result is available. It builds a `{question, answer}` pair from the turn (question comes from the new user message(s) in the turn unless `write.mode: "assistant-only"`, answer from the model's reply) and writes it via `rememberEntry()` — **fire-and-forget**: the call is never awaited on the response path, so a slow or failing cognee write adds zero latency and never fails the turn.
+
+- `withCognee(agentConfig, config)` does both at once: it appends cognee's input processor to whatever `inputProcessors` you already have and its output processor to whatever `outputProcessors` you already have (function or array form, either works), rather than replacing them.
+
+### Tools — explicit, model-driven recall and writes
+
+```ts
+import { createCogneeTools } from "@cognee/cognee-mastra";
+
+const agent = new Agent({
+  name: "assistant",
+  model: "openai/gpt-4o-mini",
+  tools: createCogneeTools({ dataset: "my-app" }),
+});
+```
+
+| Tool | Input | Output | What it does |
+|---|---|---|---|
+| `cognee_search` | `{ query, topK?, nodeName? }` | `{ results?: Hit[], error? }` | `search_type: CHUNKS`, `only_context: true`. Fast, no LLM call inside cognee. Default recommendation for "what do we know about X". |
+| `cognee_ask` | `{ question, topK? }` | `{ answer?, references?: Hit[], error? }` | `search_type: GRAPH_COMPLETION`, `only_context: false`, `include_references: true`. Reasons over the graph and returns synthesized prose. **Slow and expensive** — see [Search types](#search-types). |
+| `cognee_remember` | `{ statement, metadata? }` | `{ success?, status?, error? }` | Writes one fact via `remember()`. `metadata` entries fold into `node_set` tags (`key:value`, sanitized). |
+| `cognee_forget` *(opt-in, `tools.enableForget: true`)* | `{ dataId }` | `{ success?, error? }` | Deletes one memory item, `memory_only: true` always forced — `everything: true` can never be sent from this tool, hard-blocked in `CogneeClient.forget()` itself too. |
+
+`Hit` is `{ text, score?, source?, datasetId?, datasetName? }`.
+
+Every tool's `execute` is wrapped in `context.observe.span("cognee.<id>", …)` and **never throws** — a cognee failure comes back as `{ error: "..." }` (still matching the declared output schema) so the model can read and react to it instead of the tool call opaquely failing. `cognee_forget` is present in `createCogneeTools()`'s returned record **only** when `config.tools.enableForget === true` (env `COGNEE_ENABLE_FORGET`); the standalone `createCogneeForgetTool()` export is never gated, for a caller who wants it without opting the whole collection in.
+
+### Both together (recommended)
+
+```ts
+import { createCogneeProcessors, createCogneeTools, CogneeClient } from "@cognee/cognee-mastra";
+
+const client = new CogneeClient({ dataset: "my-app" });
+const { input, output } = createCogneeProcessors({ client });
+const tools = createCogneeTools({ client });
+
+const agent = new Agent({
+  name: "assistant",
+  model: "openai/gpt-4o-mini",
+  memory: new Memory(),
+  inputProcessors: [input],
+  outputProcessors: [output],
+  tools,
+});
+```
+
+Passing the same `CogneeClient` instance to both keeps one dataset-id cache and one JWT/API-key session instead of two. **Watch the overlap**: if the output processor is writing every turn *and* the model calls `cognee_remember`, the same fact can land twice — cognee's own graph normalization is the intended place to absorb that (this package does not deduplicate), but if you'd rather avoid it outright, set `write.mode: "never"` and rely on the tool alone, or the reverse (skip the tool, keep the processor).
+
+## Configuration reference
+
+Resolution order for every field: **explicit argument → environment variable → default**, all through one function, `resolveConfig(partial, env?)`. No field is read from `process.env` anywhere else in the package.
+
+| Key | Env var | Default | Effect |
+|---|---|---|---|
+| `baseUrl` | `COGNEE_API_URL` | `http://localhost:8000` | cognee server base URL. |
+| `apiKey` | `COGNEE_API_KEY` | *(none)* | Sent as `X-Api-Key`. Wins over `auth` when both are set. |
+| `auth.email` | `COGNEE_USER_EMAIL` | *(none)* | Used only when `apiKey` is absent. |
+| `auth.password` | `COGNEE_USER_PASSWORD` | *(none)* | Used only when `apiKey` is absent. |
+| `dataset` | `COGNEE_DATASET` | `mastra` | Dataset name under `scope: "tagged"` (the default). |
+| `datasetPrefix` | `COGNEE_DATASET_PREFIX` | `mastra_` | Prefix used by `scope: "dataset-per-resource"`. |
+| `scope` | `COGNEE_SCOPE` | `tagged` | `"tagged"` or `"dataset-per-resource"` — see [Scoping and multi-tenancy](#scoping-and-multi-tenancy). |
+| `nodeSet` | *(none)* | `[]` | Extra `node_set` tags applied to every write, alongside the resource/thread tags. |
+| `recall.enabled` | `COGNEE_RECALL_ENABLED` | `true` | Set `false` to disable the input processor's recall call entirely (tools are unaffected). |
+| `recall.searchType` | `COGNEE_SEARCH_TYPE` | `CHUNKS` | Search strategy for the *automatic* recall path. See [Search types](#search-types). |
+| `recall.topK` | `COGNEE_TOP_K` | `10` | Max passages/nodes to return. |
+| `recall.minQueryLength` | *(none — code only)* | `8` | Recall is skipped for a query shorter than this (filters "ok", "yes", …). |
+| `recall.timeoutMs` | `COGNEE_RECALL_TIMEOUT_MS` | `2500` | Per-call timeout for the recall request. Setting this (it always has a value) also disables client-side retry for that call — the recall path never retries. |
+| `recall.budgetMs` | `COGNEE_RECALL_BUDGET_MS` | `4000` | Wall-clock cap the input processor itself enforces, independent of `timeoutMs` — a hung server can add at most `budgetMs` (+~100ms) to a turn, never more. |
+| `recall.includeReferences` | *(none — code only)* | `true` | Passed as `include_references` on `recall()`. |
+| `write.mode` | `COGNEE_SAVE_MODE` | `always` | `"always"` \| `"assistant-only"` (skip capturing the user's question) \| `"never"` (output processor becomes a no-op). |
+| `write.runInBackground` | *(none — code only)* | `true` | Passed to `remember()`/`add()`. Has no effect on the output processor's own write, which goes through `rememberEntry()` — that endpoint has no `run_in_background` field. |
+| `write.maxChars` | *(none — code only)* | `8000` | Per-message truncation cap (word-boundary) before a turn is serialized for cognee. |
+| `tools.enableForget` | `COGNEE_ENABLE_FORGET` | `false` | Gates `cognee_forget` into (or out of) `createCogneeTools()`'s returned record. |
+| `tools.timeoutMs` | `COGNEE_TOOLS_TIMEOUT_MS` | `10000` | Per-call budget for every `cognee_search`/`cognee_ask`/`cognee_remember`/`cognee_forget` tool call. Setting `timeoutMs` per call also disables retry for that call unless a `retries` override is also given (`client.ts`'s `RequestOptions`) — reads (`cognee_search`/`cognee_ask`) get 0 retries at this budget, writes (`cognee_remember`/`cognee_forget`) keep 1. Without this, a tool call inherited `requestTimeoutMs` × up to `retries + 1` attempts — ~141s worst case for one model-facing tool call. |
+| `requestTimeoutMs` | `COGNEE_TIMEOUT_MS` | `30000` | Default per-request timeout for a call that sets no per-call `timeoutMs` of its own — the processors' recall/write paths (which set `recall.timeoutMs`) and the tool calls above (which set `tools.timeoutMs`) don't use this; it applies to `CogneeClient` calls made directly through the exported escape hatch, and to `ensureDataset`/`listDatasets`/etc. |
+| `retries` | `COGNEE_RETRIES` | `3` | Retry count on a 5xx/429/network failure, exponential backoff (base 3s: 3s, 6s, 12s, …). Disabled whenever a per-call `timeoutMs` is set. |
+| `debug` | `COGNEE_DEBUG` | `false` | Logs `METHOD path -> status (Nms, attempt K)` per request. Never logs headers, bodies, `apiKey`, or `password` — see [Failure behaviour](#failure-behaviour). |
+| `fetch` | *(none — code only)* | global `fetch` | Injectable, for tests. |
+
+`createCogneeProcessors()`/`createCogneeTools()`/`new CogneeClient()` never throw at construction time for a missing credential — the client throws on the first request that actually needs to authenticate, so it's always safe to build these at module scope before any credential exists.
+
+## Scoping and multi-tenancy
+
+Two modes, set via `scope` (default `"tagged"`):
+
+- **`tagged`** (default) — one dataset for the whole integration (`config.dataset`, default `"mastra"`). Every write tags `node_set: ["resource:<resourceId>", "thread:<threadId>", ...config.nodeSet]`. Every automatic recall filters with `node_name: ["resource:<resourceId>"]`.
+- **`dataset-per-resource`** — one dataset per resource, named `${datasetPrefix}${resourceId}` (default prefix `mastra_`), created lazily via `ensureDataset()` and cached in memory for the process lifetime. Not the default: it multiplies datasets, and each one needs its own cognify pipeline run.
+
+> **`node_name` filtering is retrieval scoping only.** It changes which memories a query is filtered against; anyone holding valid cognee credentials can still call `/recall` directly with a different `node_name` filter, or none at all. Whether `node_set`/`node_name` carry any RBAC semantics on the server side is undocumented in cognee.
+>
+> **If you have more than one real tenant behind one cognee server, `scope: "tagged"` does not isolate them.** Real isolation requires `scope: "dataset-per-resource"` **and** per-tenant cognee credentials (a dataset a credential cannot see is a much stronger boundary than a tag a query happens not to ask for). Do not market or rely on `scope: "tagged"` as multi-tenant.
+
+## Search types
+
+cognee exposes many `search_type` values; this package only chooses defaults for two paths and documents a third:
+
+| `search_type` | Used by | Cost | When |
+|---|---|---|---|
+| `CHUNKS` | Automatic recall (default), `cognee_search` | No LLM call inside cognee — vector/keyword lookup only. | Default. The input processor runs on *every* turn, so a per-turn hidden LLM call and its latency would be an unacceptable surprise; injected context should be evidence (raw passages), not a second model's prose. |
+| `GRAPH_COMPLETION` | `cognee_ask` only | Triggers an LLM call **inside the cognee server**, billed to the cognee server's own API key — not this conversation's. Slower (typically several seconds). | Only when the model (or you, directly via the tool) actually needs graph reasoning and a synthesized written answer, not a passage lookup. |
+| `TEMPORAL` | Neither, by default | Same class of cost as `GRAPH_COMPLETION` if it triggers reasoning; not exercised by this package's defaults. | Set `recall.searchType: "TEMPORAL"` yourself for time-aware queries ("what changed since last week") — cognee's own docs cover the semantics; this package passes the value through untouched. |
+
+Every automatic-path default is overridable via `recall.searchType`; the type itself is a plain string, not a closed enum, so any value the server accepts (`SUMMARIES`, `RAG_COMPLETION`, `CYPHER`, `AGENTIC_COMPLETION`, …) can be set without waiting on this package to catch up.
+
+## Failure behaviour
+
+- **Fail open, always.** A cognee failure in either processor never propagates to the agent turn — every network call in `CogneeInputProcessor.processInput` and `CogneeOutputProcessor.processOutputResult` sits inside a try/catch whose failure path is "return the message list unchanged" (input) or "silently stop" (output, already fire-and-forget). Tools are the one place a cognee failure is visible to anyone — as a `{ error: string }` return value the model can read, never a thrown error.
+- **Recall has a hard wall-clock budget** (`recall.budgetMs`, default 4000ms) enforced by the processor itself, independent of and on top of the client's own per-call `recall.timeoutMs` (default 2500ms) — a hung server can add at most `budgetMs` (+~100ms) to a turn, never more, regardless of what caused the delay.
+- **The recall path never retries.** Every recall call sets a per-call `timeoutMs`, and this client disables its retry loop whenever a per-call `timeoutMs` is present — a slow recall fails fast once, it does not compound the latency with 3 retries.
+- **Tool calls (`cognee_search`/`cognee_ask`/`cognee_remember`/`cognee_forget`) also get a bounded per-call budget** (`tools.timeoutMs`, default 10000ms), not the client-wide `requestTimeoutMs`/`retries` defaults — a bare tool call would otherwise inherit up to `requestTimeoutMs` × (`retries` + 1) attempts (~141s worst case, default settings) before returning to the model. Reads get 0 retries at this budget; writes keep 1.
+- **A file-backed circuit breaker guards the recall path only** (not writes), and only counts failures that actually indicate cognee is unhealthy: a 5xx response or a network/timeout failure with no response at all. A deterministic 4xx (bad API key, a 422 validation error, a `baseUrl` pointed at a server with no matching route) never counts — five of those mean "this config is broken," not "cognee is down," and must not also blackout recall for 120 seconds on top of the config problem. 5 consecutive *breaker-eligible* failures open it for 120 seconds; while open, the input processor skips the network call entirely (checked before any request is made) and returns the message list unmodified. State lives at `~/.cognee-mastra/recall-breaker.json`; a missing, unreadable, or corrupt state file degrades to *closed* (never fails open by accident because its own bookkeeping broke), and any error message persisted there has credential-shaped substrings (`apiKey: ...`, `password=...`, …) redacted before it's written.
+- **Writes have no breaker.** A slow or failing write already degrades to "silently dropped, try again next turn" — the correct failure mode for a best-effort, fire-and-forget side channel, with no user-facing latency for a breaker to protect.
+- **`debug: true` never logs a secret.** Debug output is `METHOD path -> status (Nms, attempt K)` only — no headers, no request/response bodies, so a login form's password and the bearer token it returns can never reach a log line. `redactConfigForLogging()` masks `apiKey`/`auth.password` for any caller that wants to log the resolved config itself.
+- **Runtime capability probing, not a version check.** Whether `/recall` or the legacy `/search` answers, whether `/remember` exists or writes must go through `/add`+`/cognify`, whether `/remember/entry` exists, and which auth path prefix is mounted — none of this is assumed; the client tries the modern route first, falls back once on a 404, and caches the winner per base URL for the life of the process. A 404 costs one extra round trip, once, ever, per base URL.
+
+## Compatibility
+
+- **cognee server**: talks only to the plain HTTP API — `/health`, `/api/v1/auth/login`, `/api/v1/datasets` (+ `/status`), `/api/v1/recall` (falls back to `/api/v1/search`), `/api/v1/remember` (falls back to `/api/v1/add` + `/api/v1/cognify`), `/api/v1/remember/entry` (falls back to `/api/v1/remember`), `/api/v1/forget`, `/api/v1/improve`. No cognee Python SDK dependency, no embedded server. No hard minimum server version is declared for `0.1.0` — the capability probes above are the compatibility mechanism. **Tested server version: `cognee/cognee:main` reporting `1.5.4-local`** (live smoke runs, 2026-09-07: health → ensureDataset → remember with a `session_id` → wait → recall → forget, green on three consecutive runs). What that server actually does with a session-mode write, as observed: `/remember` answers `status: "session_stored"` at once; `/datasets/status?pipeline=cognify_pipeline` returns `{}` for the dataset (no run yet), then `DATASET_PROCESSING_STARTED`, then `DATASET_PROCESSING_COMPLETED` as a background bridge cognifies the session cache into the graph; the text was recallable via `CHUNKS` after ~17–25s. Probes resolved on those runs: `recallPath: /api/v1/recall`, `rememberSupported: true` (`/remember` exists and, for session writes, cognify follows in the background), `authPrefix: /api/v1/auth`. The delay is an observation, not a guarantee: the write path is eventually consistent, and a server that bridges sessions differently may never show a `cognify_pipeline` run for the dataset at all, which is why the live test treats recall, not the status poll, as its success criterion. Two live findings worth knowing: that server enforces auth regardless of `REQUIRE_AUTHENTICATION` (JWT login as the built-in default user is the stock path; arbitrary `X-Api-Key` values are rejected), and it rejects `raw_data` writes whenever `content_type` is anything but `'code'` — which is why this client never sends `content_type` for plain text.
+- **`@mastra/core`**: peer range `>=1.64.0`. Verified directly against the real `Processor` interface (`id` required, `name` optional/display-only; four distinct output hooks — `processOutputStream`, `processOutputResult`, `processOutputStep`, `processToolResult` — of which this package uses only `processOutputResult`), `parseMemoryRequestContext`, and `inputProcessors`/`outputProcessors` wiring, both at the installed `1.64.0` devDependency and against a newer pinned source tree (`1.65.0-alpha.7`) — identical in both. The true lower bound is plausibly older (`processOutputResult` gained its `result` argument at core `1.11.0` per that package's own CHANGELOG) but was not bisected — narrowing the floor later is always a safe, non-breaking change; this package will not accidentally need to move it up in a patch release.
+- **Node**: ≥ 20.
+
+## Development
+
+```bash
+npm install
+npm run build          # tsc
+npm run typecheck      # tsc --noEmit --skipLibCheck
+npm test               # jest, unit + e2e tiers, no network, no live server
+npm run test:unit      # config / scope / format / breaker / errors
+npm run test:e2e       # processors / tools against an in-process mock cognee server
+npm run test:live      # COGNEE_LIVE=1 — opt-in, requires a real reachable cognee server; never run in CI
+```
+
+`jest.setup.ts` redirects `os.homedir()` to a temp directory for every test file, so the circuit breaker's state file never touches a real developer `~` during a test run.
+
+The mock server (`__tests__/test-utils/mock-cognee.ts`) is a real `node:http` server on an ephemeral port, not a fetch monkey-patch or `nock` — the client's actual timeout/retry/abort behaviour runs against it unmodified.
+
+## Limitations / roadmap
+
+- No observational memory or working-memory bridge (`getWorkingMemory` and related methods) — out of scope for `0.1.0`, not stubbed.
+- No streaming recall — the input processor recalls once per turn, before the model call.
+- `improve()` (session cache → permanent graph) is not called automatically on any schedule or lifecycle event — call it manually via the exported `CogneeClient` if you want it.
+- Duplicate writes are possible (and not deduplicated by this package) when both the output processor and `cognee_remember` are active for the same conversation — see [Both together](#both-together-recommended).
+- `scope: "tagged"` is explicitly not a multi-tenant isolation boundary — see [Scoping and multi-tenancy](#scoping-and-multi-tenancy).
+- Not yet published to npm as of `0.1.0` — `registry: none` in `integrations/inventory.yml`.
+
+## License / attribution
+
+MIT — see [`LICENSE`](./LICENSE). The HTTP client's retry, auth and timeout behaviour follows `integrations/openclaw`'s `CogneeHttpClient` in this repo.

--- a/integrations/mastra/__tests__/e2e/processors.test.ts
+++ b/integrations/mastra/__tests__/e2e/processors.test.ts
@@ -1,0 +1,528 @@
+/**
+ * e2e tier: `src/processors.ts` exercised against a real `node:http` mock
+ * server, through the actual `Processor` interface methods with hand-built
+ * args — not a full `Agent`/model call.
+ *
+ * Covers the four hard invariants: fail-open on any cognee failure, recall
+ * never retries or exceeds `budgetMs`, no secret in a debug log line, and
+ * `cognee_forget` gating (covered instead by `tools.test.ts`).
+ */
+
+import { jest } from "@jest/globals";
+import { RequestContext } from "@mastra/core/request-context";
+import { MessageList } from "@mastra/core/agent/message-list";
+import type { MastraDBMessage } from "@mastra/core/agent/message-list";
+import type { ProcessInputArgs, ProcessOutputResultArgs, OutputResult } from "@mastra/core/processors";
+import type { AgentConfig } from "@mastra/core/agent";
+
+import { CogneeInputProcessor, CogneeOutputProcessor, createCogneeProcessors } from "../../src/processors.js";
+import { withCognee } from "../../src/with-cognee.js";
+import { CircuitBreaker } from "../../src/breaker.js";
+import { startMockCognee, type MockCognee } from "../test-utils/mock-cognee.js";
+import { DATASET_ID, RECALL_RESPONSE, RECALL_RESPONSE_EMPTY } from "../test-utils/fixtures.js";
+import type { CogneeMastraConfig } from "../../src/types.js";
+
+// ---------------------------------------------------------------------------
+// Test harness — a stubbed Mastra turn, not a full Agent/model call.
+// ---------------------------------------------------------------------------
+
+/**
+ * Every `Processor` method's required `abort` — throws so an accidental call surfaces loudly in a
+ * test rather than silently truncating the turn.
+ */
+function abortFn(): (reason?: string) => never {
+  return (reason?: string): never => {
+    throw new Error(`processor called abort(): ${reason ?? "(no reason given)"}`);
+  };
+}
+
+/**
+ * Builds the `RequestContext` a turn carries `threadId`/`resourceId` in
+ * (`requestContext.set('MastraMemory', {...})`); omitting both reproduces "no Memory attached",
+ * where both processors must no-op.
+ */
+function memoryRequestContext(ids: { threadId?: string; resourceId?: string } = {}): RequestContext {
+  const ctx = new RequestContext();
+  if (ids.threadId !== undefined || ids.resourceId !== undefined) {
+    ctx.set("MastraMemory", {
+      thread: ids.threadId !== undefined ? { id: ids.threadId } : undefined,
+      resourceId: ids.resourceId,
+    });
+  }
+  return ctx;
+}
+
+function baseConfig(mock: MockCognee, overrides: CogneeMastraConfig = {}): CogneeMastraConfig {
+  return {
+    baseUrl: mock.url,
+    apiKey: "test-api-key",
+    dataset: "mastra-processors-test",
+    ...overrides,
+  };
+}
+
+/**
+ * Poll until `predicate()` is true, for asserting on the output processor's fire-and-forget write
+ * (never awaited by `processOutputResult` itself).
+ */
+async function waitFor(predicate: () => boolean, timeoutMs = 2000, intervalMs = 5): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
+let mock: MockCognee;
+let breakerDir: string;
+let breakerPath: string;
+
+beforeEach(async () => {
+  const { mkdtemp } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  breakerDir = await mkdtemp(join(tmpdir(), "cognee-mastra-processors-test-"));
+  breakerPath = join(breakerDir, "recall-breaker.json");
+});
+
+afterEach(async () => {
+  if (mock) {
+    await mock.close();
+    mock = undefined as unknown as MockCognee;
+  }
+  const { rm } = await import("node:fs/promises");
+  await rm(breakerDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// CogneeInputProcessor
+// ---------------------------------------------------------------------------
+
+describe("CogneeInputProcessor", () => {
+  function buildArgs(opts: {
+    threadId?: string;
+    resourceId?: string;
+    userText?: string;
+  }): { args: ProcessInputArgs; messageList: MessageList } {
+    const messageList = new MessageList({ threadId: opts.threadId, resourceId: opts.resourceId });
+    if (opts.userText !== undefined) messageList.add(opts.userText, "user");
+    const args: ProcessInputArgs = {
+      messages: messageList.get.input.db(),
+      messageList,
+      systemMessages: [],
+      state: {},
+      abort: abortFn(),
+      requestContext: memoryRequestContext(opts),
+      retryCount: 0,
+    };
+    return { args, messageList };
+  }
+
+  it("injects a context block as a 'cognee'-tagged system message on a recall hit", async () => {
+    mock = await startMockCognee();
+    const { input } = createCogneeProcessors({ ...baseConfig(mock), breaker: new CircuitBreaker({ path: breakerPath }) });
+
+    const { args, messageList } = buildArgs({
+      threadId: "thread-1",
+      resourceId: "resource-1",
+      userText: "What do you know about my display preferences?",
+    });
+
+    const result = await input.processInput(args);
+    expect(result).toBe(messageList);
+
+    const tagged = messageList.getSystemMessages("cognee");
+    expect(tagged).toHaveLength(1);
+    expect(String(tagged[0]!.content)).toContain("Relevant memory from cognee:");
+    expect(String(tagged[0]!.content)).toContain("dark mode");
+
+    const recallReq = mock.requests.find((r) => r.path === "/api/v1/recall");
+    expect(recallReq).toBeDefined();
+    const body = recallReq!.json as Record<string, unknown>;
+    expect(body.search_type).toBe("CHUNKS");
+    expect(body.only_context).toBe(true);
+    expect(body.datasets).toEqual(["mastra-processors-test"]);
+    expect(body.session_id).toBe("mastra_thread-1");
+    expect(body.node_name).toEqual(["resource:resource-1"]);
+  });
+
+  it("injects nothing on an empty recall result", async () => {
+    mock = await startMockCognee({ routes: { "POST /api/v1/recall": () => ({ status: 200, body: RECALL_RESPONSE_EMPTY }) } });
+    const { input } = createCogneeProcessors({ ...baseConfig(mock), breaker: new CircuitBreaker({ path: breakerPath }) });
+
+    const { args, messageList } = buildArgs({ threadId: "t1", resourceId: "r1", userText: "tell me about my prior conversations" });
+    const result = await input.processInput(args);
+
+    expect(result).toBe(messageList);
+    expect(messageList.getSystemMessages("cognee")).toHaveLength(0);
+  });
+
+  it("injects nothing and does not throw when the server 500s (fail-open, hard invariant #1)", async () => {
+    mock = await startMockCognee({ routes: { "POST /api/v1/recall": () => ({ status: 500, body: { detail: "boom" } }) } });
+    const breaker = new CircuitBreaker({ path: breakerPath, threshold: 1 });
+    const { input } = createCogneeProcessors({ ...baseConfig(mock), breaker });
+
+    const { args, messageList } = buildArgs({ threadId: "t1", resourceId: "r1", userText: "a sufficiently long query string" });
+
+    await expect(input.processInput(args)).resolves.toBe(messageList);
+    expect(messageList.getSystemMessages("cognee")).toHaveLength(0);
+    // the failure was recorded against the breaker (threshold: 1 -> tripped by this one call)
+    expect(await breaker.isOpen()).toBe(true);
+  });
+
+  it("does NOT record a breaker failure for a deterministic 4xx (bad key / validation error)", async () => {
+    mock = await startMockCognee({ routes: { "POST /api/v1/recall": () => ({ status: 422, body: { detail: "invalid query" } }) } });
+    const breaker = new CircuitBreaker({ path: breakerPath, threshold: 1 });
+    const { input } = createCogneeProcessors({ ...baseConfig(mock), breaker });
+
+    // Five consecutive 4xx failures must not trip the breaker (threshold: 1
+    // here) — recordFailure() is skipped for 4xx because a bad key or
+    // malformed query is a config problem, not a cognee outage; counting it
+    // would blackout recall for 120s over something the breaker can't fix.
+    for (let i = 0; i < 5; i++) {
+      const { args, messageList } = buildArgs({ threadId: "t1", resourceId: "r1", userText: "a sufficiently long query string" });
+      await expect(input.processInput(args)).resolves.toBe(messageList);
+    }
+
+    expect(await breaker.isOpen()).toBe(false);
+  });
+
+  it("injects nothing and does not throw when the server hangs past budgetMs (hard invariant #2)", async () => {
+    mock = await startMockCognee({ routes: { "POST /api/v1/recall": () => new Promise(() => {}) } });
+    // timeoutMs is set larger than budgetMs here to prove the budgetMs
+    // backstop fires independently of the client's own AbortSignal timeout
+    // (kept small, not the client's 2500ms default, so this test's one
+    // still-in-flight background request settles quickly instead of
+    // holding a real timer open for seconds after the assertions below).
+    const { input } = createCogneeProcessors({
+      ...baseConfig(mock, { recall: { budgetMs: 150, timeoutMs: 400 } }),
+      breaker: new CircuitBreaker({ path: breakerPath }),
+    });
+
+    const { args, messageList } = buildArgs({ threadId: "t1", resourceId: "r1", userText: "a sufficiently long query string" });
+
+    const startedAt = Date.now();
+    const result = await input.processInput(args);
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(result).toBe(messageList);
+    expect(messageList.getSystemMessages("cognee")).toHaveLength(0);
+    // adds < budgetMs + 100ms to the turn
+    expect(elapsedMs).toBeLessThan(150 + 100);
+  });
+
+  it("never retries the recall path, even on a 500 (hard invariant #2)", async () => {
+    mock = await startMockCognee({ failFirstN: 5 }); // every request in this test would fail if the client kept trying
+    const { input } = createCogneeProcessors({ ...baseConfig(mock), breaker: new CircuitBreaker({ path: breakerPath }) });
+
+    const { args, messageList } = buildArgs({ threadId: "t1", resourceId: "r1", userText: "a sufficiently long query string" });
+    await input.processInput(args);
+
+    const recallAttempts = mock.requests.filter((r) => r.path === "/api/v1/recall");
+    expect(recallAttempts).toHaveLength(1); // a retrying client would show 2+ attempts here
+  });
+
+  it("skips recall when the query is shorter than minQueryLength", async () => {
+    mock = await startMockCognee();
+    const { input } = createCogneeProcessors({ ...baseConfig(mock), breaker: new CircuitBreaker({ path: breakerPath }) });
+
+    const { args, messageList } = buildArgs({ threadId: "t1", resourceId: "r1", userText: "ok" }); // shorter than default minQueryLength (8)
+    const result = await input.processInput(args);
+
+    expect(result).toBe(messageList);
+    expect(mock.requests).toHaveLength(0);
+  });
+
+  it("skips recall when config.recall.enabled is false", async () => {
+    mock = await startMockCognee();
+    const { input } = createCogneeProcessors({
+      ...baseConfig(mock, { recall: { enabled: false } }),
+      breaker: new CircuitBreaker({ path: breakerPath }),
+    });
+
+    const { args } = buildArgs({ threadId: "t1", resourceId: "r1", userText: "a sufficiently long query string" });
+    await input.processInput(args);
+
+    expect(mock.requests).toHaveLength(0);
+  });
+
+  it("skips recall when the circuit breaker is already open", async () => {
+    mock = await startMockCognee();
+    const breaker = new CircuitBreaker({ path: breakerPath, threshold: 1, cooldownMs: 60_000 });
+    await breaker.recordFailure("pre-tripped for this test");
+    expect(await breaker.isOpen()).toBe(true);
+
+    const { input } = createCogneeProcessors({ ...baseConfig(mock), breaker });
+
+    const { args, messageList } = buildArgs({ threadId: "t1", resourceId: "r1", userText: "a sufficiently long query string" });
+    const result = await input.processInput(args);
+
+    expect(result).toBe(messageList);
+    expect(mock.requests).toHaveLength(0); // breaker open -> zero network calls, not even one
+  });
+
+  it("no-ops (does not call the network) when no Memory context is present", async () => {
+    mock = await startMockCognee();
+    const { input } = createCogneeProcessors({ ...baseConfig(mock), breaker: new CircuitBreaker({ path: breakerPath }) });
+
+    // No threadId/resourceId at all -> memoryRequestContext() sets nothing ->
+    // parseMemoryRequestContext() returns null.
+    const { args } = buildArgs({ userText: "a sufficiently long query string" });
+    await input.processInput(args);
+
+    expect(mock.requests).toHaveLength(0);
+  });
+
+  it("does not appear in any log line even with debug: true (hard invariant #3)", async () => {
+    mock = await startMockCognee({ requireAuth: "apiKey", apiKey: "shh-secret-value" });
+    const secret = "shh-secret-value";
+    const logSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+    try {
+      const { input } = createCogneeProcessors({
+        ...baseConfig(mock, { apiKey: secret, debug: true }),
+        breaker: new CircuitBreaker({ path: breakerPath }),
+      });
+
+      const { args } = buildArgs({ threadId: "t1", resourceId: "r1", userText: "a sufficiently long query string" });
+      await input.processInput(args);
+
+      const loggedText = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(loggedText).not.toContain(secret);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("honours COGNEE_DATASET from the environment when config.dataset is not set explicitly", async () => {
+    // createCogneeProcessors()/withCognee() route their config through
+    // resolveConfig(), so a missing config.dataset falls back to
+    // COGNEE_DATASET from the environment (mirrors tools.test.ts's
+    // env-precedence coverage for the tools path).
+    mock = await startMockCognee();
+    const originalDataset = process.env.COGNEE_DATASET;
+    try {
+      process.env.COGNEE_DATASET = "mastra-env-dataset";
+      // No `dataset` field here — only baseUrl/apiKey/breaker, so the
+      // dataset used can only have come from the env var.
+      const { input } = createCogneeProcessors({
+        baseUrl: mock.url,
+        apiKey: "test-api-key",
+        breaker: new CircuitBreaker({ path: breakerPath }),
+      });
+
+      const { args } = buildArgs({ threadId: "t1", resourceId: "r1", userText: "a sufficiently long query string" });
+      await input.processInput(args);
+
+      const recallReq = mock.requests.find((r) => r.path === "/api/v1/recall")!.json as Record<string, unknown>;
+      expect(recallReq.datasets).toEqual(["mastra-env-dataset"]);
+    } finally {
+      if (originalDataset === undefined) delete process.env.COGNEE_DATASET;
+      else process.env.COGNEE_DATASET = originalDataset;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CogneeOutputProcessor
+// ---------------------------------------------------------------------------
+
+describe("CogneeOutputProcessor", () => {
+  function buildArgs(opts: {
+    threadId?: string;
+    resourceId?: string;
+    userText?: string;
+    assistantText?: string;
+  }): { args: ProcessOutputResultArgs; messageList: MessageList; responseMessages: MastraDBMessage[] } {
+    const messageList = new MessageList({ threadId: opts.threadId, resourceId: opts.resourceId });
+    if (opts.userText !== undefined) messageList.add(opts.userText, "user");
+    if (opts.assistantText !== undefined) {
+      messageList.add({ role: "assistant", content: opts.assistantText }, "response");
+    }
+    const responseMessages = messageList.get.response.db();
+    const result: OutputResult = {
+      text: opts.assistantText ?? "",
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      finishReason: "stop",
+      steps: [],
+    };
+    const args: ProcessOutputResultArgs = {
+      messages: responseMessages,
+      messageList,
+      state: {},
+      result,
+      abort: abortFn(),
+      requestContext: memoryRequestContext(opts),
+      retryCount: 0,
+    };
+    return { args, messageList, responseMessages };
+  }
+
+  it("writes the turn once via rememberEntry, honouring write.mode: 'always' (default)", async () => {
+    mock = await startMockCognee();
+    const { output } = createCogneeProcessors(baseConfig(mock));
+
+    const { args, messageList } = buildArgs({
+      threadId: "thread-2",
+      resourceId: "resource-2",
+      userText: "what's my favorite editor theme",
+      assistantText: "You prefer dark mode and TypeScript.",
+    });
+
+    const result = await output.processOutputResult(args);
+    expect(result).toBe(messageList);
+
+    await waitFor(() => mock.requests.some((r) => r.path === "/api/v1/remember/entry"));
+    const writes = mock.requests.filter((r) => r.path === "/api/v1/remember/entry");
+    expect(writes).toHaveLength(1); // written exactly once for this turn
+
+    const body = writes[0]!.json as { entry: { type: string; question: string; answer: string }; dataset_name?: string; session_id?: string };
+    expect(body.entry.type).toBe("qa");
+    expect(body.entry.question).toContain("favorite editor theme");
+    expect(body.entry.answer).toContain("dark mode");
+    expect(body.dataset_name).toBe("mastra-processors-test");
+    expect(body.session_id).toBe("mastra_thread-2");
+  });
+
+  it("honours write.mode: 'never' — no write is ever attempted", async () => {
+    mock = await startMockCognee();
+    const { output } = createCogneeProcessors(baseConfig(mock, { write: { mode: "never" } }));
+
+    const { args } = buildArgs({
+      threadId: "t1",
+      resourceId: "r1",
+      userText: "some question",
+      assistantText: "some answer",
+    });
+    await output.processOutputResult(args);
+
+    // give any (incorrect) background write a moment to have shown up
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mock.requests).toHaveLength(0);
+  });
+
+  it("honours write.mode: 'assistant-only' — captures the reply, omits the user's question", async () => {
+    mock = await startMockCognee();
+    const { output } = createCogneeProcessors(baseConfig(mock, { write: { mode: "assistant-only" } }));
+
+    const { args } = buildArgs({
+      threadId: "t1",
+      resourceId: "r1",
+      userText: "this question must not be captured",
+      assistantText: "only this reply should be captured",
+    });
+    await output.processOutputResult(args);
+
+    await waitFor(() => mock.requests.some((r) => r.path === "/api/v1/remember/entry"));
+    const body = mock.requests.find((r) => r.path === "/api/v1/remember/entry")!.json as { entry: { question: string; answer: string } };
+    expect(body.entry.question).toBe("");
+    expect(body.entry.answer).toContain("only this reply should be captured");
+  });
+
+  it("never rejects the turn when the write fails (fail-open, hard invariant #1)", async () => {
+    mock = await startMockCognee({
+      routes: {
+        "POST /api/v1/remember/entry": () => ({ status: 500, body: { detail: "boom" } }),
+        "POST /api/v1/remember": () => ({ status: 500, body: { detail: "boom" } }),
+      },
+    });
+    // retries: 0 keeps this test's failing background write short-lived —
+    // the write path's own default retry policy is not exempted from
+    // retries the way recall's is, so a persistent 500 would otherwise run
+    // 3x exponential backoff, leaving the background promise chain running
+    // for ~20+ real seconds after the assertions below complete.
+    const { output } = createCogneeProcessors(baseConfig(mock, { retries: 0 }));
+
+    const { args, messageList } = buildArgs({
+      threadId: "t1",
+      resourceId: "r1",
+      userText: "a question",
+      assistantText: "an answer",
+    });
+
+    await expect(output.processOutputResult(args)).resolves.toBe(messageList);
+
+    // the attempt happened (and failed) in the background, but never surfaced
+    await waitFor(() => mock.requests.some((r) => r.path === "/api/v1/remember/entry"));
+  });
+
+  it("does not write when there is no Memory context (no threadId/resourceId)", async () => {
+    mock = await startMockCognee();
+    const { output } = createCogneeProcessors(baseConfig(mock));
+
+    const { args } = buildArgs({ userText: "q", assistantText: "a" }); // no threadId/resourceId passed
+    await output.processOutputResult(args);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mock.requests).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withCognee()
+// ---------------------------------------------------------------------------
+
+describe("withCognee", () => {
+  it("appends cognee's processors to an agent config with no existing processors", async () => {
+    mock = await startMockCognee();
+    // `withCognee<T extends Partial<ProcessorFields>>`'s constraint is
+    // checked against this argument's declared type at the call site — a
+    // real, load-bearing typecheck (ts-jest's transpile-only mode skips it
+    // at test-run time; `tsconfig.test.json`'s separate typecheck step is
+    // what catches it). A bare `{ name: "test-agent" }` literal fails the
+    // generic's excess-property check; routing through `unknown` to
+    // `Partial<AgentConfig>` (a real supertype, not a lie) satisfies it
+    // without hand-constructing a fully-shaped `Processor` mock.
+    const merged = withCognee({ name: "test-agent" } as unknown as Partial<AgentConfig>, baseConfig(mock));
+
+    expect(Array.isArray(merged.inputProcessors)).toBe(true);
+    expect(Array.isArray(merged.outputProcessors)).toBe(true);
+    expect((merged.inputProcessors as { id: string }[]).map((p) => p.id)).toEqual(["cognee-input"]);
+    expect((merged.outputProcessors as { id: string }[]).map((p) => p.id)).toEqual(["cognee-output"]);
+  });
+
+  it("appends after an existing array of processors, preserving order", async () => {
+    mock = await startMockCognee();
+    const existingInput = { id: "existing-input" } as unknown as { id: string };
+    const existingOutput = { id: "existing-output" } as unknown as { id: string };
+
+    const merged = withCognee(
+      { inputProcessors: [existingInput], outputProcessors: [existingOutput] } as unknown as Partial<AgentConfig>,
+      baseConfig(mock),
+    );
+
+    expect((merged.inputProcessors as { id: string }[]).map((p) => p.id)).toEqual(["existing-input", "cognee-input"]);
+    expect((merged.outputProcessors as { id: string }[]).map((p) => p.id)).toEqual(["existing-output", "cognee-output"]);
+  });
+
+  it("appends after an existing function-shaped processors field, preserving order", async () => {
+    mock = await startMockCognee();
+    const existingInput = { id: "existing-input" };
+    const inputProcessors = async () => [existingInput] as unknown as { id: string }[];
+
+    const merged = withCognee({ inputProcessors } as unknown as Partial<AgentConfig>, baseConfig(mock));
+
+    expect(typeof merged.inputProcessors).toBe("function");
+    const resolved = await (merged.inputProcessors as unknown as (ctx: unknown) => Promise<{ id: string }[]>)(
+      { requestContext: new RequestContext() },
+    );
+    expect(resolved.map((p) => p.id)).toEqual(["existing-input", "cognee-input"]);
+  });
+
+  it("does not mutate the input agentConfig object", async () => {
+    mock = await startMockCognee();
+    const original = { name: "test-agent" };
+    withCognee(original as unknown as Partial<AgentConfig>, baseConfig(mock));
+    expect(original).toEqual({ name: "test-agent" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reference constant sanity (guards against a fixture rename silently
+// de-scoping the "dark mode" assertion above)
+// ---------------------------------------------------------------------------
+
+it("fixtures sanity: RECALL_RESPONSE's first hit belongs to DATASET_ID", () => {
+  expect(RECALL_RESPONSE[0]!.dataset_id).toBe(DATASET_ID);
+});

--- a/integrations/mastra/__tests__/e2e/tools.test.ts
+++ b/integrations/mastra/__tests__/e2e/tools.test.ts
@@ -1,0 +1,372 @@
+/**
+ * e2e tier: `src/tools.ts` exercised through each tool's actual `execute()`
+ * against a real `node:http` mock server — not just the module's exports.
+ *
+ * Covers: happy-path output schema per tool, a typed `{ error }` (never
+ * throw) on a 500, `cognee_forget` gated behind `enableForget`, and that
+ * `createCogneeTools()` shares one `CogneeClient` across every tool.
+ */
+
+import { RequestContext } from "@mastra/core/request-context";
+import type { ToolExecutionContext } from "@mastra/core/tools";
+
+import {
+  createCogneeAskTool,
+  createCogneeForgetTool,
+  createCogneeRememberTool,
+  createCogneeSearchTool,
+  createCogneeTools,
+} from "../../src/tools.js";
+import { startMockCognee, type MockCognee } from "../test-utils/mock-cognee.js";
+import { DATASET_ID, RECALL_RESPONSE } from "../test-utils/fixtures.js";
+import type { CogneeMastraConfig } from "../../src/types.js";
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal, real (not `any`-cast) `ToolExecutionContext` a tool's `execute(inputData, context)`
+ * receives; `observe.span` runs the function directly, matching `@mastra/core`'s own `noopObserve`.
+ */
+function makeToolContext(agent?: { threadId?: string; resourceId?: string }): ToolExecutionContext {
+  return {
+    requestContext: new RequestContext(),
+    observe: {
+      async span<T>(_name: string, fn: () => Promise<T> | T): Promise<T> {
+        return fn();
+      },
+      log(): void {},
+    },
+    ...(agent ? { agent: { agentId: "test-agent", toolCallId: "call-1", messages: [], suspend: async () => {}, ...agent } } : {}),
+  };
+}
+
+function baseConfig(mock: MockCognee, overrides: CogneeMastraConfig = {}): CogneeMastraConfig {
+  return {
+    baseUrl: mock.url,
+    apiKey: "test-api-key",
+    dataset: "mastra-tools-test",
+    ...overrides,
+  };
+}
+
+async function callTool(tool: { execute?: unknown }, input: unknown, context: ToolExecutionContext): Promise<any> {
+  const execute = tool.execute as (i: unknown, c: ToolExecutionContext) => Promise<unknown>;
+  return execute(input, context);
+}
+
+/**
+ * A Standard Schema's `validate()` returns `{ issues }` on failure rather
+ * than throwing, so `expect(() => ...validate(x)).not.toThrow()` is vacuous
+ * (it passes for any input, valid or not). Awaits the result (`validate` may
+ * be sync or async) and hands back `{ issues }`/`{ value }` to assert on.
+ */
+async function validateAgainstSchema(schema: { "~standard": { validate: (v: unknown) => unknown } }, value: unknown) {
+  return (await schema["~standard"].validate(value)) as { issues?: ReadonlyArray<{ message: string }>; value?: unknown };
+}
+
+let mock: MockCognee;
+
+afterEach(async () => {
+  if (mock) await mock.close();
+});
+
+// ---------------------------------------------------------------------------
+// cognee_search
+// ---------------------------------------------------------------------------
+
+describe("createCogneeSearchTool", () => {
+  it("returns results matching its declared output schema on the happy path", async () => {
+    mock = await startMockCognee();
+    const tool = createCogneeSearchTool({ config: baseConfig(mock) });
+
+    const result = await callTool(tool, { query: "what does the user prefer" }, makeToolContext({ threadId: "t1", resourceId: "r1" }));
+
+    expect(result.error).toBeUndefined();
+    expect(Array.isArray(result.results)).toBe(true);
+    expect(result.results.length).toBe(RECALL_RESPONSE.length);
+    expect(result.results[0]).toMatchObject({ text: RECALL_RESPONSE[0]!.text });
+
+    // validate() against the tool's own outputSchema, not just a shape
+    // assertion, proves the returned object satisfies what the model sees.
+    // validate() returns `{ issues }` on failure rather than throwing, so
+    // the result's `issues` field is what must be asserted, not whether it threw.
+    const validation = await validateAgainstSchema(tool.outputSchema!, result);
+    expect(validation.issues).toBeUndefined();
+  });
+
+  it("outputSchema validation actually catches a bad object (negative sanity check for the mechanism above)", async () => {
+    mock = await startMockCognee();
+    const tool = createCogneeSearchTool({ config: baseConfig(mock) });
+
+    const badValidation = await validateAgainstSchema(tool.outputSchema!, { results: "not-an-array" });
+    expect(badValidation.issues).toBeDefined();
+    expect(badValidation.issues!.length).toBeGreaterThan(0);
+  });
+
+  it("respects a configured tools.timeoutMs budget instead of the client-wide 30s default", async () => {
+    mock = await startMockCognee({ routes: { "POST /api/v1/recall": () => new Promise(() => {}) } }); // never responds
+    const tool = createCogneeSearchTool({ config: baseConfig(mock, { tools: { timeoutMs: 200 } }) });
+
+    const startedAt = Date.now();
+    const result = await callTool(tool, { query: "will this ever come back" }, makeToolContext());
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(typeof result.error).toBe("string");
+    // Well under the client-wide 30s default (and its up-to-3x retry
+    // worst case) — proves this call's own `tools.timeoutMs` (not
+    // `requestTimeoutMs`) governs it, and that it retried 0 times.
+    expect(elapsedMs).toBeLessThan(2000);
+  });
+
+  it("sends CHUNKS / only_context: true", async () => {
+    mock = await startMockCognee();
+    const tool = createCogneeSearchTool({ config: baseConfig(mock) });
+    await callTool(tool, { query: "anything about deployment" }, makeToolContext());
+
+    const recallReq = mock.requests.find((r) => r.path === "/api/v1/recall");
+    expect(recallReq).toBeDefined();
+    const body = recallReq!.json as Record<string, unknown>;
+    expect(body.search_type).toBe("CHUNKS");
+    expect(body.only_context).toBe(true);
+  });
+
+  it("scopes recall to the resource's node_name tag when resourceId is present", async () => {
+    mock = await startMockCognee();
+    const tool = createCogneeSearchTool({ config: baseConfig(mock) });
+    await callTool(tool, { query: "user preferences" }, makeToolContext({ resourceId: "user-42" }));
+
+    const body = mock.requests.find((r) => r.path === "/api/v1/recall")!.json as Record<string, unknown>;
+    expect(body.node_name).toContain("resource:user-42");
+  });
+
+  it("returns a typed { error } object, never throws, on a 500", async () => {
+    mock = await startMockCognee({
+      routes: { "POST /api/v1/recall": () => ({ status: 500, body: { detail: "boom" } }) },
+    });
+    // cognee_search's own recall() call always passes an explicit per-call
+    // `timeoutMs` (resolved.tools.timeoutMs), which itself implies 0
+    // retries — no `retries: 0` config workaround needed here.
+    const tool = createCogneeSearchTool({ config: baseConfig(mock) });
+
+    const result = await callTool(tool, { query: "will this fail" }, makeToolContext());
+
+    expect(typeof result.error).toBe("string");
+    expect(result.results).toBeUndefined();
+    const validation = await validateAgainstSchema(tool.outputSchema!, result);
+    expect(validation.issues).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cognee_ask
+// ---------------------------------------------------------------------------
+
+describe("createCogneeAskTool", () => {
+  it("returns a synthesized answer + references on the happy path", async () => {
+    mock = await startMockCognee();
+    const tool = createCogneeAskTool({ config: baseConfig(mock) });
+
+    const result = await callTool(tool, { question: "what does the user prefer?" }, makeToolContext());
+
+    expect(result.error).toBeUndefined();
+    expect(typeof result.answer).toBe("string");
+    expect(result.answer.length).toBeGreaterThan(0);
+    expect(Array.isArray(result.references)).toBe(true);
+  });
+
+  it("sends GRAPH_COMPLETION / include_references: true / only_context: false", async () => {
+    mock = await startMockCognee();
+    const tool = createCogneeAskTool({ config: baseConfig(mock) });
+    await callTool(tool, { question: "why did the deploy fail" }, makeToolContext());
+
+    const body = mock.requests.find((r) => r.path === "/api/v1/recall")!.json as Record<string, unknown>;
+    expect(body.search_type).toBe("GRAPH_COMPLETION");
+    expect(body.include_references).toBe(true);
+    expect(body.only_context).toBe(false);
+  });
+
+  it("returns a typed { error } object, never throws, on a 500", async () => {
+    mock = await startMockCognee({
+      routes: { "POST /api/v1/recall": () => ({ status: 500, body: { detail: "graph completion exploded" } }) },
+    });
+    // cognee_ask's own recall() call always passes an explicit per-call
+    // `timeoutMs`, which itself implies 0 retries — no `retries: 0` config
+    // workaround needed here.
+    const tool = createCogneeAskTool({ config: baseConfig(mock) });
+
+    const result = await callTool(tool, { question: "will this fail" }, makeToolContext());
+
+    expect(typeof result.error).toBe("string");
+    expect(result.answer).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cognee_remember
+// ---------------------------------------------------------------------------
+
+describe("createCogneeRememberTool", () => {
+  it("writes the statement via /remember and reports success on the happy path", async () => {
+    mock = await startMockCognee();
+    const tool = createCogneeRememberTool({ config: baseConfig(mock) });
+
+    const result = await callTool(
+      tool,
+      { statement: "The user prefers dark mode.", metadata: { category: "preference" } },
+      makeToolContext({ threadId: "t1", resourceId: "r1" }),
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+
+    const rememberReq = mock.requests.find((r) => r.path === "/api/v1/remember");
+    expect(rememberReq).toBeDefined();
+    expect(rememberReq!.body).toContain("The user prefers dark mode.");
+    // metadata folded into node_set — multipart form field, so assert on the raw body text.
+    // "category:preference": the literal ":" is the tag separator this
+    // package inserts itself (matching scope.ts's buildTag); sanitizeId()
+    // only escapes characters outside [A-Za-z0-9_-] plus ".", neither of
+    // which "category"/"preference" contain, so both sides pass through
+    // unescaped here.
+    expect(rememberReq!.body).toContain("category:preference");
+  });
+
+  it(
+    "returns a typed { error } object, never throws, on a 500",
+    async () => {
+      mock = await startMockCognee({
+        routes: { "POST /api/v1/remember": () => ({ status: 500, body: { detail: "write failed" } }) },
+      });
+      // cognee_remember passes its own bounded `{ timeoutMs, retries: 1 }`
+      // per call, so this exercises a real one-retry-on-a-write
+      // (~RETRY_BASE_DELAY_MS backoff) — hence the longer test timeout.
+      const tool = createCogneeRememberTool({ config: baseConfig(mock) });
+
+      const result = await callTool(tool, { statement: "this will fail to save" }, makeToolContext());
+
+      expect(result.success).toBe(false);
+      expect(typeof result.error).toBe("string");
+    },
+    10_000,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// cognee_forget
+// ---------------------------------------------------------------------------
+
+describe("createCogneeForgetTool", () => {
+  it("calls /forget with memory_only: true forced, and never sends everything: true", async () => {
+    mock = await startMockCognee();
+    const tool = createCogneeForgetTool({ config: baseConfig(mock) });
+
+    const result = await callTool(tool, { dataId: "data-1" }, makeToolContext());
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+
+    const forgetReq = mock.requests.find((r) => r.path === "/api/v1/forget");
+    expect(forgetReq).toBeDefined();
+    const body = forgetReq!.json as Record<string, unknown>;
+    expect(body.data_id).toBe("data-1");
+    expect(body.memory_only).toBe(true);
+    expect(body.everything).toBeUndefined();
+  });
+
+  it(
+    "returns a typed { error } object, never throws, on a 500",
+    async () => {
+      mock = await startMockCognee({
+        routes: { "POST /api/v1/forget": () => ({ status: 500, body: { detail: "forget failed" } }) },
+      });
+      // Same as cognee_remember above: cognee_forget gets its own bounded
+      // `{ timeoutMs, retries: 1 }` per call — hence the longer test timeout.
+      const tool = createCogneeForgetTool({ config: baseConfig(mock) });
+
+      const result = await callTool(tool, { dataId: "data-1" }, makeToolContext());
+
+      expect(result.success).toBe(false);
+      expect(typeof result.error).toBe("string");
+    },
+    10_000,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// createCogneeTools — collection factory
+// ---------------------------------------------------------------------------
+
+describe("createCogneeTools", () => {
+  it("returns cognee_search / cognee_ask / cognee_remember, and NOT cognee_forget, by default", async () => {
+    mock = await startMockCognee();
+    const tools = createCogneeTools(baseConfig(mock));
+
+    expect(Object.keys(tools).sort()).toEqual(["cognee_ask", "cognee_remember", "cognee_search"]);
+    expect(tools.cognee_forget).toBeUndefined();
+  });
+
+  it("includes cognee_forget when config.tools.enableForget is true", async () => {
+    mock = await startMockCognee();
+    const tools = createCogneeTools({ ...baseConfig(mock), tools: { enableForget: true } });
+
+    expect(Object.keys(tools).sort()).toEqual(["cognee_ask", "cognee_forget", "cognee_remember", "cognee_search"]);
+  });
+
+  it("includes cognee_forget when COGNEE_ENABLE_FORGET=true is set in the environment", async () => {
+    mock = await startMockCognee();
+    // `createCogneeTools(config)` resolves `config.tools.enableForget` via
+    // `resolveConfig()` (argument -> environment variable -> default), so
+    // leaving `tools.enableForget` unset and setting the env var instead
+    // proves the env fallback reaches this gate, not just the
+    // explicit-argument path already covered above.
+    const originalEnv = process.env.COGNEE_ENABLE_FORGET;
+    try {
+      process.env.COGNEE_ENABLE_FORGET = "true";
+      const tools = createCogneeTools(baseConfig(mock));
+      expect(tools.cognee_forget).toBeDefined();
+    } finally {
+      if (originalEnv === undefined) delete process.env.COGNEE_ENABLE_FORGET;
+      else process.env.COGNEE_ENABLE_FORGET = originalEnv;
+    }
+  });
+
+  it("shares one CogneeClient (and its dataset-id cache) across every tool it returns", async () => {
+    mock = await startMockCognee();
+    const tools = createCogneeTools({ ...baseConfig(mock), scope: "tagged" });
+
+    await callTool(tools.cognee_search!, { query: "first call" }, makeToolContext({ resourceId: "r1" }));
+    await callTool(
+      tools.cognee_remember!,
+      { statement: "second call, different tool" },
+      makeToolContext({ resourceId: "r1" }),
+    );
+
+    // Both calls hit the mock; neither tool ever calls ensureDataset()
+    // directly (recall/remember pass datasetName, not a resolved id), so
+    // this instead proves the two tools reached the same server/session
+    // scope rather than each building an independent, differently-configured
+    // client — the recall and remember requests both carry the tagged
+    // dataset name from one shared resolved config.
+    const recallReq = mock.requests.find((r) => r.path === "/api/v1/recall")!.json as Record<string, unknown>;
+    const rememberReq = mock.requests.find((r) => r.path === "/api/v1/remember")!;
+    expect(recallReq.datasets).toEqual(["mastra-tools-test"]);
+    expect(rememberReq.body).toContain("mastra-tools-test");
+  });
+
+  it("each returned tool's execute still round-trips end to end against the mock", async () => {
+    mock = await startMockCognee();
+    const tools = createCogneeTools({ ...baseConfig(mock), tools: { enableForget: true } });
+
+    const searchResult = await callTool(tools.cognee_search!, { query: "q" }, makeToolContext());
+    const askResult = await callTool(tools.cognee_ask!, { question: "q?" }, makeToolContext());
+    const rememberResult = await callTool(tools.cognee_remember!, { statement: "s" }, makeToolContext());
+    const forgetResult = await callTool(tools.cognee_forget!, { dataId: DATASET_ID }, makeToolContext());
+
+    expect(searchResult.error).toBeUndefined();
+    expect(askResult.error).toBeUndefined();
+    expect(rememberResult.error).toBeUndefined();
+    expect(forgetResult.error).toBeUndefined();
+  });
+});

--- a/integrations/mastra/__tests__/integration/capabilities.test.ts
+++ b/integrations/mastra/__tests__/integration/capabilities.test.ts
@@ -1,0 +1,251 @@
+/**
+ * `src/capabilities.ts` caches, per base URL, which route variant a cognee
+ * server has — recall vs search, prefixed vs unprefixed auth — and the pure
+ * resolve* state machines behind that cache.
+ *
+ * Covers the pure logic directly (no network) and, network-backed, that the
+ * cache is shared across independent CogneeClient instances on one base URL.
+ */
+
+import { CogneeClient } from "../../src/client.js";
+import { CogneeApiError } from "../../src/errors.js";
+import {
+  getCapabilities,
+  isRouteMissing,
+  resetCapabilities,
+  resolveAuthPrefix,
+  resolveRecallPath,
+  REMEMBER_IMPLIES_COGNIFY,
+  type AuthPrefix,
+  type RecallPath,
+} from "../../src/capabilities.js";
+import { startMockCognee, MOCK_API_KEY, MOCK_JWT_TOKEN, type MockCognee } from "../test-utils/mock-cognee.js";
+import { LOGIN_RESPONSE } from "../test-utils/fixtures.js";
+
+let mock: MockCognee;
+
+afterEach(async () => {
+  if (mock) await mock.close();
+});
+
+// ---------------------------------------------------------------------------
+// isRouteMissing
+// ---------------------------------------------------------------------------
+
+describe("isRouteMissing", () => {
+  it("is true only for a CogneeApiError with status 404", () => {
+    expect(isRouteMissing(new CogneeApiError("not found", { status: 404 }))).toBe(true);
+    expect(isRouteMissing(new CogneeApiError("server error", { status: 500 }))).toBe(false);
+    expect(isRouteMissing(new CogneeApiError("bad request", { status: 400 }))).toBe(false);
+    expect(isRouteMissing(new Error("not a CogneeApiError"))).toBe(false);
+    expect(isRouteMissing("not even an Error")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveRecallPath — pure logic, synthetic `run`
+// ---------------------------------------------------------------------------
+
+describe("resolveRecallPath (pure logic)", () => {
+  it("tries /recall first; a cache with nothing set calls the primary path directly", async () => {
+    const cache = getCapabilities("test://recall-pure-1");
+    const calls: RecallPath[] = [];
+    const result = await resolveRecallPath(cache, async (path) => {
+      calls.push(path);
+      return `ok:${path}`;
+    });
+    expect(result).toBe("ok:/api/v1/recall");
+    expect(calls).toEqual(["/api/v1/recall"]);
+    expect(cache.recallPath).toBe("/api/v1/recall");
+  });
+
+  it("falls back to /search exactly once on a 404, and caches /search as the winner", async () => {
+    const cache = getCapabilities("test://recall-pure-2");
+    const calls: RecallPath[] = [];
+    const result = await resolveRecallPath(cache, async (path) => {
+      calls.push(path);
+      if (path === "/api/v1/recall") throw new CogneeApiError("not found", { status: 404 });
+      return `ok:${path}`;
+    });
+    expect(result).toBe("ok:/api/v1/search");
+    expect(calls).toEqual(["/api/v1/recall", "/api/v1/search"]);
+    expect(cache.recallPath).toBe("/api/v1/search");
+
+    // A second call must go straight to /search — no repeat of the 404 probe.
+    const secondResult = await resolveRecallPath(cache, async (path) => {
+      calls.push(path);
+      return `ok:${path}`;
+    });
+    expect(secondResult).toBe("ok:/api/v1/search");
+    expect(calls).toEqual(["/api/v1/recall", "/api/v1/search", "/api/v1/search"]);
+  });
+
+  it("a non-404 error on /recall propagates, but STILL caches /recall as the winner (route exists)", async () => {
+    const cache = getCapabilities("test://recall-pure-3");
+    const calls: RecallPath[] = [];
+    await expect(
+      resolveRecallPath(cache, async (path) => {
+        calls.push(path);
+        throw new CogneeApiError("validation error", { status: 422 });
+      }),
+    ).rejects.toMatchObject({ status: 422 });
+
+    expect(calls).toEqual(["/api/v1/recall"]); // never tried /search — 422 means the route exists, just rejected this call.
+    expect(cache.recallPath).toBe("/api/v1/recall");
+  });
+
+  it("once cached, uses the cached path directly even if the OTHER path would also work", async () => {
+    const cache = getCapabilities("test://recall-pure-4");
+    cache.recallPath = "/api/v1/search";
+    const calls: RecallPath[] = [];
+    const result = await resolveRecallPath(cache, async (path) => {
+      calls.push(path);
+      return `ok:${path}`;
+    });
+    expect(result).toBe("ok:/api/v1/search");
+    expect(calls).toEqual(["/api/v1/search"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAuthPrefix — pure logic, synthetic `run`
+// ---------------------------------------------------------------------------
+
+describe("resolveAuthPrefix (pure logic)", () => {
+  it("tries /api/v1/auth first and caches it on success", async () => {
+    const cache = getCapabilities("test://auth-pure-1");
+    const calls: AuthPrefix[] = [];
+    const result = await resolveAuthPrefix(cache, async (prefix) => {
+      calls.push(prefix);
+      return `token:${prefix}`;
+    });
+    expect(result).toBe("token:/api/v1/auth");
+    expect(cache.authPrefix).toBe("/api/v1/auth");
+    expect(calls).toEqual(["/api/v1/auth"]);
+  });
+
+  it("falls back to the unprefixed /auth exactly once on a 404, and caches it", async () => {
+    const cache = getCapabilities("test://auth-pure-2");
+    const calls: AuthPrefix[] = [];
+    const result = await resolveAuthPrefix(cache, async (prefix) => {
+      calls.push(prefix);
+      if (prefix === "/api/v1/auth") throw new CogneeApiError("not found", { status: 404 });
+      return `token:${prefix}`;
+    });
+    expect(result).toBe("token:/auth");
+    expect(calls).toEqual(["/api/v1/auth", "/auth"]);
+    expect(cache.authPrefix).toBe("/auth");
+
+    const second = await resolveAuthPrefix(cache, async (prefix) => {
+      calls.push(prefix);
+      return `token:${prefix}`;
+    });
+    expect(second).toBe("token:/auth");
+    expect(calls).toEqual(["/api/v1/auth", "/auth", "/auth"]); // no repeat probe.
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCapabilities / resetCapabilities — the per-base-URL registry itself
+// ---------------------------------------------------------------------------
+
+describe("getCapabilities registry", () => {
+  it("returns the SAME object for the same base URL (shared mutable state)", () => {
+    resetCapabilities("test://registry-1");
+    const a = getCapabilities("test://registry-1");
+    const b = getCapabilities("test://registry-1");
+    expect(a).toBe(b);
+  });
+
+  it("returns independent objects for different base URLs", () => {
+    const a = getCapabilities("test://registry-2a");
+    const b = getCapabilities("test://registry-2b");
+    expect(a).not.toBe(b);
+  });
+
+  it("resetCapabilities(url) clears only that url's entry", () => {
+    const a = getCapabilities("test://registry-3a");
+    a.recallPath = "/api/v1/search";
+    getCapabilities("test://registry-3b").recallPath = "/api/v1/recall";
+
+    resetCapabilities("test://registry-3a");
+
+    expect(getCapabilities("test://registry-3a").recallPath).toBeUndefined();
+    expect(getCapabilities("test://registry-3b").recallPath).toBe("/api/v1/recall");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REMEMBER_IMPLIES_COGNIFY — fixed fact, not a runtime probe
+// ---------------------------------------------------------------------------
+
+describe("REMEMBER_IMPLIES_COGNIFY", () => {
+  it("is true — /remember's own handler runs cognify as part of the same pipeline", () => {
+    expect(REMEMBER_IMPLIES_COGNIFY).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Network-backed: auth prefix fallback against the real mock server
+// ---------------------------------------------------------------------------
+
+describe("auth prefix fallback (network)", () => {
+  it("falls back to unprefixed /auth/login when /api/v1/auth/login 404s, and caches the winner", async () => {
+    // The mock's built-in auth-exempt list only knows the prefixed
+    // `/api/v1/auth/login`, not this test's unprefixed fallback route, so
+    // `requireAuth: "jwt"` here would 401 the unprefixed login call itself.
+    // The manual header check on `/api/v1/datasets` below gets the same
+    // coverage without that false failure.
+    mock = await startMockCognee({
+      routes: {
+        "POST /api/v1/auth/login": () => ({ status: 404, body: { detail: "not mounted" } }),
+        "POST /auth/login": () => ({ status: 200, body: LOGIN_RESPONSE }),
+        "GET /api/v1/datasets": (req) =>
+          req.headers["authorization"] === `Bearer ${MOCK_JWT_TOKEN}`
+            ? { status: 200, body: [] }
+            : { status: 401, body: { detail: "missing or invalid bearer token" } },
+      },
+    });
+    const client = new CogneeClient({ baseUrl: mock.url, auth: { email: "user@example.com", password: "s3cret" } });
+
+    const result = await client.listDatasets();
+
+    expect(result).toBeDefined();
+    expect(mock.requests.filter((r) => r.path === "/api/v1/auth/login").length).toBe(1);
+    expect(mock.requests.filter((r) => r.path === "/auth/login").length).toBe(1);
+    const datasetReq = mock.requests.find((r) => r.path === "/api/v1/datasets")!;
+    expect(datasetReq.headers["authorization"]).toBe(`Bearer ${MOCK_JWT_TOKEN}`);
+    expect(getCapabilities(mock.url).authPrefix).toBe("/auth");
+
+    // A second, independent client pointed at the same base URL must reuse
+    // the cached prefix decision — never re-probing the prefixed route.
+    const secondClient = new CogneeClient({ baseUrl: mock.url, auth: { email: "user2@example.com", password: "s3cret2" } });
+    await secondClient.login();
+    expect(mock.requests.filter((r) => r.path === "/api/v1/auth/login").length).toBe(1); // unchanged.
+    expect(mock.requests.filter((r) => r.path === "/auth/login").length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Network-backed: the cache is shared across independent CogneeClient
+// instances pointed at the same base URL
+// ---------------------------------------------------------------------------
+
+describe("capability cache is shared across CogneeClient instances (network)", () => {
+  it("a second client reusing a base URL whose /recall was already found missing skips straight to /search", async () => {
+    mock = await startMockCognee({
+      routes: { "POST /api/v1/recall": () => ({ status: 404, body: { detail: "no such route" } }) },
+    });
+    const clientA = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+    await clientA.recall({ query: "first client, triggers the probe" });
+
+    expect(mock.requests.filter((r) => r.path === "/api/v1/recall").length).toBe(1);
+
+    const clientB = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+    await clientB.recall({ query: "second client, same base URL" });
+
+    // clientB never re-probes /recall — it inherits clientA's cached decision.
+    expect(mock.requests.filter((r) => r.path === "/api/v1/recall").length).toBe(1);
+    expect(mock.requests.filter((r) => r.path === "/api/v1/search").length).toBe(2);
+  });
+});

--- a/integrations/mastra/__tests__/integration/client-auth.test.ts
+++ b/integrations/mastra/__tests__/integration/client-auth.test.ts
@@ -1,0 +1,173 @@
+/**
+ * `CogneeClient` auth: X-Api-Key header, JWT login + token reuse, the
+ * 401-triggers-one-relogin-and-retry path (JWT mode only), apiKey winning
+ * over auth, and the no-credentials error shape.
+ *
+ * Real `node:http` mock server throughout — auth headers and the login form
+ * body are asserted on the wire, not on fetch call arguments.
+ */
+
+import { jest } from "@jest/globals";
+import { CogneeClient } from "../../src/client.js";
+import { startMockCognee, MOCK_API_KEY, MOCK_JWT_TOKEN, type MockCognee } from "../test-utils/mock-cognee.js";
+import { LIST_DATASETS_RESPONSE } from "../test-utils/fixtures.js";
+
+let mock: MockCognee;
+
+afterEach(async () => {
+  if (mock) await mock.close();
+});
+
+// ---------------------------------------------------------------------------
+// X-Api-Key
+// ---------------------------------------------------------------------------
+
+describe("X-Api-Key header", () => {
+  it("sends X-Api-Key when apiKey is configured, and never also a Bearer token", async () => {
+    mock = await startMockCognee({ requireAuth: "apiKey" });
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    await client.listDatasets();
+
+    const req = mock.requests.find((r) => r.path === "/api/v1/datasets");
+    expect(req).toBeDefined();
+    expect(req!.headers["x-api-key"]).toBe(MOCK_API_KEY);
+    // X-Api-Key alone, never also a stale Bearer token — asserted on the
+    // wire, not just on client internals.
+    expect(req!.headers["authorization"]).toBeUndefined();
+  });
+
+  it("never calls the login route when an apiKey is configured", async () => {
+    mock = await startMockCognee({ requireAuth: "apiKey" });
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    await client.listDatasets();
+    await client.ensureDataset("some-dataset");
+
+    expect(mock.requests.some((r) => r.path === "/api/v1/auth/login")).toBe(false);
+  });
+
+  it("apiKey wins over auth when both are configured", async () => {
+    mock = await startMockCognee({ requireAuth: "apiKey" });
+    const client = new CogneeClient({
+      baseUrl: mock.url,
+      apiKey: MOCK_API_KEY,
+      // Wrong on purpose — if the client ever fell back to these, the
+      // request would either 401 (wrong route, no key) or hit the login
+      // route, either of which this test would catch.
+      auth: { email: "someone@example.com", password: "this-should-never-be-used" },
+    });
+
+    const result = await client.listDatasets();
+
+    expect(result).toEqual(LIST_DATASETS_RESPONSE);
+    expect(mock.requests.some((r) => r.path === "/api/v1/auth/login")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JWT login flow
+// ---------------------------------------------------------------------------
+
+describe("JWT login flow", () => {
+  it("logs in once (form-encoded username/password) and reuses the cached token across multiple requests", async () => {
+    mock = await startMockCognee({ requireAuth: "jwt" });
+    const client = new CogneeClient({ baseUrl: mock.url, auth: { email: "user@example.com", password: "s3cret" } });
+
+    const first = await client.listDatasets();
+    const second = await client.listDatasets();
+
+    expect(first).toEqual(LIST_DATASETS_RESPONSE);
+    expect(second).toEqual(LIST_DATASETS_RESPONSE);
+
+    const loginRequests = mock.requests.filter((r) => r.path === "/api/v1/auth/login");
+    expect(loginRequests.length).toBe(1); // token cached in memory, never re-fetched for a second call.
+
+    const login = loginRequests[0]!;
+    expect(login.headers["content-type"]).toContain("application/x-www-form-urlencoded");
+    // OAuth2PasswordRequestForm field names are `username`/`password`, not `email`.
+    expect(login.body).toContain("username=user%40example.com");
+    expect(login.body).toContain("password=s3cret");
+
+    const datasetRequests = mock.requests.filter((r) => r.path === "/api/v1/datasets");
+    expect(datasetRequests.length).toBe(2);
+    for (const req of datasetRequests) {
+      expect(req.headers["authorization"]).toBe(`Bearer ${MOCK_JWT_TOKEN}`);
+      expect(req.headers["x-api-key"]).toBeUndefined();
+    }
+  });
+
+  it("throws a clear, non-retryable error when neither apiKey nor auth credentials are configured", async () => {
+    mock = await startMockCognee();
+    const client = new CogneeClient({ baseUrl: mock.url });
+
+    await expect(client.listDatasets()).rejects.toThrow(/no credentials configured/i);
+    // The no-credentials error throws only on the first authenticated
+    // request, never at construction time, and never reaches the network
+    // (a status-0 CogneeApiError, not a route hit).
+    expect(mock.requests.length).toBe(0);
+  });
+
+  it("re-logs in exactly once and retries the same request after a 401 (JWT mode only)", async () => {
+    let datasetCalls = 0;
+    mock = await startMockCognee({
+      requireAuth: false, // full control over the 401 sequence via the override below instead.
+      routes: {
+        "GET /api/v1/datasets": () => {
+          datasetCalls += 1;
+          // Simulate an expired/rotated token on the first call only.
+          if (datasetCalls === 1) return { status: 401, body: { detail: "token expired" } };
+          return { status: 200, body: LIST_DATASETS_RESPONSE };
+        },
+      },
+    });
+    const client = new CogneeClient({ baseUrl: mock.url, auth: { email: "user@example.com", password: "s3cret" } });
+
+    const result = await client.listDatasets();
+
+    expect(result).toEqual(LIST_DATASETS_RESPONSE);
+    expect(datasetCalls).toBe(2); // original 401 + the one silent retry.
+    const loginRequests = mock.requests.filter((r) => r.path === "/api/v1/auth/login");
+    expect(loginRequests.length).toBe(2); // initial login + the re-login the 401 triggers.
+  });
+
+  it("does NOT re-log-in on a 401 when an apiKey is configured (a bad key is not a stale token)", async () => {
+    mock = await startMockCognee({
+      requireAuth: false,
+      routes: {
+        "GET /api/v1/datasets": () => ({ status: 401, body: { detail: "invalid api key" } }),
+      },
+    });
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: "bad-key", retries: 0 });
+
+    await expect(client.listDatasets()).rejects.toMatchObject({ status: 401 });
+    expect(mock.requests.some((r) => r.path === "/api/v1/auth/login")).toBe(false);
+    expect(mock.requests.filter((r) => r.path === "/api/v1/datasets").length).toBe(1);
+  });
+
+  it("never logs the password or the returned access token on the JWT login path, even with debug: true", async () => {
+    mock = await startMockCognee({ requireAuth: "jwt" });
+    const password = "s3cret-password-must-not-be-logged";
+    const logSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+    try {
+      const client = new CogneeClient({
+        baseUrl: mock.url,
+        auth: { email: "user@example.com", password },
+        debug: true,
+      });
+
+      await client.listDatasets();
+
+      // `debugLog` (client.ts) is gated by `debug: true` and fires for both
+      // the login and dataset requests — this proves it ran, not just that
+      // logging is silent by default, while asserting neither the password
+      // nor the returned token reaches a log line.
+      expect(logSpy).toHaveBeenCalled();
+      const loggedText = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(loggedText).not.toContain(password);
+      expect(loggedText).not.toContain(MOCK_JWT_TOKEN);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/integrations/mastra/__tests__/integration/client-recall.test.ts
+++ b/integrations/mastra/__tests__/integration/client-recall.test.ts
@@ -1,0 +1,262 @@
+/**
+ * `CogneeClient.recall()` — retry/backoff, per-call timeout opt-out, and the
+ * `/recall` -> `/search` capability fallback.
+ *
+ * Retry/backoff tests run Jest's fake timers against a real `node:http` mock
+ * server in-process, since real backoff waits (3s/6s/12s) would otherwise cost
+ * real wall-clock time per test. Fake-timer scope stays narrow (setTimeout,
+ * setInterval, Date only) so Node's own socket internals keep their own
+ * microtask/immediate timers.
+ */
+
+import { jest } from "@jest/globals";
+import { CogneeClient } from "../../src/client.js";
+import { CogneeApiError } from "../../src/errors.js";
+import { getCapabilities, resetCapabilities } from "../../src/capabilities.js";
+import { startMockCognee, MOCK_API_KEY, type MockCognee } from "../test-utils/mock-cognee.js";
+import { RECALL_RESPONSE, SEARCH_RESPONSE } from "../test-utils/fixtures.js";
+
+let mock: MockCognee;
+
+afterEach(async () => {
+  if (mock) await mock.close();
+  // A test that throws before its own jest.useRealTimers() must not leak
+  // fake timers into later tests in this file (each test file gets a fresh
+  // worker, but not necessarily fresh timer state within one file).
+  jest.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// Fake-timer harness: advance the virtual clock in small steps, real-awaiting
+// between each step, until `promise` settles or a step budget is exhausted.
+// This tolerates the (real, unavoidable) interleaving between the mock
+// server's genuine async I/O and the virtual retry-delay clock — a single
+// large `advanceTimersByTimeAsync` call can race a timer that gets scheduled
+// mid-advance; stepping avoids relying on that ordering.
+// ---------------------------------------------------------------------------
+
+/**
+ * Captured before any test installs fake timers, so this harness can hand
+ * out a genuine (unfaked) real-time yield between virtual-clock advances —
+ * see the loop below for why that turned out to be necessary.
+ */
+const realSetTimeout = globalThis.setTimeout;
+function realDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => realSetTimeout(resolve, ms));
+}
+
+async function drainWithFakeTimers<T>(
+  promise: Promise<T>,
+  options: { stepMs?: number; maxSteps?: number } = {},
+): Promise<T> {
+  // advanceTimersByTimeAsync needs a generous budget, not the nominal delay:
+  // real socket I/O interleaved with the faked timer can leave small advances
+  // unsettled without erroring. 60 * 15_000ms costs only milliseconds of real
+  // time and clears the ~21s (3s+6s+12s) worst case with wide margin.
+  const stepMs = options.stepMs ?? 15_000;
+  const maxSteps = options.maxSteps ?? 60;
+
+  let settled = false;
+  let outcome: { ok: true; value: T } | { ok: false; error: unknown } | undefined;
+  promise.then(
+    (value) => {
+      settled = true;
+      outcome = { ok: true, value };
+    },
+    (error: unknown) => {
+      settled = true;
+      outcome = { ok: false, error };
+    },
+  );
+
+  for (let step = 0; step < maxSteps && !settled; step++) {
+    // eslint-disable-next-line no-await-in-loop -- each step must observe the previous one's
+    // effects.
+    await jest.advanceTimersByTimeAsync(stepMs);
+    // advanceTimersByTimeAsync alone doesn't always flush enough event-loop
+    // turns for this in-process mock server's real TCP round trip; a real
+    // 1ms yield here makes the drain reliable regardless of test ordering.
+    // eslint-disable-next-line no-await-in-loop
+    if (!settled) await realDelay(1);
+  }
+
+  if (!settled) {
+    throw new Error(`drainWithFakeTimers: promise never settled after ${stepMs * maxSteps}ms of virtual time`);
+  }
+  if (outcome!.ok) return outcome!.value;
+  throw outcome!.error;
+}
+
+function useNarrowFakeTimers(): void {
+  // Only setTimeout/setInterval/Date are virtualized; the mock server is a
+  // real http.Server sharing this process's event loop, so nextTick,
+  // setImmediate, and queueMicrotask must stay real or Node's socket
+  // internals could starve.
+  jest.useFakeTimers({
+    doNotFake: ["nextTick", "setImmediate", "clearImmediate", "queueMicrotask", "hrtime", "performance"],
+  });
+}
+
+/**
+ * Far larger than any virtual-time budget this file advances to: guarantees
+ * `CogneeClient`'s own `requestTimeoutMs` `AbortController` timer never
+ * fires mid-test off the advanced fake clock and aborts an attempt that
+ * would otherwise have completed normally.
+ */
+const NO_PRACTICAL_TIMEOUT_MS = 10_000_000;
+
+// ---------------------------------------------------------------------------
+// Retry + exponential backoff (fake timers)
+// ---------------------------------------------------------------------------
+
+describe("retry with exponential backoff", () => {
+  it("retries on 500 and succeeds once the server recovers, waiting 3s then 6s between attempts", async () => {
+    mock = await startMockCognee({ failFirstN: 2 }); // first 2 requests of ANY route fail; the 3rd (2nd retry) succeeds.
+    const client = new CogneeClient({
+      baseUrl: mock.url,
+      apiKey: MOCK_API_KEY,
+      retries: 3,
+      requestTimeoutMs: NO_PRACTICAL_TIMEOUT_MS,
+    });
+
+    useNarrowFakeTimers();
+    const hits = await drainWithFakeTimers(client.recall({ query: "backoff success case" }));
+    jest.useRealTimers();
+
+    expect(hits.length).toBe(RECALL_RESPONSE.length);
+    expect(hits[0]!.text).toBe(RECALL_RESPONSE[0]!.text);
+
+    const recallRequests = mock.requests.filter((r) => r.path === "/api/v1/recall");
+    expect(recallRequests.length).toBe(3); // 1 initial attempt + 2 retries.
+  });
+
+  it("gives up after exhausting retries (3 retries = 4 total attempts), waiting 3s/6s/12s between them", async () => {
+    mock = await startMockCognee({ failFirstN: 100 }); // every request fails — retries never recover.
+    const client = new CogneeClient({
+      baseUrl: mock.url,
+      apiKey: MOCK_API_KEY,
+      retries: 3,
+      requestTimeoutMs: NO_PRACTICAL_TIMEOUT_MS,
+    });
+
+    useNarrowFakeTimers();
+    const rejection = drainWithFakeTimers(client.recall({ query: "backoff exhaustion case" })).catch(
+      (error: unknown) => error,
+    );
+    const error = await rejection;
+    jest.useRealTimers();
+
+    expect(error).toMatchObject({ status: 500 });
+    const recallRequests = mock.requests.filter((r) => r.path === "/api/v1/recall");
+    expect(recallRequests.length).toBe(4); // 1 initial attempt + 3 retries, then give up.
+  });
+
+  it("honours a lower configured retries count", async () => {
+    mock = await startMockCognee({ failFirstN: 100 });
+    const client = new CogneeClient({
+      baseUrl: mock.url,
+      apiKey: MOCK_API_KEY,
+      retries: 1,
+      requestTimeoutMs: NO_PRACTICAL_TIMEOUT_MS,
+    });
+
+    useNarrowFakeTimers();
+    const rejection = drainWithFakeTimers(client.recall({ query: "one retry only" })).catch((error: unknown) => error);
+    const error = await rejection;
+    jest.useRealTimers();
+
+    expect(error).toBeInstanceOf(CogneeApiError);
+    expect(mock.requests.filter((r) => r.path === "/api/v1/recall").length).toBe(2); // 1 initial + 1 retry.
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-call timeoutMs disables retries entirely
+// ---------------------------------------------------------------------------
+
+describe("no retry when a per-call timeoutMs is set", () => {
+  it("makes exactly one attempt and fails fast on a 500, even with client.retries > 0", async () => {
+    mock = await startMockCognee({ failFirstN: 100 });
+    // retries: 3 at the client level — proves it's the per-call `timeoutMs`,
+    // not a client-wide setting, that switches retries off.
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY, retries: 3 });
+
+    await expect(client.recall({ query: "no retry" }, { timeoutMs: 500 })).rejects.toMatchObject({ status: 500 });
+
+    expect(mock.requests.filter((r) => r.path === "/api/v1/recall").length).toBe(1);
+  });
+
+  it("aborts on timeout when the server is slower than the per-call timeoutMs", async () => {
+    mock = await startMockCognee({ latencyMs: 300 });
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    const before = Date.now();
+    await expect(client.recall({ query: "will time out" }, { timeoutMs: 80 })).rejects.toMatchObject({
+      status: 0,
+      message: expect.stringMatching(/timed out/i),
+    });
+    const elapsed = Date.now() - before;
+
+    // Real timers here (no fake-timer harness in this test) — the abort
+    // should fire close to timeoutMs and must not have waited for the
+    // server's full 300ms latency, let alone a retry's 3s backoff.
+    expect(elapsed).toBeLessThan(300);
+    expect(mock.requests.filter((r) => r.path === "/api/v1/recall").length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /recall -> /search capability fallback
+// ---------------------------------------------------------------------------
+
+describe("/recall -> /search fallback", () => {
+  it("falls back to /search exactly once on a 404, then uses /search directly (never re-probes /recall)", async () => {
+    mock = await startMockCognee({
+      routes: { "POST /api/v1/recall": () => ({ status: 404, body: { detail: "no such route" } }) },
+    });
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    const firstHits = await client.recall({ query: "first call — triggers the probe" });
+    const secondHits = await client.recall({ query: "second call — should reuse the cached decision" });
+
+    // Both calls succeed via the legacy /search route's response shape.
+    expect(firstHits[0]!.text).toBe(SEARCH_RESPONSE[0]!.search_result);
+    expect(secondHits[0]!.text).toBe(SEARCH_RESPONSE[0]!.search_result);
+
+    const recallRequests = mock.requests.filter((r) => r.path === "/api/v1/recall");
+    const searchRequests = mock.requests.filter((r) => r.path === "/api/v1/search");
+    // Exactly one probe of /recall, ever — never re-attempted once the 404 is cached.
+    expect(recallRequests.length).toBe(1);
+    expect(searchRequests.length).toBe(2);
+
+    expect(getCapabilities(mock.url).recallPath).toBe("/api/v1/search");
+  });
+
+  it("never falls back when /recall works — /search is never called", async () => {
+    mock = await startMockCognee();
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    await client.recall({ query: "recall works fine" });
+    await client.recall({ query: "recall works fine again" });
+
+    expect(mock.requests.filter((r) => r.path === "/api/v1/recall").length).toBe(2);
+    expect(mock.requests.some((r) => r.path === "/api/v1/search")).toBe(false);
+    expect(getCapabilities(mock.url).recallPath).toBe("/api/v1/recall");
+  });
+
+  it("a non-404 failure on /recall propagates without ever trying /search", async () => {
+    resetCapabilities();
+    mock = await startMockCognee({
+      routes: { "POST /api/v1/recall": () => ({ status: 422, body: { detail: "bad query" } }) },
+    });
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY, retries: 0 });
+
+    await expect(client.recall({ query: "malformed on purpose" })).rejects.toMatchObject({ status: 422 });
+
+    expect(mock.requests.some((r) => r.path === "/api/v1/search")).toBe(false);
+    // A non-404 error still proves the route exists — cached as the winner
+    // per `resolveRecallPath`'s doc comment, so a later call doesn't pay a
+    // needless fallback attempt either.
+    expect(getCapabilities(mock.url).recallPath).toBe("/api/v1/recall");
+  });
+});

--- a/integrations/mastra/__tests__/integration/client-status.test.ts
+++ b/integrations/mastra/__tests__/integration/client-status.test.ts
@@ -1,0 +1,75 @@
+/**
+ * `CogneeClient.datasetStatus()` and the recall-item text fallback, against
+ * the real `node:http` mock server, using the response shapes a live
+ * `cognee/cognee:main` 1.5.4 was observed to send.
+ */
+
+import { CogneeClient } from "../../src/client.js";
+import { extractPipelineStatus, isPipelineCompleted } from "../../src/pipeline-status.js";
+import { startMockCognee, MOCK_API_KEY, type MockCognee } from "../test-utils/mock-cognee.js";
+
+let mock: MockCognee;
+
+afterEach(async () => {
+  await mock?.close();
+});
+
+describe("datasetStatus()", () => {
+  it("builds the dataset/pipeline query and returns the server's flat enum-valued map", async () => {
+    mock = await startMockCognee({
+      routes: {
+        "GET /api/v1/datasets/status": (req) => ({
+          status: 200,
+          body: { [String(req.query.dataset)]: "DATASET_PROCESSING_COMPLETED" },
+        }),
+      },
+    });
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    const response = await client.datasetStatus("ds-42");
+
+    const req = mock.requests.find((r) => r.path.startsWith("/api/v1/datasets/status"))!;
+    expect(req.query.dataset).toBe("ds-42");
+    expect(req.query.pipeline).toBe("cognify_pipeline");
+    expect(extractPipelineStatus(response, "ds-42")).toBe("DATASET_PROCESSING_COMPLETED");
+    expect(isPipelineCompleted(extractPipelineStatus(response, "ds-42"))).toBe(true);
+  });
+
+  it("returns an empty map (dataset absent) for a dataset with no run yet, without throwing", async () => {
+    mock = await startMockCognee({
+      routes: { "GET /api/v1/datasets/status": () => ({ status: 200, body: {} }) },
+    });
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    const response = await client.datasetStatus("ds-42");
+    expect(extractPipelineStatus(response, "ds-42")).toBeUndefined();
+  });
+});
+
+describe("recall() item text fallback", () => {
+  it("composes readable text for a session-cache item that has no `text` field", async () => {
+    mock = await startMockCognee({
+      routes: {
+        "POST /api/v1/recall": () => ({
+          status: 200,
+          body: [
+            { source: "session", question: "What is the capital?", answer: "Poseidonia", context: "Atlantis" },
+            { source: "session_context", content: "Earlier the user mentioned Atlantis." },
+            { source: "graph", text: "A plain chunk." },
+          ],
+        }),
+      },
+    });
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    const hits = await client.recall({ query: "capital", search_type: "CHUNKS", top_k: 3, only_context: true });
+
+    expect(hits.map((h) => h.text)).toEqual([
+      "Question: What is the capital?\nAnswer: Poseidonia\nContext: Atlantis",
+      "Earlier the user mentioned Atlantis.",
+      "A plain chunk.",
+    ]);
+    // None of them is a JSON dump of the record.
+    for (const hit of hits) expect(hit.text.startsWith("{")).toBe(false);
+  });
+});

--- a/integrations/mastra/__tests__/integration/client-write.test.ts
+++ b/integrations/mastra/__tests__/integration/client-write.test.ts
@@ -1,0 +1,235 @@
+/**
+ * `CogneeClient` write paths: `/remember` -> `/add`+`/cognify` fallback;
+ * `/remember/entry` -> `/remember` fallback; multipart body shape for
+ * `remember()`/`add()`; `ensureDataset()`'s dataset-id cache.
+ *
+ * Real `node:http` mock server throughout — every assertion reads the actual
+ * bytes/headers the client put on the wire, not fetch call arguments.
+ */
+
+import { CogneeClient } from "../../src/client.js";
+import { getCapabilities } from "../../src/capabilities.js";
+import { startMockCognee, MOCK_API_KEY, type MockCognee } from "../test-utils/mock-cognee.js";
+import { DATASET_ID, DATASET_NAME } from "../test-utils/fixtures.js";
+
+let mock: MockCognee;
+
+afterEach(async () => {
+  if (mock) await mock.close();
+});
+
+// ---------------------------------------------------------------------------
+// /remember -> /add + /cognify fallback
+// ---------------------------------------------------------------------------
+
+describe("/remember -> /add+/cognify fallback", () => {
+  it("falls back to add()+cognify() on a 404, and never re-probes /remember afterward", async () => {
+    mock = await startMockCognee({
+      routes: { "POST /api/v1/remember": () => ({ status: 404, body: { detail: "no such route" } }) },
+    });
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    const first = await client.remember({ raw_data: ["fact one"], datasetName: "ds1", session_id: "sess-1" });
+    expect(first.status).toBe("completed");
+
+    const second = await client.remember({ raw_data: ["fact two"], datasetName: "ds1", session_id: "sess-1" });
+    expect(second.status).toBe("completed");
+
+    // Exactly one probe of /remember, ever.
+    expect(mock.requests.filter((r) => r.path === "/api/v1/remember").length).toBe(1);
+    // Both writes went through the fallback leg.
+    expect(mock.requests.filter((r) => r.path === "/api/v1/add").length).toBe(2);
+    expect(mock.requests.filter((r) => r.path === "/api/v1/cognify").length).toBe(2);
+
+    expect(getCapabilities(mock.url).rememberSupported).toBe(false);
+  });
+
+  it("uses /remember directly, and never calls /add or /cognify, when /remember works", async () => {
+    mock = await startMockCognee();
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    await client.remember({ raw_data: ["fact"], datasetName: "ds1" });
+
+    expect(mock.requests.filter((r) => r.path === "/api/v1/remember").length).toBe(1);
+    expect(mock.requests.some((r) => r.path === "/api/v1/add")).toBe(false);
+    expect(mock.requests.some((r) => r.path === "/api/v1/cognify")).toBe(false);
+    expect(getCapabilities(mock.url).rememberSupported).toBe(true);
+  });
+
+  it("cognify() in the fallback leg is called with the dataset id add() returned", async () => {
+    mock = await startMockCognee({
+      routes: {
+        "POST /api/v1/remember": () => ({ status: 404, body: { detail: "no such route" } }),
+        "POST /api/v1/add": () => ({ status: 200, body: { status: "completed", dataset_id: "ds-from-add" } }),
+      },
+    });
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    await client.remember({ raw_data: ["fact"], datasetName: "ds1" });
+
+    const cognifyReq = mock.requests.find((r) => r.path === "/api/v1/cognify");
+    expect(cognifyReq).toBeDefined();
+    expect((cognifyReq!.json as Record<string, unknown>).dataset_ids).toEqual(["ds-from-add"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /remember/entry -> /remember fallback
+// ---------------------------------------------------------------------------
+
+describe("/remember/entry -> /remember fallback", () => {
+  it("falls back to remember() (turn serialized as raw_data) on a 404, and never re-probes /remember/entry", async () => {
+    mock = await startMockCognee({
+      routes: { "POST /api/v1/remember/entry": () => ({ status: 404, body: { detail: "no such route" } }) },
+    });
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    const result = await client.rememberEntry({
+      entry: { type: "qa", question: "What does the user prefer?", answer: "Dark mode." },
+      dataset_name: "ds1",
+      session_id: "sess-1",
+    });
+    expect(result.status).toBe("completed");
+
+    await client.rememberEntry({
+      entry: { type: "qa", question: "second question", answer: "second answer" },
+      dataset_name: "ds1",
+      session_id: "sess-1",
+    });
+
+    expect(mock.requests.filter((r) => r.path === "/api/v1/remember/entry").length).toBe(1);
+    const rememberRequests = mock.requests.filter((r) => r.path === "/api/v1/remember");
+    expect(rememberRequests.length).toBe(2);
+    // The QA entry serialized as text (client.ts's local formatQAEntryAsText).
+    expect(rememberRequests[0]!.body).toContain("Q: What does the user prefer?");
+    expect(rememberRequests[0]!.body).toContain("A: Dark mode.");
+
+    expect(getCapabilities(mock.url).rememberEntrySupported).toBe(false);
+  });
+
+  it("uses /remember/entry directly, and never calls /remember, when the route works", async () => {
+    mock = await startMockCognee();
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    await client.rememberEntry({
+      entry: { type: "qa", question: "q", answer: "a" },
+      dataset_name: "ds1",
+    });
+
+    expect(mock.requests.filter((r) => r.path === "/api/v1/remember/entry").length).toBe(1);
+    expect(mock.requests.some((r) => r.path === "/api/v1/remember")).toBe(false);
+    expect(getCapabilities(mock.url).rememberEntrySupported).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multipart body shape (remember/add are multipart, not JSON)
+// ---------------------------------------------------------------------------
+
+describe("multipart body shape", () => {
+  it("remember() sends a multipart/form-data body with every field as its own part", async () => {
+    mock = await startMockCognee();
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    await client.remember({
+      raw_data: ["fact one", "fact two"],
+      datasetName: "ds1",
+      session_id: "sess-1",
+      node_set: ["resource:r1", "thread:t1"],
+      run_in_background: true,
+    });
+
+    const req = mock.requests.find((r) => r.path === "/api/v1/remember")!;
+    expect(req.headers["content-type"]).toContain("multipart/form-data");
+
+    // Every raw_data item is its own `name="raw_data"` part (not a joined/CSV field).
+    expect(req.body.match(/name="raw_data"/g)?.length).toBe(2);
+    expect(req.body).toContain("fact one");
+    expect(req.body).toContain("fact two");
+    expect(req.body).toContain('name="datasetName"');
+    expect(req.body).toContain("ds1");
+    expect(req.body).toContain('name="session_id"');
+    expect(req.body).toContain("sess-1");
+    expect(req.body.match(/name="node_set"/g)?.length).toBe(2);
+    expect(req.body).toContain("resource:r1");
+    expect(req.body).toContain("thread:t1");
+    // content_type must never be sent — a live cognee 1.5.4 rejects raw_data
+    // for any content_type other than 'code'; plain text is the server default.
+    expect(req.body).not.toContain('name="content_type"');
+    expect(req.body).toContain('name="run_in_background"');
+    expect(req.body).toContain("true");
+    // datasetId was never set — its part must be entirely absent, not sent empty.
+    expect(req.body).not.toContain('name="datasetId"');
+  });
+
+  it("add() sends the same multipart shape minus session_id (add() has no session concept)", async () => {
+    mock = await startMockCognee();
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    await client.add({ raw_data: ["fact"], datasetId: DATASET_ID, node_set: ["resource:r1"], run_in_background: false });
+
+    const req = mock.requests.find((r) => r.path === "/api/v1/add")!;
+    expect(req.headers["content-type"]).toContain("multipart/form-data");
+    expect(req.body).toContain('name="raw_data"');
+    expect(req.body).toContain('name="datasetId"');
+    expect(req.body).toContain(DATASET_ID);
+    expect(req.body).toContain('name="node_set"');
+    expect(req.body).not.toContain('name="session_id"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dataset id cache (name -> id, in memory, for process lifetime)
+// ---------------------------------------------------------------------------
+
+describe("ensureDataset() dataset-id cache", () => {
+  it("calls POST /api/v1/datasets exactly once for N sequential calls with the same name", async () => {
+    mock = await startMockCognee();
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    const first = await client.ensureDataset(DATASET_NAME);
+    const second = await client.ensureDataset(DATASET_NAME);
+    const third = await client.ensureDataset(DATASET_NAME);
+
+    expect(first).toEqual(second);
+    expect(second).toEqual(third);
+    expect(mock.requests.filter((r) => r.path === "/api/v1/datasets" && r.method === "POST").length).toBe(1);
+  });
+
+  it("collapses N concurrent calls with the same name onto a single in-flight request", async () => {
+    mock = await startMockCognee({ latencyMs: 20 }); // latency wide enough that the race is meaningful.
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    const [a, b, c] = await Promise.all([
+      client.ensureDataset("concurrent-ds"),
+      client.ensureDataset("concurrent-ds"),
+      client.ensureDataset("concurrent-ds"),
+    ]);
+
+    expect(a).toEqual(b);
+    expect(b).toEqual(c);
+    expect(mock.requests.filter((r) => r.path === "/api/v1/datasets" && r.method === "POST").length).toBe(1);
+  });
+
+  it("calls POST /api/v1/datasets once PER DISTINCT name", async () => {
+    mock = await startMockCognee();
+    const client = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    await client.ensureDataset("ds-a");
+    await client.ensureDataset("ds-b");
+    await client.ensureDataset("ds-a"); // repeat — must not add a 3rd call.
+
+    expect(mock.requests.filter((r) => r.path === "/api/v1/datasets" && r.method === "POST").length).toBe(2);
+  });
+
+  it("the cache is per-client-instance, not global — a second client re-fetches", async () => {
+    mock = await startMockCognee();
+    const clientA = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+    const clientB = new CogneeClient({ baseUrl: mock.url, apiKey: MOCK_API_KEY });
+
+    await clientA.ensureDataset("shared-name");
+    await clientB.ensureDataset("shared-name");
+
+    expect(mock.requests.filter((r) => r.path === "/api/v1/datasets" && r.method === "POST").length).toBe(2);
+  });
+});

--- a/integrations/mastra/__tests__/live/smoke.live.test.ts
+++ b/integrations/mastra/__tests__/live/smoke.live.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Live smoke test — the only file here that talks to a real cognee server.
+ * Excluded from `npm test`; run explicitly with `COGNEE_LIVE=1 npm run
+ * test:live` against a server from `examples/docker-compose.smoke.yml` (or
+ * `COGNEE_LIVE_URL` elsewhere).
+ *
+ * Sequence: health -> ensureDataset -> remember -> poll status+recall until
+ * recallable (cap 180s) -> forget.
+ */
+
+import { CogneeClient } from "../../src/client.js";
+import { getCapabilities } from "../../src/capabilities.js";
+import { extractPipelineStatus, isPipelineCompleted, isPipelineFailed } from "../../src/pipeline-status.js";
+
+const LIVE = process.env.COGNEE_LIVE === "1";
+const BASE_URL = process.env.COGNEE_LIVE_URL || "http://localhost:8000";
+
+const POLL_INTERVAL_MS = 2_000;
+/** Cap 180s, then fail with a clear message. */
+const COGNIFY_POLL_CAP_MS = 180_000;
+/**
+ * Generous — real network calls to a real LLM-backed pipeline, not the mock server's near-instant
+ * responses.
+ */
+const TEST_TIMEOUT_MS = COGNIFY_POLL_CAP_MS + 60_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("cognee live smoke test", () => {
+  if (!LIVE) {
+    test.skip("skipped — set COGNEE_LIVE=1 (and optionally COGNEE_LIVE_URL) to run against a real cognee server", () => {
+      // intentionally empty — test.skip never executes this body.
+    });
+    return;
+  }
+
+  it(
+    "completes the full ingest -> cognify -> recall -> forget cycle against a real server",
+    async () => {
+      // Auth: cognee/cognee:main (cognee 1.5.4) enforces auth on the API
+      // routes regardless of REQUIRE_AUTHENTICATION, and rejects arbitrary
+      // X-Api-Key values, so the stock-server path is a JWT login as the
+      // built-in default user. COGNEE_API_KEY (if set) still wins for
+      // servers configured with API-key auth.
+      const client = new CogneeClient({
+        baseUrl: BASE_URL,
+        ...(process.env.COGNEE_API_KEY
+          ? { apiKey: process.env.COGNEE_API_KEY }
+          : {
+              auth: {
+                email: process.env.COGNEE_USER_EMAIL ?? "default_user@example.com",
+                password: process.env.COGNEE_USER_PASSWORD ?? "default_password",
+              },
+            }),
+      });
+
+      // 1. GET /health — also the live-test gate, per client.ts's own doc comment.
+      const health = await client.health();
+      console.log("[live-smoke] GET /health ->", health);
+      expect(health.status).toBeDefined();
+      if (health.status && health.status !== "ready") {
+        throw new Error(
+          `cognee server at ${BASE_URL} reported health status "${health.status}" (reason: ${health.reason ?? "none given"}) — aborting before writing any data.`,
+        );
+      }
+
+      // 2. ensureDataset — a fresh name per run so repeated live runs never collide.
+      const datasetName = `mastra-live-smoke-${Date.now()}`;
+      const dataset = await client.ensureDataset(datasetName);
+      console.log("[live-smoke] ensureDataset ->", dataset);
+      expect(dataset.id).toBeTruthy();
+
+      // 3. remember a distinctive sentence.
+      const marker = `live-smoke-marker-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const sentence = `The distinctive smoke-test fact for this run is: ${marker}.`;
+      const sessionId = `live-smoke-session-${Date.now()}`;
+      const rememberedAt = Date.now();
+      const rememberResult = await client.remember({
+        raw_data: [sentence],
+        datasetId: dataset.id,
+        session_id: sessionId,
+        run_in_background: true,
+      });
+      console.log("[live-smoke] remember ->", rememberResult);
+
+      // 4. wait until the sentence is recallable (cap 180s), watching both
+      // the cognify pipeline status and recall itself. On cognee 1.5.4 a
+      // session-mode remember() answers session_stored immediately with no
+      // pipeline run for a while, then a background bridge runs cognify —
+      // recall finding the marker is the success criterion; status is only logged.
+      const recallMarker = async () => {
+        const hits = await client.recall({
+          query: marker,
+          search_type: "CHUNKS",
+          dataset_ids: [dataset.id],
+          top_k: 5,
+          only_context: true,
+        });
+        return { hits, found: hits.some((hit) => hit.text.includes(marker)) };
+      };
+
+      const deadline = rememberedAt + COGNIFY_POLL_CAP_MS;
+      let lastStatus: string | undefined;
+      let completedAt: number | undefined;
+      let recalled: Awaited<ReturnType<typeof recallMarker>> | undefined;
+      while (Date.now() < deadline) {
+        const statusResponse = await client.datasetStatus(dataset.id);
+        lastStatus = extractPipelineStatus(statusResponse, dataset.id);
+        console.log("[live-smoke] datasetStatus ->", lastStatus ?? statusResponse);
+        if (isPipelineFailed(lastStatus)) {
+          throw new Error(`cognee's cognify pipeline reported "${lastStatus}" for dataset ${dataset.id} (${datasetName}).`);
+        }
+        if (isPipelineCompleted(lastStatus) && completedAt === undefined) completedAt = Date.now();
+
+        try {
+          const attempt = await recallMarker();
+          if (attempt.found) {
+            recalled = attempt;
+            break;
+          }
+        } catch (error) {
+          // "No data found" (404-ish) until the first cognify lands — expected while waiting.
+          console.log("[live-smoke] recall not ready yet:", error instanceof Error ? error.message : String(error));
+        }
+        await sleep(POLL_INTERVAL_MS);
+      }
+      const recallableDelayMs = Date.now() - rememberedAt;
+      if (!recalled) {
+        throw new Error(
+          `the remembered sentence did not become recallable within ${COGNIFY_POLL_CAP_MS}ms for dataset ` +
+            `${dataset.id} (${datasetName}) — last observed pipeline status: ${lastStatus ?? "none"}. Check the server logs.`,
+        );
+      }
+      // The write path is eventually consistent — an observation from this
+      // run, not a guarantee this package makes anywhere else.
+      console.log(
+        `[live-smoke] ingest -> recallable delay observed this run: ~${recallableDelayMs}ms` +
+          (completedAt !== undefined
+            ? ` (cognify_pipeline completed at ~${completedAt - rememberedAt}ms)`
+            : ` (cognify_pipeline status at that moment: ${lastStatus ?? "no run for this dataset"})`),
+      );
+
+      // 5. the recall that found it.
+      const hits = recalled.hits;
+      console.log(
+        "[live-smoke] recall hits ->",
+        hits.map((hit) => hit.text),
+      );
+      expect(recalled.found).toBe(true);
+
+      // 6. forget(memory_only: true) — cleans up this run's data; never `everything: true`.
+      const forgetResult = await client.forget({ dataset_id: dataset.id, memory_only: true });
+      console.log("[live-smoke] forget ->", forgetResult);
+
+      // Print the resolved capability probes for whichever server this run
+      // hit — paste into the PR description alongside the server version
+      // (health.version, README compatibility table).
+      const caps = getCapabilities(client.baseUrl);
+      console.log("[live-smoke] resolved capability probes:", {
+        serverVersion: health.version,
+        recallPath: caps.recallPath,
+        rememberSupported: caps.rememberSupported,
+        rememberEntrySupported: caps.rememberEntrySupported,
+        authPrefix: caps.authPrefix,
+        ingestToRecallableDelayMs: recallableDelayMs,
+      });
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/integrations/mastra/__tests__/test-utils/fixtures.ts
+++ b/integrations/mastra/__tests__/test-utils/fixtures.ts
@@ -1,0 +1,169 @@
+/**
+ * Happy-path response bodies for every cognee HTTP route `mock-cognee.ts`
+ * serves by default; `routes`/`failFirstN`/`latencyMs` overrides in
+ * integration/e2e tests build on top of these. Shapes match `src/types.ts`'s
+ * wire DTOs — see that file's header for the source each one traces to.
+ *
+ * Pure data: no I/O, no `process.env` reads.
+ */
+
+import type {
+  DatasetDTO,
+  DatasetStatusResponse,
+  HealthResponse,
+  LoginResponse,
+  RecallResponse,
+  RememberResult,
+  SearchResponse,
+} from "../../src/types.js";
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixed token `mock-cognee.ts` issues from `POST /api/v1/auth/login`, and in
+ * `requireAuth: "jwt"` mode the only bearer token it accepts. Exported so
+ * auth tests can assert reuse (login once, same token on every later call).
+ */
+export const MOCK_JWT_TOKEN = "mock-jwt-token";
+
+/** The `X-Api-Key` value `mock-cognee.ts` accepts in `requireAuth: "apiKey"` mode. */
+export const MOCK_API_KEY = "test-api-key";
+
+/** fastapi-users bearer login response for `POST /api/v1/auth/login`. */
+export const LOGIN_RESPONSE: LoginResponse = {
+  access_token: MOCK_JWT_TOKEN,
+  token_type: "bearer",
+};
+
+// ---------------------------------------------------------------------------
+// /health (always public)
+// ---------------------------------------------------------------------------
+
+export const HEALTH_RESPONSE: HealthResponse = {
+  status: "ready",
+  health: "ok",
+  version: "0.20.0",
+};
+
+// ---------------------------------------------------------------------------
+// /datasets
+// ---------------------------------------------------------------------------
+
+export const DATASET_ID = "ds-1";
+export const DATASET_NAME = "mastra";
+
+/** `POST /api/v1/datasets`: idempotent create-or-return, single object. */
+export const ENSURE_DATASET_RESPONSE: DatasetDTO = {
+  id: DATASET_ID,
+  name: DATASET_NAME,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: null,
+  owner_id: "owner-1",
+};
+
+/** `GET /api/v1/datasets` list response. */
+export const LIST_DATASETS_RESPONSE: DatasetDTO[] = [ENSURE_DATASET_RESPONSE];
+
+// ---------------------------------------------------------------------------
+// /recall (primary read path) and legacy /search
+// ---------------------------------------------------------------------------
+
+/**
+ * Two hits: one `graph`-sourced (the common case) and one `session`-sourced,
+ * so `format.ts`'s normalization (RecallResponseItem → RecallHit) has more
+ * than one `source` value to prove it handles generically.
+ */
+export const RECALL_RESPONSE: RecallResponse = [
+  {
+    source: "graph",
+    text: "The user prefers dark mode and TypeScript over JavaScript.",
+    score: 0.91,
+    dataset_id: DATASET_ID,
+    dataset_name: DATASET_NAME,
+    metadata: { node_type: "entity" },
+  },
+  {
+    source: "session",
+    text: "Earlier in this thread, the user asked about deployment on Railway.",
+    score: 0.74,
+    dataset_id: DATASET_ID,
+    dataset_name: DATASET_NAME,
+    metadata: {},
+  },
+];
+
+/**
+ * `POST /api/v1/recall` with an empty corpus/no matches: the "no results" path `format.ts` must
+ * turn into `null`, not an empty block.
+ */
+export const RECALL_RESPONSE_EMPTY: RecallResponse = [];
+
+/**
+ * `POST /api/v1/search` legacy fallback: a different response shape from
+ * `/recall` (see `SearchResponseItem`'s doc comment in `types.ts`), using a
+ * free-form `search_result` wrapper rather than the normalized `text`/`source`
+ * envelope.
+ */
+export const SEARCH_RESPONSE: SearchResponse = [
+  {
+    search_result: "The user prefers dark mode and TypeScript over JavaScript.",
+    dataset_id: DATASET_ID,
+    dataset_name: DATASET_NAME,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// /remember, /remember/entry, /add, /cognify: write paths
+// ---------------------------------------------------------------------------
+
+export const REMEMBER_RESPONSE: RememberResult = {
+  status: "completed",
+  dataset_id: DATASET_ID,
+};
+
+export const REMEMBER_ENTRY_RESPONSE: RememberResult = {
+  status: "completed",
+  dataset_id: DATASET_ID,
+  entry_id: "entry-1",
+};
+
+export const ADD_RESPONSE: RememberResult = {
+  status: "completed",
+  dataset_id: DATASET_ID,
+  data_ids: ["data-1"],
+};
+
+export const COGNIFY_RESPONSE: RememberResult = {
+  status: "completed",
+  dataset_ids: [DATASET_ID],
+};
+
+// ---------------------------------------------------------------------------
+// /forget
+// ---------------------------------------------------------------------------
+
+export const FORGET_RESPONSE: RememberResult = {
+  status: "completed",
+};
+
+// ---------------------------------------------------------------------------
+// /datasets/status is polled only by the live smoke test; query-shaped, so
+// the default is a function of the requested dataset id, not a constant.
+// ---------------------------------------------------------------------------
+
+export function datasetStatusResponse(datasetId: string = DATASET_ID): DatasetStatusResponse {
+  // The enum-name spelling a live cognee 1.5.4 returns, not the lowercase
+  // "completed" of older API docs.
+  return { [datasetId]: "DATASET_PROCESSING_COMPLETED" };
+}
+
+// ---------------------------------------------------------------------------
+// /improve
+// ---------------------------------------------------------------------------
+
+export const IMPROVE_RESPONSE: RememberResult = {
+  status: "completed",
+  dataset_id: DATASET_ID,
+};

--- a/integrations/mastra/__tests__/test-utils/mock-cognee.ts
+++ b/integrations/mastra/__tests__/test-utils/mock-cognee.ts
@@ -1,0 +1,283 @@
+/**
+ * A real `node:http` server standing in for cognee, not a stubbed
+ * `global.fetch`: `CogneeClient` drives real `fetch`/`AbortSignal` calls, and
+ * retry/backoff timing, abort timeouts, multipart body shape, and the JWT
+ * login-then-reuse flow only exist on the wire — a stub would only prove
+ * "the client built some arguments." Lives in `test-utils/` rather than
+ * `unit|integration|...` so Jest's `testMatch` (see `jest.config.mjs`) does
+ * not try to run it as a suite.
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import {
+  ADD_RESPONSE,
+  COGNIFY_RESPONSE,
+  datasetStatusResponse,
+  ENSURE_DATASET_RESPONSE,
+  FORGET_RESPONSE,
+  HEALTH_RESPONSE,
+  IMPROVE_RESPONSE,
+  LIST_DATASETS_RESPONSE,
+  LOGIN_RESPONSE,
+  MOCK_API_KEY,
+  MOCK_JWT_TOKEN,
+  RECALL_RESPONSE,
+  REMEMBER_ENTRY_RESPONSE,
+  REMEMBER_RESPONSE,
+  SEARCH_RESPONSE,
+} from "./fixtures.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** One request as seen by the mock, normalized and recorded for assertions. */
+export interface RecordedRequest {
+  method: string;
+  /** Pathname only — no query string, no origin. */
+  path: string;
+  query: Record<string, string>;
+  /** Header names as Node lower-cases them (`x-api-key`, `authorization`, …). */
+  headers: Record<string, string>;
+  /** Raw body text — multipart included. Empty string for bodyless requests. */
+  body: string;
+  /**
+   * Parsed JSON body when `content-type` was `application/json` and it parsed; otherwise
+   * `undefined`.
+   */
+  json?: unknown;
+}
+
+/**
+ * What a route handler sees. Same shape as `RecordedRequest`, named separately so a handler reading
+ * a request reads distinctly from the harness recording one.
+ */
+export type MockRequest = RecordedRequest;
+
+/** What a route handler returns to script the response. */
+export interface MockResponse {
+  status: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+/**
+ * A per-route override. Returning a `MockResponse` sends it, after any
+ * `latencyMs` delay and JSON-stringifying a non-string `body`. A handler
+ * that never resolves makes the request hang indefinitely — used by e2e
+ * tests to prove `budgetMs` is respected against a server that never answers.
+ */
+export type RouteHandler = (req: MockRequest) => MockResponse | Promise<MockResponse>;
+
+export type AuthMode = "apiKey" | "jwt" | false;
+
+export interface StartMockCogneeOptions {
+  /**
+   * Per-route overrides, keyed `"<METHOD> <path>"` with the method
+   * uppercased and the path exactly as the client sends it (always
+   * `/api/v1`-prefixed except `/health`), e.g. `"POST /api/v1/recall"`.
+   * Overrides fully replace the built-in default, including its status code.
+   */
+  routes?: Record<string, RouteHandler>;
+  /**
+   * Delay, in ms, applied to every response (default-served or overridden) before it is written.
+   * Used to test timeouts/`budgetMs`.
+   */
+  latencyMs?: number;
+  /**
+   * Fail the first N requests of any route with a 500, then fall through to
+   * normal handling for the rest. Global rather than per-route: a test
+   * needing per-route failure counts should register a `routes` override
+   * with its own closure-scoped counter instead.
+   */
+  failFirstN?: number;
+  /**
+   * `"apiKey"`: every request except `GET /health` must carry
+   * `X-Api-Key: <apiKey>` (default `MOCK_API_KEY`) or get 401. `"jwt"`:
+   * every request except `GET /health` and `POST /api/v1/auth/login` must
+   * carry `Authorization: Bearer <MOCK_JWT_TOKEN>` or get 401. `false`
+   * (default): no auth enforcement.
+   */
+  requireAuth?: AuthMode;
+  /**
+   * Overrides the accepted API key when `requireAuth: "apiKey"`. Default `MOCK_API_KEY` from
+   * `fixtures.ts`.
+   */
+  apiKey?: string;
+}
+
+export interface MockCognee {
+  /** Base URL to hand `CogneeClient`, e.g. `http://127.0.0.1:54321`. */
+  url: string;
+  /**
+   * Every request received, in arrival order, including ones the mock rejected for auth or forced
+   * to fail.
+   */
+  requests: RecordedRequest[];
+  close(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Default route table: the happy-path response for every endpoint, from fixtures.
+// ---------------------------------------------------------------------------
+
+function defaultRoutes(): Record<string, RouteHandler> {
+  return {
+    "GET /health": () => ({ status: 200, body: HEALTH_RESPONSE }),
+    "POST /api/v1/auth/login": () => ({ status: 200, body: LOGIN_RESPONSE }),
+
+    "POST /api/v1/datasets": () => ({ status: 200, body: ENSURE_DATASET_RESPONSE }),
+    "GET /api/v1/datasets": () => ({ status: 200, body: LIST_DATASETS_RESPONSE }),
+    "GET /api/v1/datasets/status": (req) => ({
+      status: 200,
+      body: datasetStatusResponse(req.query.dataset),
+    }),
+
+    "POST /api/v1/remember": () => ({ status: 200, body: REMEMBER_RESPONSE }),
+    "POST /api/v1/remember/entry": () => ({ status: 200, body: REMEMBER_ENTRY_RESPONSE }),
+    "POST /api/v1/add": () => ({ status: 200, body: ADD_RESPONSE }),
+    "POST /api/v1/cognify": () => ({ status: 200, body: COGNIFY_RESPONSE }),
+
+    "POST /api/v1/recall": () => ({ status: 200, body: RECALL_RESPONSE }),
+    "POST /api/v1/search": () => ({ status: 200, body: SEARCH_RESPONSE }),
+
+    "POST /api/v1/forget": () => ({ status: 200, body: FORGET_RESPONSE }),
+    "POST /api/v1/improve": () => ({ status: 200, body: IMPROVE_RESPONSE }),
+  };
+}
+
+/**
+ * Routes that are never subject to `requireAuth`, in either mode: `/health` needs no auth, and
+ * login cannot require the credential it exists to issue.
+ */
+const AUTH_EXEMPT_ROUTES = new Set(["GET /health", "POST /api/v1/auth/login"]);
+
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function startMockCognee(options: StartMockCogneeOptions = {}): Promise<MockCognee> {
+  const overrides = options.routes ?? {};
+  const routes = defaultRoutes();
+  const latencyMs = options.latencyMs ?? 0;
+  const failFirstN = options.failFirstN ?? 0;
+  const requireAuth: AuthMode = options.requireAuth ?? false;
+  const expectedApiKey = options.apiKey ?? MOCK_API_KEY;
+
+  const requests: RecordedRequest[] = [];
+  let failuresServed = 0;
+
+  const server: Server = createServer((req, res) => {
+    void handle(req, res);
+  });
+
+  async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) chunks.push(chunk as Buffer);
+    const body = Buffer.concat(chunks).toString("utf8");
+
+    const parsedUrl = new URL(req.url ?? "/", "http://127.0.0.1");
+    const path = parsedUrl.pathname;
+    const method = (req.method ?? "GET").toUpperCase();
+
+    let json: unknown;
+    const contentType = req.headers["content-type"] ?? "";
+    if (body && contentType.includes("application/json")) {
+      try {
+        json = JSON.parse(body);
+      } catch {
+        json = undefined;
+      }
+    }
+
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(req.headers)) {
+      headers[key] = Array.isArray(value) ? value.join(",") : (value ?? "");
+    }
+
+    const recorded: RecordedRequest = {
+      method,
+      path,
+      query: Object.fromEntries(parsedUrl.searchParams),
+      headers,
+      body,
+      json,
+    };
+    requests.push(recorded);
+
+    const routeKey = `${method} ${path}`;
+
+    if (requireAuth && !AUTH_EXEMPT_ROUTES.has(routeKey)) {
+      if (requireAuth === "apiKey") {
+        if (headers["x-api-key"] !== expectedApiKey) {
+          return send(res, 401, { detail: "missing or invalid X-Api-Key" }, latencyMs);
+        }
+      } else if (requireAuth === "jwt") {
+        const expected = `Bearer ${MOCK_JWT_TOKEN}`;
+        if (headers["authorization"] !== expected) {
+          return send(res, 401, { detail: "missing or invalid bearer token" }, latencyMs);
+        }
+      }
+    }
+
+    if (failuresServed < failFirstN) {
+      failuresServed += 1;
+      return send(res, 500, { detail: "mock: scripted failure" }, latencyMs);
+    }
+
+    const handler = overrides[routeKey] ?? routes[routeKey];
+    if (!handler) {
+      return send(res, 404, { detail: `mock has no route for ${method} ${path}` }, latencyMs);
+    }
+
+    let result: MockResponse;
+    try {
+      result = await handler(recorded);
+    } catch (err) {
+      result = {
+        status: 500,
+        body: { detail: `mock route handler threw: ${err instanceof Error ? err.message : String(err)}` },
+      };
+    }
+    return send(res, result.status, result.body, latencyMs, result.headers);
+  }
+
+  async function send(
+    res: ServerResponse,
+    status: number,
+    body: unknown,
+    delayMs: number,
+    extraHeaders?: Record<string, string>,
+  ): Promise<void> {
+    if (delayMs > 0) await sleep(delayMs);
+    const payload = typeof body === "string" ? body : JSON.stringify(body ?? {});
+    res.writeHead(status, {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(payload),
+      ...extraHeaders,
+    });
+    res.end(payload);
+  }
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("mock cognee server did not report a port");
+  }
+  const url = `http://127.0.0.1:${address.port}`;
+
+  return {
+    url,
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+export { MOCK_API_KEY, MOCK_JWT_TOKEN };

--- a/integrations/mastra/__tests__/unit/breaker.test.ts
+++ b/integrations/mastra/__tests__/unit/breaker.test.ts
@@ -1,0 +1,205 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CircuitBreaker,
+  DEFAULT_BREAKER_COOLDOWN_MS,
+  DEFAULT_BREAKER_THRESHOLD,
+  defaultBreakerPath,
+} from "../../src/breaker.js";
+
+/** Deterministic, manually-advanced clock — no real sleeping in this suite. */
+function fakeClock(startMs = 1_700_000_000_000) {
+  let t = startMs;
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+describe("CircuitBreaker", () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "cognee-mastra-breaker-test-"));
+    path = join(dir, "recall-breaker.json");
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("defaults to threshold 5 and cooldown 120s", () => {
+    expect(DEFAULT_BREAKER_THRESHOLD).toBe(5);
+    expect(DEFAULT_BREAKER_COOLDOWN_MS).toBe(120_000);
+  });
+
+  it("defaultBreakerPath() is namespaced under a .cognee-mastra directory", () => {
+    // Does not assert defaultBreakerPath() resolves under jest.setup.ts's
+    // sandboxed homedir: under this package's ts-jest ESM preset, its
+    // `jest.mock("node:os", ...)` does not intercept a plain ESM `import
+    // { homedir }`, so homedir() still returns the real OS home here. Every
+    // other test passes an explicit `path` instead.
+    expect(defaultBreakerPath()).toContain(".cognee-mastra");
+    expect(defaultBreakerPath().endsWith("recall-breaker.json")).toBe(true);
+  });
+
+  it("stays closed below the failure threshold", async () => {
+    const clock = fakeClock();
+    const breaker = new CircuitBreaker({ threshold: 5, cooldownMs: 120_000, path, now: clock.now });
+    for (let i = 0; i < 4; i++) await breaker.recordFailure(`err ${i}`);
+    expect(await breaker.isOpen()).toBe(false);
+    expect(await breaker.remainingCooldownMs()).toBe(0);
+  });
+
+  it("opens for exactly cooldownMs on the 5th consecutive failure", async () => {
+    const clock = fakeClock();
+    const breaker = new CircuitBreaker({ threshold: 5, cooldownMs: 120_000, path, now: clock.now });
+    for (let i = 0; i < 5; i++) await breaker.recordFailure(`err ${i}`);
+
+    expect(await breaker.isOpen()).toBe(true);
+    expect(await breaker.remainingCooldownMs()).toBe(120_000);
+
+    clock.advance(60_000); // halfway through cooldown
+    expect(await breaker.isOpen()).toBe(true);
+    expect(await breaker.remainingCooldownMs()).toBe(60_000);
+  });
+
+  it("half-opens (closes) the instant the fake clock crosses the cooldown boundary", async () => {
+    const clock = fakeClock();
+    const breaker = new CircuitBreaker({ threshold: 5, cooldownMs: 120_000, path, now: clock.now });
+    for (let i = 0; i < 5; i++) await breaker.recordFailure("boom");
+
+    clock.advance(119_999);
+    expect(await breaker.isOpen()).toBe(true);
+
+    clock.advance(1); // now exactly at cooldown_until — no longer > now()
+    expect(await breaker.isOpen()).toBe(false);
+    expect(await breaker.remainingCooldownMs()).toBe(0);
+  });
+
+  it("re-trips immediately on a failed half-open probe (failures are not reset on trip)", async () => {
+    const clock = fakeClock();
+    const breaker = new CircuitBreaker({ threshold: 2, cooldownMs: 1_000, path, now: clock.now });
+    await breaker.recordFailure("err 1");
+    await breaker.recordFailure("err 2");
+    expect(await breaker.isOpen()).toBe(true);
+
+    clock.advance(1_001); // cooldown elapses -> half-open
+    expect(await breaker.isOpen()).toBe(false);
+
+    await breaker.recordFailure("probe failed"); // failures accumulate past threshold again
+    expect(await breaker.isOpen()).toBe(true);
+    expect(await breaker.remainingCooldownMs()).toBe(1_000);
+  });
+
+  it("recordSuccess fully resets failures and cooldown", async () => {
+    const clock = fakeClock();
+    const breaker = new CircuitBreaker({ threshold: 3, cooldownMs: 60_000, path, now: clock.now });
+    await breaker.recordFailure("e1");
+    await breaker.recordFailure("e2");
+    await breaker.recordFailure("e3");
+    expect(await breaker.isOpen()).toBe(true);
+
+    await breaker.recordSuccess();
+    expect(await breaker.isOpen()).toBe(false);
+    expect(await breaker.remainingCooldownMs()).toBe(0);
+
+    const state = JSON.parse(await readFile(path, "utf-8"));
+    expect(state.failures).toBe(0);
+    expect(state.cooldownUntilMs).toBe(0);
+  });
+
+  it("missing state file means closed (never fails open on absence)", async () => {
+    const clock = fakeClock();
+    const breaker = new CircuitBreaker({ path: join(dir, "does-not-exist.json"), now: clock.now });
+    expect(await breaker.isOpen()).toBe(false);
+    expect(await breaker.remainingCooldownMs()).toBe(0);
+  });
+
+  it("corrupt (non-JSON) state file degrades to closed", async () => {
+    await mkdir(dir, { recursive: true });
+    await writeFile(path, "{ this is not valid json", "utf-8");
+    const breaker = new CircuitBreaker({ path, now: fakeClock().now });
+    expect(await breaker.isOpen()).toBe(false);
+  });
+
+  it("state file with the wrong shape (valid JSON, implausible fields) degrades to closed", async () => {
+    await writeFile(path, JSON.stringify({ hello: "world" }), "utf-8");
+    const breaker = new CircuitBreaker({ path, now: fakeClock().now });
+    expect(await breaker.isOpen()).toBe(false);
+  });
+
+  it("state file that is valid JSON but not an object (e.g. an array) degrades to closed", async () => {
+    await writeFile(path, JSON.stringify([1, 2, 3]), "utf-8");
+    const breaker = new CircuitBreaker({ path, now: fakeClock().now });
+    expect(await breaker.isOpen()).toBe(false);
+  });
+
+  it("a failure recorded against a corrupt state file overwrites it with valid state (self-healing)", async () => {
+    await writeFile(path, "not json at all", "utf-8");
+    const clock = fakeClock();
+    const breaker = new CircuitBreaker({ threshold: 1, cooldownMs: 5_000, path, now: clock.now });
+    await breaker.recordFailure("boom");
+    const state = JSON.parse(await readFile(path, "utf-8"));
+    expect(state.failures).toBe(1);
+    expect(state.cooldownUntilMs).toBe(clock.now() + 5_000);
+  });
+
+  it("persists failures/cooldown across independent CircuitBreaker instances sharing a path", async () => {
+    const clock = fakeClock();
+    const first = new CircuitBreaker({ threshold: 3, cooldownMs: 10_000, path, now: clock.now });
+    await first.recordFailure("e1");
+    await first.recordFailure("e2");
+
+    const second = new CircuitBreaker({ threshold: 3, cooldownMs: 10_000, path, now: clock.now });
+    expect(await second.isOpen()).toBe(false);
+    await second.recordFailure("e3"); // 3rd failure, from a different instance
+    expect(await second.isOpen()).toBe(true);
+    expect(await first.isOpen()).toBe(true); // same file, same verdict
+  });
+
+  it("truncates an overly long error message to 300 chars", async () => {
+    const breaker = new CircuitBreaker({ threshold: 1, path, now: fakeClock().now });
+    await breaker.recordFailure(new Error("x".repeat(1000)));
+    const state = JSON.parse(await readFile(path, "utf-8"));
+    expect(state.lastError.length).toBe(300);
+  });
+
+  it("accepts a plain string or an Error for recordFailure", async () => {
+    const breaker = new CircuitBreaker({ threshold: 1, path, now: fakeClock().now });
+    await breaker.recordFailure("plain string reason");
+    const state = JSON.parse(await readFile(path, "utf-8"));
+    expect(state.lastError).toBe("plain string reason");
+  });
+
+  it("redacts an apiKey/password-shaped substring out of a persisted error message", async () => {
+    const breaker = new CircuitBreaker({ threshold: 1, path, now: fakeClock().now });
+    await breaker.recordFailure(new Error("cognee API responded with status 422: invalid apiKey: sk-super-secret-value"));
+    const state = JSON.parse(await readFile(path, "utf-8"));
+    expect(state.lastError).not.toContain("sk-super-secret-value");
+    expect(state.lastError).toContain("REDACTED");
+  });
+
+  it("redacts a password=... substring out of a persisted error message", async () => {
+    const breaker = new CircuitBreaker({ threshold: 1, path, now: fakeClock().now });
+    await breaker.recordFailure(new Error("login rejected: password=hunter2-do-not-log-me"));
+    const state = JSON.parse(await readFile(path, "utf-8"));
+    expect(state.lastError).not.toContain("hunter2-do-not-log-me");
+    expect(state.lastError).toContain("REDACTED");
+  });
+
+  it("uses default threshold/cooldown when not overridden, with a fake clock", async () => {
+    const clock = fakeClock();
+    const breaker = new CircuitBreaker({ path, now: clock.now }); // no threshold/cooldownMs given
+    for (let i = 0; i < DEFAULT_BREAKER_THRESHOLD; i++) await breaker.recordFailure(`e${i}`);
+    expect(await breaker.isOpen()).toBe(true);
+    clock.advance(DEFAULT_BREAKER_COOLDOWN_MS - 1);
+    expect(await breaker.isOpen()).toBe(true);
+    clock.advance(1);
+    expect(await breaker.isOpen()).toBe(false);
+  });
+});

--- a/integrations/mastra/__tests__/unit/config.test.ts
+++ b/integrations/mastra/__tests__/unit/config.test.ts
@@ -1,0 +1,326 @@
+/**
+ * No network, no real `process.env` mutation: every case passes its own
+ * `env` object as the second argument (see `config.ts`'s header comment).
+ */
+
+import { describe, expect, it, jest } from "@jest/globals";
+import {
+  DEFAULT_BASE_URL,
+  DEFAULT_DATASET,
+  DEFAULT_DATASET_PREFIX,
+  DEFAULT_ENABLE_FORGET,
+  DEFAULT_INCLUDE_REFERENCES,
+  DEFAULT_MIN_QUERY_LENGTH,
+  DEFAULT_RECALL_BUDGET_MS,
+  DEFAULT_RECALL_ENABLED,
+  DEFAULT_RECALL_TIMEOUT_MS,
+  DEFAULT_REQUEST_TIMEOUT_MS,
+  DEFAULT_RETRIES,
+  DEFAULT_RUN_IN_BACKGROUND,
+  DEFAULT_SCOPE,
+  DEFAULT_SEARCH_TYPE,
+  DEFAULT_TOP_K,
+  DEFAULT_TOOLS_TIMEOUT_MS,
+  DEFAULT_WRITE_MAX_CHARS,
+  DEFAULT_WRITE_MODE,
+  redactConfigForLogging,
+  resolveConfig,
+} from "../../src/config.js";
+
+/** A clean env object with no COGNEE_* keys, so a test only sees the vars it sets. */
+function emptyEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return { ...overrides };
+}
+
+describe("resolveConfig — defaults", () => {
+  it("fills every field with its default when nothing is supplied", () => {
+    const resolved = resolveConfig({}, emptyEnv());
+
+    expect(resolved.baseUrl).toBe(DEFAULT_BASE_URL);
+    expect(resolved.apiKey).toBeUndefined();
+    expect(resolved.auth).toBeUndefined();
+    expect(resolved.dataset).toBe(DEFAULT_DATASET);
+    expect(resolved.datasetPrefix).toBe(DEFAULT_DATASET_PREFIX);
+    expect(resolved.scope).toBe(DEFAULT_SCOPE);
+    expect(resolved.nodeSet).toEqual([]);
+
+    expect(resolved.recall).toEqual({
+      enabled: DEFAULT_RECALL_ENABLED,
+      searchType: DEFAULT_SEARCH_TYPE,
+      topK: DEFAULT_TOP_K,
+      minQueryLength: DEFAULT_MIN_QUERY_LENGTH,
+      timeoutMs: DEFAULT_RECALL_TIMEOUT_MS,
+      budgetMs: DEFAULT_RECALL_BUDGET_MS,
+      includeReferences: DEFAULT_INCLUDE_REFERENCES,
+    });
+
+    expect(resolved.write).toEqual({
+      mode: DEFAULT_WRITE_MODE,
+      runInBackground: DEFAULT_RUN_IN_BACKGROUND,
+      maxChars: DEFAULT_WRITE_MAX_CHARS,
+    });
+
+    expect(resolved.tools).toEqual({ enableForget: DEFAULT_ENABLE_FORGET, timeoutMs: DEFAULT_TOOLS_TIMEOUT_MS });
+
+    expect(resolved.requestTimeoutMs).toBe(DEFAULT_REQUEST_TIMEOUT_MS);
+    expect(resolved.retries).toBe(DEFAULT_RETRIES);
+    expect(resolved.debug).toBe(false);
+    expect(resolved.fetch).toBeUndefined();
+  });
+
+  it("never throws when no credential is supplied at all", () => {
+    expect(() => resolveConfig({}, emptyEnv())).not.toThrow();
+    expect(() => resolveConfig(undefined, emptyEnv())).not.toThrow();
+  });
+
+  it("defaults nodeSet to a fresh empty array each call, not a shared reference", () => {
+    const a = resolveConfig({}, emptyEnv());
+    const b = resolveConfig({}, emptyEnv());
+    expect(a.nodeSet).not.toBe(b.nodeSet);
+  });
+});
+
+describe("resolveConfig — precedence: explicit > env > default", () => {
+  it("baseUrl / COGNEE_API_URL", () => {
+    expect(resolveConfig({}, emptyEnv()).baseUrl).toBe(DEFAULT_BASE_URL);
+    expect(resolveConfig({}, emptyEnv({ COGNEE_API_URL: "http://env:9000" })).baseUrl).toBe("http://env:9000");
+    expect(
+      resolveConfig({ baseUrl: "http://explicit:9000" }, emptyEnv({ COGNEE_API_URL: "http://env:9000" })).baseUrl,
+    ).toBe("http://explicit:9000");
+  });
+
+  it("apiKey / COGNEE_API_KEY", () => {
+    expect(resolveConfig({}, emptyEnv()).apiKey).toBeUndefined();
+    expect(resolveConfig({}, emptyEnv({ COGNEE_API_KEY: "env-key" })).apiKey).toBe("env-key");
+    expect(resolveConfig({ apiKey: "explicit-key" }, emptyEnv({ COGNEE_API_KEY: "env-key" })).apiKey).toBe(
+      "explicit-key",
+    );
+  });
+
+  it("auth.email / COGNEE_USER_EMAIL and auth.password / COGNEE_USER_PASSWORD, independently", () => {
+    const envOnly = resolveConfig({}, emptyEnv({ COGNEE_USER_EMAIL: "e@env", COGNEE_USER_PASSWORD: "p-env" }));
+    expect(envOnly.auth).toEqual({ email: "e@env", password: "p-env" });
+
+    const explicitWins = resolveConfig(
+      { auth: { email: "e@explicit" } },
+      emptyEnv({ COGNEE_USER_EMAIL: "e@env", COGNEE_USER_PASSWORD: "p-env" }),
+    );
+    expect(explicitWins.auth).toEqual({ email: "e@explicit", password: "p-env" });
+  });
+
+  it("both apiKey and auth can be resolved simultaneously — precedence between them is a client-side concern, not resolveConfig's to erase", () => {
+    const resolved = resolveConfig(
+      { apiKey: "explicit-key", auth: { email: "e@x", password: "p" } },
+      emptyEnv(),
+    );
+    expect(resolved.apiKey).toBe("explicit-key");
+    expect(resolved.auth).toEqual({ email: "e@x", password: "p" });
+  });
+
+  it("dataset / COGNEE_DATASET", () => {
+    expect(resolveConfig({}, emptyEnv({ COGNEE_DATASET: "env-ds" })).dataset).toBe("env-ds");
+    expect(resolveConfig({ dataset: "explicit-ds" }, emptyEnv({ COGNEE_DATASET: "env-ds" })).dataset).toBe(
+      "explicit-ds",
+    );
+  });
+
+  it("datasetPrefix / COGNEE_DATASET_PREFIX", () => {
+    expect(resolveConfig({}, emptyEnv({ COGNEE_DATASET_PREFIX: "env_" })).datasetPrefix).toBe("env_");
+    expect(
+      resolveConfig({ datasetPrefix: "explicit_" }, emptyEnv({ COGNEE_DATASET_PREFIX: "env_" })).datasetPrefix,
+    ).toBe("explicit_");
+  });
+
+  it("scope / COGNEE_SCOPE, with an invalid value falling back to default", () => {
+    expect(resolveConfig({}, emptyEnv({ COGNEE_SCOPE: "dataset-per-resource" })).scope).toBe(
+      "dataset-per-resource",
+    );
+    expect(
+      resolveConfig({ scope: "dataset-per-resource" }, emptyEnv({ COGNEE_SCOPE: "tagged" })).scope,
+    ).toBe("dataset-per-resource");
+    expect(resolveConfig({}, emptyEnv({ COGNEE_SCOPE: "bogus" })).scope).toBe(DEFAULT_SCOPE);
+  });
+
+  it("nodeSet is explicit-only (no env equivalent) and is copied, not aliased", () => {
+    const tags = ["extra:tag"];
+    const resolved = resolveConfig({ nodeSet: tags }, emptyEnv());
+    expect(resolved.nodeSet).toEqual(["extra:tag"]);
+    expect(resolved.nodeSet).not.toBe(tags);
+  });
+
+  it("recall.enabled / COGNEE_RECALL_ENABLED (boolean parsing)", () => {
+    expect(resolveConfig({}, emptyEnv({ COGNEE_RECALL_ENABLED: "false" })).recall.enabled).toBe(false);
+    expect(resolveConfig({}, emptyEnv({ COGNEE_RECALL_ENABLED: "0" })).recall.enabled).toBe(false);
+    expect(resolveConfig({}, emptyEnv({ COGNEE_RECALL_ENABLED: "true" })).recall.enabled).toBe(true);
+    expect(
+      resolveConfig({ recall: { enabled: true } }, emptyEnv({ COGNEE_RECALL_ENABLED: "false" })).recall.enabled,
+    ).toBe(true);
+  });
+
+  it("recall.searchType / COGNEE_SEARCH_TYPE passes through verbatim, no validation", () => {
+    expect(resolveConfig({}, emptyEnv({ COGNEE_SEARCH_TYPE: "GRAPH_COMPLETION" })).recall.searchType).toBe(
+      "GRAPH_COMPLETION",
+    );
+    expect(
+      resolveConfig({ recall: { searchType: "TEMPORAL" } }, emptyEnv({ COGNEE_SEARCH_TYPE: "GRAPH_COMPLETION" }))
+        .recall.searchType,
+    ).toBe("TEMPORAL");
+  });
+
+  it("recall.topK / COGNEE_TOP_K (int parsing)", () => {
+    expect(resolveConfig({}, emptyEnv({ COGNEE_TOP_K: "25" })).recall.topK).toBe(25);
+    expect(resolveConfig({ recall: { topK: 3 } }, emptyEnv({ COGNEE_TOP_K: "25" })).recall.topK).toBe(3);
+    // malformed env value degrades to default rather than NaN
+    expect(resolveConfig({}, emptyEnv({ COGNEE_TOP_K: "not-a-number" })).recall.topK).toBe(DEFAULT_TOP_K);
+  });
+
+  it("recall.timeoutMs / COGNEE_RECALL_TIMEOUT_MS and recall.budgetMs / COGNEE_RECALL_BUDGET_MS", () => {
+    const resolved = resolveConfig(
+      {},
+      emptyEnv({ COGNEE_RECALL_TIMEOUT_MS: "1000", COGNEE_RECALL_BUDGET_MS: "2000" }),
+    );
+    expect(resolved.recall.timeoutMs).toBe(1000);
+    expect(resolved.recall.budgetMs).toBe(2000);
+  });
+
+  it("recall.minQueryLength and recall.includeReferences have no env var — explicit or default only", () => {
+    expect(resolveConfig({}, emptyEnv()).recall.minQueryLength).toBe(DEFAULT_MIN_QUERY_LENGTH);
+    expect(resolveConfig({ recall: { minQueryLength: 20 } }, emptyEnv()).recall.minQueryLength).toBe(20);
+    expect(resolveConfig({}, emptyEnv()).recall.includeReferences).toBe(true);
+    expect(resolveConfig({ recall: { includeReferences: false } }, emptyEnv()).recall.includeReferences).toBe(
+      false,
+    );
+  });
+
+  it("write.mode / COGNEE_SAVE_MODE, with an invalid value falling back to default", () => {
+    expect(resolveConfig({}, emptyEnv({ COGNEE_SAVE_MODE: "assistant-only" })).write.mode).toBe(
+      "assistant-only",
+    );
+    expect(
+      resolveConfig({ write: { mode: "never" } }, emptyEnv({ COGNEE_SAVE_MODE: "always" })).write.mode,
+    ).toBe("never");
+    expect(resolveConfig({}, emptyEnv({ COGNEE_SAVE_MODE: "bogus" })).write.mode).toBe(DEFAULT_WRITE_MODE);
+  });
+
+  it("write.runInBackground and write.maxChars have no env var — explicit or default only", () => {
+    expect(resolveConfig({}, emptyEnv()).write.runInBackground).toBe(true);
+    expect(resolveConfig({ write: { runInBackground: false } }, emptyEnv()).write.runInBackground).toBe(false);
+    expect(resolveConfig({}, emptyEnv()).write.maxChars).toBe(DEFAULT_WRITE_MAX_CHARS);
+    expect(resolveConfig({ write: { maxChars: 500 } }, emptyEnv()).write.maxChars).toBe(500);
+  });
+
+  it("tools.enableForget / COGNEE_ENABLE_FORGET (boolean parsing)", () => {
+    expect(resolveConfig({}, emptyEnv({ COGNEE_ENABLE_FORGET: "true" })).tools.enableForget).toBe(true);
+    expect(
+      resolveConfig({ tools: { enableForget: false } }, emptyEnv({ COGNEE_ENABLE_FORGET: "true" })).tools
+        .enableForget,
+    ).toBe(false);
+    expect(resolveConfig({}, emptyEnv()).tools.enableForget).toBe(false);
+  });
+
+  it("tools.timeoutMs / COGNEE_TOOLS_TIMEOUT_MS", () => {
+    expect(resolveConfig({}, emptyEnv()).tools.timeoutMs).toBe(DEFAULT_TOOLS_TIMEOUT_MS);
+    expect(resolveConfig({}, emptyEnv({ COGNEE_TOOLS_TIMEOUT_MS: "5000" })).tools.timeoutMs).toBe(5000);
+    expect(
+      resolveConfig({ tools: { timeoutMs: 1234 } }, emptyEnv({ COGNEE_TOOLS_TIMEOUT_MS: "5000" })).tools.timeoutMs,
+    ).toBe(1234);
+  });
+
+  it("requestTimeoutMs / COGNEE_TIMEOUT_MS", () => {
+    expect(resolveConfig({}, emptyEnv({ COGNEE_TIMEOUT_MS: "60000" })).requestTimeoutMs).toBe(60000);
+    expect(
+      resolveConfig({ requestTimeoutMs: 1234 }, emptyEnv({ COGNEE_TIMEOUT_MS: "60000" })).requestTimeoutMs,
+    ).toBe(1234);
+  });
+
+  it("retries / COGNEE_RETRIES", () => {
+    expect(resolveConfig({}, emptyEnv({ COGNEE_RETRIES: "5" })).retries).toBe(5);
+    expect(resolveConfig({ retries: 0 }, emptyEnv({ COGNEE_RETRIES: "5" })).retries).toBe(0);
+  });
+
+  it("debug / COGNEE_DEBUG (boolean parsing)", () => {
+    const debugSpy = jest.spyOn(console, "debug").mockImplementation(() => undefined);
+    try {
+      expect(resolveConfig({}, emptyEnv({ COGNEE_DEBUG: "true" })).debug).toBe(true);
+      expect(resolveConfig({ debug: false }, emptyEnv({ COGNEE_DEBUG: "true" })).debug).toBe(false);
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+
+  it("fetch is explicit-only — never read from env, never defaulted to a stand-in", () => {
+    const injected = (() => Promise.resolve(new Response())) as unknown as typeof fetch;
+    expect(resolveConfig({ fetch: injected }, emptyEnv()).fetch).toBe(injected);
+    expect(resolveConfig({}, emptyEnv()).fetch).toBeUndefined();
+  });
+
+  it("honors explicit false/0/empty-array values rather than treating them as absent", () => {
+    expect(resolveConfig({ recall: { enabled: false } }, emptyEnv()).recall.enabled).toBe(false);
+    expect(resolveConfig({ retries: 0 }, emptyEnv()).retries).toBe(0);
+    expect(resolveConfig({ nodeSet: [] }, emptyEnv({ COGNEE_DATASET: "x" })).nodeSet).toEqual([]);
+  });
+});
+
+describe("resolveConfig — secret redaction", () => {
+  it("never logs apiKey or auth.password even with debug: true", () => {
+    const debugSpy = jest.spyOn(console, "debug").mockImplementation(() => undefined);
+    try {
+      resolveConfig(
+        { debug: true, apiKey: "super-secret-key", auth: { email: "user@example.com", password: "super-secret-pw" } },
+        emptyEnv(),
+      );
+
+      expect(debugSpy).toHaveBeenCalledTimes(1);
+      const loggedArgs = debugSpy.mock.calls[0];
+      const serialized = loggedArgs.map((arg) => (typeof arg === "string" ? arg : JSON.stringify(arg))).join(" ");
+
+      expect(serialized).not.toContain("super-secret-key");
+      expect(serialized).not.toContain("super-secret-pw");
+      // The non-secret email is allowed through; only apiKey/password are redacted.
+      expect(serialized).toContain("user@example.com");
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+
+  it("does not log at all when debug is false (the default)", () => {
+    const debugSpy = jest.spyOn(console, "debug").mockImplementation(() => undefined);
+    try {
+      resolveConfig({ apiKey: "super-secret-key" }, emptyEnv());
+      expect(debugSpy).not.toHaveBeenCalled();
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+
+  it("redactConfigForLogging masks apiKey and auth.password, drops fetch, and leaves everything else intact", () => {
+    const injected = (() => Promise.resolve(new Response())) as unknown as typeof fetch;
+    const resolved = resolveConfig(
+      {
+        apiKey: "super-secret-key",
+        auth: { email: "user@example.com", password: "super-secret-pw" },
+        dataset: "my-app",
+        fetch: injected,
+      },
+      emptyEnv(),
+    );
+
+    const safe = redactConfigForLogging(resolved);
+    const serialized = JSON.stringify(safe);
+
+    expect(serialized).not.toContain("super-secret-key");
+    expect(serialized).not.toContain("super-secret-pw");
+    expect(safe.apiKey).toBe("***REDACTED***");
+    expect((safe.auth as { email?: string; password?: string }).password).toBe("***REDACTED***");
+    expect((safe.auth as { email?: string; password?: string }).email).toBe("user@example.com");
+    expect(safe.dataset).toBe("my-app");
+    expect("fetch" in safe).toBe(false);
+  });
+
+  it("redactConfigForLogging leaves apiKey/auth undefined when they were never set", () => {
+    const resolved = resolveConfig({}, emptyEnv());
+    const safe = redactConfigForLogging(resolved);
+    expect(safe.apiKey).toBeUndefined();
+    expect(safe.auth).toBeUndefined();
+  });
+});

--- a/integrations/mastra/__tests__/unit/errors.test.ts
+++ b/integrations/mastra/__tests__/unit/errors.test.ts
@@ -1,0 +1,138 @@
+import { CogneeApiError, isBreakerError, isRetryable } from "../../src/errors.js";
+
+describe("CogneeApiError.fromResponse", () => {
+  it("extracts the message from a `detail` body (FastAPI-style envelope)", () => {
+    const err = CogneeApiError.fromResponse(422, { detail: "invalid payload" }, { url: "/api/v1/recall", method: "POST" });
+    expect(err).toBeInstanceOf(CogneeApiError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("CogneeApiError");
+    expect(err.message).toBe("invalid payload");
+    expect(err.status).toBe(422);
+    expect(err.url).toBe("/api/v1/recall");
+    expect(err.method).toBe("POST");
+    expect(err.body).toEqual({ detail: "invalid payload" });
+  });
+
+  it("extracts the message from an `error` body (ad-hoc route handler envelope)", () => {
+    const err = CogneeApiError.fromResponse(422, { error: "validation failed" });
+    expect(err.message).toBe("validation failed");
+  });
+
+  it("extracts the message from a bare `message` body (e.g. /health failure)", () => {
+    const err = CogneeApiError.fromResponse(503, { message: "not ready" });
+    expect(err.message).toBe("not ready");
+  });
+
+  it("falls back to a generic message when the body has none of the known keys", () => {
+    const err = CogneeApiError.fromResponse(500, { unexpected: "shape" });
+    expect(err.message).toBe("cognee API responded with status 500");
+  });
+
+  it("falls back to a generic message when the body is a non-string or empty", () => {
+    expect(CogneeApiError.fromResponse(404, undefined).message).toBe("cognee API responded with status 404");
+    expect(CogneeApiError.fromResponse(404, null).message).toBe("cognee API responded with status 404");
+    expect(CogneeApiError.fromResponse(404, "").message).toBe("cognee API responded with status 404");
+    expect(CogneeApiError.fromResponse(404, "   ").message).toBe("cognee API responded with status 404");
+  });
+
+  it("uses a plain string body verbatim as the message", () => {
+    const err = CogneeApiError.fromResponse(409, "conflict: dataset locked");
+    expect(err.message).toBe("conflict: dataset locked");
+  });
+
+  it("prefers `detail` over `error` over `message` when more than one key is present", () => {
+    const err = CogneeApiError.fromResponse(422, { detail: "from detail", error: "from error", message: "from message" });
+    expect(err.message).toBe("from detail");
+  });
+});
+
+describe("CogneeApiError.fromNetworkError", () => {
+  it("uses status 0 and the underlying Error's message", () => {
+    const err = CogneeApiError.fromNetworkError(new Error("ECONNREFUSED"), { url: "http://localhost:8000/health" });
+    expect(err.status).toBe(0);
+    expect(err.message).toBe("cognee request failed: ECONNREFUSED");
+    expect(err.url).toBe("http://localhost:8000/health");
+  });
+
+  it("stringifies a non-Error cause", () => {
+    const err = CogneeApiError.fromNetworkError("boom");
+    expect(err.status).toBe(0);
+    expect(err.message).toBe("cognee request failed: boom");
+  });
+});
+
+describe("CogneeApiError.fromTimeout", () => {
+  it("uses status 0 and reports the configured timeout", () => {
+    const err = CogneeApiError.fromTimeout(2500, { method: "POST", url: "/api/v1/recall" });
+    expect(err.status).toBe(0);
+    expect(err.message).toBe("cognee request timed out after 2500ms");
+    expect(err.method).toBe("POST");
+  });
+});
+
+describe("isRetryable — status -> class matrix", () => {
+  it.each([402, 403, 404, 409, 422])("status %d is NOT retryable (cognee's stable 'no')", (status) => {
+    expect(isRetryable(status)).toBe(false);
+  });
+
+  it.each([500, 502, 503, 504, 599])("5xx status %d IS retryable", (status) => {
+    expect(isRetryable(status)).toBe(true);
+  });
+
+  it("429 (rate limited) is retryable", () => {
+    expect(isRetryable(429)).toBe(true);
+  });
+
+  it("2xx/3xx are not retryable (never reached from an error path, but the table has no opinion in the affirmative)", () => {
+    expect(isRetryable(200)).toBe(false);
+    expect(isRetryable(304)).toBe(false);
+  });
+
+  it("400 (generic bad request, not in the explicit matrix) is not retryable", () => {
+    expect(isRetryable(400)).toBe(false);
+  });
+
+  it("401 (unauthorized, not in the explicit matrix) is not retryable", () => {
+    expect(isRetryable(401)).toBe(false);
+  });
+
+  it("0 (network error / timeout, no response) has no opinion from this table", () => {
+    expect(isRetryable(0)).toBe(false);
+  });
+
+  it("600 (out of the 5xx band) is not retryable", () => {
+    expect(isRetryable(600)).toBe(false);
+  });
+});
+
+describe("isBreakerError — status -> breaker-eligibility matrix", () => {
+  it.each([402, 403, 404, 409, 422])(
+    "status %d does NOT count against the breaker (a deterministic 4xx, not evidence cognee is down)",
+    (status) => {
+      expect(isBreakerError(status)).toBe(false);
+    },
+  );
+
+  it("400 / 401 / 429 also do not count against the breaker", () => {
+    expect(isBreakerError(400)).toBe(false);
+    expect(isBreakerError(401)).toBe(false);
+    expect(isBreakerError(429)).toBe(false);
+  });
+
+  it.each([500, 502, 503, 504, 599])("5xx status %d DOES count against the breaker", (status) => {
+    expect(isBreakerError(status)).toBe(true);
+  });
+
+  it("0 (network error / timeout, no response) counts against the breaker", () => {
+    expect(isBreakerError(0)).toBe(true);
+  });
+
+  it("2xx/3xx are not breaker-eligible (never reached from an error path)", () => {
+    expect(isBreakerError(200)).toBe(false);
+    expect(isBreakerError(304)).toBe(false);
+  });
+
+  it("600 (out of the 5xx band) does not count against the breaker", () => {
+    expect(isBreakerError(600)).toBe(false);
+  });
+});

--- a/integrations/mastra/__tests__/unit/format.test.ts
+++ b/integrations/mastra/__tests__/unit/format.test.ts
@@ -1,0 +1,166 @@
+import {
+  TRUNCATION_MARKER,
+  extractMessageText,
+  formatContextBlock,
+  messageToText,
+  truncateAtWordBoundary,
+} from "../../src/format.js";
+import type { RecallHit } from "../../src/types.js";
+
+describe("truncateAtWordBoundary", () => {
+  it("returns short text unchanged, with no truncation marker", () => {
+    expect(truncateAtWordBoundary("hello world", 100)).toBe("hello world");
+  });
+
+  it("returns the exact-length text unchanged", () => {
+    const text = "12345";
+    expect(truncateAtWordBoundary(text, 5)).toBe(text);
+  });
+
+  it("cuts at the last word boundary at or before maxChars", () => {
+    const text = "the quick brown fox jumps over the lazy dog";
+    // "the quick brown fox " is 20 chars; cut at 22 should land inside "fox jumps"
+    const result = truncateAtWordBoundary(text, 22);
+    expect(result.endsWith(TRUNCATION_MARKER)).toBe(true);
+    const withoutMarker = result.slice(0, -TRUNCATION_MARKER.length);
+    expect(withoutMarker.length).toBeLessThanOrEqual(22);
+    // must not have cut mid-word: what's left, minus the marker, is a
+    // prefix of the original text ending exactly at a space (or the string).
+    expect(text.startsWith(withoutMarker)).toBe(true);
+    expect(withoutMarker.endsWith(" ")).toBe(false); // trimmed
+    const cutPoint = withoutMarker.length;
+    expect(cutPoint === text.length || text[cutPoint] === " ").toBe(true);
+  });
+
+  it("falls back to a hard cut when no boundary exists in range", () => {
+    const text = "supercalifragilisticexpialidocious";
+    const result = truncateAtWordBoundary(text, 10);
+    expect(result).toBe(text.slice(0, 10) + TRUNCATION_MARKER);
+  });
+
+  it("treats newlines and tabs as boundaries too", () => {
+    const text = "line one\nline two is much longer than the cutoff";
+    const result = truncateAtWordBoundary(text, 12);
+    expect(result.startsWith("line one")).toBe(true);
+    expect(result).not.toMatch(/\n.*\S/); // did not cut mid-second-line without a boundary
+  });
+
+  it("maxChars <= 0 returns empty string", () => {
+    expect(truncateAtWordBoundary("anything", 0)).toBe("");
+    expect(truncateAtWordBoundary("anything", -5)).toBe("");
+  });
+
+  it("empty input returns empty output", () => {
+    expect(truncateAtWordBoundary("", 10)).toBe("");
+  });
+});
+
+describe("extractMessageText", () => {
+  it("passes through a plain string", () => {
+    expect(extractMessageText("hello")).toBe("hello");
+  });
+
+  it("joins an AI-SDK-style parts array", () => {
+    const content = [{ type: "text", text: "hello" }, { type: "text", text: "world" }];
+    expect(extractMessageText(content)).toBe("hello\nworld");
+  });
+
+  it("skips non-text parts (tool calls, etc.) without throwing", () => {
+    const content = [{ type: "text", text: "hi" }, { type: "tool-call", toolName: "x" }, "raw"];
+    expect(extractMessageText(content)).toBe("hi\nraw");
+  });
+
+  it("reads a bare {text} object", () => {
+    expect(extractMessageText({ text: "hello" })).toBe("hello");
+  });
+
+  it("returns '' for content with no extractable text", () => {
+    expect(extractMessageText({ type: "tool-call" })).toBe("");
+    expect(extractMessageText([{ type: "tool-call" }])).toBe("");
+    expect(extractMessageText(null)).toBe("");
+    expect(extractMessageText(undefined)).toBe("");
+  });
+});
+
+describe("messageToText", () => {
+  it("prefixes with the role when present", () => {
+    expect(messageToText({ role: "user", content: "hi there" })).toBe("user: hi there");
+  });
+
+  it("omits the role prefix when absent", () => {
+    expect(messageToText({ content: "hi there" })).toBe("hi there");
+  });
+
+  it("returns '' for a message with no extractable text", () => {
+    expect(messageToText({ role: "assistant", content: [{ type: "tool-call" }] })).toBe("");
+  });
+
+  it("truncates the content (not the role prefix) on a word boundary at maxChars", () => {
+    const longText = Array.from({ length: 50 }, (_, i) => `word${i}`).join(" ");
+    const result = messageToText({ role: "user", content: longText }, 30);
+    expect(result.startsWith("user: ")).toBe(true);
+    const contentPart = result.slice("user: ".length);
+    expect(contentPart.length).toBeLessThanOrEqual(30 + TRUNCATION_MARKER.length);
+    expect(contentPart.endsWith(TRUNCATION_MARKER)).toBe(true);
+    expect(longText.startsWith(contentPart.slice(0, -TRUNCATION_MARKER.length))).toBe(true);
+  });
+
+  it("defaults maxChars to 8000, applied to content only", () => {
+    const longText = "x".repeat(9000);
+    const result = messageToText({ role: "user", content: longText });
+    // maxChars bounds the extracted content (hard-cut: no boundary in an
+    // unbroken run of "x"); the role prefix is added on top, uncounted.
+    expect(result).toBe(`user: ${"x".repeat(8000)}${TRUNCATION_MARKER}`);
+  });
+});
+
+describe("formatContextBlock", () => {
+  const hit = (overrides: Partial<RecallHit> = {}): RecallHit => ({ text: "some fact", ...overrides });
+
+  it("returns null for an empty hit list", () => {
+    expect(formatContextBlock([])).toBeNull();
+  });
+
+  it("returns null when every hit has blank/missing text", () => {
+    expect(formatContextBlock([hit({ text: "" }), hit({ text: "   " })])).toBeNull();
+  });
+
+  it("renders a heading plus one numbered line per hit", () => {
+    const block = formatContextBlock([hit({ text: "fact one" }), hit({ text: "fact two" })]);
+    expect(block).not.toBeNull();
+    const lines = block!.split("\n");
+    expect(lines[0]).toBe("Relevant memory from cognee:");
+    expect(lines[1]).toBe("1. fact one");
+    expect(lines[2]).toBe("2. fact two");
+  });
+
+  it("appends a source annotation when available", () => {
+    const block = formatContextBlock([hit({ text: "fact", source: "graph" })]);
+    expect(block).toBe("Relevant memory from cognee:\n1. fact (source: graph)");
+  });
+
+  it("falls back to datasetName then datasetId for the source annotation", () => {
+    const byName = formatContextBlock([hit({ text: "fact", datasetName: "myapp" })]);
+    expect(byName).toContain("(source: myapp)");
+    const byId = formatContextBlock([hit({ text: "fact", datasetId: "ds-1" })]);
+    expect(byId).toContain("(source: ds-1)");
+  });
+
+  it("omits blank hits from the middle of the list without renumbering gaps oddly", () => {
+    const block = formatContextBlock([hit({ text: "keep one" }), hit({ text: "" }), hit({ text: "keep two" })]);
+    const lines = block!.split("\n");
+    expect(lines).toEqual(["Relevant memory from cognee:", "1. keep one", "2. keep two"]);
+  });
+
+  it("honours a custom heading", () => {
+    const block = formatContextBlock([hit()], { heading: "Custom:" });
+    expect(block!.startsWith("Custom:\n")).toBe(true);
+  });
+
+  it("truncates a long hit's text on a word boundary at maxCharsPerHit", () => {
+    const longText = Array.from({ length: 50 }, (_, i) => `word${i}`).join(" ");
+    const block = formatContextBlock([hit({ text: longText })], { maxCharsPerHit: 20 });
+    const line = block!.split("\n")[1];
+    expect(line.includes(TRUNCATION_MARKER)).toBe(true);
+  });
+});

--- a/integrations/mastra/__tests__/unit/pipeline-status.test.ts
+++ b/integrations/mastra/__tests__/unit/pipeline-status.test.ts
@@ -1,0 +1,43 @@
+import { extractPipelineStatus, isPipelineCompleted, isPipelineFailed } from "../../src/pipeline-status.js";
+
+describe("isPipelineCompleted / isPipelineFailed", () => {
+  it.each(["DATASET_PROCESSING_COMPLETED", "completed", "COMPLETED"])("%s counts as completed", (s) => {
+    expect(isPipelineCompleted(s)).toBe(true);
+    expect(isPipelineFailed(s)).toBe(false);
+  });
+
+  it.each(["DATASET_PROCESSING_ERRORED", "failed", "errored", "SOMETHING_FAILED"])("%s counts as failed", (s) => {
+    expect(isPipelineFailed(s)).toBe(true);
+    expect(isPipelineCompleted(s)).toBe(false);
+  });
+
+  it.each(["DATASET_PROCESSING_STARTED", "DATASET_PROCESSING_INITIATED", "running", "pending", "", undefined, null])(
+    "%s is neither completed nor failed (still in flight / not started)",
+    (s) => {
+      expect(isPipelineCompleted(s)).toBe(false);
+      expect(isPipelineFailed(s)).toBe(false);
+    },
+  );
+});
+
+describe("extractPipelineStatus", () => {
+  it("reads the flat single-pipeline map a live server returns", () => {
+    expect(extractPipelineStatus({ "ds-1": "DATASET_PROCESSING_STARTED" }, "ds-1")).toBe("DATASET_PROCESSING_STARTED");
+  });
+
+  it("reads the nested multi-pipeline shape", () => {
+    expect(extractPipelineStatus({ "ds-1": { cognify_pipeline: "DATASET_PROCESSING_COMPLETED" } }, "ds-1")).toBe(
+      "DATASET_PROCESSING_COMPLETED",
+    );
+  });
+
+  it("returns undefined for a dataset with no run yet (empty map), not an error", () => {
+    expect(extractPipelineStatus({}, "ds-1")).toBeUndefined();
+    expect(extractPipelineStatus({ "ds-2": "DATASET_PROCESSING_COMPLETED" }, "ds-1")).toBeUndefined();
+  });
+
+  it("tolerates a non-object response", () => {
+    expect(extractPipelineStatus(null, "ds-1")).toBeUndefined();
+    expect(extractPipelineStatus("nope", "ds-1")).toBeUndefined();
+  });
+});

--- a/integrations/mastra/__tests__/unit/scope.test.ts
+++ b/integrations/mastra/__tests__/unit/scope.test.ts
@@ -1,0 +1,194 @@
+import {
+  DEFAULT_DATASET,
+  DEFAULT_DATASET_PREFIX,
+  buildTag,
+  datasetNameForResource,
+  resolveScope,
+  resourceTag,
+  sanitizeId,
+  sessionIdFor,
+  threadTag,
+} from "../../src/scope.js";
+
+describe("sanitizeId", () => {
+  it("leaves safe characters untouched", () => {
+    expect(sanitizeId("abc123_-XYZ")).toBe("abc123_-XYZ");
+  });
+
+  it("encodes colons and spaces", () => {
+    expect(sanitizeId("user:1")).toBe("user%3A1");
+    expect(sanitizeId("hello world")).toBe("hello%20world");
+  });
+
+  it("encodes dots (illegal in a cognee dataset name)", () => {
+    const encoded = sanitizeId("a.b");
+    expect(encoded).not.toContain(".");
+    expect(encoded).toBe("a%2Eb");
+  });
+
+  it("never leaves a raw space or dot in its output, for arbitrary ids", () => {
+    const ids = ["a b.c:d", "...", "   ", "no-op", "tab\ttab", "emoji 🎉 dept.", "a%2Eb"];
+    for (const id of ids) {
+      const out = sanitizeId(id);
+      expect(out).not.toMatch(/[ .]/);
+    }
+  });
+
+  it("is injective for a representative set of colliding-looking inputs", () => {
+    const ids = ["a:b", "a%3Ab", "a.b", "a%2Eb", "a b", "a%20b", "resource:x", "thread:x", "a", "a "];
+    const encoded = ids.map(sanitizeId);
+    expect(new Set(encoded).size).toBe(ids.length);
+  });
+});
+
+describe("buildTag / resourceTag / threadTag", () => {
+  it("builds a stable kind:id tag", () => {
+    expect(buildTag("resource", "acme")).toBe("resource:acme");
+    expect(resourceTag("acme")).toBe("resource:acme");
+    expect(threadTag("t-1")).toBe("thread:t-1");
+  });
+
+  it("produces collision-free tags for ids containing ':' or spaces", () => {
+    // A resourceId that itself contains ':' must not be able to masquerade
+    // as a different kind:id pair once embedded in the tag: "resource:evil"
+    // built from resourceId="thread:evil" must differ from the real
+    // threadTag("evil").
+    const trickyResource = resourceTag("thread:evil");
+    expect(trickyResource).toBe("resource:thread%3Aevil");
+    expect(trickyResource).not.toBe(threadTag("evil"));
+    expect(trickyResource).not.toBe("resource:thread:evil");
+
+    const spaced = resourceTag("north america");
+    expect(spaced).toBe("resource:north%20america");
+    expect(spaced).not.toContain(" ");
+  });
+
+  it("two distinct resourceIds never collide after tagging", () => {
+    const ids = ["a:b", "a%3Ab", "a b", "a.b", "plain"];
+    const tags = ids.map(resourceTag);
+    expect(new Set(tags).size).toBe(ids.length);
+  });
+});
+
+describe("sessionIdFor", () => {
+  it("prefixes with mastra_", () => {
+    expect(sessionIdFor("thread-42")).toBe("mastra_thread-42");
+  });
+
+  it("passes ':' and spaces through unsanitized (no shared delimiter grammar to protect)", () => {
+    expect(sessionIdFor("a:b")).toBe("mastra_a:b");
+    expect(sessionIdFor("a b")).toBe("mastra_a b");
+  });
+
+  it("returns '' for a missing threadId", () => {
+    expect(sessionIdFor(undefined)).toBe("");
+    expect(sessionIdFor(null)).toBe("");
+    expect(sessionIdFor("")).toBe("");
+  });
+
+  it("is injective for distinct thread ids (fixed prefix + distinct suffix)", () => {
+    const ids = ["a", "b", "a:b", "ab", ":ab"];
+    const sessions = ids.map(sessionIdFor);
+    expect(new Set(sessions).size).toBe(ids.length);
+  });
+});
+
+describe("datasetNameForResource", () => {
+  it("tagged mode (default) always returns the single shared dataset", () => {
+    expect(datasetNameForResource({}, "resource-1")).toBe(DEFAULT_DATASET);
+    expect(datasetNameForResource({ scope: "tagged" }, "resource-1")).toBe(DEFAULT_DATASET);
+    expect(datasetNameForResource({ scope: "tagged", dataset: "myapp" }, "resource-1")).toBe("myapp");
+    // resourceId is irrelevant in tagged mode
+    expect(datasetNameForResource({ dataset: "myapp" }, undefined)).toBe("myapp");
+  });
+
+  it("dataset-per-resource mode derives one dataset name per resource", () => {
+    expect(datasetNameForResource({ scope: "dataset-per-resource" }, "acme")).toBe(
+      `${DEFAULT_DATASET_PREFIX}acme`,
+    );
+  });
+
+  it("dataset-per-resource honours a custom prefix", () => {
+    expect(
+      datasetNameForResource({ scope: "dataset-per-resource", datasetPrefix: "app_" }, "acme"),
+    ).toBe("app_acme");
+  });
+
+  it("dataset-per-resource sanitizes an unsafe resourceId (no space/dot in the result)", () => {
+    const name = datasetNameForResource({ scope: "dataset-per-resource" }, "acme corp.inc");
+    expect(name).not.toMatch(/[ .]/);
+    expect(name).toBe(`${DEFAULT_DATASET_PREFIX}acme%20corp%2Einc`);
+  });
+
+  it("dataset-per-resource falls back to a fixed suffix with no resourceId", () => {
+    expect(datasetNameForResource({ scope: "dataset-per-resource" }, undefined)).toBe(
+      `${DEFAULT_DATASET_PREFIX}default`,
+    );
+  });
+
+  it("two distinct resourceIds never collide into the same per-resource dataset name", () => {
+    const ids = ["a b", "a.b", "a:b", "a%20b"];
+    const names = ids.map((id) => datasetNameForResource({ scope: "dataset-per-resource" }, id));
+    expect(new Set(names).size).toBe(ids.length);
+  });
+});
+
+describe("resolveScope", () => {
+  it("tagged mode: dataset fixed, session_id prefixed, node_set has both tags", () => {
+    const resolved = resolveScope({ dataset: "myapp" }, { threadId: "t1", resourceId: "r1" });
+    expect(resolved.dataset).toBe("myapp");
+    expect(resolved.sessionId).toBe("mastra_t1");
+    expect(resolved.nodeSet).toEqual(["resource:r1", "thread:t1"]);
+    expect(resolved.nodeNameFilter).toEqual(["resource:r1"]);
+  });
+
+  it("appends config.nodeSet extras after the resource/thread tags", () => {
+    const resolved = resolveScope(
+      { dataset: "myapp", nodeSet: ["env:prod", "team:core"] },
+      { threadId: "t1", resourceId: "r1" },
+    );
+    expect(resolved.nodeSet).toEqual(["resource:r1", "thread:t1", "env:prod", "team:core"]);
+  });
+
+  it("omits a tag whose id is absent, and narrows the recall filter to the thread with no resourceId", () => {
+    const resolved = resolveScope({ dataset: "myapp" }, { threadId: "t1" });
+    expect(resolved.nodeSet).toEqual(["thread:t1"]);
+    expect(resolved.nodeNameFilter).toEqual(["thread:t1"]);
+    expect(resolved.sessionId).toBe("mastra_t1");
+  });
+
+  it("clears the recall filter only when neither id is present", () => {
+    const resolved = resolveScope({ dataset: "myapp" }, {});
+    expect(resolved.nodeNameFilter).toEqual([]);
+    expect(resolved.nodeSet).toEqual([]);
+  });
+
+  it("prefers the resource filter over the thread filter when both ids are present", () => {
+    const resolved = resolveScope({ dataset: "myapp" }, { threadId: "t1", resourceId: "r1" });
+    expect(resolved.nodeNameFilter).toEqual(["resource:r1"]);
+  });
+
+  it("no threadId at all: sessionId is '', thread tag absent", () => {
+    const resolved = resolveScope({ dataset: "myapp" }, { resourceId: "r1" });
+    expect(resolved.sessionId).toBe("");
+    expect(resolved.nodeSet).toEqual(["resource:r1"]);
+  });
+
+  it("dataset-per-resource mode: dataset derives from resourceId, tags unaffected", () => {
+    const resolved = resolveScope(
+      { scope: "dataset-per-resource", datasetPrefix: "app_" },
+      { threadId: "t1", resourceId: "acme" },
+    );
+    expect(resolved.dataset).toBe("app_acme");
+    expect(resolved.nodeSet).toEqual(["resource:acme", "thread:t1"]);
+    expect(resolved.nodeNameFilter).toEqual(["resource:acme"]);
+  });
+
+  it("stays stable and collision-free for ids containing ':' or spaces end to end", () => {
+    const a = resolveScope({ dataset: "myapp" }, { threadId: "team:a b", resourceId: "user:1" });
+    const b = resolveScope({ dataset: "myapp" }, { threadId: "team", resourceId: "a b:user:1" });
+    expect(a.nodeSet).not.toEqual(b.nodeSet);
+    expect(new Set([...a.nodeSet, ...b.nodeSet]).size).toBe(a.nodeSet.length + b.nodeSet.length);
+    expect(a.sessionId).toBe("mastra_team:a b");
+  });
+});

--- a/integrations/mastra/examples/basic-agent.ts
+++ b/integrations/mastra/examples/basic-agent.ts
@@ -1,0 +1,91 @@
+/**
+ * Basic usage: `withCognee()` on a Mastra `Agent` — automatic recall
+ * (pre-turn) and capture (post-turn), no change to conversation flow. Run:
+ * `docker compose -f examples/docker-compose.smoke.yml up`, then
+ * `npx tsx examples/basic-agent.ts`.
+ *
+ * Only fires when the agent also has a Mastra `Memory` attached and the call
+ * passes `memory: { thread, resource }` — `withCognee()` appends processors only.
+ */
+
+import { Agent, type AgentConfig } from "@mastra/core/agent";
+// `@mastra/memory` is a peer of `@mastra/core`, not a dependency of this
+// package — install it in your own project (`npm i @mastra/memory`) the
+// same way you would for any other Mastra agent that wants message
+// persistence. Not present in this monorepo's own devDependencies (this
+// example is excluded from this package's own `tsconfig.json`/`tsc` run —
+// see the top-level `exclude: ["examples"]` — precisely so a peer this
+// package itself never imports doesn't have to be installed just to build
+// the library).
+import { Memory } from "@mastra/memory";
+
+import { withCognee } from "../index.js";
+
+// Declared as its own typed constant (rather than an inline object literal
+// passed straight into `withCognee()`) so TypeScript infers `withCognee`'s
+// generic parameter from the full `AgentConfig` shape below, instead of
+// falling back to its `Partial<ProcessorFields>` constraint and rejecting
+// `id`/`name`/`model`/`memory` as excess properties on the literal.
+const baseAgentConfig: AgentConfig = {
+  id: "support-agent",
+  name: "Support Agent",
+  instructions:
+    "You are a helpful support agent. Use anything cognee recalls about this user or thread as background " +
+    "context, but always answer the user's actual question directly.",
+  model: "openai/gpt-5.2",
+  // A bare Memory is enough to plumb thread/resource ids through to
+  // cognee's processors, even if you don't otherwise rely on Mastra's own
+  // message history — see the file header note above.
+  memory: new Memory(),
+};
+
+export const supportAgent = new Agent(
+  withCognee(
+    baseAgentConfig,
+    {
+      // Explicit config here wins over COGNEE_* env vars, which win over
+      // this package's own defaults.
+      baseUrl: process.env.COGNEE_API_URL ?? "http://localhost:8000",
+      apiKey: process.env.COGNEE_API_KEY,
+      dataset: "support-agent",
+      recall: {
+        // CHUNKS is already this package's default for the automatic path
+        // (no per-turn LLM cost inside cognee) — spelled out here for clarity.
+        searchType: "CHUNKS",
+        topK: 5,
+      },
+      write: {
+        // Only capture the assistant's own answers automatically; skip
+        // re-ingesting the user's question verbatim (it's already in
+        // Mastra's own message history via `memory: new Memory()` above).
+        mode: "assistant-only",
+      },
+    },
+  ),
+);
+
+async function main(): Promise<void> {
+  const threadId = "example-thread-1";
+  const resourceId = "example-user-1";
+
+  const first = await supportAgent.generate([{ role: "user", content: "I prefer dark mode and TypeScript." }], {
+    memory: { thread: threadId, resource: resourceId },
+  });
+  console.log("assistant:", first.text);
+
+  // A later turn, possibly in a different process/session, same thread +
+  // resource: the input processor recalls what cognee has ingested so far
+  // (subject to cognee's own ingest -> cognify -> recallable latency — see
+  // the README's "Failure behaviour" note; this is not immediate).
+  const second = await supportAgent.generate([{ role: "user", content: "What editor theme do I use?" }], {
+    memory: { thread: threadId, resource: resourceId },
+  });
+  console.log("assistant:", second.text);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/integrations/mastra/examples/docker-compose.smoke.yml
+++ b/integrations/mastra/examples/docker-compose.smoke.yml
@@ -1,0 +1,20 @@
+# Minimal cognee server for local dev and the live smoke test — embedded
+# SQLite + LanceDB + Kuzu, no external services to stand up.
+#
+# Usage: `LLM_API_KEY=sk-... docker compose -f examples/docker-compose.smoke.yml up`,
+# then `COGNEE_LIVE=1 npm run test:live` from this package's root.
+#
+# Auth is enforced on every route regardless of REQUIRE_AUTHENTICATION
+# (cognee 1.5.4); default_user@example.com / default_password ships built in.
+services:
+  cognee:
+    image: cognee/cognee:main
+    ports: ["8000:8000"]
+    # Offline variant (no OpenAI key needed): replace LLM_API_KEY below with
+    #   LLM_PROVIDER: "ollama"
+    #   LLM_MODEL: "ollama_chat/llama3.1"
+    #   EMBEDDING_PROVIDER: "fastembed"
+    # (needs a separately-running Ollama instance with llama3.1 pulled;
+    # fastembed runs embeddings locally, no external embedding key needed).
+    environment:
+      LLM_API_KEY: ${LLM_API_KEY}

--- a/integrations/mastra/examples/tools-only-agent.ts
+++ b/integrations/mastra/examples/tools-only-agent.ts
@@ -1,0 +1,55 @@
+/**
+ * Tools-only usage: `createCogneeTools()` as ordinary `Agent` tools, no
+ * input/output processors wired in — the model decides when to search, ask,
+ * or write to cognee itself. Independent of `createCogneeProcessors`/
+ * `withCognee` (see `examples/basic-agent.ts` for that path).
+ *
+ * Run: `docker compose -f examples/docker-compose.smoke.yml up`, then
+ * `npx tsx examples/tools-only-agent.ts`.
+ */
+
+import { Agent } from "@mastra/core/agent";
+
+import { createCogneeTools } from "../index.js";
+
+const cogneeTools = createCogneeTools({
+  baseUrl: process.env.COGNEE_API_URL ?? "http://localhost:8000",
+  apiKey: process.env.COGNEE_API_KEY,
+  dataset: "tools-only-agent",
+  // Destructive and opt-in only — omit this entirely unless the agent needs
+  // to delete specific memories on explicit user request. Left here only to
+  // show the knob exists.
+  tools: { enableForget: false },
+});
+
+export const researchAgent = new Agent({
+  id: "research-agent",
+  name: "Research Agent",
+  instructions:
+    "You have three cognee tools: cognee_search (fast, cheap, use it first for lookups), cognee_ask (slow and " +
+    "expensive — an LLM call runs inside cognee — only use it when you need graph reasoning over a " +
+    "written synthesis, not a quick fact check), and cognee_remember (call it explicitly when the user asks you " +
+    "to remember something, or when you learn a durable fact worth keeping beyond this conversation).",
+  model: "openai/gpt-5.2",
+  tools: cogneeTools,
+  // No `memory` field at all — this agent has no message history of its
+  // own. That's fine for the tools-only surface (unlike `withCognee()`'s
+  // processors, `createCogneeTools()` does not need a Mastra `Memory`
+  // instance or a `memory: { thread, resource }` call option to function —
+  // see `src/processors.ts`'s file header for why that requirement is
+  // specific to the processor surface).
+});
+
+async function main(): Promise<void> {
+  const result = await researchAgent.generate([
+    { role: "user", content: "Remember that our deployment target is Railway, then tell me what you just saved." },
+  ]);
+  console.log("assistant:", result.text);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/integrations/mastra/index.ts
+++ b/integrations/mastra/index.ts
@@ -1,0 +1,81 @@
+/**
+ * `@cognee/cognee-mastra` — public barrel. Re-exports `createCogneeProcessors`,
+ * `withCognee`, `createCogneeTools`, the four per-tool factories,
+ * `CogneeClient` (the escape hatch), `resolveConfig`, `VERSION`, and every
+ * public type these surfaces take or return. Not re-exported:
+ * `src/capabilities.ts` and `src/scope.ts`/`src/format.ts`'s helpers —
+ * internal implementation details of `CogneeClient`/the processors/the tools.
+ */
+
+export { VERSION } from "./src/version.js";
+export { CogneeApiError, isRetryable } from "./src/errors.js";
+export type {
+  SearchType,
+  ContextFormat,
+  CogneeMastraConfig,
+  CogneeRecallConfig,
+  CogneeWriteConfig,
+  CogneeToolsConfig,
+  CogneeAuthConfig,
+  HealthResponse,
+  LoginRequest,
+  LoginResponse,
+  DatasetDTO,
+  EnsureDatasetRequest,
+  RecallRequest,
+  RecallResponseItem,
+  RecallResponse,
+  SearchResponseItem,
+  SearchResponse,
+  RememberRequest,
+  AddRequest,
+  CognifyRequest,
+  QAEntryDTO,
+  RememberEntryRequest,
+  RememberResult,
+  ForgetRequest,
+  PipelineRunStatusValue,
+  DatasetStatusResponse,
+  ImproveRequest,
+  RecallHit,
+} from "./src/types.js";
+
+// -- Client (escape hatch) ---------------------------------------------------
+
+export { CogneeClient } from "./src/client.js";
+export type { RequestOptions } from "./src/client.js";
+
+// -- Config (resolveConfig) --------------------------------------------------
+
+export { resolveConfig, redactConfigForLogging } from "./src/config.js";
+export type {
+  ResolvedCogneeConfig,
+  ResolvedCogneeRecallConfig,
+  ResolvedCogneeWriteConfig,
+  ResolvedCogneeToolsConfig,
+} from "./src/config.js";
+
+// -- Circuit breaker (escape hatch for CogneeProcessorsConfig.breaker) ------
+
+export { CircuitBreaker, DEFAULT_BREAKER_THRESHOLD, DEFAULT_BREAKER_COOLDOWN_MS } from "./src/breaker.js";
+export type { CircuitBreakerOptions } from "./src/breaker.js";
+
+// -- Processors ---------------------------------------------------------------
+
+export { CogneeInputProcessor, CogneeOutputProcessor, createCogneeProcessors } from "./src/processors.js";
+export type { CogneeProcessorOptions, CogneeProcessors, CogneeProcessorsConfig } from "./src/processors.js";
+
+// -- withCognee ----------------------------------------------------------------
+
+export { withCognee } from "./src/with-cognee.js";
+
+// -- Tools -----------------------------------------------------------------------
+
+export {
+  createCogneeSearchTool,
+  createCogneeAskTool,
+  createCogneeRememberTool,
+  createCogneeForgetTool,
+  createCogneeTools,
+} from "./src/tools.js";
+export type { CogneeToolFactoryOptions, CogneeToolsFactoryConfig } from "./src/tools.js";

--- a/integrations/mastra/jest.config.mjs
+++ b/integrations/mastra/jest.config.mjs
@@ -1,0 +1,33 @@
+/**
+ * ts-jest, ESM mode: this package is "type": "module" (NodeNext resolution,
+ * so sources use .js-suffixed relative imports). extensionsToTreatAsEsm and
+ * ts-jest/presets/default-esm make Jest run .ts files as native ES modules;
+ * this requires Node's --experimental-vm-modules flag, which the
+ * test/test:live scripts in package.json already pass.
+ */
+
+/** @type {import('jest').Config} */
+export default {
+  preset: "ts-jest/presets/default-esm",
+  testEnvironment: "node",
+  extensionsToTreatAsEsm: [".ts"],
+  // Rewrites the .js extension NodeNext requires in relative imports back to
+  // extension-less specifiers, so ts-jest's resolver finds the .ts source
+  // instead of a nonexistent .js file.
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  // isolatedModules lives in tsconfig.json, not here — ts-jest 29 deprecates
+  // this option and warns (TS151002) if set on both.
+  transform: {
+    "^.+\\.tsx?$": ["ts-jest", { useESM: true }],
+  },
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  // *.test.ts keeps __tests__/test-utils/** (helpers, not specs) out of the
+  // suite; testPathIgnorePatterns additionally skips __tests__/live/ so
+  // `npm test` never touches it even without the CLI's own ignore flag.
+  testMatch: ["<rootDir>/__tests__/**/*.test.ts"],
+  testPathIgnorePatterns: ["/node_modules/", "<rootDir>/__tests__/live/"],
+  collectCoverageFrom: ["src/**/*.ts"],
+  coverageProvider: "v8",
+};

--- a/integrations/mastra/jest.setup.ts
+++ b/integrations/mastra/jest.setup.ts
@@ -1,0 +1,31 @@
+/**
+ * Suite-wide sandbox for `os.homedir()`. `src/breaker.ts` persists circuit
+ * breaker state under the developer's home directory, so any test that
+ * trips or persists it would write there unless redirected here instead.
+ * Setting `process.env.HOME` does not work: jest gives each test file its
+ * own `process.env`, which never reaches the C-level `getenv` libuv's
+ * `uv_os_homedir` reads.
+ */
+
+// Imported explicitly rather than used as an ambient global: under this
+// package's ESM preset, Jest doesn't inject `jest` into module scope the way
+// it does for CommonJS, so a bare `jest.mock(...)` reference throws
+// ReferenceError here.
+import { jest } from "@jest/globals";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+
+const actualOs = jest.requireActual<typeof import("node:os")>("node:os");
+
+/** One sandbox home per test file (each gets its own module registry). */
+const sandboxHome = mkdtempSync(join(actualOs.tmpdir(), "cognee-mastra-sandbox-home-"));
+
+// A test needing per-case control can declare its own `jest.mock("node:os",
+// ...)`, which wins over this one.
+jest.mock("node:os", () => ({
+  ...jest.requireActual<typeof import("node:os")>("node:os"),
+  homedir: () => sandboxHome,
+}));
+
+// Surfaced so a failing test can report where its state went.
+(globalThis as Record<string, unknown>).__COGNEE_SANDBOX_HOME__ = sandboxHome;

--- a/integrations/mastra/package-lock.json
+++ b/integrations/mastra/package-lock.json
@@ -1,0 +1,7044 @@
+{
+  "name": "@cognee/cognee-mastra",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@cognee/cognee-mastra",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@mastra/core": "^1.64.0",
+        "@mastra/memory": "^1.28.2",
+        "@types/jest": "^30.0.0",
+        "@types/node": "^20.0.0",
+        "jest": "^30.2.0",
+        "ts-jest": "^29.4.6",
+        "typescript": "^5.9.0",
+        "zod": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@mastra/core": ">=1.64.0",
+        "zod": "^3.25.0"
+      }
+    },
+    "node_modules/@a2a-js/sdk-v0_3": {
+      "name": "@a2a-js/sdk",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.14.tgz",
+      "integrity": "sha512-F6Ew1AtPzCLhTn8h9yiqTe7DiDf6XVrSnq9V1YqSl9eWqPm6anMveTiKdCSb/76cW0YiJc24rNaUrVezFFHbqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.10.2",
+        "@grpc/grpc-js": "^1.11.0",
+        "express": "^4.21.2 || ^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        },
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@a2a-js/sdk-v1": {
+      "name": "@a2a-js/sdk",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-1.0.1.tgz",
+      "integrity": "sha512-CJQdh3Wzwo8qIx5UUkSJ7+7BEI16PB+MXMHHNSmx8JQsQed2HlQgvx1ENOiKUfYA3PlcEvxIwv14dBblhDuPmw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jose": "^6.2.3",
+        "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.10.2",
+        "@grpc/grpc-js": "^1.11.0",
+        "express": "^4.21.2 || ^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        },
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils-v6": {
+      "name": "@ai-sdk/provider-utils",
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.40.tgz",
+      "integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils-v7": {
+      "name": "@ai-sdk/provider-utils",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.13.tgz",
+      "integrity": "sha512-fScDJMDnTbx32kLDQqp0MvPjvwkgiwvlBxlmIg7XW5PbS91LG6JjH3PQG+34oMFglqfpQA355e24OdGj5PPoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils-v7/node_modules/@ai-sdk/provider": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.4.tgz",
+      "integrity": "sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-v5": {
+      "name": "@ai-sdk/provider",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
+      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-v6": {
+      "name": "@ai-sdk/provider",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-v7": {
+      "name": "@ai-sdk/provider",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.4.tgz",
+      "integrity": "sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-2.1.5.tgz",
+      "integrity": "sha512-VwGZqqjAWPICTmxUZnbpEfO60LhPWzquik+bmyXGY7pYRn6diEvCI5i6Ca+J6o2y4vS73HrpuMTo2dOvUevH8w==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.5.1.tgz",
+      "integrity": "sha512-u5Ncuc+gXVUwjNMFQOnphHo2Qx2DxyC8Dvpmf4HCx4y0kvSkRRNiQYRixrvOP4V7y52JcSuNxqochCt0PpdHVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.5.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.5.1",
+        "jest-util": "30.5.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.5.1.tgz",
+      "integrity": "sha512-BL9g6CJUUhIbdoAflz/Va658erSSXUIvU8XUYiWNTbZljJjZ5yaC9EJ9/dQ19rpbYV3ZOK4sBACqhPaTyhoUIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.5.1",
+        "@jest/pattern": "30.5.0",
+        "@jest/reporters": "30.5.1",
+        "@jest/test-result": "30.5.1",
+        "@jest/transform": "30.5.1",
+        "@jest/types": "30.5.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.5.1",
+        "jest-config": "30.5.1",
+        "jest-haste-map": "30.5.1",
+        "jest-message-util": "30.5.1",
+        "jest-regex-util": "30.5.0",
+        "jest-resolve": "30.5.1",
+        "jest-resolve-dependencies": "30.5.1",
+        "jest-runner": "30.5.1",
+        "jest-runtime": "30.5.1",
+        "jest-snapshot": "30.5.1",
+        "jest-util": "30.5.1",
+        "jest-validate": "30.5.1",
+        "jest-watcher": "30.5.1",
+        "pretty-format": "30.5.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.5.0.tgz",
+      "integrity": "sha512-OsqBjHXCn8cadasoAZBP6nWYvMsRhpMzGXTpxJ5aO04NlbdhIz+FVe3q49l0AwVhsz/cEmIpBes6gAFl1/dWQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.5.1.tgz",
+      "integrity": "sha512-eYJAkOsrpwDXPcoLNEG6lN9Zo3Cy35pxnVQD74vyIfsi/Q8wB/lZFsEjU4wrecOgT4ZviQDZaX/cFIJyMdMxTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.5.1",
+        "@jest/types": "30.5.1",
+        "@types/node": "*",
+        "jest-mock": "30.5.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.5.1.tgz",
+      "integrity": "sha512-uOGd40P/COyUp9xHf5jeGiGJC2/ANg+2+Tk9/xN5/LxmlY/r/gxsPrx3DTEtaRZsLAX4wgNSLEDELZ5bmVs2bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "30.5.1",
+        "jest-snapshot": "30.5.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.5.1.tgz",
+      "integrity": "sha512-WcRWhHQdTMRDpyWKZ/6MINBmovI7zeD+bL8wFjCncRV3NQOwKy1X45IfyblfHR4k/XciIlNEdFL9QjFO+HNKOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.5.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.5.1.tgz",
+      "integrity": "sha512-rEkV6YzpBXo/L9cnj2ibyuYZuyGiNWaPUsyCu3HYJbqCV4jnEiKmf7hId20z8eKjZ0JQ9jtIYKxRSmYB/OYSsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.5.1",
+        "@sinonjs/fake-timers": "^15.4.0",
+        "@types/node": "*",
+        "jest-message-util": "30.5.1",
+        "jest-mock": "30.5.1",
+        "jest-util": "30.5.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.5.0.tgz",
+      "integrity": "sha512-9/2VUPitAjmBzbvDvqrxmvB7BzWsBW0WmkkojX1ODuxX1NLGxx9gfaZpHB0z8DtJ9uhGNmZG/VXBhf8uO0OV8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.5.1.tgz",
+      "integrity": "sha512-VhqvQ251XIC7pk46YymI3HCeBLOdvriDw9zibekodAHEwoVvbVVgpU5H13GvmyOAzxtZCfsm1uvzqkaqJf2I+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.5.1",
+        "@jest/expect": "30.5.1",
+        "@jest/types": "30.5.1",
+        "jest-mock": "30.5.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.5.0.tgz",
+      "integrity": "sha512-HdNQYSdRTEBNrginaqzQtTjG0HRMfrra/z6Ok7uL3S87vSlarIVohEsJsSj5edu3MiHoHjAkvPROz5ZjoKai+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.5.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/reporters": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.5.1.tgz",
+      "integrity": "sha512-RbUXIfv85KxitJn4l3MpAoMilkvXe2QCO5lXxHWftywo/VdZ5vkEoHRDgphcxP6qmoIkUaN8/UZj6NhdkIFdJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "30.5.1",
+        "@jest/test-result": "30.5.1",
+        "@jest/transform": "30.5.1",
+        "@jest/types": "30.5.1",
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^13.0.6",
+        "graceful-fs": "^4.2.11",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "30.5.1",
+        "jest-util": "30.5.1",
+        "jest-worker": "30.5.1",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.5.0.tgz",
+      "integrity": "sha512-/hunigyNpc4RCjC0VaW3f5RCUZVM2+WQ65qP7z083Gmvac7or2LI50XVNOtE4YPgBpV0yxYiAgorAPGniCoJmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.5.1.tgz",
+      "integrity": "sha512-V3wnxNtiVmw5PPVg433Cn3VdXnsOeu/ofLw3KC04Bn2y1wIlU5kozXQn48rhrgj/02LrCVtntTEF1yBha0XSUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.5.1",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.5.0.tgz",
+      "integrity": "sha512-xWpTJP9D0bDFGbPGT8XuWSwwha/iHADyyKzUnMx4UbdgnHugxrDaQFO4RZ8x4ZsFzRP6pNii8uvlgKCDxCIuDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "callsites": "^3.1.0",
+        "convert-source-map": "^2.0.0",
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.5.1.tgz",
+      "integrity": "sha512-A/1S6ZBdpic50E0pxLgvaB9XNPL4k7AksmG69OO2oiotxciWZwHkbOec+qbIi+uUtIIByOVlXJUl97oZUsz+Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.5.1",
+        "@jest/types": "30.5.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.5.1.tgz",
+      "integrity": "sha512-SHcPnrjdVRYJv6y6l4JUTy4Jccu7zmO6BmiOfOA34UiVBto22s19WiDC0A/2qfM7MWB/qdcoqfSIRMitpjTT4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.5.1",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.5.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.5.1.tgz",
+      "integrity": "sha512-EDnDhn0jleU9ZhpVoA4gvqw+Ev0iw/r5upNT2b79RiwiaTiYAMMhvNJP3lmocjIe5J2ZkoNr0B3K/J6O5GIm4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.5.1",
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "babel-plugin-istanbul": "^8.0.0",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.5.1",
+        "jest-regex-util": "30.5.0",
+        "jest-util": "30.5.1",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.5.1.tgz",
+      "integrity": "sha512-LvVYn83nnXPl+Rg98nvcFgjx6nRMTArhSn6RAX/w3ELn54S8A42TYZvsCMdGUqTM8S0wyXbtlQdU6Hi6dykj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.5.0",
+        "@jest/schemas": "30.5.0",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@mastra/core": {
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@mastra/core/-/core-1.64.0.tgz",
+      "integrity": "sha512-+fuvDeORYWIb+SJrGQlXQi6r1JCxd05g3SNCDepnO910j4uqxMWf5s22Ta0sRSR5zbKRx2NUZoWPAfQt2xF4hQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@a2a-js/sdk-v0_3": "npm:@a2a-js/sdk@~0.3.14",
+        "@a2a-js/sdk-v1": "npm:@a2a-js/sdk@~1.0.1",
+        "@ai-sdk/provider-utils-v6": "npm:@ai-sdk/provider-utils@4.0.40",
+        "@ai-sdk/provider-utils-v7": "npm:@ai-sdk/provider-utils@5.0.13",
+        "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.3",
+        "@ai-sdk/provider-v6": "npm:@ai-sdk/provider@3.0.14",
+        "@ai-sdk/provider-v7": "npm:@ai-sdk/provider@4.0.4",
+        "@isaacs/ttlcache": "^2.1.5",
+        "@lukeed/uuid": "^2.0.1",
+        "@mastra/schema-compat": "1.3.8",
+        "@modelcontextprotocol/server": "2.0.0",
+        "@sindresorhus/slugify": "^2.2.1",
+        "@standard-schema/spec": "^1.1.0",
+        "ajv": "^8.20.0",
+        "chat": "^4.34.0",
+        "croner": "^10.0.1",
+        "dotenv": "^17.3.1",
+        "execa": "^9.6.1",
+        "fastq": "^1.20.1",
+        "gray-matter": "^4.0.3",
+        "ignore": "^7.0.5",
+        "jpeg-js": "^0.4.4",
+        "json-schema": "^0.4.0",
+        "lru-cache": "^11.2.7",
+        "p-map": "^7.0.4",
+        "p-retry": "^7.1.1",
+        "picomatch": "^4.0.3",
+        "posthog-node": "^5.46.1",
+        "tokenx": "^1.3.0",
+        "ws": "^8.21.0",
+        "xxhash-wasm": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@mastra/memory": {
+      "version": "1.28.2",
+      "resolved": "https://registry.npmjs.org/@mastra/memory/-/memory-1.28.2.tgz",
+      "integrity": "sha512-XneY2QdmC/nUjfaax7z4Qdnsw6WgsFWc1QZFd79AkQHl0g0bDvpwjQlbDZ6wnZ2YygRDCWVt0Ew3dDI2Ao3QXg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mastra/schema-compat": "1.3.8",
+        "async-mutex": "^0.5.0",
+        "diff": "^8.0.3",
+        "json-schema": "^0.4.0",
+        "lru-cache": "^11.2.7",
+        "probe-image-size": "^7.2.3",
+        "tokenx": "^1.3.0",
+        "xxhash-wasm": "^1.1.0",
+        "zod": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "peerDependencies": {
+        "@mastra/core": ">=1.4.1-0 <2.0.0-0"
+      }
+    },
+    "node_modules/@mastra/memory/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@mastra/schema-compat": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@mastra/schema-compat/-/schema-compat-1.3.8.tgz",
+      "integrity": "sha512-uGGQlb/QAIgghHf/FQLfnpHbUMXWWJDFlv0FQ/p0K6TjT8OVdWC9uNPdwQmFYu8Fzut4Z+LmzNkJ5S378/41Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema-to-zod": "^2.7.0",
+        "zod-from-json-schema": "^0.5.2"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
+      }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+      "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.6.0",
+        "@parcel/watcher-darwin-arm64": "2.6.0",
+        "@parcel/watcher-darwin-x64": "2.6.0",
+        "@parcel/watcher-freebsd-x64": "2.6.0",
+        "@parcel/watcher-linux-arm-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm-musl": "2.6.0",
+        "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm64-musl": "2.6.0",
+        "@parcel/watcher-linux-x64-glibc": "2.6.0",
+        "@parcel/watcher-linux-x64-musl": "2.6.0",
+        "@parcel/watcher-win32-arm64": "2.6.0",
+        "@parcel/watcher-win32-x64": "2.6.0"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+      "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+      "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+      "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+      "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+      "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+      "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+      "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+      "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+      "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+      "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+      "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+      "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.50.5",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.50.5.tgz",
+      "integrity": "sha512-afEchuShDaVIoxAIj76kDZQ1DhfesDmgfVp+mtTzsA3wlc8DF5uoz8YjuTjnxOicWkpP5HCDqYidK/1kT125Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.409.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.409.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.409.0.tgz",
+      "integrity": "sha512-239umoaZVb2GBaXeEyJpwFvjhrrChJH8NHCwiao23EBSu3NA6EN0MTMoaHSmMEf4yjiXEFFoYJA6FjJAXF5HGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/slugify": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.2.1.tgz",
+      "integrity": "sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/transliterate": "^1.0.0",
+        "escape-string-regexp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/transliterate": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-1.6.0.tgz",
+      "integrity": "sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
+      "integrity": "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.5.1.tgz",
+      "integrity": "sha512-ge1xUVZS91ml09YRMgRGgeKJ4YJpcOiuwteAxFBYLugQyp7cRw+hHej6Ho0vPjvLrjq60bb7JPHH9LAMA1/krA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "30.5.1",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^8.0.0",
+        "babel-preset-jest": "30.5.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-8.0.0.tgz",
+      "integrity": "sha512-18wCskrN3DgbuBmp1gr7LBGT8xdz5xhQQqFvFhVxbkl8VBCrMKQ2YtqBWtUal1Zrc1HTuX0011+Brjw78TCFkg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "workspaces": [
+        "test/babel-8"
+      ],
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.5.0.tgz",
+      "integrity": "sha512-gtGo1B+u14jrZQv6TdSWIWkTqclboo7Qn+dFAGUOIuXLFuJKAdg3U5MIWzZnW4vfUb4dX9skmAMiby86e/SF4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.5.0.tgz",
+      "integrity": "sha512-ZGPn5ClP4lBDpuOK8W1yQIOy359HmbnZv3suucAlIe+SEE9yDsxV4S2PjSbH2Vc97U+WmzYD7vw3kr8NsQ/i6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.5.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1 || ^8.0.0"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chat": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/chat/-/chat-4.40.0.tgz",
+      "integrity": "sha512-slu3VDxItlelEZ8A5vqzlmtT2WErqj2YCGuhhcNx+Ev0+wHeBUqUDUA7hXkca+BfFtW1ZX7ECcySCTG2q2gefg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@workflow/serde": "4.1.0-beta.2",
+        "mdast-util-to-string": "^4.0.0",
+        "remark-gfm": "^4.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "remend": "^1.2.1",
+        "unified": "^11.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "ai": "^6.0.182 || ^7.0.0",
+        "workflow": "^5.0.0-beta.35",
+        "zod": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ai": {
+          "optional": true
+        },
+        "workflow": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/chat/node_modules/@workflow/serde": {
+      "version": "4.1.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0-beta.2.tgz",
+      "integrity": "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/croner": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
+      "integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "other",
+          "url": "https://paypal.me/hexagonpp"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/hexagon"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.422",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+      "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit-x": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.5.1.tgz",
+      "integrity": "sha512-m8YrYgvKe9+9gEnWEuKz+qCGfHqkrff7PPfyDnOFkjsfYRKqiYyOxDFMFieCGAuhtk/VNm63tvNgKZVzVy+Hvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.5.1",
+        "@jest/get-type": "30.5.0",
+        "jest-matcher-utils": "30.5.1",
+        "jest-message-util": "30.5.1",
+        "jest-mock": "30.5.1",
+        "jest-util": "30.5.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+      "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.5.1.tgz",
+      "integrity": "sha512-3qrR8+ZXFnn7y0H2yjWQNkGGBLBY4zTRoTMAq9zJcgwLLtlyonfsCLviIXK9xuE2KgIyM+M36AFcoK2DgFR36w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.5.1",
+        "@jest/types": "30.5.1",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.5.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.5.1.tgz",
+      "integrity": "sha512-0+bvMM/ENhDI29Z8q1r4HxiDIi4G5tnBmSw4esfPQoj9q8Nik7KIyuxHkTVnnniJQf05SxpGaKDQ+4h28ynGPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "jest-util": "30.5.1",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-changed-files/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.5.1.tgz",
+      "integrity": "sha512-NgliezXQ6yznqR4W5Gqw++0cZSbBZlF0NknNIAE5VmSJKWOtmWJmWnBq3TSkUOVBTPrT7FGGhVdA8DLWnxo2Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.5.1",
+        "@jest/expect": "30.5.1",
+        "@jest/test-result": "30.5.1",
+        "@jest/types": "30.5.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "co": "^4.6.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.5.1",
+        "jest-matcher-utils": "30.5.1",
+        "jest-message-util": "30.5.1",
+        "jest-runtime": "30.5.1",
+        "jest-snapshot": "30.5.1",
+        "jest-util": "30.5.1",
+        "p-limit": "^3.1.0",
+        "pretty-format": "30.5.1",
+        "pure-rand": "^7.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.5.1.tgz",
+      "integrity": "sha512-uwNYepWgaNBCplm42fCIUZTf/tIEHIy5AYvx7eL1BrwIgyjPt+2poouR23UO2yopIP+kV8oZFHfv+l4pg/8prQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.5.1",
+        "@jest/test-result": "30.5.1",
+        "@jest/types": "30.5.1",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.5.1",
+        "jest-util": "30.5.1",
+        "jest-validate": "30.5.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.5.1.tgz",
+      "integrity": "sha512-L8PKM2X/ngG8PxfLMqglKGZjylPgw84bVPUlMY9W/o76TnLqPWrmQgsaT0HrheGdRtpGE5FbmREA0Kvb+Qx5gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.5.0",
+        "@jest/pattern": "30.5.0",
+        "@jest/test-sequencer": "30.5.1",
+        "@jest/types": "30.5.1",
+        "babel-jest": "30.5.1",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^13.0.6",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.5.1",
+        "jest-docblock": "30.5.0",
+        "jest-environment-node": "30.5.1",
+        "jest-regex-util": "30.5.0",
+        "jest-resolve": "30.5.1",
+        "jest-runner": "30.5.1",
+        "jest-util": "30.5.1",
+        "jest-validate": "30.5.1",
+        "parse-json": "^5.2.0",
+        "pretty-format": "30.5.1",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "esbuild-register": ">=3.4.0",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "esbuild-register": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.5.1.tgz",
+      "integrity": "sha512-e3cNNMpv8Kh20MjjphTXs+3Vz7DQyLM1nft7KJhnh46atFhjVJRa+0Hq0beywuwsACtMQUBihQkFl8zxb7gt1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.5.0",
+        "@jest/get-type": "30.5.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.5.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.5.0.tgz",
+      "integrity": "sha512-NwDqcxtoZi33RhuW+zJS/RVA3rmheQ8BnwpYZuc/Eruaz6seQb7+aoCeDZu/3X7W2XmD8DbSo9Pn72DbKsBFYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.5.1.tgz",
+      "integrity": "sha512-S1af0TU4v1EZ/AUlkFs/sxf/5KGsbAT9kRgdyoMX/x72y7C8ZEgETE5o1TPnbKRnrbprc5FR/moYLfdRmqEjsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.5.0",
+        "@jest/types": "30.5.1",
+        "chalk": "^4.1.2",
+        "jest-util": "30.5.1",
+        "pretty-format": "30.5.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.5.1.tgz",
+      "integrity": "sha512-LrPj3sPMjsQoOB3jrb8p/sa+XkSFNKo60TTsyc+EB2kxQJHgbwElpXnx1yX25fdFn5958FIObRtcLSHyV8VIAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.5.1",
+        "@jest/fake-timers": "30.5.1",
+        "@jest/types": "30.5.1",
+        "@types/node": "*",
+        "jest-mock": "30.5.1",
+        "jest-util": "30.5.1",
+        "jest-validate": "30.5.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.5.1.tgz",
+      "integrity": "sha512-VIFgt67jW480YDxKfEv9IYQKrFpYt7bOCMn3VsnjK7AK9qo7p6acpnA1DHwsVOULE3dTaYew/6JaTD/d0VDHoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.5.1",
+        "@parcel/watcher": "^2.6.0",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "fdir": "^6.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.5.0",
+        "jest-util": "30.5.1",
+        "jest-worker": "30.5.1",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.5.1.tgz",
+      "integrity": "sha512-gt4GT2aWgEoCNTcBe4rqS74xTIUJxi+UD9SNSu9aOk5LmTEd6fS5KSTmAKAfitCCktQHNN+upUuL6EkBfFbMDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.5.0",
+        "pretty-format": "30.5.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.5.1.tgz",
+      "integrity": "sha512-aroZVqwOz/wC2y6pC+obgFWKV9viaQWQTTSB6W5H55+egtUczIfXR/rxExTv92xD/ADYwpqaYfVWx1aqwKg7FA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.5.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.5.1",
+        "pretty-format": "30.5.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.5.1.tgz",
+      "integrity": "sha512-UdQlLdd9wL/Ys7xRErckqwD6wPlSZYueosSWuHc1r2ztGLwlgPvtSJq2+BPEgaEY13WLvfFbmhTj8pba0Sd1jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.5.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.5.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.5.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.5.1.tgz",
+      "integrity": "sha512-9fVjc3leUpGID2/by/LU4Dvdcp7PFh9LlxS3QRWK3ABm+KtvEVsG/AEGeLY3gKOZsjkBxyfwGltoAVlW7dygHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.5.1",
+        "@jest/types": "30.5.1",
+        "@types/node": "*",
+        "jest-util": "30.5.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.5.0.tgz",
+      "integrity": "sha512-Mg0WK7A6xRHLSA1udJ8y9f3lM0uUhFTBnLKzwPmqB9AylvpleJ6BLemR8K9dK27DY+cesDryoA7yLZCAHsPG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.5.1.tgz",
+      "integrity": "sha512-wprhLejRtwN6h8ZgaqC0eYjGJ1uMdGPT/+b3eFncbG4NWuuP9QL+vWwRinu9waw7hkOLcpMJGVJAMgBwsPssMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.5.1",
+        "jest-util": "30.5.1",
+        "jest-validate": "30.5.1",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.12.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.5.1.tgz",
+      "integrity": "sha512-JKpXGONDcTaunrNVn8KCl6qAnwl06jIkvv70lhq0Ze47lsPx9sH5HoeEUiXX6iFGnliHN/qpIbQ0l38wrVmXaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "30.5.0",
+        "jest-snapshot": "30.5.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.5.1.tgz",
+      "integrity": "sha512-FPlQE4+mwnFxXmpPrSi836KV2ZzvK1g6/nPCT8o5BcoDUUNJQeHo1/Qdkoe/QeoL4M7OeJpbnGUhYKhC1VMdaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.5.1",
+        "@jest/environment": "30.5.1",
+        "@jest/source-map": "30.5.0",
+        "@jest/test-result": "30.5.1",
+        "@jest/transform": "30.5.1",
+        "@jest/types": "30.5.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.5.0",
+        "jest-environment-node": "30.5.1",
+        "jest-haste-map": "30.5.1",
+        "jest-leak-detector": "30.5.1",
+        "jest-message-util": "30.5.1",
+        "jest-resolve": "30.5.1",
+        "jest-runtime": "30.5.1",
+        "jest-util": "30.5.1",
+        "jest-watcher": "30.5.1",
+        "jest-worker": "30.5.1",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.5.1.tgz",
+      "integrity": "sha512-UB88+NRkK2Tw/OqV7dofYcyiUGrVZtD41k/N0xQOs9fG//57XHK7JLWG52HD1UYpUAhjK4xm6DBvFX3yWudsMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.5.1",
+        "@jest/fake-timers": "30.5.1",
+        "@jest/globals": "30.5.1",
+        "@jest/source-map": "30.5.0",
+        "@jest/test-result": "30.5.1",
+        "@jest/transform": "30.5.1",
+        "@jest/types": "30.5.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.2.0",
+        "collect-v8-coverage": "^1.0.2",
+        "es-module-lexer": "^2.1.0",
+        "glob": "^13.0.6",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.5.1",
+        "jest-message-util": "30.5.1",
+        "jest-mock": "30.5.1",
+        "jest-regex-util": "30.5.0",
+        "jest-resolve": "30.5.1",
+        "jest-snapshot": "30.5.1",
+        "jest-util": "30.5.1",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.5.1.tgz",
+      "integrity": "sha512-cNWFdSb5xuDGl8hKkAZJ3YtI/PzHpAPFV+HUXWIOG8rMhpDTLVbvAc2d2wRicoYw2wGsJGLaurJT6BLC97bLXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.5.1",
+        "@jest/get-type": "30.5.0",
+        "@jest/snapshot-utils": "30.5.1",
+        "@jest/transform": "30.5.1",
+        "@jest/types": "30.5.1",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.5.1",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.5.1",
+        "jest-matcher-utils": "30.5.1",
+        "jest-message-util": "30.5.1",
+        "jest-util": "30.5.1",
+        "pretty-format": "30.5.1",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.5.1.tgz",
+      "integrity": "sha512-yKuxmNy2rSbTXw+3SIPanJo+nV4/BS1p26v44IYBFMsswSQySfMMcPHErnOncda7i9HEz0q605rIhSTBVgrZTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.5.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.5.1.tgz",
+      "integrity": "sha512-i/buJ56wTpxihE93hQYNMfdOThS87+HGvLZzZJmU4xggPcdTYQq051iwALLCHp3q+SkCGH+EFejQZz5EbBSkkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.5.0",
+        "@jest/types": "30.5.1",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
+        "leven": "^3.1.0",
+        "pretty-format": "30.5.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.5.1.tgz",
+      "integrity": "sha512-+FHJ7C+S7b3ySfhA1aFmoa6TztsnwZVv84ycPRn0tVN93np2EU4b8C/KadqA3l6igdjgLBTnUotab9ER0HLG8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.5.1",
+        "@jest/types": "30.5.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "jest-util": "30.5.1",
+        "string-length": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.5.1.tgz",
+      "integrity": "sha512-Cbxh5v7AoLuFRmFJSM4/aHdQ68rjXvUWr716EE0Dh3I7T+T/3FgFKhOERGXHcU2Meftq9+9zxPM3TSNyI9D+HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.5.1",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+      "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-zod": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-zod/-/json-schema-to-zod-2.8.1.tgz",
+      "integrity": "sha512-fRr1mHgZ7hboLKBUdR428gd9dIHUFGivUqOeiDcSmyXkNZCtB1uGaZLvsjZ4GaN5pwBIs+TGIOf6s+Rp5/R/zA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "json-schema-to-zod": "dist/cjs/cli.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/needle": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/needle/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.7.tgz",
+      "integrity": "sha512-VaWRu2i4FJNRtiRWCuuQRgfQ1B7a6+gMSrO+3j0EQi/k0ULfS9kosRxGoiqwzIjZTDI02tGfk5mXXltLg6QtfQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/posthog-node": {
+      "version": "5.51.6",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.51.6.tgz",
+      "integrity": "sha512-r+Ge3p0OnOcOWeTnvKZmAtDwECeIoyNTyxBxuZc8wM6RHCQ9j2Xrhogrf39HSq1Y2gIOpWLqIDRmWDcu7xmqcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.50.0"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.5.1.tgz",
+      "integrity": "sha512-byhRAPguVKMQIj4kjJwJ5lAskVhfuiSdiYl/aLTWpgkGEmic2jYhJh1yE9ih8Ox44Xg9ccCT11/S6QrzSJuNrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/react-is-18": "npm:react-is@^18.3.1",
+        "@jest/react-is-19": "npm:react-is@^19.2.5",
+        "@jest/schemas": "30.5.0",
+        "ansi-styles": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.1.tgz",
+      "integrity": "sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/probe-image-size": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.4.0.tgz",
+      "integrity": "sha512-cdEprVtZxV+awMde9X+4jILBFYh4CARxVrQaMl4wY4YcPWbul9jntXrIW95NInBDyJwcVUP3U0T6yukN8rMBaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "needle": "^2.5.2",
+        "stream-parser": "~0.3.1"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remend": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/remend/-/remend-1.3.1.tgz",
+      "integrity": "sha512-N3DiY5qbRPoa5vkxn1oDLMyXOVTeo6Hp+XOj6SIqJAYUgLS0Q587gILPMom/qm86AQ/ZrcOdwEIzCz8V3J0nxQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2"
+      }
+    },
+    "node_modules/stream-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/stream-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.3.6"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/test-exclude/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tokenx": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tokenx/-/tokenx-1.6.0.tgz",
+      "integrity": "sha512-CKTjk345ajvBAUp5xUI9a5KKN0zU0lBueVHQbCskH1Hp6WkUKsPW2qGCYNs0pxNyfzxfo+IIjdt2W4sMbw/qBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.4.12",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
+      "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.8.5",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-from-json-schema": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/zod-from-json-schema/-/zod-from-json-schema-0.5.6.tgz",
+      "integrity": "sha512-U33AJ7ZWS6y9XNSzMWcdy8hRAvZmWhTtpYJu0SXPT5AArbc9nq2ur7Magzmn5RF9KBV4b3FP0nCpmqqlfXlR9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.0.17"
+      }
+    },
+    "node_modules/zod-from-json-schema/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/integrations/mastra/package.json
+++ b/integrations/mastra/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@cognee/cognee-mastra",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Cognee knowledge-graph memory layer for Mastra agents: input/output processors for automatic recall and capture, plus explicit cognee_search / cognee_ask / cognee_remember tools, over cognee's HTTP API.",
+  "license": "MIT",
+  "author": {
+    "name": "Cognee",
+    "url": "https://www.cognee.ai"
+  },
+  "homepage": "https://github.com/topoteretes/cognee-integrations/tree/main/integrations/mastra#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/topoteretes/cognee-integrations.git",
+    "directory": "integrations/mastra"
+  },
+  "bugs": {
+    "url": "https://github.com/topoteretes/cognee-integrations/issues"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit --skipLibCheck",
+    "typecheck:test": "tsc --noEmit --skipLibCheck -p tsconfig.test.json",
+    "typecheck:all": "npm run typecheck && npm run typecheck:test",
+    "test": "node --experimental-vm-modules node_modules/.bin/jest --testPathIgnorePatterns __tests__/live --passWithNoTests",
+    "test:live": "COGNEE_LIVE=1 node --experimental-vm-modules node_modules/.bin/jest __tests__/live --testPathIgnorePatterns=/node_modules/",
+    "test:unit": "node --experimental-vm-modules node_modules/.bin/jest __tests__/unit",
+    "test:integration": "node --experimental-vm-modules node_modules/.bin/jest __tests__/integration",
+    "test:e2e": "node --experimental-vm-modules node_modules/.bin/jest __tests__/e2e"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.64.0",
+    "zod": "^3.25.0 || ^4.0.0"
+  },
+  "devDependencies": {
+    "@mastra/core": "^1.64.0",
+    "@mastra/memory": "^1.28.2",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^20.0.0",
+    "jest": "^30.2.0",
+    "ts-jest": "^29.4.6",
+    "typescript": "^5.9.0",
+    "zod": "^3.25.0"
+  }
+}

--- a/integrations/mastra/src/breaker.ts
+++ b/integrations/mastra/src/breaker.ts
@@ -1,0 +1,163 @@
+/**
+ * File-backed circuit breaker for cognee's recall path: only answers "is
+ * the breaker open" / "record a failure" / "record a success". Classifying
+ * which HTTP failures are breaker-eligible (5xx/network vs 4xx) belongs to
+ * `errors.ts`'s `isBreakerError`, keeping that logic in one place.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+
+/** 5 consecutive failures trip the breaker. */
+export const DEFAULT_BREAKER_THRESHOLD = 5;
+/** 120s cooldown once tripped. */
+export const DEFAULT_BREAKER_COOLDOWN_MS = 120_000;
+
+/**
+ * `~/.cognee-mastra/recall-breaker.json` — package-scoped, not shared with
+ * other Cognee integrations' breakers, so one unrelated tool's failures
+ * can't trip this one. Resolved at call time (not module load) so per-test `os.homedir()`
+ * sandboxing always applies.
+ */
+export function defaultBreakerPath(): string {
+  return join(homedir(), ".cognee-mastra", "recall-breaker.json");
+}
+
+interface BreakerState {
+  failures: number;
+  cooldownUntilMs: number;
+  lastError?: string;
+}
+
+const CLOSED_STATE: Readonly<BreakerState> = Object.freeze({ failures: 0, cooldownUntilMs: 0 });
+
+function isPlausibleState(value: unknown): value is { failures: number; cooldownUntilMs: number; lastError?: unknown } {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.failures === "number" &&
+    Number.isFinite(v.failures) &&
+    typeof v.cooldownUntilMs === "number" &&
+    Number.isFinite(v.cooldownUntilMs)
+  );
+}
+
+export interface CircuitBreakerOptions {
+  /** Consecutive failures before the breaker opens. Default 5. */
+  threshold?: number;
+  /** Cooldown once opened, in ms. Default 120_000 (120s). */
+  cooldownMs?: number;
+  /** State file path. Default `~/.cognee-mastra/recall-breaker.json`. */
+  path?: string;
+  /**
+   * Clock — injectable so a test can pass `now: () => t` and move `t` forward deterministically.
+   * Default `Date.now`.
+   */
+  now?: () => number;
+}
+
+/**
+ * Cheap to construct, stateless in memory — every call re-reads the state file, so multiple
+ * instances (or processes) sharing `path` observe and contribute to the same trip/cooldown.
+ */
+export class CircuitBreaker {
+  private readonly threshold: number;
+  private readonly cooldownMs: number;
+  private readonly path: string;
+  private readonly now: () => number;
+
+  constructor(options: CircuitBreakerOptions = {}) {
+    this.threshold = options.threshold ?? DEFAULT_BREAKER_THRESHOLD;
+    this.cooldownMs = options.cooldownMs ?? DEFAULT_BREAKER_COOLDOWN_MS;
+    this.path = options.path ?? defaultBreakerPath();
+    this.now = options.now ?? Date.now;
+  }
+
+  /**
+   * Missing file, unreadable file, invalid JSON, or a shape that doesn't look like `BreakerState`
+   * all degrade to the closed state — a breaker must never fail open merely because its own
+   * bookkeeping file is broken.
+   */
+  private async load(): Promise<BreakerState> {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(await readFile(this.path, "utf-8"));
+    } catch {
+      return { ...CLOSED_STATE };
+    }
+    if (!isPlausibleState(raw)) return { ...CLOSED_STATE };
+    return {
+      failures: raw.failures,
+      cooldownUntilMs: raw.cooldownUntilMs,
+      lastError: typeof raw.lastError === "string" ? raw.lastError : undefined,
+    };
+  }
+
+  /**
+   * Best-effort persistence — a write failure (e.g. read-only home) must never throw into a
+   * caller's request path.
+   */
+  private async save(state: BreakerState): Promise<void> {
+    try {
+      await mkdir(dirname(this.path), { recursive: true });
+      await writeFile(this.path, JSON.stringify(state), "utf-8");
+    } catch {
+      // best-effort; the in-memory decision for *this* call already happened.
+    }
+  }
+
+  /** Whether the breaker currently blocks calls (i.e. still within cooldown). */
+  async isOpen(): Promise<boolean> {
+    const state = await this.load();
+    return state.cooldownUntilMs > this.now();
+  }
+
+  /** Milliseconds remaining until the breaker allows calls again; 0 when closed or half-open. */
+  async remainingCooldownMs(): Promise<number> {
+    const state = await this.load();
+    const remaining = state.cooldownUntilMs - this.now();
+    return remaining > 0 ? remaining : 0;
+  }
+
+  /**
+   * Opens for `cooldownMs` once `failures` reaches `threshold`. Failures
+   * aren't reset on trip: after cooldown elapses the breaker half-opens, and one failed probe
+   * re-trips immediately rather than requiring `threshold` fresh failures.
+   */
+  async recordFailure(error?: unknown): Promise<void> {
+    const state = await this.load();
+    state.failures += 1;
+    const message = toMessage(error);
+    if (message !== undefined) state.lastError = message.slice(0, 300);
+    if (state.failures >= this.threshold) {
+      state.cooldownUntilMs = this.now() + this.cooldownMs;
+    }
+    await this.save(state);
+  }
+
+  /** Record a success: fully resets the breaker (failures and cooldown both cleared). */
+  async recordSuccess(): Promise<void> {
+    const state = await this.load();
+    if (state.failures === 0 && state.cooldownUntilMs === 0) return; // avoid write churn on the happy path
+    await this.save({ ...CLOSED_STATE });
+  }
+}
+
+/**
+ * Redacts credential-shaped substrings before persisting an error to the
+ * breaker's state file — `CogneeApiError.message` can carry text lifted
+ * straight from a server's JSON body, so this defends by pattern rather than by tracking specific
+ * known secrets.
+ */
+const SENSITIVE_PATTERN = /\b(api[_-]?key|password|access[_-]?token|bearer|authorization)\b\s*[:=]\s*\S+/gi;
+
+function sanitizeErrorMessage(message: string): string {
+  return message.replace(SENSITIVE_PATTERN, (_match, key: string) => `${key}=***REDACTED***`);
+}
+
+function toMessage(error: unknown): string | undefined {
+  if (error === undefined) return undefined;
+  const raw = error instanceof Error ? error.message : String(error);
+  return sanitizeErrorMessage(raw);
+}

--- a/integrations/mastra/src/capabilities.ts
+++ b/integrations/mastra/src/capabilities.ts
@@ -1,0 +1,149 @@
+/**
+ * Runtime capability probing + cache for a cognee server: recall route
+ * (`/recall` vs legacy `/search`), remember route (vs `/add`+`/cognify`),
+ * remember/entry route, and auth prefix (`/api/v1/auth` vs `/auth`).
+ *
+ * No extra probe request is fired: `resolveRecallPath`/`resolveAuthPrefix`
+ * drive the real request `client.ts` already needed, fall back once on a
+ * 404, and cache the winner per base URL for the process lifetime.
+ */
+
+import { CogneeApiError } from "./errors.js";
+
+// ---------------------------------------------------------------------------
+// Capability shape + per-base-URL cache
+// ---------------------------------------------------------------------------
+
+export type RecallPath = "/api/v1/recall" | "/api/v1/search";
+export type AuthPrefix = "/api/v1/auth" | "/auth";
+
+/**
+ * What has been learned about one cognee base URL so far. Every field starts
+ * `undefined` ("unknown, not yet probed") and is set at most a handful of
+ * times: `recallPath`/`authPrefix` are set the first time either call
+ * resolves (success on the primary path also "sets" it, so the common case —
+ * a fully up-to-date server — writes this exactly once per field with zero
+ * extra network cost); `rememberSupported`/`rememberEntrySupported` are only
+ * ever written to `false` (the "confirmed absent, degrade forever" case) —
+ * a `true` value is never persisted for them because the happy path never
+ * needs to remember success, only the one-time discovery of absence.
+ */
+export interface CogneeCapabilities {
+  recallPath?: RecallPath;
+  rememberSupported?: boolean;
+  rememberEntrySupported?: boolean;
+  authPrefix?: AuthPrefix;
+}
+
+/**
+ * cognee's `get_remember_router.py` handler for `/remember` ingests the
+ * data and runs cognify as one pipeline before responding — a fixed fact
+ * about the endpoint's contract, not a runtime probe result. It only
+ * matters to the `add()`+`cognify()` fallback leg: that leg must call
+ * `cognify()` itself precisely because plain `add()` does not. Exported so
+ * `client.ts`'s fallback path can reference why it calls cognify
+ * explicitly, rather than hard-coding the reasoning inline.
+ */
+export const REMEMBER_IMPLIES_COGNIFY = true as const;
+
+const registry = new Map<string, CogneeCapabilities>();
+
+/**
+ * One capability record per cognee base URL, shared by every `CogneeClient`
+ * instance pointed at that URL, for the life of the process. Two clients
+ * constructed against the same `baseUrl` — e.g. one used by the input
+ * processor, one by a tool — share a single decision instead of each
+ * paying their own 404.
+ */
+export function getCapabilities(baseUrl: string): CogneeCapabilities {
+  let entry = registry.get(baseUrl);
+  if (!entry) {
+    entry = {};
+    registry.set(baseUrl, entry);
+  }
+  return entry;
+}
+
+/**
+ * Test-only escape hatch: drop cached capability state so a test can exercise
+ * the probe path again against a fresh mock server. Not called anywhere in
+ * production code.
+ */
+export function resetCapabilities(baseUrl?: string): void {
+  if (baseUrl) registry.delete(baseUrl);
+  else registry.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Shape-preserving fallback helpers
+// ---------------------------------------------------------------------------
+
+/** A 404 means "this route is not mounted on this server" — the signal this
+ *  module falls back on. Any other status (400, 401, 409, 422, 5xx, ...)
+ *  means the route exists and something else is wrong, so it must propagate
+ *  unchanged rather than trigger a fallback that would mask it. */
+export function isRouteMissing(error: unknown): boolean {
+  return error instanceof CogneeApiError && error.status === 404;
+}
+
+/**
+ * Resolve which recall route this base URL answers on, then run the actual
+ * request. `run` receives the path to call and is responsible for parsing
+ * *that* path's response shape (`/recall` and its legacy `/search` alias
+ * share a request DTO but not a response one — see `types.ts`'s
+ * `SearchResponseItem` doc — so only the caller, which knows both shapes,
+ * can normalize correctly).
+ *
+ * - Cache already set: call the known-good path directly. No 404 is ever
+ *   paid again for this base URL.
+ * - Cache unset: try `/api/v1/recall`. A 404 falls back once to
+ *   `/api/v1/search`; whichever responds (even with a non-404 error) decides
+ *   the cached path, because a non-404 error still proves the route exists.
+ */
+export async function resolveRecallPath<T>(
+  cache: CogneeCapabilities,
+  run: (path: RecallPath) => Promise<T>,
+): Promise<T> {
+  if (cache.recallPath) return run(cache.recallPath);
+  try {
+    const result = await run("/api/v1/recall");
+    cache.recallPath = "/api/v1/recall";
+    return result;
+  } catch (error) {
+    if (isRouteMissing(error)) {
+      const result = await run("/api/v1/search");
+      cache.recallPath = "/api/v1/search";
+      return result;
+    }
+    // Not a 404: /api/v1/recall exists (or the failure is unrelated to
+    // routing, e.g. a network error) — cache it as the winner so a later
+    // call doesn't re-attempt a fallback that was never warranted, then
+    // let the real error propagate.
+    cache.recallPath = "/api/v1/recall";
+    throw error;
+  }
+}
+
+/**
+ * Same pattern as `resolveRecallPath`, for the login route's path prefix:
+ * probe both, prefer the prefixed one, cache the winner.
+ */
+export async function resolveAuthPrefix<T>(
+  cache: CogneeCapabilities,
+  run: (prefix: AuthPrefix) => Promise<T>,
+): Promise<T> {
+  if (cache.authPrefix) return run(cache.authPrefix);
+  try {
+    const result = await run("/api/v1/auth");
+    cache.authPrefix = "/api/v1/auth";
+    return result;
+  } catch (error) {
+    if (isRouteMissing(error)) {
+      const result = await run("/auth");
+      cache.authPrefix = "/auth";
+      return result;
+    }
+    cache.authPrefix = "/api/v1/auth";
+    throw error;
+  }
+}

--- a/integrations/mastra/src/client.ts
+++ b/integrations/mastra/src/client.ts
@@ -1,0 +1,683 @@
+/**
+ * `CogneeClient` is the only place in this package that talks to the
+ * network. Retry/auth semantics follow @cognee/cognee-openclaw's client,
+ * except this one also retries 5xx/429/network failures, not just timeouts
+ * (see `errors.ts#isRetryable`). Takes an already-resolved
+ * `CogneeMastraConfig`; never reads `process.env` itself.
+ */
+
+import {
+  getCapabilities,
+  isRouteMissing,
+  resolveAuthPrefix,
+  resolveRecallPath,
+  type AuthPrefix,
+  type RecallPath,
+} from "./capabilities.js";
+import { CogneeApiError, isRetryable } from "./errors.js";
+import type {
+  AddRequest,
+  CogneeMastraConfig,
+  CognifyRequest,
+  DatasetDTO,
+  DatasetStatusResponse,
+  ForgetRequest,
+  HealthResponse,
+  ImproveRequest,
+  LoginResponse,
+  QAEntryDTO,
+  RecallHit,
+  RecallRequest,
+  RecallResponse,
+  RecallResponseItem,
+  RememberEntryRequest,
+  RememberRequest,
+  RememberResult,
+  SearchResponse,
+  SearchResponseItem,
+} from "./types.js";
+
+// -- Constants --------------------------------------------------------------
+
+const DEFAULT_BASE_URL = "http://localhost:8000";
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_RETRIES = 3;
+/** Exponential backoff base, in ms. Attempt N's delay (N >= 1) is
+ *  `RETRY_BASE_DELAY_MS * 2 ** (N - 1)`: 3s, 6s, 12s, ... */
+const RETRY_BASE_DELAY_MS = 3_000;
+/** Login gets its own timeout/retry budget instead of inheriting
+ *  requestTimeoutMs × (retries+1) — else a 10s-bounded tool call could sit
+ *  ~141s in login on an unresponsive server before its own bound applied. */
+const LOGIN_TIMEOUT_MS = 10_000;
+const LOGIN_RETRIES = 1;
+
+/** Per-call override for any request method. Setting `timeoutMs` alone
+ *  disables retries for that call (the recall path relies on this); set
+ *  `retries` explicitly to keep some retries within a bounded budget. */
+export interface RequestOptions {
+  timeoutMs?: number;
+  retries?: number;
+}
+
+// -- CogneeClient -------------------------------------------------------------
+
+export class CogneeClient {
+  readonly baseUrl: string;
+
+  private apiKey: string | undefined;
+  private readonly email: string | undefined;
+  private readonly password: string | undefined;
+  private readonly requestTimeoutMs: number;
+  private readonly retries: number;
+  private readonly debug: boolean;
+  private readonly fetchImpl: typeof fetch;
+
+  private authToken: string | undefined;
+  private loginPromise: Promise<void> | undefined;
+
+  /** ensureDataset()'s cache, keyed by name; datasetInFlight collapses
+   *  concurrent calls for the same name onto one request. */
+  private readonly datasetCache = new Map<string, DatasetDTO>();
+  private readonly datasetInFlight = new Map<string, Promise<DatasetDTO>>();
+
+  constructor(config: CogneeMastraConfig = {}) {
+    this.baseUrl = stripTrailingSlash(config.baseUrl?.trim() || DEFAULT_BASE_URL);
+    // apiKey wins over auth: enforced by never reading auth once apiKey is
+    // set (ensureAuth()/login()), not by clearing fields here.
+    this.apiKey = config.apiKey?.trim() || undefined;
+    this.email = config.auth?.email;
+    this.password = config.auth?.password;
+    this.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.retries = config.retries ?? DEFAULT_RETRIES;
+    this.debug = config.debug ?? false;
+    this.fetchImpl = config.fetch ?? fetch;
+  }
+
+  /** Inject/replace the API key post-construction; from then on X-Api-Key
+   *  is used and the JWT fallback is never consulted again. */
+  setApiKey(key: string): void {
+    const trimmed = key.trim();
+    if (trimmed) this.apiKey = trimmed;
+  }
+
+  // -- Auth -------------------------------------------------------------
+
+  private buildAuthHeaders(): Record<string, string> {
+    if (this.apiKey) {
+      // Never also send a stale Bearer token: a server validating
+      // Authorization as JWT could reject on a bogus Bearer first.
+      return { "X-Api-Key": this.apiKey };
+    }
+    if (this.authToken) {
+      return { Authorization: `Bearer ${this.authToken}` };
+    }
+    return {};
+  }
+
+  private async ensureAuth(): Promise<void> {
+    if (this.apiKey || this.authToken) return;
+    if (!this.email || !this.password) {
+      // status 0 keeps this out of isRetryable's 5xx/429 matrix so retry
+      // never spins on a config problem retrying can't fix.
+      throw new CogneeApiError(
+        "cognee client has no credentials configured — set apiKey, or auth.email + auth.password",
+        { status: 0 },
+      );
+    }
+    if (!this.loginPromise) {
+      this.loginPromise = this.login().catch((error: unknown) => {
+        this.loginPromise = undefined;
+        throw error;
+      });
+    }
+    return this.loginPromise;
+  }
+
+  /** POST {authPrefix}/auth/login, form-encoded (fastapi-users'
+   *  OAuth2PasswordRequestForm — username/password field names).
+   *  Callable directly to force re-authentication; always overwrites the
+   *  cached token. */
+  async login(): Promise<void> {
+    if (!this.email || !this.password) {
+      throw new CogneeApiError(
+        "cognee client has no credentials configured — set apiKey, or auth.email + auth.password",
+        { status: 0 },
+      );
+    }
+    const cache = getCapabilities(this.baseUrl);
+    const token = await resolveAuthPrefix(cache, (prefix) => this.performLogin(prefix));
+    this.authToken = token;
+  }
+
+  private async performLogin(prefix: AuthPrefix): Promise<string> {
+    const url = `${this.baseUrl}${prefix}/login`;
+    const body = new URLSearchParams({ username: this.email ?? "", password: this.password ?? "" }).toString();
+    const { data } = await this.request<LoginResponse>(
+      `${prefix}/login`,
+      { method: "POST", headers: { "Content-Type": "application/x-www-form-urlencoded" }, body },
+      { skipAuth: true, timeoutMs: Math.min(LOGIN_TIMEOUT_MS, this.requestTimeoutMs), retries: LOGIN_RETRIES },
+    );
+    if (!data || typeof data.access_token !== "string" || !data.access_token) {
+      throw new CogneeApiError("cognee login succeeded but the response had no access_token", {
+        status: 0,
+        url,
+        method: "POST",
+      });
+    }
+    return data.access_token;
+  }
+
+  // -- Health -------------------------------------------------------------
+
+  /** GET /health — no /api/v1 prefix, no auth; parses and returns the body
+   *  on any status (even 503) instead of throwing, since cognee's health
+   *  router keeps status/health/reason meaningful on failure too. */
+  async health(): Promise<HealthResponse> {
+    const url = `${this.baseUrl}/health`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.requestTimeoutMs);
+    const startedAt = Date.now();
+    try {
+      const response = await this.fetchImpl(url, { method: "GET", signal: controller.signal });
+      const body = await this.parseBody(response);
+      this.debugLog("GET", url, response.status, Date.now() - startedAt, 0);
+      return (body && typeof body === "object" ? body : {}) as HealthResponse;
+    } catch (error) {
+      throw this.normalizeTransportError(error, url, "GET", this.requestTimeoutMs);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  // -- Datasets -------------------------------------------------------------
+
+  /** POST /api/v1/datasets — idempotent create-or-return by name; safe to
+   *  call on every write since cognee returns the existing dataset unchanged. */
+  async ensureDataset(name: string, opts: RequestOptions = {}): Promise<DatasetDTO> {
+    const cached = this.datasetCache.get(name);
+    if (cached) return cached;
+    let pending = this.datasetInFlight.get(name);
+    if (!pending) {
+      pending = this.createDataset(name, opts)
+        .then((dto) => {
+          this.datasetCache.set(name, dto);
+          return dto;
+        })
+        .finally(() => {
+          this.datasetInFlight.delete(name);
+        });
+      this.datasetInFlight.set(name, pending);
+    }
+    return pending;
+  }
+
+  private async createDataset(name: string, opts: RequestOptions): Promise<DatasetDTO> {
+    const { data } = await this.request<DatasetDTO>(
+      "/api/v1/datasets",
+      { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name }) },
+      { timeoutMs: opts.timeoutMs, retries: opts.retries },
+    );
+    return data;
+  }
+
+  /** GET /api/v1/datasets — every dataset the authenticated user can read. */
+  async listDatasets(opts: RequestOptions = {}): Promise<DatasetDTO[]> {
+    const { data } = await this.request<DatasetDTO[]>(
+      "/api/v1/datasets",
+      { method: "GET" },
+      { timeoutMs: opts.timeoutMs, retries: opts.retries },
+    );
+    return Array.isArray(data) ? data : [];
+  }
+
+  /** GET /api/v1/datasets/status; pipeline values are add_pipeline |
+   *  cognify_pipeline | code_graph_pipeline, hence the default below. */
+  async datasetStatus(
+    datasetId: string,
+    pipeline: string = "cognify_pipeline",
+    opts: RequestOptions = {},
+  ): Promise<DatasetStatusResponse> {
+    const query = new URLSearchParams();
+    query.append("dataset", datasetId);
+    query.append("pipeline", pipeline);
+    const { data } = await this.request<DatasetStatusResponse>(
+      `/api/v1/datasets/status?${query.toString()}`,
+      { method: "GET" },
+      { timeoutMs: opts.timeoutMs, retries: opts.retries },
+    );
+    return data;
+  }
+
+  // -- Writes: remember / add / cognify -------------------------------------
+
+  /** POST /api/v1/remember — primary write path; cognee's
+   *  get_remember_router.py combines add+cognify (and bridges session_id's
+   *  session cache into the graph) behind one route, so a successful call
+   *  never needs an explicit cognify(). Falls back once to add()+cognify()
+   *  on a 404, cached per base URL via capabilities.ts. */
+  async remember(input: RememberRequest, opts: RequestOptions = {}): Promise<RememberResult> {
+    const cache = getCapabilities(this.baseUrl);
+    if (cache.rememberSupported === false) {
+      return this.rememberViaAddCognify(input, opts);
+    }
+    try {
+      const result = await this.rememberDirect(input, opts);
+      cache.rememberSupported = true;
+      return result;
+    } catch (error) {
+      if (cache.rememberSupported === undefined && isRouteMissing(error)) {
+        const result = await this.rememberViaAddCognify(input, opts);
+        cache.rememberSupported = false;
+        return result;
+      }
+      throw error;
+    }
+  }
+
+  private async rememberDirect(input: RememberRequest, opts: RequestOptions): Promise<RememberResult> {
+    const { data } = await this.request<RememberResult>(
+      "/api/v1/remember",
+      { method: "POST", body: this.buildRememberForm(input) },
+      { timeoutMs: opts.timeoutMs, retries: opts.retries },
+    );
+    return data;
+  }
+
+  // Fallback leg for remember(): same write split into add()+cognify(),
+  // minus session_id — get_add_router.py declares no such form field.
+  private async rememberViaAddCognify(input: RememberRequest, opts: RequestOptions): Promise<RememberResult> {
+    const addResult = await this.add(
+      {
+        raw_data: input.raw_data,
+        datasetName: input.datasetName,
+        datasetId: input.datasetId,
+        node_set: input.node_set,
+        run_in_background: input.run_in_background,
+      },
+      opts,
+    );
+    const datasetId = typeof addResult["dataset_id"] === "string" ? (addResult["dataset_id"] as string) : input.datasetId;
+    const datasetNames = !datasetId && input.datasetName ? [input.datasetName] : undefined;
+    await this.cognify(datasetId ? [datasetId] : [], { ...opts, datasetNames });
+    return addResult;
+  }
+
+  /** POST /api/v1/add — fallback leg 1 when `/remember` is absent. */
+  async add(input: AddRequest, opts: RequestOptions = {}): Promise<RememberResult> {
+    const { data } = await this.request<RememberResult>(
+      "/api/v1/add",
+      { method: "POST", body: this.buildAddForm(input) },
+      { timeoutMs: opts.timeoutMs, retries: opts.retries },
+    );
+    return data;
+  }
+
+  /** POST /api/v1/cognify — fallback leg 2, paired with `add()`. */
+  async cognify(
+    datasetIds: string[] = [],
+    opts: RequestOptions & { datasetNames?: string[] } = {},
+  ): Promise<RememberResult> {
+    const body: CognifyRequest = {
+      run_in_background: true,
+      ...(datasetIds.length ? { dataset_ids: datasetIds } : {}),
+      ...(opts.datasetNames && opts.datasetNames.length ? { datasets: opts.datasetNames } : {}),
+    };
+    const { data } = await this.request<RememberResult>(
+      "/api/v1/cognify",
+      { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) },
+      { timeoutMs: opts.timeoutMs, retries: opts.retries },
+    );
+    return data;
+  }
+
+  /** POST /api/v1/remember/entry; the 404 fallback below exists
+   *  defensively for older servers that mount it differently. */
+  async rememberEntry(input: RememberEntryRequest, opts: RequestOptions = {}): Promise<RememberResult> {
+    const cache = getCapabilities(this.baseUrl);
+    if (cache.rememberEntrySupported === false) {
+      return this.rememberEntryViaRemember(input, opts);
+    }
+    try {
+      const result = await this.rememberEntryDirect(input, opts);
+      cache.rememberEntrySupported = true;
+      return result;
+    } catch (error) {
+      if (cache.rememberEntrySupported === undefined && isRouteMissing(error)) {
+        const result = await this.rememberEntryViaRemember(input, opts);
+        cache.rememberEntrySupported = false;
+        return result;
+      }
+      throw error;
+    }
+  }
+
+  private async rememberEntryDirect(input: RememberEntryRequest, opts: RequestOptions): Promise<RememberResult> {
+    const { data } = await this.request<RememberResult>(
+      "/api/v1/remember/entry",
+      { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(input) },
+      { timeoutMs: opts.timeoutMs, retries: opts.retries },
+    );
+    return data;
+  }
+
+  // Fallback leg: degrades to remember() with the turn serialized as
+  // raw_data — loses typed session-cache indexing but stays recallable.
+  private async rememberEntryViaRemember(input: RememberEntryRequest, opts: RequestOptions): Promise<RememberResult> {
+    return this.remember(
+      {
+        raw_data: [formatQAEntryAsText(input.entry)],
+        datasetName: input.dataset_name,
+        datasetId: input.dataset_id,
+        session_id: input.session_id,
+      },
+      opts,
+    );
+  }
+
+  private buildRememberForm(input: RememberRequest): FormData {
+    const form = new FormData();
+    for (const item of input.raw_data) form.append("raw_data", item);
+    if (input.datasetName) form.append("datasetName", input.datasetName);
+    if (input.datasetId) form.append("datasetId", input.datasetId);
+    if (input.session_id) form.append("session_id", input.session_id);
+    if (input.node_set) for (const tag of input.node_set) form.append("node_set", tag);
+    if (typeof input.run_in_background === "boolean") {
+      form.append("run_in_background", String(input.run_in_background));
+    }
+    return form;
+  }
+
+  private buildAddForm(input: AddRequest): FormData {
+    const form = new FormData();
+    for (const item of input.raw_data) form.append("raw_data", item);
+    if (input.datasetName) form.append("datasetName", input.datasetName);
+    if (input.datasetId) form.append("datasetId", input.datasetId);
+    if (input.node_set) for (const tag of input.node_set) form.append("node_set", tag);
+    if (typeof input.run_in_background === "boolean") {
+      form.append("run_in_background", String(input.run_in_background));
+    }
+    return form;
+  }
+
+  // -- Reads: recall ---------------------------------------------------------
+
+  /** POST /api/v1/recall, falling back once to the legacy POST
+   *  /api/v1/search on a 404. Both shapes normalize into RecallHit[] here,
+   *  not in the shared probe helper — see resolveRecallPath's doc. */
+  async recall(input: RecallRequest, opts: RequestOptions = {}): Promise<RecallHit[]> {
+    const cache = getCapabilities(this.baseUrl);
+    return resolveRecallPath(cache, (path) => this.performRecall(path, input, opts));
+  }
+
+  private async performRecall(path: RecallPath, input: RecallRequest, opts: RequestOptions): Promise<RecallHit[]> {
+    const { data } = await this.request<unknown>(
+      path,
+      { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(input) },
+      { timeoutMs: opts.timeoutMs, retries: opts.retries },
+    );
+    return path === "/api/v1/recall"
+      ? normalizeRecallResponse(data as RecallResponse)
+      : normalizeSearchResponse(data as SearchResponse);
+  }
+
+  // -- Forget -----------------------------------------------------------------
+
+  /** POST /api/v1/forget. everything: true is hard-blocked here too, not
+   *  only in tools.ts's cognee_forget — CogneeClient is itself an escape
+   *  hatch any direct caller could reach. */
+  async forget(input: ForgetRequest, opts: RequestOptions = {}): Promise<RememberResult> {
+    if (input.everything) {
+      throw new CogneeApiError(
+        "cognee client refuses forget({ everything: true }) — this permanently deletes every dataset the authenticated user owns. Use the cognee server/CLI directly if that is really intended.",
+        { status: 0 },
+      );
+    }
+    const { data } = await this.request<RememberResult>(
+      "/api/v1/forget",
+      { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(input) },
+      { timeoutMs: opts.timeoutMs, retries: opts.retries },
+    );
+    return data;
+  }
+
+  // -- Improve (optional) -----------------------------------------------
+
+  /** POST /api/v1/improve — off by default (`improveOnThreadEnd: false`);
+   *  exposed here for a caller who wants to trigger it manually. */
+  async improve(input: ImproveRequest, opts: RequestOptions = {}): Promise<unknown> {
+    const { data } = await this.request<unknown>(
+      "/api/v1/improve",
+      { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(input) },
+      { timeoutMs: opts.timeoutMs, retries: opts.retries },
+    );
+    return data;
+  }
+
+  // -- Shared HTTP transport: auth + retry + timeout + error wrapping --------
+
+  /** Every method above calls through here: attach auth headers, run under
+   *  an AbortSignal timeout, retry with RETRY_BASE_DELAY_MS exponential
+   *  backoff, and re-login once on a 401 (JWT mode only) before retrying.
+   *
+   *  maxRetries is 0 whenever the caller passed a per-call timeoutMs (the
+   *  recall path never retries), else this.retries; an explicit
+   *  options.retries overrides both, letting a bounded-budget write keep
+   *  one retry within its own budget. Retryable failures are
+   *  errors.ts#isRetryable (5xx, 429) plus status 0 network/timeout
+   *  failures, which isRetryable has no opinion on. */
+  private async request<T>(
+    path: string,
+    init: { method: string; headers?: Record<string, string>; body?: RequestInit["body"] },
+    options: { timeoutMs?: number; retries?: number; skipAuth?: boolean } = {},
+  ): Promise<{ status: number; data: T }> {
+    if (!options.skipAuth) await this.ensureAuth();
+
+    const url = `${this.baseUrl}${path}`;
+    const perCallTimeout = options.timeoutMs;
+    const timeoutMs = perCallTimeout ?? this.requestTimeoutMs;
+    const maxRetries = options.retries !== undefined ? options.retries : perCallTimeout !== undefined ? 0 : this.retries;
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      if (attempt > 0) {
+        await sleep(RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
+      }
+
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      const startedAt = Date.now();
+      try {
+        const headers = options.skipAuth
+          ? { ...init.headers }
+          : { ...this.buildAuthHeaders(), ...init.headers };
+        const response = await this.fetchImpl(url, {
+          method: init.method,
+          headers,
+          body: init.body,
+          signal: controller.signal,
+        });
+
+        // 401 in JWT mode only (a bad API key isn't a stale token): drop
+        // the cached token and retry once, independent of maxRetries.
+        if (response.status === 401 && !options.skipAuth && !this.apiKey) {
+          clearTimeout(timer);
+          this.authToken = undefined;
+          this.loginPromise = undefined;
+          await this.ensureAuth();
+
+          const retryController = new AbortController();
+          const retryTimer = setTimeout(() => retryController.abort(), timeoutMs);
+          try {
+            const retryHeaders = { ...this.buildAuthHeaders(), ...init.headers };
+            const retryResponse = await this.fetchImpl(url, {
+              method: init.method,
+              headers: retryHeaders,
+              body: init.body,
+              signal: retryController.signal,
+            });
+            const result = await this.finish<T>(retryResponse, url, init.method);
+            this.debugLog(init.method, url, retryResponse.status, Date.now() - startedAt, attempt);
+            return result;
+          } finally {
+            clearTimeout(retryTimer);
+          }
+        }
+
+        const result = await this.finish<T>(response, url, init.method);
+        clearTimeout(timer);
+        this.debugLog(init.method, url, response.status, Date.now() - startedAt, attempt);
+        return result;
+      } catch (error) {
+        clearTimeout(timer);
+        const normalized = this.normalizeTransportError(error, url, init.method, timeoutMs);
+        lastError = normalized;
+        this.debugLog(init.method, url, normalized.status, Date.now() - startedAt, attempt, normalized.message);
+        const retryable = normalized.status === 0 || isRetryable(normalized.status);
+        if (retryable && attempt < maxRetries) continue;
+        throw normalized;
+      }
+    }
+    // Unreachable: the loop above always returns or throws; kept for type safety.
+    throw lastError ?? new CogneeApiError("cognee request failed for an unknown reason", { status: 0, url, method: init.method });
+  }
+
+  // Where a raw Response becomes either data or a typed CogneeApiError
+  // (with the parsed body attached) for every caller in this file.
+  private async finish<T>(response: Response, url: string, method: string): Promise<{ status: number; data: T }> {
+    const body = await this.parseBody(response);
+    if (!response.ok) {
+      throw CogneeApiError.fromResponse(response.status, body, { url, method });
+    }
+    return { status: response.status, data: body as T };
+  }
+
+  // Shape-agnostic: most responses are JSON, some error paths (and
+  // /health's failure body) are plain text, and an empty body is undefined.
+  private async parseBody(response: Response): Promise<unknown> {
+    const text = await response.text();
+    if (!text) return undefined;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+
+  // Normalizes any thrown value into a CogneeApiError with status always
+  // populated: a CogneeApiError passes through; an AbortError (our own
+  // timeout, no caller AbortSignal exists here) becomes fromTimeout;
+  // anything else becomes fromNetworkError. Both use status 0 — no
+  // response was ever received.
+  private normalizeTransportError(error: unknown, url: string, method: string, timeoutMs: number): CogneeApiError {
+    if (error instanceof CogneeApiError) return error;
+    const isAbort = error instanceof DOMException || (error instanceof Error && error.name === "AbortError");
+    if (isAbort) return CogneeApiError.fromTimeout(timeoutMs, { url, method });
+    return CogneeApiError.fromNetworkError(error, { url, method });
+  }
+
+  // Gated by config.debug; logs method/path/status/timing only, never
+  // headers or a body, so login's password/token can never reach a log line.
+  private debugLog(
+    method: string,
+    url: string,
+    status: number,
+    durationMs: number,
+    attempt: number,
+    note?: string,
+  ): void {
+    if (!this.debug) return;
+    const safeUrl = url.split("?")[0];
+    const suffix = note ? ` (${note})` : "";
+    // eslint-disable-next-line no-console -- intentional, gated debug output
+    console.debug(
+      `[cognee-mastra] ${method} ${safeUrl} -> ${status} (${durationMs}ms, attempt ${attempt + 1})${suffix}`,
+    );
+  }
+}
+
+// -- Helpers (module-private) -------------------------------------------------
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Renders a QAEntryDTO as plain text for the rememberEntry() -> remember() fallback leg.
+function formatQAEntryAsText(entry: QAEntryDTO): string {
+  const parts = [`Q: ${entry.question}`, `A: ${entry.answer}`];
+  if (entry.context) parts.push(`Context: ${entry.context}`);
+  return parts.join("\n");
+}
+
+function safeStringify(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function normalizeRecallResponse(items: unknown): RecallHit[] {
+  if (!Array.isArray(items)) return [];
+  return items.map(normalizeRecallResponseItem);
+}
+
+/** Best-effort readable text for a /recall item with no `text`: on cognee
+ *  1.5.4 every observed item already has one, so this covers the session-
+ *  cache shapes (question/answer/context, or a bare content) so a
+ *  pre-bridge session hit reads as prose, not a JSON dump. */
+function composeRecallText(record: Record<string, unknown>): string {
+  const str = (v: unknown): string | undefined => (typeof v === "string" && v.trim() ? v : undefined);
+  const content = str(record["content"]);
+  if (content) return content;
+  const question = str(record["question"]);
+  const answer = str(record["answer"]);
+  const context = str(record["context"]);
+  if (question || answer || context) {
+    return [question && `Question: ${question}`, answer && `Answer: ${answer}`, context && `Context: ${context}`]
+      .filter(Boolean)
+      .join("\n");
+  }
+  return safeStringify(record);
+}
+
+function normalizeRecallResponseItem(item: unknown): RecallHit {
+  if (!item || typeof item !== "object") {
+    return { text: safeStringify(item) };
+  }
+  const record = item as RecallResponseItem;
+  return {
+    text: typeof record.text === "string" ? record.text : composeRecallText(record),
+    score: record.score ?? null,
+    datasetId: record.dataset_id ?? null,
+    datasetName: record.dataset_name ?? null,
+    source: typeof record.source === "string" ? record.source : undefined,
+    metadata: record.metadata,
+  };
+}
+
+// Different parse from normalizeRecallResponseItem on purpose: /search
+// wraps a free-form search_result (SearchResponseItem), not /recall's envelope.
+function normalizeSearchResponse(items: unknown): RecallHit[] {
+  if (!Array.isArray(items)) return [];
+  return items.map(normalizeSearchResponseItem);
+}
+
+function normalizeSearchResponseItem(item: unknown): RecallHit {
+  if (!item || typeof item !== "object") {
+    return { text: safeStringify(item) };
+  }
+  const record = item as SearchResponseItem;
+  const raw = record.search_result;
+  const text = typeof raw === "string" ? raw : Array.isArray(raw) ? raw.map(String).join("\n") : safeStringify(raw);
+  return {
+    text,
+    datasetId: record.dataset_id ?? null,
+    datasetName: record.dataset_name ?? null,
+  };
+}

--- a/integrations/mastra/src/config.ts
+++ b/integrations/mastra/src/config.ts
@@ -1,0 +1,255 @@
+/**
+ * `resolveConfig()` — the single place in this package that reads
+ * `process.env`. Resolution order: explicit argument -> environment
+ * variable -> default, field by field. `client.ts`/`processors.ts`/`tools.ts`
+ * call it once and program against the fully-defaulted `ResolvedCogneeConfig`.
+ * `env` defaults to `process.env` but is injectable for tests.
+ */
+
+import type {
+  CogneeAuthConfig,
+  CogneeMastraConfig,
+  CogneeRecallConfig,
+  CogneeToolsConfig,
+  CogneeWriteConfig,
+  SearchType,
+} from "./types.js";
+
+// ---- Defaults ----
+
+export const DEFAULT_BASE_URL = "http://localhost:8000";
+export const DEFAULT_DATASET = "mastra";
+export const DEFAULT_DATASET_PREFIX = "mastra_";
+export const DEFAULT_SCOPE = "tagged" as const;
+
+export const DEFAULT_RECALL_ENABLED = true;
+/** CHUNKS, not GRAPH_COMPLETION, for the automatic per-turn injection path. */
+export const DEFAULT_SEARCH_TYPE: SearchType = "CHUNKS";
+export const DEFAULT_TOP_K = 10;
+export const DEFAULT_MIN_QUERY_LENGTH = 8;
+export const DEFAULT_RECALL_TIMEOUT_MS = 2_500;
+export const DEFAULT_RECALL_BUDGET_MS = 4_000;
+export const DEFAULT_INCLUDE_REFERENCES = true;
+
+export const DEFAULT_WRITE_MODE = "always" as const;
+export const DEFAULT_RUN_IN_BACKGROUND = true;
+export const DEFAULT_WRITE_MAX_CHARS = 8_000;
+
+export const DEFAULT_ENABLE_FORGET = false;
+/**
+ * `tools.ts`'s per-call budget for cognee_search/cognee_ask/cognee_remember/cognee_forget — well
+ * below `requestTimeoutMs`'s 30s default so a model-facing tool call can't inherit 30s x
+ * (retries+1) worst-case latency.
+ */
+export const DEFAULT_TOOLS_TIMEOUT_MS = 10_000;
+
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+export const DEFAULT_RETRIES = 3;
+export const DEFAULT_DEBUG = false;
+
+// ---- Resolved shape ----
+
+export type ResolvedCogneeRecallConfig = Required<CogneeRecallConfig>;
+export type ResolvedCogneeWriteConfig = Required<CogneeWriteConfig>;
+export type ResolvedCogneeToolsConfig = Required<CogneeToolsConfig>;
+
+/**
+ * `CogneeMastraConfig` with every field that has a default filled in.
+ * `apiKey`, `auth`, `nodeSet`, `fetch` stay optional — they have no
+ * meaningful default (empty `nodeSet` is the identity value; `fetch` is only ever explicit).
+ */
+export interface ResolvedCogneeConfig {
+  baseUrl: string;
+  apiKey?: string;
+  auth?: CogneeAuthConfig;
+
+  dataset: string;
+  datasetPrefix: string;
+  scope: "tagged" | "dataset-per-resource";
+  nodeSet: string[];
+
+  recall: ResolvedCogneeRecallConfig;
+  write: ResolvedCogneeWriteConfig;
+  tools: ResolvedCogneeToolsConfig;
+
+  requestTimeoutMs: number;
+  retries: number;
+  debug: boolean;
+  fetch?: typeof fetch;
+}
+
+// ---- Env-parsing helpers ----
+// Tolerant of malformed values: a typo'd env var falls back to the default rather than propagating
+// NaN/undefined.
+
+function readString(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const value = env[key];
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readInt(env: NodeJS.ProcessEnv, key: string): number | undefined {
+  const raw = readString(env, key);
+  if (raw === undefined) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function readBool(env: NodeJS.ProcessEnv, key: string): boolean | undefined {
+  const raw = readString(env, key)?.toLowerCase();
+  if (raw === undefined) return undefined;
+  if (["1", "true", "yes", "on"].includes(raw)) return true;
+  if (["0", "false", "no", "off"].includes(raw)) return false;
+  return undefined;
+}
+
+function resolveField<T>(explicit: T | undefined, envValue: T | undefined, fallback: T): T {
+  if (explicit !== undefined) return explicit;
+  if (envValue !== undefined) return envValue;
+  return fallback;
+}
+
+// ---- resolveConfig ----
+
+/**
+ * Resolve a `CogneeMastraConfig` partial into a fully-defaulted
+ * `ResolvedCogneeConfig`. Never throws for a missing credential — safe to
+ * call at module scope before any credential exists; `CogneeClient` raises on the first request
+ * that actually needs one.
+ */
+export function resolveConfig(
+  partial: CogneeMastraConfig = {},
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedCogneeConfig {
+  const baseUrl = resolveField(partial.baseUrl, readString(env, "COGNEE_API_URL"), DEFAULT_BASE_URL);
+
+  // apiKey wins over auth when both are present (enforced in client.ts); both are resolved
+  // independently so neither is silently dropped from the resolved config.
+  const apiKey = resolveField(partial.apiKey, readString(env, "COGNEE_API_KEY"), undefined);
+
+  const email = resolveField(partial.auth?.email, readString(env, "COGNEE_USER_EMAIL"), undefined);
+  const password = resolveField(partial.auth?.password, readString(env, "COGNEE_USER_PASSWORD"), undefined);
+  const auth: CogneeAuthConfig | undefined =
+    email !== undefined || password !== undefined ? { email, password } : undefined;
+
+  const dataset = resolveField(partial.dataset, readString(env, "COGNEE_DATASET"), DEFAULT_DATASET);
+  const datasetPrefix = resolveField(
+    partial.datasetPrefix,
+    readString(env, "COGNEE_DATASET_PREFIX"),
+    DEFAULT_DATASET_PREFIX,
+  );
+
+  const rawScope = resolveField(partial.scope, readString(env, "COGNEE_SCOPE"), DEFAULT_SCOPE);
+  const scope: "tagged" | "dataset-per-resource" =
+    rawScope === "tagged" || rawScope === "dataset-per-resource" ? rawScope : DEFAULT_SCOPE;
+
+  const nodeSet = partial.nodeSet ? [...partial.nodeSet] : [];
+
+  const recall: ResolvedCogneeRecallConfig = {
+    enabled: resolveField(
+      partial.recall?.enabled,
+      readBool(env, "COGNEE_RECALL_ENABLED"),
+      DEFAULT_RECALL_ENABLED,
+    ),
+    // Passed through as-is (not validated against a runtime enum) so this package never trails the
+    // server's own SearchType growth.
+    searchType: resolveField(
+      partial.recall?.searchType,
+      readString(env, "COGNEE_SEARCH_TYPE") as SearchType | undefined,
+      DEFAULT_SEARCH_TYPE,
+    ),
+    topK: resolveField(partial.recall?.topK, readInt(env, "COGNEE_TOP_K"), DEFAULT_TOP_K),
+    minQueryLength: resolveField(partial.recall?.minQueryLength, undefined, DEFAULT_MIN_QUERY_LENGTH),
+    timeoutMs: resolveField(
+      partial.recall?.timeoutMs,
+      readInt(env, "COGNEE_RECALL_TIMEOUT_MS"),
+      DEFAULT_RECALL_TIMEOUT_MS,
+    ),
+    budgetMs: resolveField(
+      partial.recall?.budgetMs,
+      readInt(env, "COGNEE_RECALL_BUDGET_MS"),
+      DEFAULT_RECALL_BUDGET_MS,
+    ),
+    includeReferences: resolveField(partial.recall?.includeReferences, undefined, DEFAULT_INCLUDE_REFERENCES),
+  };
+
+  const rawWriteMode = resolveField(partial.write?.mode, readString(env, "COGNEE_SAVE_MODE"), DEFAULT_WRITE_MODE);
+  const writeMode: "always" | "assistant-only" | "never" =
+    rawWriteMode === "always" || rawWriteMode === "assistant-only" || rawWriteMode === "never"
+      ? rawWriteMode
+      : DEFAULT_WRITE_MODE;
+
+  const write: ResolvedCogneeWriteConfig = {
+    mode: writeMode,
+    runInBackground: resolveField(partial.write?.runInBackground, undefined, DEFAULT_RUN_IN_BACKGROUND),
+    maxChars: resolveField(partial.write?.maxChars, undefined, DEFAULT_WRITE_MAX_CHARS),
+  };
+
+  const tools: ResolvedCogneeToolsConfig = {
+    enableForget: resolveField(
+      partial.tools?.enableForget,
+      readBool(env, "COGNEE_ENABLE_FORGET"),
+      DEFAULT_ENABLE_FORGET,
+    ),
+    timeoutMs: resolveField(
+      partial.tools?.timeoutMs,
+      readInt(env, "COGNEE_TOOLS_TIMEOUT_MS"),
+      DEFAULT_TOOLS_TIMEOUT_MS,
+    ),
+  };
+
+  const requestTimeoutMs = resolveField(
+    partial.requestTimeoutMs,
+    readInt(env, "COGNEE_TIMEOUT_MS"),
+    DEFAULT_REQUEST_TIMEOUT_MS,
+  );
+  const retries = resolveField(partial.retries, readInt(env, "COGNEE_RETRIES"), DEFAULT_RETRIES);
+  const debug = resolveField(partial.debug, readBool(env, "COGNEE_DEBUG"), DEFAULT_DEBUG);
+
+  const resolved: ResolvedCogneeConfig = {
+    baseUrl,
+    apiKey,
+    auth,
+    dataset,
+    datasetPrefix,
+    scope,
+    nodeSet,
+    recall,
+    write,
+    tools,
+    requestTimeoutMs,
+    retries,
+    debug,
+    fetch: partial.fetch,
+  };
+
+  if (debug) {
+    // eslint-disable-next-line no-console -- intentional: this *is* the debug channel.
+    console.debug("[cognee-mastra] resolved config:", redactConfigForLogging(resolved));
+  }
+
+  return resolved;
+}
+
+// ---- Redaction: the only thing this package is allowed to hand to a logger ----
+
+const REDACTED = "***REDACTED***";
+
+/**
+ * A copy of a resolved config safe to log: `apiKey`/`auth.password` masked,
+ * `fetch` dropped entirely (a function value logs as noise and carries no
+ * secret). `client.ts`'s own debug logging should route through this same helper rather than
+ * re-deriving redaction rules.
+ */
+export function redactConfigForLogging(config: ResolvedCogneeConfig): Record<string, unknown> {
+  const { fetch: _fetch, ...rest } = config;
+  return {
+    ...rest,
+    apiKey: rest.apiKey !== undefined ? REDACTED : undefined,
+    auth:
+      rest.auth !== undefined
+        ? { email: rest.auth.email, password: rest.auth.password !== undefined ? REDACTED : undefined }
+        : undefined,
+  };
+}

--- a/integrations/mastra/src/errors.ts
+++ b/integrations/mastra/src/errors.ts
@@ -1,0 +1,118 @@
+/**
+ * `CogneeApiError` — the one error type `client.ts` throws for any
+ * non-2xx cognee response, plus `isRetryable(status)`, the single source of
+ * truth for the client's retry loop and the 402/403/404/409/422/5xx matrix.
+ *
+ * The server's error envelope isn't uniform: most failures come back as
+ * `{detail: "..."}`, but some routes use `{error: "..."}` instead (e.g.
+ * `get_recall_router.py`'s 422 branch), and `/health` uses a bare `message`
+ * key — `extractMessage` below checks all three.
+ */
+
+/** Context captured alongside the HTTP status for debugging/logging. */
+export interface CogneeApiErrorOptions {
+  status: number;
+  /**
+   * Parsed JSON body when the response was JSON, raw text otherwise, undefined if the body could
+   * not be read at all.
+   */
+  body?: unknown;
+  url?: string;
+  method?: string;
+  cause?: unknown;
+}
+
+/**
+ * Thrown for any cognee response outside 2xx, and for network/timeout failures with no response
+ * (status `0` — callers check `status > 0` to tell the two apart).
+ */
+export class CogneeApiError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+  readonly url?: string;
+  readonly method?: string;
+
+  constructor(message: string, options: CogneeApiErrorOptions) {
+    super(message, options.cause !== undefined ? { cause: options.cause } : undefined);
+    this.name = "CogneeApiError";
+    this.status = options.status;
+    this.body = options.body;
+    this.url = options.url;
+    this.method = options.method;
+
+    // Keeps `instanceof CogneeApiError` correct even under a downstream re-transpile that breaks
+    // the Error prototype chain.
+    Object.setPrototypeOf(this, CogneeApiError.prototype);
+  }
+
+  /**
+   * Build a `CogneeApiError` from a fetch Response's status + parsed body, deriving a
+   * human-readable message from whichever error-envelope key the server used.
+   */
+  static fromResponse(
+    status: number,
+    body: unknown,
+    context: { url?: string; method?: string } = {},
+  ): CogneeApiError {
+    const message = extractMessage(body) ?? `cognee API responded with status ${status}`;
+    return new CogneeApiError(message, { status, body, ...context });
+  }
+
+  /**
+   * Build a `CogneeApiError` for a request that never got a response (network error, DNS failure,
+   * connection refused). `status` is 0 — never a real HTTP status — so `isRetryable`/`status > 0`
+   * checks can tell this apart from a real 4xx/5xx.
+   */
+  static fromNetworkError(
+    cause: unknown,
+    context: { url?: string; method?: string } = {},
+  ): CogneeApiError {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return new CogneeApiError(`cognee request failed: ${message}`, { status: 0, cause, ...context });
+  }
+
+  /**
+   * Build a `CogneeApiError` for a request aborted by an `AbortSignal` timeout. `status` is 0,
+   * matching `fromNetworkError` — a timeout never received a response either.
+   */
+  static fromTimeout(timeoutMs: number, context: { url?: string; method?: string } = {}): CogneeApiError {
+    return new CogneeApiError(`cognee request timed out after ${timeoutMs}ms`, { status: 0, ...context });
+  }
+}
+
+function extractMessage(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") {
+    return typeof body === "string" && body.trim() ? body : undefined;
+  }
+  const record = body as Record<string, unknown>;
+  for (const key of ["detail", "error", "message"]) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Whether a failed request at this status is worth retrying: `5xx`
+ * (transient server failure) and `429` (rate limited) are; cognee's stable
+ * "no" matrix (`402/403/404/409/422`) is not — retrying just repeats the
+ * same failure at N× latency. `0` (network/timeout, no response) returns
+ * `false` here too, but `client.ts`'s retry loop treats connection failures as retryable on its own
+ * terms — this table simply has no opinion on status `0`.
+ */
+export function isRetryable(status: number): boolean {
+  if (status === 429) return true;
+  return status >= 500 && status < 600;
+}
+
+/**
+ * Whether a failed recall at this status counts against the breaker
+ * (`breaker.ts`) — narrower than `isRetryable`: `429` is worth retrying but
+ * isn't evidence cognee is unhealthy. Only `0` (network/timeout) and `5xx`
+ * trip it; cognee's stable "no" matrix plus `401`/`400`/`429` is a
+ * deterministic response to this request (bad key, malformed query, wrong baseUrl) — breaking on it
+ * would blackout recall for 120s over a config problem, not an outage.
+ */
+export function isBreakerError(status: number): boolean {
+  return status === 0 || (status >= 500 && status < 600);
+}

--- a/integrations/mastra/src/format.ts
+++ b/integrations/mastra/src/format.ts
@@ -1,0 +1,123 @@
+/**
+ * Text formatting across the cognee boundary: `messageToText` turns a
+ * Mastra message into plain text for `rememberEntry` (word-boundary
+ * truncated at `config.write.maxChars`, default 8000); `formatContextBlock`
+ * turns `RecallHit[]` into the system-message block the input processor
+ * injects, or `null` on an empty result set. Pure functions only — no
+ * network, filesystem, or clock — so both are unit-testable with plain fixtures.
+ */
+
+import type { RecallHit } from "./types.js";
+
+// ---- Word-boundary truncation ----
+
+/** Appended to a truncated string so callers/tests/LLMs can tell truncation happened. */
+export const TRUNCATION_MARKER = "…";
+
+/**
+ * Truncate `text` to at most `maxChars`, cutting at the last whitespace at
+ * or before that point rather than mid-word; falls back to a hard cut only
+ * when no boundary exists in range. Truncated results get `TRUNCATION_MARKER`
+ * appended; `maxChars <= 0` returns `""`; text already `<= maxChars` is returned unchanged.
+ */
+export function truncateAtWordBoundary(text: string, maxChars: number): string {
+  if (maxChars <= 0) return "";
+  if (text.length <= maxChars) return text;
+
+  const slice = text.slice(0, maxChars);
+  const boundary = Math.max(slice.lastIndexOf(" "), slice.lastIndexOf("\n"), slice.lastIndexOf("\t"));
+  // boundary === 0 would produce an empty cut — treat that like -1 (no boundary) and hard-cut
+  // instead.
+  const cut = boundary > 0 ? slice.slice(0, boundary) : slice;
+
+  return cut.trimEnd() + TRUNCATION_MARKER;
+}
+
+// ---- Message -> text ----
+
+/**
+ * Minimal shape this module needs from a Mastra message — not
+ * `MastraDBMessage`, so this stays a pure, dependency-free formatter.
+ * `content` accepts anything `extractMessageText` understands: a string, an AI-SDK parts array, or
+ * a bare `{text}` object.
+ */
+export interface FormattableMessage {
+  role?: string;
+  content: unknown;
+}
+
+/**
+ * Best-effort plain-text extraction from `content`, whichever shape it arrives in; non-text parts
+ * (tool calls, images) are silently skipped rather than stringified.
+ */
+export function extractMessageText(content: unknown): string {
+  if (typeof content === "string") return content;
+
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => extractPartText(part))
+      .filter((s): s is string => Boolean(s))
+      .join("\n");
+  }
+
+  return extractPartText(content) ?? "";
+}
+
+function extractPartText(part: unknown): string | undefined {
+  if (typeof part === "string") return part;
+  if (part && typeof part === "object") {
+    const text = (part as Record<string, unknown>).text;
+    if (typeof text === "string") return text;
+  }
+  return undefined;
+}
+
+/**
+ * Render one message as cognee-ingestible text: `"<role>: <text>"` when a
+ * role is present, content truncated on a word boundary to `maxChars`
+ * (default 8000) BEFORE the role prefix is added — truncating the
+ * already-prefixed string risks landing the boundary search inside the
+ * prefix itself (e.g. `"user: "`), returning almost nothing of the actual
+ * content. Returns `""` (never `null`) for a message with no extractable text — unlike
+ * `formatContextBlock`, an empty message is still a valid unit to join into a turn's write.
+ */
+export function messageToText(message: FormattableMessage, maxChars = 8000): string {
+  const text = extractMessageText(message.content).trim();
+  if (!text) return "";
+  const truncated = truncateAtWordBoundary(text, maxChars);
+  return message.role ? `${message.role}: ${truncated}` : truncated;
+}
+
+// ---- Recall hits -> injected context block ----
+
+export interface FormatContextOptions {
+  /** First line of the block. Default: `"Relevant memory from cognee:"`. */
+  heading?: string;
+  /** Per-hit truncation, word-boundary (default 2000). */
+  maxCharsPerHit?: number;
+}
+
+const DEFAULT_HEADING = "Relevant memory from cognee:";
+const DEFAULT_MAX_CHARS_PER_HIT = 2000;
+
+/**
+ * Render recall hits as the system-message block `CogneeInputProcessor`
+ * injects. Returns `null` (not an empty string or heading-only block) when
+ * `hits` is empty or every hit's `text` is blank, so the processor can skip injection on a "no
+ * results" recall.
+ */
+export function formatContextBlock(hits: readonly RecallHit[], options: FormatContextOptions = {}): string | null {
+  const usable = hits.filter((hit) => typeof hit.text === "string" && hit.text.trim().length > 0);
+  if (usable.length === 0) return null;
+
+  const heading = options.heading ?? DEFAULT_HEADING;
+  const maxCharsPerHit = options.maxCharsPerHit ?? DEFAULT_MAX_CHARS_PER_HIT;
+
+  const lines = usable.map((hit, index) => {
+    const text = truncateAtWordBoundary(hit.text.trim(), maxCharsPerHit);
+    const source = hit.source ?? hit.datasetName ?? hit.datasetId ?? undefined;
+    return source ? `${index + 1}. ${text} (source: ${source})` : `${index + 1}. ${text}`;
+  });
+
+  return [heading, ...lines].join("\n");
+}

--- a/integrations/mastra/src/pipeline-status.ts
+++ b/integrations/mastra/src/pipeline-status.ts
@@ -1,0 +1,48 @@
+/**
+ * Pipeline-run status values as a live cognee server reports them: GET
+ * /api/v1/datasets/status returns the server's PipelineRunStatus enum name
+ * per dataset (DATASET_PROCESSING_STARTED/COMPLETED/ERRORED on
+ * cognee/cognee:main 1.5.4), while older docs and some bodies use lowercase
+ * completed/failed. A dataset with no run under the requested pipeline is
+ * absent from the map ({}) — treat that as "not started yet", not an error.
+ */
+
+export type PipelineStatusValue =
+  | "DATASET_PROCESSING_INITIATED"
+  | "DATASET_PROCESSING_STARTED"
+  | "DATASET_PROCESSING_COMPLETED"
+  | "DATASET_PROCESSING_ERRORED"
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | string;
+
+/** True for any spelling of "the run finished successfully". */
+export function isPipelineCompleted(status: string | undefined | null): boolean {
+  const s = (status ?? "").toUpperCase();
+  return s === "COMPLETED" || s.endsWith("_COMPLETED");
+}
+
+/** True for any spelling of "the run finished with an error". */
+export function isPipelineFailed(status: string | undefined | null): boolean {
+  const s = (status ?? "").toUpperCase();
+  return s === "FAILED" || s === "ERRORED" || s.endsWith("_ERRORED") || s.endsWith("_FAILED");
+}
+
+/**
+ * Read one dataset's status out of a `/datasets/status` response. Handles
+ * the flat `{ [datasetId]: status }` map a single-pipeline query returns and
+ * the nested `{ [datasetId]: { [pipeline]: status } }` shape of a
+ * multi-pipeline query; `undefined` when the dataset has no run yet.
+ */
+export function extractPipelineStatus(response: unknown, datasetId: string): string | undefined {
+  if (!response || typeof response !== "object") return undefined;
+  const value = (response as Record<string, unknown>)[datasetId];
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object") {
+    const first = Object.values(value as Record<string, unknown>).find((v) => typeof v === "string");
+    return typeof first === "string" ? first : undefined;
+  }
+  return undefined;
+}

--- a/integrations/mastra/src/processors.ts
+++ b/integrations/mastra/src/processors.ts
@@ -1,0 +1,312 @@
+/**
+ * `CogneeInputProcessor` / `CogneeOutputProcessor` — automatic recall/capture
+ * for a Mastra agent. Recall runs in `processInput`, capture in
+ * `processOutputResult`, fired once per turn. Both read `threadId`/
+ * `resourceId` from `args.requestContext` via `parseMemoryRequestContext`,
+ * same as Mastra's `SemanticRecall`, so they stay inert without a Mastra
+ * `Memory` instance and a thread/resource id passed per call.
+ */
+
+import { parseMemoryRequestContext } from "@mastra/core/memory";
+import type { MastraDBMessage, MessageList } from "@mastra/core/agent/message-list";
+import type { Processor, ProcessInputArgs, ProcessInputResult, ProcessOutputResultArgs } from "@mastra/core/processors";
+
+import type { CogneeMastraConfig, SearchType } from "./types.js";
+import { resolveConfig } from "./config.js";
+import { resolveScope } from "./scope.js";
+import { messageToText, extractMessageText, formatContextBlock, type FormattableMessage } from "./format.js";
+import { CircuitBreaker } from "./breaker.js";
+import { CogneeApiError, isBreakerError } from "./errors.js";
+import { CogneeClient } from "./client.js";
+
+const DEFAULT_MIN_QUERY_LENGTH = 8;
+const DEFAULT_SEARCH_TYPE: SearchType = "CHUNKS";
+const DEFAULT_TOP_K = 10;
+/** Per-call recall timeout; disables client-side retry when set (see client.ts). */
+const DEFAULT_RECALL_TIMEOUT_MS = 2_500;
+const DEFAULT_RECALL_BUDGET_MS = 4_000;
+const DEFAULT_INCLUDE_REFERENCES = true;
+const DEFAULT_WRITE_MAX_CHARS = 8_000;
+// Mirrors config.ts's defaults as literals so this file stays constructible without
+// resolveConfig().
+
+// MastraDBMessage.content is `{content?; parts?}`, not a shape
+// extractMessageText understands directly — mirrors SemanticRecall's own unwrap.
+function dbMessageText(message: MastraDBMessage): string {
+  const content = message.content as unknown;
+  if (typeof content === "string") return content;
+  if (content && typeof content === "object") {
+    const c = content as { content?: unknown; parts?: unknown };
+    if (typeof c.content === "string" && c.content) return c.content;
+    if (Array.isArray(c.parts)) {
+      return extractMessageText(c.parts);
+    }
+  }
+  return "";
+}
+
+function toFormattable(message: MastraDBMessage): FormattableMessage {
+  return { role: message.role, content: dbMessageText(message) };
+}
+
+/**
+ * Last user-role message's text, truncated to 2000 chars, or `null`.
+ * Doesn't special-case Studio's `role: 'signal'` turn — a query-less turn
+ * already fails open below, so missing it just skips one recall.
+ */
+function extractRecallQuery(messages: MastraDBMessage[]): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (!message || message.role !== "user") continue;
+    const text = dbMessageText(message).trim();
+    if (text) return text.slice(0, 2000);
+  }
+  return null;
+}
+
+/**
+ * Races `promise` against a `budgetMs` wall-clock timer so a hung recall
+ * can't hold the turn open past `budgetMs`, backstopping the client's own
+ * `timeoutMs` (which normally fires first). The losing `promise` is not
+ * cancelled (no caller-supplied `AbortController`) but is still handled via `.then` so a late
+ * response never becomes an unhandled rejection.
+ */
+function withBudget<T>(promise: Promise<T>, budgetMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`cognee recall exceeded budgetMs (${budgetMs}ms)`));
+    }, budgetMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+export interface CogneeProcessorOptions {
+  /**
+   * Shared client; `createCogneeProcessors()` builds one from `config` when not supplied directly.
+   */
+  client: CogneeClient;
+  config: CogneeMastraConfig;
+  /**
+   * Circuit breaker for the recall path only (write path has none — see `CogneeOutputProcessor`).
+   * Defaults to a new instance; tests inject their own.
+   */
+  breaker?: CircuitBreaker;
+}
+
+// ---- CogneeInputProcessor: pre-turn recall ----
+
+/**
+ * Recalls from cognee before the model call and injects the result as a
+ * system message via `messageList.addSystem(block, "cognee")`. Fails open
+ * on every error path — a cognee failure here must never break the turn.
+ */
+export class CogneeInputProcessor implements Processor {
+  readonly id = "cognee-input";
+  readonly name = "CogneeInputProcessor";
+
+  private readonly breaker: CircuitBreaker;
+
+  constructor(private readonly opts: CogneeProcessorOptions) {
+    this.breaker = opts.breaker ?? new CircuitBreaker();
+  }
+
+  async processInput(args: ProcessInputArgs): Promise<ProcessInputResult> {
+    const { messages, messageList, requestContext } = args;
+    const recallConfig = this.opts.config.recall;
+
+    if (recallConfig?.enabled === false) return messageList;
+
+    // Fail-open boundary: everything below degrades to returning messageList
+    // unchanged on any error, including parseMemoryRequestContext itself throwing.
+    try {
+      // No memory context means no scope to recall into, same no-op as
+      // SemanticRecall's own guard.
+      const memoryContext = parseMemoryRequestContext(requestContext);
+      if (!memoryContext) return messageList;
+
+      const { thread, resourceId } = memoryContext;
+      const threadId = thread?.id;
+
+      const query = extractRecallQuery(messages);
+      const minQueryLength = recallConfig?.minQueryLength ?? DEFAULT_MIN_QUERY_LENGTH;
+      if (!query || query.length < minQueryLength) return messageList;
+
+      // Checked before any network call — an open breaker sends zero requests.
+      if (await this.breaker.isOpen()) return messageList;
+
+      const scope = resolveScope(this.opts.config, { threadId, resourceId });
+      const timeoutMs = recallConfig?.timeoutMs ?? DEFAULT_RECALL_TIMEOUT_MS;
+      const budgetMs = recallConfig?.budgetMs ?? DEFAULT_RECALL_BUDGET_MS;
+
+      const hits = await withBudget(
+        this.opts.client.recall(
+          {
+            query,
+            search_type: recallConfig?.searchType ?? DEFAULT_SEARCH_TYPE,
+            top_k: recallConfig?.topK ?? DEFAULT_TOP_K,
+            only_context: true,
+            // resolveScope only resolves a dataset *name*, so scoping goes through `datasets`, not
+            // `dataset_ids`.
+            datasets: [scope.dataset],
+            session_id: scope.sessionId || undefined,
+            node_name: scope.nodeNameFilter.length ? scope.nodeNameFilter : undefined,
+            include_references: recallConfig?.includeReferences ?? DEFAULT_INCLUDE_REFERENCES,
+          },
+          // Per-call timeoutMs disables the client's own retry (client.ts).
+          { timeoutMs },
+        ),
+        budgetMs,
+      );
+
+      // Awaited (not fire-and-forget) so a failure is visible to the very next call on this breaker
+      // instance.
+      await this.breaker.recordSuccess();
+
+      const block = formatContextBlock(hits);
+      if (block) messageList.addSystem(block, "cognee");
+      return messageList;
+    } catch (error) {
+      // Only a breaker-eligible failure (5xx, or network/timeout with no
+      // response) counts against the breaker — a deterministic 4xx (bad key,
+      // validation error, wrong baseUrl) is a config problem, not an outage.
+      const status = error instanceof CogneeApiError ? error.status : 0;
+      if (isBreakerError(status)) {
+        await this.breaker.recordFailure(error);
+      }
+      return messageList;
+    }
+  }
+}
+
+// ---- CogneeOutputProcessor: post-turn capture ----
+
+/**
+ * Persists the completed turn into cognee, fire-and-forget, honouring
+ * `config.write.mode`. Uses `processOutputResult` — the one output hook
+ * that fires once with the full generation result, unlike
+ * `processOutputStream`/`processOutputStep`. Fails open like
+ * `CogneeInputProcessor`. No circuit breaker: a dropped write just retries
+ * next turn, with no user-facing latency to protect.
+ */
+export class CogneeOutputProcessor implements Processor {
+  readonly id = "cognee-output";
+  readonly name = "CogneeOutputProcessor";
+
+  constructor(private readonly opts: CogneeProcessorOptions) {}
+
+  // Declared as Promise<MessageList | MastraDBMessage[]>, not
+  // Promise<ProcessorMessageResult> — that type is already Promise-wrapped, so nesting it fails
+  // structural assignment against Processor's signature.
+  async processOutputResult(args: ProcessOutputResultArgs): Promise<MessageList | MastraDBMessage[]> {
+    const { messages, messageList, requestContext } = args;
+    const passthrough = messageList ?? messages;
+    const writeConfig = this.opts.config.write;
+
+    if (writeConfig?.mode === "never") return passthrough;
+
+    // Same fail-open rule as processInput: a throwing parseMemoryRequestContext is treated like a
+    // null one.
+    let memoryContext: ReturnType<typeof parseMemoryRequestContext>;
+    try {
+      memoryContext = parseMemoryRequestContext(requestContext);
+    } catch {
+      return passthrough;
+    }
+    if (!memoryContext) return passthrough;
+
+    const { thread, resourceId } = memoryContext;
+    const threadId = thread?.id;
+    if (!threadId) return passthrough;
+
+    // Fire-and-forget: returns `passthrough` immediately while `persistTurn`
+    // keeps running; the `.catch` here only guards a synchronous throw before persistTurn's own try
+    // block starts.
+    void this.persistTurn({ messages, messageList, threadId, resourceId }).catch(() => {});
+
+    return passthrough;
+  }
+
+  private async persistTurn(input: {
+    messages: MastraDBMessage[];
+    messageList: MessageList | undefined;
+    threadId: string;
+    resourceId?: string;
+  }): Promise<void> {
+    const writeConfig = this.opts.config.write;
+    const maxChars = writeConfig?.maxChars ?? DEFAULT_WRITE_MAX_CHARS;
+
+    try {
+      const answer = input.messages
+        .map((message) => messageToText(toFormattable(message), maxChars))
+        .filter(Boolean)
+        .join("\n");
+
+      let question = "";
+      if (writeConfig?.mode !== "assistant-only" && input.messageList) {
+        const messageList = input.messageList;
+        const newUserMessages = messageList.get.input.db().filter((message) => messageList.isNewMessage(message));
+        question = newUserMessages
+          .map((message) => messageToText(toFormattable(message), maxChars))
+          .filter(Boolean)
+          .join("\n");
+      }
+
+      if (!answer && !question) return; // nothing extractable this turn — not worth a write.
+
+      const scope = resolveScope(this.opts.config, { threadId: input.threadId, resourceId: input.resourceId });
+
+      // rememberEntry() already owns the 404-fallback to remember() internally.
+      await this.opts.client.rememberEntry({
+        entry: { type: "qa", question, answer },
+        dataset_name: scope.dataset,
+        session_id: scope.sessionId || undefined,
+      });
+    } catch {
+      // fire-and-forget: never propagate anywhere a caller could observe it.
+    }
+  }
+}
+
+// ---- createCogneeProcessors: one-call wiring ----
+
+export interface CogneeProcessors {
+  input: CogneeInputProcessor;
+  output: CogneeOutputProcessor;
+}
+
+/**
+ * Config for `createCogneeProcessors()`/`withCognee()`: `CogneeMastraConfig`
+ * plus escape hatches to reuse an existing `CogneeClient` (shared with
+ * `createCogneeTools()`) and to inject a breaker (tests).
+ */
+export interface CogneeProcessorsConfig extends CogneeMastraConfig {
+  client?: CogneeClient;
+  breaker?: CircuitBreaker;
+}
+
+/**
+ * Resolves `config` through `resolveConfig()` once, builds a shared
+ * `CogneeClient` when `config.client` isn't supplied, and passes the same
+ * client to both processors so recall and write share one dataset-id cache.
+ * Never throws for a missing credential — `CogneeClient` defers that to the first request.
+ */
+export function createCogneeProcessors(config: CogneeProcessorsConfig = {}): CogneeProcessors {
+  const { client: providedClient, breaker: providedBreaker, ...rest } = config;
+  const resolved = resolveConfig(rest);
+  const client = providedClient ?? new CogneeClient(resolved);
+  const breaker = providedBreaker ?? new CircuitBreaker();
+  const opts: CogneeProcessorOptions = { client, config: resolved, breaker };
+  return {
+    input: new CogneeInputProcessor(opts),
+    output: new CogneeOutputProcessor(opts),
+  };
+}

--- a/integrations/mastra/src/scope.ts
+++ b/integrations/mastra/src/scope.ts
@@ -1,0 +1,111 @@
+/**
+ * Mastra id -> cognee scope mapping. Pure, no I/O — `client.ts` does the
+ * actual `ensureDataset`/`remember`/`recall` calls.
+ *
+ * `CogneeMastraConfig.scope` (default `"tagged"`): one shared dataset with
+ * per-thread `session_id` and `node_set` tags, recall narrowed by
+ * `node_name: ["resource:<id>"]` (retrieval scoping, not access control);
+ * `"dataset-per-resource"` uses `${datasetPrefix}${resourceId}` instead.
+ */
+
+import type { CogneeMastraConfig } from "./types.js";
+
+export const DEFAULT_DATASET = "mastra";
+export const DEFAULT_DATASET_PREFIX = "mastra_";
+/** Placeholder resource suffix when `dataset-per-resource` is used without a resourceId. */
+const NO_RESOURCE = "default";
+
+/**
+ * Percent-encodes everything outside `[A-Za-z0-9_-]` plus `.` (which
+ * `encodeURIComponent` leaves alone); since `.` in the output only ever came from a literal `.` in
+ * the input, this stays collision-free, and the result also has no space or `.`, satisfying
+ * cognee's `check_dataset_name`.
+ */
+export function sanitizeId(id: string): string {
+  return encodeURIComponent(id).replace(/\./g, "%2E");
+}
+
+/** Build one `node_set`/`node_name` tag: `"<kind>:<sanitized-id>"`. */
+export function buildTag(kind: string, id: string): string {
+  return `${kind}:${sanitizeId(id)}`;
+}
+
+/** `"resource:<resourceId>"` tag. */
+export function resourceTag(resourceId: string): string {
+  return buildTag("resource", resourceId);
+}
+
+/** `"thread:<threadId>"` tag. */
+export function threadTag(threadId: string): string {
+  return buildTag("thread", threadId);
+}
+
+/**
+ * cognee `session_id` for a Mastra thread: `"mastra_<threadId>"`, unsanitized (opaque string,
+ * cognee places no character restriction on it). Returns `""` for an absent threadId so callers can
+ * do `if (sessionId)` without special-casing `undefined` vs `""`.
+ */
+export function sessionIdFor(threadId: string | undefined | null): string {
+  return threadId ? `mastra_${threadId}` : "";
+}
+
+/** Config fields `scope.ts` reads — a narrow slice of `CogneeMastraConfig`. */
+export type ScopeConfig = Pick<CogneeMastraConfig, "scope" | "dataset" | "datasetPrefix" | "nodeSet">;
+
+/**
+ * Dataset name for a resource under the configured scope mode: `"tagged"`
+ * (default) always returns `config.dataset`; `"dataset-per-resource"`
+ * returns `${datasetPrefix}${sanitize(resourceId)}`, falling back to `"default"` when no resourceId
+ * is available.
+ */
+export function datasetNameForResource(config: ScopeConfig, resourceId?: string | null): string {
+  if ((config.scope ?? "tagged") === "dataset-per-resource") {
+    const prefix = config.datasetPrefix ?? DEFAULT_DATASET_PREFIX;
+    const suffix = resourceId ? sanitizeId(resourceId) : NO_RESOURCE;
+    return `${prefix}${suffix}`;
+  }
+  return config.dataset ?? DEFAULT_DATASET;
+}
+
+export interface ScopeIds {
+  threadId?: string | null;
+  resourceId?: string | null;
+}
+
+export interface ResolvedScope {
+  /** dataset to read/write for this thread/resource, per the configured scope mode. */
+  dataset: string;
+  /** `mastra_<threadId>`, or `""` when no threadId is available. */
+  sessionId: string;
+  /**
+   * node_set tags to attach on write — resource + thread + `config.nodeSet` extras, in that order.
+   */
+  nodeSet: string[];
+  /**
+   * node_name filter for recall: `["resource:<id>"]` when a resourceId is
+   * available, else `["thread:<id>"]`, else `[]` when neither id is present.
+   */
+  nodeNameFilter: string[];
+}
+
+/**
+ * Turn a Mastra thread/resource pair plus config into everything `client.ts` needs to scope one
+ * `recall()`/`remember()` call.
+ */
+export function resolveScope(config: ScopeConfig, ids: ScopeIds): ResolvedScope {
+  const dataset = datasetNameForResource(config, ids.resourceId);
+  const sessionId = sessionIdFor(ids.threadId);
+
+  const nodeSet: string[] = [];
+  if (ids.resourceId) nodeSet.push(resourceTag(ids.resourceId));
+  if (ids.threadId) nodeSet.push(threadTag(ids.threadId));
+  if (config.nodeSet?.length) nodeSet.push(...config.nodeSet);
+
+  const nodeNameFilter = ids.resourceId
+    ? [resourceTag(ids.resourceId)]
+    : ids.threadId
+      ? [threadTag(ids.threadId)]
+      : [];
+
+  return { dataset, sessionId, nodeSet, nodeNameFilter };
+}

--- a/integrations/mastra/src/tools.ts
+++ b/integrations/mastra/src/tools.ts
@@ -1,0 +1,391 @@
+/**
+ * `createCogneeSearchTool` / `createCogneeAskTool` / `createCogneeRememberTool` /
+ * `createCogneeForgetTool` and the `createCogneeTools(config)` collection
+ * factory — the explicit, agent-driven half of this package's dual surface.
+ * Follows the Mastra/tavily tool-factory idiom: a function returning a
+ * `Tool` built with `createTool()`, using its own Zod `inputSchema`/
+ * `outputSchema`/`execute(inputData, context)` shape.
+ */
+
+import { z } from "zod";
+import { createTool, type Tool, type ToolSet } from "@mastra/core/tools";
+
+import { CogneeClient } from "./client.js";
+import { CogneeApiError } from "./errors.js";
+import { resolveConfig, type ResolvedCogneeConfig } from "./config.js";
+import { resolveScope, sanitizeId } from "./scope.js";
+import type { CogneeMastraConfig, RecallHit } from "./types.js";
+
+/**
+ * `Tool<any, ...>`, not bare `Tool`: `unknown` defaults make `execute`'s `inputData` contravariant,
+ * so a concrete `Tool<{query: string}, ...>` isn't assignable to `Tool<unknown, ...>`; `any`
+ * matches Mastra's own `ToolSet`.
+ */
+type AnyCogneeTool = Tool<any, any, any, any, any, any, any>;
+
+// ---- Shared: lazy client + resolved-config plumbing ----
+
+/**
+ * Every factory resolves `process.env` exactly once via `resolveConfig()`; tools operate on the
+ * fully-defaulted `ResolvedCogneeConfig`, never a raw `CogneeMastraConfig` field directly.
+ */
+interface FactoryContext {
+  /**
+   * Lazily constructs (and thereafter reuses) the shared `CogneeClient` — see
+   * `resolveFactoryContext` below.
+   */
+  getClient: () => CogneeClient;
+  resolved: ResolvedCogneeConfig;
+}
+
+export interface CogneeToolFactoryOptions {
+  /**
+   * Reuse an already-constructed client (e.g. the one `withCognee()`'s processors already hold)
+   * instead of building a new one.
+   */
+  client?: CogneeClient;
+  /**
+   * Config resolved via `resolveConfig()` when `client` (or the internal `shared` context
+   * `createCogneeTools()` passes) is absent.
+   */
+  config?: CogneeMastraConfig;
+  /**
+   * @internal Set only by `createCogneeTools()` so every tool it builds shares one client/config.
+   * Not meant for external callers — use `client` or `config`.
+   */
+  shared?: FactoryContext;
+}
+
+/**
+ * Resolves config once, returning a `getClient()` accessor that lazily builds (and reuses) the
+ * `CogneeClient`; only calling a tool's `execute` can throw for a missing credential, never this
+ * call itself.
+ */
+function resolveFactoryContext(options: CogneeToolFactoryOptions): FactoryContext {
+  if (options.shared) return options.shared;
+
+  const resolved = resolveConfig(options.config ?? {});
+  let cached: CogneeClient | undefined = options.client;
+  const getClient = (): CogneeClient => {
+    if (!cached) cached = new CogneeClient(resolved);
+    return cached;
+  };
+  return { getClient, resolved };
+}
+
+// ---- Shared: error/result helpers ----
+
+/** Every tool's `execute` funnels a caught error through this — never a throw. */
+function toErrorMessage(error: unknown): string {
+  if (error instanceof CogneeApiError) return error.message;
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+/**
+ * `RecallHit` -> the model-facing shape declared by every tool's `RecallHitSchema` below — `null`,
+ * not `undefined`, for absent optional fields, matching `.nullable()`'s wire shape.
+ */
+function toHitDTO(hit: RecallHit): z.infer<typeof RecallHitSchema> {
+  return {
+    text: hit.text,
+    score: hit.score ?? null,
+    source: hit.source,
+    datasetId: hit.datasetId ?? null,
+    datasetName: hit.datasetName ?? null,
+  };
+}
+
+/**
+ * `cognee_remember`'s `metadata` -> `node_set` tags. Both key and value pass through `sanitizeId`
+ * (scope.ts) — metadata keys are caller-supplied, unlike `scope.ts`'s own hardcoded
+ * `resource:`/`thread:` tag kinds, so they need the same collision-safety treatment `sanitizeId`
+ * already gives ids.
+ */
+function metadataToTags(metadata: Record<string, string | number | boolean> | undefined): string[] {
+  if (!metadata) return [];
+  return Object.entries(metadata).map(([key, value]) => `${sanitizeId(key)}:${sanitizeId(String(value))}`);
+}
+
+// ---- Shared: recall-hit schema (used by both cognee_search and cognee_ask) ----
+
+const RecallHitSchema = z.object({
+  text: z.string(),
+  score: z.number().nullable().optional(),
+  source: z.string().optional(),
+  datasetId: z.string().nullable().optional(),
+  datasetName: z.string().nullable().optional(),
+});
+
+// ---- cognee_search: fast semantic passage recall ----
+
+const SearchInputSchema = z.object({
+  query: z.string().min(1).describe("Natural-language question or topic to search cognee's memory for."),
+  topK: z.number().int().positive().max(50).optional().describe("Max passages to return. Default 10."),
+  nodeName: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Advanced: restrict results to these exact node tags. Usually left unset — the tool already scopes results to the current resource automatically.",
+    ),
+});
+
+const SearchOutputSchema = z.object({
+  results: z.array(RecallHitSchema).optional().describe("Matching passages, most relevant first."),
+  error: z.string().optional().describe("Present, and `results` absent, when the search failed."),
+});
+
+/**
+ * Fast semantic passage recall (`search_type: CHUNKS`, `only_context: true`,
+ * no LLM call inside cognee) — the cheap default the model should reach for before `cognee_ask`.
+ */
+export function createCogneeSearchTool(options: CogneeToolFactoryOptions = {}): AnyCogneeTool {
+  const { getClient, resolved } = resolveFactoryContext(options);
+
+  return createTool({
+    id: "cognee_search",
+    description:
+      "Search cognee's long-term memory for relevant passages. Fast and cheap — no LLM call happens inside " +
+      "cognee for this tool, just a vector/keyword lookup. Use this as the default for 'what do we know about " +
+      "X', 'find anything about Y', or 'have we discussed Z before' questions. Returns raw text passages with a " +
+      "relevance score, not a synthesized answer — if you need cognee to reason over the graph and produce a " +
+      "written answer instead of passages, use cognee_ask (that one is slow and expensive; prefer this tool first).",
+    inputSchema: SearchInputSchema,
+    outputSchema: SearchOutputSchema,
+    execute: async (input, context) => {
+      return context.observe.span("cognee.cognee_search", async () => {
+        try {
+          const scope = resolveScope(resolved, { threadId: context.agent?.threadId, resourceId: context.agent?.resourceId });
+          const nodeName = [...scope.nodeNameFilter, ...(input.nodeName ?? [])];
+          const hits = await getClient().recall(
+            {
+              query: input.query,
+              search_type: "CHUNKS",
+              datasets: [scope.dataset],
+              top_k: input.topK ?? resolved.recall.topK,
+              only_context: true,
+              session_id: scope.sessionId || undefined,
+              node_name: nodeName.length > 0 ? nodeName : undefined,
+            },
+            // Explicit bounded budget: a bare call would inherit the
+            // client-wide 30s x (retries+1) worst case. `timeoutMs` alone implies 0 retries
+            // (client.ts) — right for a read.
+            { timeoutMs: resolved.tools.timeoutMs },
+          );
+          return { results: hits.map(toHitDTO) };
+        } catch (error) {
+          return { error: toErrorMessage(error) };
+        }
+      });
+    },
+  });
+}
+
+// ---- cognee_ask: graph Q&A, expensive/slow ----
+
+const AskInputSchema = z.object({
+  question: z.string().min(1).describe("The question to have cognee reason over its knowledge graph and answer."),
+  topK: z.number().int().positive().max(50).optional().describe("Max supporting graph nodes to consider. Default 10."),
+});
+
+const AskOutputSchema = z.object({
+  answer: z.string().optional().describe("Cognee's synthesized answer. Absent (with `error` set) on failure."),
+  references: z
+    .array(RecallHitSchema)
+    .optional()
+    .describe("Graph nodes/passages that back the answer (include_references: true)."),
+  error: z.string().optional().describe("Present, and `answer` absent, when the request failed."),
+});
+
+/**
+ * Graph question-answering (`GRAPH_COMPLETION`, `include_references: true`,
+ * `only_context: false`) — the only surface here billed against cognee's
+ * own API key for an extra LLM call; the tool description warns the model before it calls this.
+ */
+export function createCogneeAskTool(options: CogneeToolFactoryOptions = {}): AnyCogneeTool {
+  const { getClient, resolved } = resolveFactoryContext(options);
+
+  return createTool({
+    id: "cognee_ask",
+    description:
+      "Ask cognee's knowledge graph a question and get back a reasoned, synthesized answer. EXPENSIVE AND SLOW " +
+      "compared to cognee_search: this triggers an additional LLM call inside the cognee server (billed to the " +
+      "cognee server's own API key, not this conversation's) and typically takes several seconds. Only use this " +
+      "when you actually need graph reasoning or a written synthesis — for a quick lookup of relevant passages, " +
+      "use cognee_search instead; it is faster and cheaper and usually enough.",
+    inputSchema: AskInputSchema,
+    outputSchema: AskOutputSchema,
+    execute: async (input, context) => {
+      return context.observe.span("cognee.cognee_ask", async () => {
+        try {
+          const scope = resolveScope(resolved, { threadId: context.agent?.threadId, resourceId: context.agent?.resourceId });
+          const hits = await getClient().recall(
+            {
+              query: input.question,
+              search_type: "GRAPH_COMPLETION",
+              datasets: [scope.dataset],
+              top_k: input.topK ?? resolved.recall.topK,
+              only_context: false,
+              include_references: resolved.recall.includeReferences,
+              session_id: scope.sessionId || undefined,
+              node_name: scope.nodeNameFilter.length > 0 ? scope.nodeNameFilter : undefined,
+            },
+            // Same bounded budget as cognee_search. GRAPH_COMPLETION is
+            // already slow/expensive; still one bounded attempt, not 30s x (retries+1).
+            { timeoutMs: resolved.tools.timeoutMs },
+          );
+          const answer = hits
+            .map((hit) => hit.text)
+            .filter((text) => text.trim().length > 0)
+            .join("\n\n");
+          return {
+            answer,
+            references: hits.length > 0 ? hits.map(toHitDTO) : undefined,
+          };
+        } catch (error) {
+          return { error: toErrorMessage(error) };
+        }
+      });
+    },
+  });
+}
+
+// ---- cognee_remember: explicit write ----
+
+const RememberInputSchema = z.object({
+  statement: z.string().min(1).describe("The fact or statement to remember, written out in plain language."),
+  metadata: z
+    .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+    .optional()
+    .describe("Optional key/value tags attached to this memory, e.g. { category: 'preference' }."),
+});
+
+const RememberOutputSchema = z.object({
+  success: z.boolean().optional(),
+  status: z.string().optional().describe("cognee's own pipeline-run status for this write, when available."),
+  error: z.string().optional().describe("Present, and `success: false`, when the write failed."),
+});
+
+/**
+ * Explicit write of a statement/fact. `metadata` folds into `node_set` via
+ * `metadataToTags` above — cognee's write endpoints have no separate metadata field.
+ */
+export function createCogneeRememberTool(options: CogneeToolFactoryOptions = {}): AnyCogneeTool {
+  const { getClient, resolved } = resolveFactoryContext(options);
+
+  return createTool({
+    id: "cognee_remember",
+    description:
+      "Explicitly save a fact or statement to cognee's long-term memory, so it can be recalled in future " +
+      "conversations (via cognee_search/cognee_ask or the automatic recall this package also provides). Use this " +
+      "for durable facts worth remembering beyond this conversation — user preferences, decisions, stable " +
+      "context — not for routine conversational turns, which the output processor (if configured) already " +
+      "captures on its own.",
+    inputSchema: RememberInputSchema,
+    outputSchema: RememberOutputSchema,
+    execute: async (input, context) => {
+      return context.observe.span("cognee.cognee_remember", async () => {
+        try {
+          const scope = resolveScope(resolved, { threadId: context.agent?.threadId, resourceId: context.agent?.resourceId });
+          const result = await getClient().remember(
+            {
+              raw_data: [input.statement],
+              datasetName: scope.dataset,
+              session_id: scope.sessionId || undefined,
+              node_set: [...scope.nodeSet, ...metadataToTags(input.metadata)],
+              run_in_background: resolved.write.runInBackground,
+            },
+            // Same bounded budget as the read tools, but a write can afford
+            // one retry within it — a transient 500 shouldn't cost the model a whole failed call.
+            { timeoutMs: resolved.tools.timeoutMs, retries: 1 },
+          );
+          return { success: true, status: typeof result?.status === "string" ? result.status : undefined };
+        } catch (error) {
+          return { success: false, error: toErrorMessage(error) };
+        }
+      });
+    },
+  });
+}
+
+// ---- cognee_forget: destructive, opt-in only ----
+
+const ForgetInputSchema = z.object({
+  dataId: z.string().min(1).describe("The cognee data id of the specific memory item to forget."),
+});
+
+const ForgetOutputSchema = z.object({
+  success: z.boolean().optional(),
+  error: z.string().optional().describe("Present, and `success: false`, when the forget request failed."),
+});
+
+/**
+ * Destructive deletion of one memory item; always forces `memory_only: true`
+ * (never `everything: true`), enforced here and independently in
+ * `CogneeClient.forget`. Not gated by `enableForget` itself — see `createCogneeTools()` below for
+ * that gate.
+ */
+export function createCogneeForgetTool(options: CogneeToolFactoryOptions = {}): AnyCogneeTool {
+  const { getClient, resolved } = resolveFactoryContext(options);
+
+  return createTool({
+    id: "cognee_forget",
+    description:
+      "DESTRUCTIVE: permanently deletes one specific memory item from cognee by its data id (memory_only mode — " +
+      "the underlying source data cognee ingested is not deleted, only this memory-graph entry). Only call this " +
+      "when the user has explicitly asked to forget, delete, or remove something specific that was remembered. " +
+      "Never call this speculatively or to 'clean up' — there is no undo.",
+    inputSchema: ForgetInputSchema,
+    outputSchema: ForgetOutputSchema,
+    execute: async (input, context) => {
+      return context.observe.span("cognee.cognee_forget", async () => {
+        try {
+          // Same bounded write budget as cognee_remember: one retry within
+          // `resolved.tools.timeoutMs`.
+          await getClient().forget(
+            { data_id: input.dataId, memory_only: true },
+            { timeoutMs: resolved.tools.timeoutMs, retries: 1 },
+          );
+          return { success: true };
+        } catch (error) {
+          return { success: false, error: toErrorMessage(error) };
+        }
+      });
+    },
+  });
+}
+
+// ---- createCogneeTools: collection factory ----
+
+export interface CogneeToolsFactoryConfig extends CogneeMastraConfig {
+  /**
+   * Reuse an already-constructed client (e.g. shared with
+   * `createCogneeProcessors()`/`withCognee()`) instead of building a new one.
+   */
+  client?: CogneeClient;
+}
+
+/**
+ * `createCogneeTools(config)` -> `Record<string, Tool>` (the tavily/
+ * perplexity collection-factory pattern). Builds one `CogneeClient` lazily
+ * and shares it, and the resolved config, across every tool this call
+ * returns. `cognee_forget` is included only when
+ * `config.tools.enableForget === true`; the standalone `createCogneeForgetTool` export is never
+ * gated.
+ */
+export function createCogneeTools(config: CogneeToolsFactoryConfig = {}): ToolSet {
+  const { client, ...cogneeConfig } = config;
+  const shared = resolveFactoryContext({ client, config: cogneeConfig });
+
+  const tools: ToolSet = {
+    cognee_search: createCogneeSearchTool({ shared }),
+    cognee_ask: createCogneeAskTool({ shared }),
+    cognee_remember: createCogneeRememberTool({ shared }),
+  };
+
+  if (shared.resolved.tools.enableForget) {
+    tools.cognee_forget = createCogneeForgetTool({ shared });
+  }
+
+  return tools;
+}

--- a/integrations/mastra/src/types.ts
+++ b/integrations/mastra/src/types.ts
@@ -1,0 +1,298 @@
+/**
+ * Config surface and wire DTOs for cognee's HTTP API. No I/O — client.ts is
+ * the only file that talks to the network. Wire shapes are checked against
+ * cognee's route handlers rather than assumed from docs, since several
+ * diverge from what the docs suggest.
+ */
+
+// -- Search types -------------------------------------------------------------
+
+/** cognee's retrieval strategies, verbatim from SearchType(str, Enum) in
+ *  cognee/modules/search/types/SearchType.py. A plain string union, not a
+ *  TS enum, so resolveConfig can round-trip COGNEE_SEARCH_TYPE with no
+ *  runtime object to import. */
+export type SearchType =
+  | "SUMMARIES"
+  | "CHUNKS"
+  | "RAG_COMPLETION"
+  | "HYBRID_COMPLETION"
+  | "TRIPLET_COMPLETION"
+  | "GRAPH_COMPLETION"
+  | "GRAPH_COMPLETION_DECOMPOSITION"
+  | "GRAPH_SUMMARY_COMPLETION"
+  | "CYPHER"
+  | "NATURAL_LANGUAGE"
+  | "GRAPH_COMPLETION_COT"
+  | "GRAPH_COMPLETION_CONTEXT_EXTENSION"
+  | "FEELING_LUCKY"
+  | "TEMPORAL"
+  | "CODING_RULES"
+  | "CHUNKS_LEXICAL"
+  | "AGENTIC_COMPLETION"
+  | "CODE"
+  | "GRAPH_REPORT"
+  | "SKILLS";
+
+/** Shape of an `only_context: true` recall/search result. */
+export type ContextFormat = "context" | "prompt";
+
+// -- Config surface (resolveConfig reads process.env against this) ----------
+
+export interface CogneeRecallConfig {
+  enabled?: boolean;
+  searchType?: SearchType;
+  topK?: number;
+  /** Skip recall for queries shorter than this (e.g. "ok", "yes"). */
+  minQueryLength?: number;
+  /** Per-call timeout; disables retry when set. */
+  timeoutMs?: number;
+  /** Wall-clock cap the input processor must respect. */
+  budgetMs?: number;
+  includeReferences?: boolean;
+}
+
+export interface CogneeWriteConfig {
+  mode?: "always" | "assistant-only" | "never";
+  runInBackground?: boolean;
+  /** Per-turn truncation cap on write payload size. */
+  maxChars?: number;
+}
+
+export interface CogneeToolsConfig {
+  /** Gates cognee_forget out of createCogneeTools() when false. */
+  enableForget?: boolean;
+  /** Per-call budget for the cognee_* tools; since a per-call timeoutMs
+   *  disables retries (client.ts), reads get 0 retries here while writes
+   *  keep 1. */
+  timeoutMs?: number;
+}
+
+/** Used only when apiKey is absent. */
+export interface CogneeAuthConfig {
+  email?: string;
+  password?: string;
+}
+
+/** Full config surface; resolution order is explicit argument -> env var ->
+ *  default, implemented by config.ts's resolveConfig — nothing else in this
+ *  package reads process.env directly. */
+export interface CogneeMastraConfig {
+  baseUrl?: string;
+  /** Wins over `auth` when both are set. */
+  apiKey?: string;
+  auth?: CogneeAuthConfig;
+
+  dataset?: string;
+  datasetPrefix?: string;
+  /** Mapping lives in scope.ts. */
+  scope?: "tagged" | "dataset-per-resource";
+  nodeSet?: string[];
+
+  recall?: CogneeRecallConfig;
+  write?: CogneeWriteConfig;
+  tools?: CogneeToolsConfig;
+
+  /** Distinct from recall.timeoutMs. */
+  requestTimeoutMs?: number;
+  /** Disabled whenever a per-call timeoutMs is set (client.ts). */
+  retries?: number;
+  /** Debug logging must redact apiKey/password. */
+  debug?: boolean;
+  fetch?: typeof fetch;
+}
+
+// -- Wire DTOs — /health ------------------------------------------------------
+
+/** GET /health. 200 body is {status:"ready", health, version}; a 503
+ *  narrows to {status:"not ready"} and may omit health/version. All fields
+ *  optional so a partial/older server body still parses. */
+export interface HealthResponse {
+  status?: "ready" | "not ready" | string;
+  health?: string;
+  version?: string;
+  reason?: string;
+}
+
+// -- Wire DTOs — auth ---------------------------------------------------------
+
+/** POST /api/v1/auth/login, form-encoded (fastapi-users'
+ *  OAuth2PasswordRequestForm — username, not email). */
+export interface LoginRequest {
+  username: string;
+  password: string;
+}
+
+/** fastapi-users' default bearer-token login response shape. */
+export interface LoginResponse {
+  access_token: string;
+  token_type: string;
+}
+
+// -- Wire DTOs — /datasets -----------------------------------------------------
+
+/** DatasetDTO from get_datasets_router.py; both list and create-or-return resolve to this shape. */
+export interface DatasetDTO {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at?: string | null;
+  owner_id: string;
+}
+
+/** POST /api/v1/datasets body (DatasetCreationPayload). */
+export interface EnsureDatasetRequest {
+  name: string;
+}
+
+// -- Wire DTOs — /recall (primary read path) and its /search legacy fallback --
+
+/** Body shared by POST /api/v1/recall and its /search fallback:
+ *  RecallPayloadDTO and SearchPayloadDTO declare the same fields this
+ *  adapter sends. Only fields used here are typed; the server accepts more. */
+export interface RecallRequest {
+  query: string;
+  search_type?: SearchType;
+  datasets?: string[];
+  dataset_ids?: string[];
+  top_k?: number;
+  only_context?: boolean;
+  context_format?: ContextFormat;
+  include_references?: boolean;
+  session_id?: string;
+  node_name?: string[];
+}
+
+/** One item from POST /api/v1/recall's array; the server defines this as a
+ *  discriminated union on source, but it's typed loosely here (optional
+ *  fields plus a [key: string]: unknown escape hatch) since format.ts only
+ *  needs renderable text plus provenance. RecallHit below is the
+ *  normalized shape the rest of the package programs against. */
+export interface RecallResponseItem {
+  source: "session" | "trace" | "session_context" | "graph" | "code" | "tools" | "skills" | "system" | string;
+  text?: string;
+  score?: number | null;
+  dataset_id?: string | null;
+  dataset_name?: string | null;
+  metadata?: Record<string, unknown>;
+  raw?: Record<string, unknown>;
+  structured?: unknown;
+  kind?: string;
+  search_type?: string;
+  [key: string]: unknown;
+}
+
+/** Full response body of POST /api/v1/recall. */
+export type RecallResponse = RecallResponseItem[];
+
+/** POST /api/v1/search's response item — a free-form {search_result,
+ *  dataset_id, dataset_name} wrapper, not /recall's normalized text/source
+ *  envelope, despite sharing a request DTO with it. client.ts normalizes
+ *  both shapes into RecallHit rather than reusing one parser. */
+export interface SearchResponseItem {
+  search_result: unknown;
+  dataset_id?: string | null;
+  dataset_name?: string | null;
+}
+
+/** Full response body of the legacy POST /api/v1/search fallback. */
+export type SearchResponse = SearchResponseItem[];
+
+// -- Wire DTOs — /remember (primary write path) and /remember/entry -----------
+
+/** Multipart form for POST /api/v1/remember; datasetName or datasetId is
+ *  required. content_type is never sent — cognee 1.5.4 rejects raw_data
+ *  unless content_type='code'. */
+export interface RememberRequest {
+  raw_data: string[];
+  datasetName?: string;
+  datasetId?: string;
+  session_id?: string;
+  node_set?: string[];
+  run_in_background?: boolean;
+}
+
+/**
+ * POST /api/v1/add — fallback leg 1 when /remember is absent. Same shape as RememberRequest minus
+ * session_id (add has no session concept).
+ */
+export interface AddRequest {
+  raw_data: string[];
+  datasetName?: string;
+  datasetId?: string;
+  node_set?: string[];
+  run_in_background?: boolean;
+}
+
+/** POST /api/v1/cognify — fallback leg 2, paired with AddRequest. */
+export interface CognifyRequest {
+  dataset_ids?: string[];
+  datasets?: string[];
+  run_in_background?: boolean;
+}
+
+/** A Q&A turn for the session cache (cognee/memory/entries.py's QAEntry);
+ *  saveTurn() maps question/answer/context onto the Mastra turn. */
+export interface QAEntryDTO {
+  type: "qa";
+  question: string;
+  answer: string;
+  context?: string;
+}
+
+/** JSON body for POST /api/v1/remember/entry. Typed narrowly to the qa
+ *  variant this adapter sends; the server also accepts trace/feedback/
+ *  skill_run entries this package never constructs. */
+export interface RememberEntryRequest {
+  entry: QAEntryDTO;
+  dataset_name?: string;
+  dataset_id?: string;
+  session_id?: string;
+}
+
+/** Response body common to /remember, /add, /cognify, /remember/entry;
+ *  only status is load-bearing — an errored run is still 200-shaped,
+ *  surfaced as HTTP 409. */
+export interface RememberResult {
+  status?: "completed" | "running" | "errored" | string;
+  [key: string]: unknown;
+}
+
+// -- Wire DTOs — /forget -------------------------------------------------------
+
+/** ForgetPayloadDTO from get_forget_router.py; dataset (not dataset_name)
+ *  and dataset_id are mutually exclusive. everything:true is hard-blocked in tools.ts. */
+export interface ForgetRequest {
+  data_id?: string;
+  dataset?: string;
+  dataset_id?: string;
+  memory_only?: boolean;
+  everything?: boolean;
+}
+
+// -- Wire DTOs — /datasets/status and /improve --------------------------------
+
+/** GET /api/v1/datasets/status response. Pipeline values are add_pipeline,
+ *  cognify_pipeline, code_graph_pipeline — not the bare "cognify". A
+ *  single-pipeline query returns a flat {dataset_id: status} map. */
+export type { PipelineStatusValue as PipelineRunStatusValue } from "./pipeline-status.js";
+
+export type DatasetStatusResponse = Record<string, string | Record<string, string>>;
+
+/** POST /api/v1/improve body. Optional, off by default. */
+export interface ImproveRequest {
+  dataset_id: string;
+  session_ids: string[];
+}
+
+// -- Adapter-internal types — normalized recall hit. --------------------------
+
+/** The shape format.ts/processors.ts/tools.ts program against; client.ts's
+ *  recall() normalizes both /recall and /search shapes into this. */
+export interface RecallHit {
+  text: string;
+  score?: number | null;
+  datasetId?: string | null;
+  datasetName?: string | null;
+  source?: string;
+  metadata?: Record<string, unknown>;
+}

--- a/integrations/mastra/src/version.ts
+++ b/integrations/mastra/src/version.ts
@@ -1,0 +1,12 @@
+/**
+ * Package version, kept in sync with `package.json` by hand (no codegen
+ * step in this package). This is a plain literal rather than a
+ * `require("../package.json")` read because the build target is ESM/NodeNext
+ * without `resolveJsonModule` wired in, and a literal keeps `dist/` free of
+ * a runtime dependency on the source tree's `package.json` file existing
+ * next to it after publish.
+ *
+ * `CHANGELOG.md`'s latest entry must match this value; nothing enforces
+ * that automatically — bump both by hand on release.
+ */
+export const VERSION = "0.1.0";

--- a/integrations/mastra/src/with-cognee.ts
+++ b/integrations/mastra/src/with-cognee.ts
@@ -1,0 +1,85 @@
+/**
+ * `withCognee(agentConfig, config)` — convenience wrapper that merges
+ * cognee's input/output processors into an `Agent` config (precedent:
+ * Supermemory's `withSupermemory()`).
+ *
+ * Merge semantics mirror the idiom Mastra's own `Agent` class uses
+ * internally to merge signal-provider processors onto a user-supplied
+ * `inputProcessors`/`outputProcessors` value: both fields are either a plain
+ * array or a `(ctx: { requestContext }) => Processor[] | Promise<Processor[]>`
+ * function, so a correct merge has to handle both shapes.
+ */
+
+import type { AgentConfig } from "@mastra/core/agent";
+import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from "@mastra/core/processors";
+
+import { createCogneeProcessors, type CogneeProcessorsConfig } from "./processors.js";
+
+/**
+ * The slice of `AgentConfig` this helper reads/writes. Typed as a `Pick` off
+ * the real `AgentConfig` rather than redeclared, so a signature change to
+ * either field upstream is a type error here instead of a silent drift.
+ */
+type ProcessorFields = Pick<AgentConfig, "inputProcessors" | "outputProcessors">;
+
+/**
+ * Append `extra` to whichever shape `existing` already is. `undefined` (no
+ * existing processors) short-circuits to `extra` itself rather than
+ * wrapping a trivial array in a needless function.
+ */
+function appendInput(
+  existing: AgentConfig["inputProcessors"],
+  extra: InputProcessorOrWorkflow[],
+): AgentConfig["inputProcessors"] {
+  if (!existing) return extra;
+  if (typeof existing === "function") {
+    return async (ctx) => {
+      const resolved = await existing(ctx);
+      return [...resolved, ...extra];
+    };
+  }
+  return [...existing, ...extra];
+}
+
+/** Symmetric to `appendInput`, for `outputProcessors`. */
+function appendOutput(
+  existing: AgentConfig["outputProcessors"],
+  extra: OutputProcessorOrWorkflow[],
+): AgentConfig["outputProcessors"] {
+  if (!existing) return extra;
+  if (typeof existing === "function") {
+    return async (ctx) => {
+      const resolved = await existing(ctx);
+      return [...resolved, ...extra];
+    };
+  }
+  return [...existing, ...extra];
+}
+
+/**
+ * Merges `createCogneeProcessors(config)`'s `input`/`output` processors into
+ * `agentConfig`, appending to whatever `inputProcessors`/`outputProcessors`
+ * the caller already has (array or function form), and returns a new config
+ * object — `agentConfig` itself is not mutated.
+ *
+ * Ordering: cognee's input processor is appended after the caller's existing
+ * input processors (so user-authored recall/guardrail processors still see
+ * the raw query unmodified), and cognee's output processor is appended after
+ * the caller's existing output processors (so it captures the final,
+ * fully-processed turn).
+ *
+ * `withCognee()` only wires the processors: they stay inert until the
+ * resulting `agentConfig` is used with an agent that has some Mastra
+ * `Memory` attached and is called with a `threadId`/`resourceId`.
+ */
+export function withCognee<T extends Partial<ProcessorFields>>(
+  agentConfig: T,
+  config: CogneeProcessorsConfig = {},
+): T & ProcessorFields {
+  const { input, output } = createCogneeProcessors(config);
+  return {
+    ...agentConfig,
+    inputProcessors: appendInput(agentConfig.inputProcessors as AgentConfig["inputProcessors"], [input]),
+    outputProcessors: appendOutput(agentConfig.outputProcessors as AgentConfig["outputProcessors"], [output]),
+  };
+}

--- a/integrations/mastra/tsconfig.json
+++ b/integrations/mastra/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "sourceMap": true,
+    "isolatedModules": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2022"],
+    "types": ["node", "jest"],
+    "skipLibCheck": true
+  },
+  "include": ["index.ts", "src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "__tests__", "examples"]
+}

--- a/integrations/mastra/tsconfig.test.json
+++ b/integrations/mastra/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "sourceMap": false,
+    "rootDir": "."
+  },
+  "include": ["index.ts", "src/**/*.ts", "__tests__/**/*.ts", "examples/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Context: #369

Adds `integrations/mastra` (`@cognee/cognee-mastra`, 0.1.0): cognee as a memory layer for Mastra agents, over the plain HTTP API, no cognee SDK dependency. Same shape as the other agent-framework integrations here: nothing in Mastra or cognee is patched.

## What it is

- **Processors** (`createCogneeProcessors()` / `withCognee()`): a Mastra input processor that calls `/api/v1/recall` before the model call and injects the hits as a system message, and an output processor that saves the turn through `/api/v1/remember/entry` afterwards, fire-and-forget. Both fail open, so a cognee outage never breaks an agent turn.
- **Tools** (`createCogneeTools()`): `cognee_search` (CHUNKS, no LLM call inside cognee), `cognee_ask` (GRAPH_COMPLETION, opt-in cost), `cognee_remember`, and `cognee_forget` (off by default, `everything: true` is hard-blocked).
- **`CogneeClient`**: retry with backoff on 5xx/429/network errors, `X-Api-Key` or JWT login with one silent re-login on 401, per-call timeouts, a file-backed circuit breaker on the recall path only. Retry and auth semantics follow the openclaw integration's client.
- **Scoping**: one dataset with `session_id = mastra_<threadId>` and `resource:`/`thread:` node_set tags by default, or a dataset per resource. The README is explicit that tag filtering only narrows retrieval and is no substitute for per-tenant credentials.
- **Capability probes**: `/recall` vs `/search`, `/remember` vs `/add`+`/cognify`, `/remember/entry`, and the auth prefix are probed once per base URL and cached, so the package works across server versions without a version check.

## Verification

- 239 tests against an in-process `node:http` mock of the cognee routes (unit, integration, e2e), plus `npm run typecheck:all`; both green on zod 3.25 and zod 4.5.
- Live smoke test (`COGNEE_LIVE=1 npm run test:live`) against `cognee/cognee:main` reporting `1.5.4-local`, run several times on 2026-09-07. Resolved probes from that server:

```
serverVersion: '1.5.4-local'
recallPath: '/api/v1/recall'
rememberSupported: true
authPrefix: '/api/v1/auth'
ingestToRecallableDelayMs: ~15000-25000
```

Three things about that server that shaped the code, in case they are useful to other integrations: it enforces auth on every API route regardless of `REQUIRE_AUTHENTICATION` (the built-in `default_user@example.com` works for local runs); it rejects `raw_data` writes with any `content_type` other than `code`, so the client never sends `content_type` for text; and `/datasets/status` returns the `DATASET_PROCESSING_*` enum names rather than lowercase `completed`/`failed`.

## Questions for maintainers

1. Are `node_set`/`node_name` meant to carry any access-control semantics server-side, or purely retrieval filtering? The README currently says the latter.
2. Is `@cognee/cognee-mastra` the right npm name and scope? `registry: none` in inventory.yml until you decide.
3. Does `/remember` deduplicate identical text within a session, or should the processors do that client-side?

Happy to split this into smaller PRs if that is easier to review.
