### PR TITLE
fix(codex): drop the `|| python` hook fallback that breaks Windows PowerShell

### DIFF
--- a/integrations/codex/plugins/cognee/hooks.json
+++ b/integrations/codex/plugins/cognee/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/scripts/session-start.py\" || python \"${PLUGIN_ROOT}/scripts/session-start.py\"",
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/session-start.py\"",
             "timeout": 120,
             "statusMessage": "Initializing Cognee memory..."
           }
@@ -18,13 +18,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/scripts/session-context-lookup.py\" || python \"${PLUGIN_ROOT}/scripts/session-context-lookup.py\"",
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/session-context-lookup.py\"",
             "timeout": 120,
             "statusMessage": "Searching session memory..."
           },
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/scripts/store-user-prompt.py\" || python \"${PLUGIN_ROOT}/scripts/store-user-prompt.py\"",
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/store-user-prompt.py\"",
             "timeout": 120,
             "statusMessage": "Saving user prompt..."
           }
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/scripts/store-to-session.py\" || python \"${PLUGIN_ROOT}/scripts/store-to-session.py\"",
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/store-to-session.py\"",
             "timeout": 120,
             "statusMessage": "Saving tool trace..."
           }
@@ -49,13 +49,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/scripts/store-to-session.py\" --stop || python \"${PLUGIN_ROOT}/scripts/store-to-session.py\" --stop",
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/store-to-session.py\" --stop",
             "timeout": 120,
             "statusMessage": "Saving assistant response..."
           },
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/scripts/credits-refresh.py\" || python \"${PLUGIN_ROOT}/scripts/credits-refresh.py\"",
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/credits-refresh.py\"",
             "timeout": 10
           }
         ]
@@ -66,7 +66,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/scripts/pre-compact.py\" || python \"${PLUGIN_ROOT}/scripts/pre-compact.py\"",
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/pre-compact.py\"",
             "timeout": 120,
             "statusMessage": "Building memory anchor..."
           }
@@ -78,7 +78,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/scripts/sync-session-to-graph.py\" --session-end || python \"${PLUGIN_ROOT}/scripts/sync-session-to-graph.py\" --session-end",
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/sync-session-to-graph.py\" --session-end",
             "statusMessage": "Syncing session memory..."
           }
         ]


### PR DESCRIPTION
## Context

User feedback CC-0032: on Windows, every Codex hook fails with `hook exited with code 1`, at session start and on every turn — with the plugin installed (`1.5.3` in the report) and its skills reading fine.

## Cause

The hook commands were:

```
python3 "${PLUGIN_ROOT}/scripts/session-start.py" || python "${PLUGIN_ROOT}/scripts/session-start.py"
```

`&&` / `||` are pipeline chain operators added in **PowerShell 7**. Windows PowerShell 5.1 — still the default shell, and a version this plugin already accounts for (the 1.4.x changelog note about 5.1 writing a UTF-8 BOM) — treats `||` as a parse error and exits 1.

Three things point at the shell rather than the scripts:

1. **The scripts cannot exit 1.** `session-start.py`, `session-context-lookup.py`, `store-user-prompt.py`, `store-to-session.py`, `credits-refresh.py` and `pre-compact.py` all wrap their body in `try/except` and only `hook_log(...)`. The failure happens before Python runs.
2. **Codex uses PowerShell on Windows.** Its own tool calls in the report are `Get-Content -Raw`, `Get-Command cognee-cli, cognee -ErrorAction SilentlyContinue | Format-List`.
3. **Claude Code runs the identical command string fine on the same machine**, so it is the host's shell choice, not the plugin's Python.

## Change

One file. Removes the ` || python ...` half of all 8 hook commands, leaving a bare command plus one quoted argument — which parses in `sh`, `cmd.exe`, and both PowerShell generations.

- On Windows this can only improve matters: the current form never parses there at all.
- On POSIX the fallback was purely defensive; `python3` is the norm there.
- A Windows box running python.org's installer with no `python3.exe` on PATH remains unsupported — unchanged by this.

## Caveats for the reviewer

- Nothing in the repo documents which shell Codex uses for hooks, so the PowerShell-5.1 parse error is the best-supported explanation rather than a reproduced one — I have no Windows box to confirm on. If Codex actually shells out via `cmd.exe`, this change is still safe (bare commands parse there too), but the root cause would be elsewhere and hooks would keep failing. Worth having the reporter re-test.
- I left `plugin.json` `version` and the CHANGELOG alone, since this repo bumps those in a separate release step.
- The second half of CC-0032 — "no Cognee status visible anywhere for Codex" — is **not** addressed here. There is no statusline registration in `hooks.json` or `.codex-plugin/plugin.json`, and `cognee-statusline.sh` is a POSIX shell script; the Cognee frontend already reflects this, rendering the status-line callout for Claude Code only. That is a feature request, not a regression, so it needs its own decision.