### PR TITLE
refactor: raise recall budgets for claude, codex, and openclaw

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "author": {
         "name": "Cognee"
       },

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": {
     "name": "Cognee",
     "url": "https://www.cognee.ai"

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,6 +10,18 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.2]
+
+### Changed
+- **Per-prompt recall waits long enough for growing graphs.** The defaults
+  for `COGNEE_RECALL_TIMEOUT` (per scope) and `COGNEE_RECALL_BUDGET` (whole
+  hook) go from 2.5s/4s to 6s/8s. Graph search time grows with the dataset,
+  and a scope that overruns its timeout is recorded as zero hits, so the old
+  caps could silently drop graph memory from recall once a graph got large.
+  Both values remain overridable via the environment or `~/.cognee/.env`. The
+  cheap scopes are unaffected, so a fast prompt is not slower; only a slow
+  graph query is now allowed to complete instead of being discarded.
+
 ## [1.5.1]
 
 ### Removed

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -300,11 +300,18 @@ async def _run(prompt: str, cwd: str = "") -> dict | None:
     }
 
     # Hard time-box: this hook is on the keystroke->answer path, so recall must
-    # never be the long pole. Each scope gets a short per-call timeout, and the
-    # whole loop stops once the overall budget is spent. Partial results are fine.
-    recall_timeout = _float_env("COGNEE_RECALL_TIMEOUT", 2.5)
+    # never be the long pole. Each scope gets a per-call timeout, and the whole
+    # loop stops once the overall budget is spent. Partial results are fine.
+    #
+    # Defaults (6s per scope, 8s overall) are sized for the graph scope, which
+    # runs last and is the only expensive call. Graph search time grows with
+    # the dataset, and a scope that overruns is recorded as zero hits, so a cap
+    # tuned for a small graph silently drops graph memory once the graph grows.
+    # The cheap scopes (session/trace/session_context/code) finish quickly, so
+    # nearly the whole budget is left for graph.
+    recall_timeout = _float_env("COGNEE_RECALL_TIMEOUT", 6.0)
     recall_start = time.monotonic()
-    budget_deadline = recall_start + _float_env("COGNEE_RECALL_BUDGET", 4.0)
+    budget_deadline = recall_start + _float_env("COGNEE_RECALL_BUDGET", 8.0)
     # Respect the shared circuit breaker: when the server has been failing (tripped
     # by the explicit recall path), skip this per-prompt recall rather than hammering
     # a down backend on every keystroke.

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,6 +10,18 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.2]
+
+### Changed
+- **Per-prompt recall waits long enough for growing graphs.** The defaults
+  for `COGNEE_RECALL_TIMEOUT` (per scope) and `COGNEE_RECALL_BUDGET` (whole
+  hook) go from 2.5s/4s to 6s/8s. Graph search time grows with the dataset,
+  and a scope that overruns its timeout is recorded as zero hits, so the old
+  caps could silently drop graph memory from recall once a graph got large.
+  Both values remain overridable via the environment or `~/.cognee/.env`. The
+  cheap scopes are unaffected, so a fast prompt is not slower; only a slow
+  graph query is now allowed to complete instead of being discarded.
+
 ## [1.6.1]
 
 ### Removed

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -335,10 +335,17 @@ async def _run(prompt: str, cwd: str = "") -> dict | None:
     }
 
     # Hard time-box: this hook is on the keystroke->answer path, so recall must
-    # never be the long pole. Each scope gets a short per-call timeout, and the
-    # whole loop stops once the overall budget is spent. Partial results are fine.
-    recall_timeout = _float_env("COGNEE_RECALL_TIMEOUT", 2.5)
-    budget_deadline = time.monotonic() + _float_env("COGNEE_RECALL_BUDGET", 4.0)
+    # never be the long pole. Each scope gets a per-call timeout, and the whole
+    # loop stops once the overall budget is spent. Partial results are fine.
+    #
+    # Defaults (6s per scope, 8s overall) are sized for the graph scope, which
+    # runs last and is the only expensive call. Graph search time grows with
+    # the dataset, and a scope that overruns is recorded as zero hits, so a cap
+    # tuned for a small graph silently drops graph memory once the graph grows.
+    # The cheap scopes (session/trace/session_context/code) finish quickly, so
+    # nearly the whole budget is left for graph.
+    recall_timeout = _float_env("COGNEE_RECALL_TIMEOUT", 6.0)
+    budget_deadline = time.monotonic() + _float_env("COGNEE_RECALL_BUDGET", 8.0)
     # Respect the shared circuit breaker: when the server has been failing (tripped
     # by the explicit recall path), skip this per-prompt recall rather than hammering
     # a down backend on every keystroke.

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -23,7 +23,7 @@ integrations:
     registry: npm
     package_name: "@cognee/cognee-openclaw"
     cognee_dependency: http-api
-    current_version: "2026.9.2"
+    current_version: "2026.9.8"
     migration_status: done
     notes: "OpenClaw plugin with auto-recall/capture hooks"
 
@@ -34,7 +34,7 @@ integrations:
     registry: none
     package_name: null
     cognee_dependency: sdk
-    current_version: "1.5.1"
+    current_version: "1.5.2"
     migration_status: done
     notes: "Claude Code plugin – session storage via hooks, recall via context lookup, session-to-graph sync"
 
@@ -67,7 +67,7 @@ integrations:
     registry: codex-marketplace
     package_name: null
     cognee_dependency: cli
-    current_version: "1.6.1"
+    current_version: "1.6.2"
     migration_status: done
     notes: "Codex local plugin marketplace with Cognee CLI skills for setup, memory, codebase ingestion, and UI launch"
 

--- a/integrations/openclaw/CHANGELOG.md
+++ b/integrations/openclaw/CHANGELOG.md
@@ -11,6 +11,17 @@ reports an update only when the published npm version changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/). Versions are
 date-based (`YYYY.M.D`), matching the OpenClaw plugin ecosystem.
 
+## [2026.9.8]
+
+### Changed
+- **Per-prompt recall waits long enough for growing graphs.** `recallTimeoutMs`
+  (per recall call) and `recallBudgetMs` (whole recall step) default to `6000` and
+  `8000`, up from `2500` and `4000`, matching the Claude Code and Codex plugins.
+  Graph search time grows with the dataset, and a call that overruns its timeout
+  contributes nothing, so the old caps could silently drop graph memory from recall
+  once a graph got large. Both remain configurable; the cheap scopes are unaffected,
+  so a fast prompt is not slower.
+
 ## [2026.9.2]
 
 ### Fixed

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -551,8 +551,8 @@ Recall runs on the prompt hot path, so it is bounded: each recall call gets a sh
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `recallTimeoutMs` | number | `2500` | Per recall HTTP call timeout (no retries) |
-| `recallBudgetMs` | number | `4000` | Overall wall-clock budget for the recall step per prompt |
+| `recallTimeoutMs` | number | `6000` | Per recall HTTP call timeout (no retries) |
+| `recallBudgetMs` | number | `8000` | Overall wall-clock budget for the recall step per prompt |
 | `recallBreakerThreshold` | number | `5` | Consecutive failures (network/timeout/5xx) before the breaker opens |
 | `recallBreakerCooldownMs` | number | `120000` | How long recall is skipped once the breaker opens |
 

--- a/integrations/openclaw/__tests__/e2e/test_recallSelfHealing.ts
+++ b/integrations/openclaw/__tests__/e2e/test_recallSelfHealing.ts
@@ -216,7 +216,7 @@ describe("recall budget + circuit breaker", () => {
 
       const { api, emit } = createApi();
       const pending = emit("before_prompt_build", { prompt: "what did we discuss" }, { agentId: "will" });
-      await jest.advanceTimersByTimeAsync(4_500); // past the 4s default budget
+      await jest.advanceTimersByTimeAsync(8_500); // past the 8s default budget
       const results = await pending;
 
       expect(results.find((r) => r !== undefined)).toBeUndefined();
@@ -233,6 +233,6 @@ describe("recall budget + circuit breaker", () => {
     const { emit } = createApi();
     await emit("before_prompt_build", { prompt: "what did we discuss" }, { agentId: "will" });
 
-    expect(mockRecall).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 2_500 }));
+    expect(mockRecall).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 6_000 }));
   });
 });

--- a/integrations/openclaw/__tests__/e2e/test_sessionCapture.ts
+++ b/integrations/openclaw/__tests__/e2e/test_sessionCapture.ts
@@ -79,11 +79,26 @@ const realSetImmediate = globalThis.setImmediate;
  * chain awaits real fs I/O (state loading, dataset-state save), which only
  * completes when the loop actually turns — a fixed number of fake advances
  * races a slow CI disk and flakes.
+ *
+ * One `readFile` alone is several libuv round trips (open/fstat/read/close),
+ * each needing its own poll phase, and the chain strings many such calls
+ * together — so a single setImmediate per step was not enough on a loaded CI
+ * runner and the loop ran out of steps before the chain reached unregister.
+ * Each step now yields `yieldsPerStep` real loop turns, and the step cap is
+ * generous: the loop exits as soon as `done()` holds, so the cap only matters
+ * when the chain is genuinely stuck, and fake-clock advances are cheap.
  */
-async function advanceUntil(done: () => boolean, maxSteps = 60, stepMs = 1_000): Promise<void> {
+async function advanceUntil(
+  done: () => boolean,
+  maxSteps = 300,
+  stepMs = 1_000,
+  yieldsPerStep = 10,
+): Promise<void> {
   for (let i = 0; i < maxSteps && !done(); i++) {
     await jest.advanceTimersByTimeAsync(stepMs);
-    await new Promise<void>((r) => realSetImmediate(r));
+    for (let j = 0; j < yieldsPerStep && !done(); j++) {
+      await new Promise<void>((r) => realSetImmediate(r));
+    }
   }
 }
 

--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cognee/cognee-openclaw",
-  "version": "2026.9.2",
+  "version": "2026.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cognee/cognee-openclaw",
-      "version": "2026.9.2",
+      "version": "2026.9.8",
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^20.0.0",

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/cognee-openclaw",
-  "version": "2026.9.2",
+  "version": "2026.9.8",
   "type": "module",
   "description": "OpenClaw Cognee-backed memory plugin with auto-recall/capture",
   "author": {

--- a/integrations/openclaw/src/config.ts
+++ b/integrations/openclaw/src/config.ts
@@ -21,10 +21,14 @@ export const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
 export const DEFAULT_INGESTION_TIMEOUT_MS = 300_000;
 
 // Recall hot path — same defaults as the claude-code/codex integrations
-// (COGNEE_RECALL_TIMEOUT=2.5s, COGNEE_RECALL_BUDGET=4s,
+// (COGNEE_RECALL_TIMEOUT=6s, COGNEE_RECALL_BUDGET=8s,
 //  COGNEE_BREAKER_THRESHOLD=5, COGNEE_BREAKER_COOLDOWN=120s).
-export const DEFAULT_RECALL_TIMEOUT_MS = 2_500;
-export const DEFAULT_RECALL_BUDGET_MS = 4_000;
+// Sized for the graph scope, which runs last and is the only expensive call:
+// graph search time grows with the dataset, and a call that overruns its
+// timeout contributes nothing, so a cap tuned for a small graph silently
+// drops graph memory once the graph grows.
+export const DEFAULT_RECALL_TIMEOUT_MS = 6_000;
+export const DEFAULT_RECALL_BUDGET_MS = 8_000;
 export const DEFAULT_RECALL_BREAKER_THRESHOLD = 5;
 export const DEFAULT_RECALL_BREAKER_COOLDOWN_MS = 120_000;
 

--- a/integrations/openclaw/src/types.ts
+++ b/integrations/openclaw/src/types.ts
@@ -210,9 +210,9 @@ export type CogneePluginConfig = {
   ingestionTimeoutMs?: number;
 
   // --- Recall budget + circuit breaker (claude/codex parity) ---
-  /** Per recall HTTP call timeout on the prompt hot path (no retries). Default: 2500 */
+  /** Per recall HTTP call timeout on the prompt hot path (no retries). Default: 6000 */
   recallTimeoutMs?: number;
-  /** Overall wall-clock budget for the recall step per prompt. Default: 4000 */
+  /** Overall wall-clock budget for the recall step per prompt. Default: 8000 */
   recallBudgetMs?: number;
   /** Consecutive breaker-eligible failures (network/timeout/5xx) before the breaker opens. Default: 5 */
   recallBreakerThreshold?: number;

--- a/integrations/openclaw/src/version.ts
+++ b/integrations/openclaw/src/version.ts
@@ -26,7 +26,7 @@ import { UPDATE_CHECK_PATH } from "./persistence.js";
  * Fallback version used when api.version is unset. The drift-guard test in
  * __tests__/unit/test_version.ts asserts this stays equal to package.json.
  */
-export const PLUGIN_VERSION = "2026.9.2";
+export const PLUGIN_VERSION = "2026.9.8";
 
 const NPM_LATEST_URL = "https://registry.npmjs.org/@cognee/cognee-openclaw/latest";
 const DEFAULT_INTERVAL_SECONDS = 86_400; // 24h

--- a/integrations/tests/README.md
+++ b/integrations/tests/README.md
@@ -219,7 +219,7 @@ Non-obvious rules this tier encodes (each one learned by getting it wrong —
 - **The venv is seeded** from the host's `~/.cognee-plugin/venv` so boot is ~15s
   instead of a multi-minute `uv` install. That caches the *install* only.
 - **Recall timeouts are raised** (`COGNEE_RECALL_TIMEOUT`/`_BUDGET`). Production
-  keeps them tight (2.5s/4s) so memory can never stall an interactive prompt, and
+  keeps them tight (6s/8s) so memory can never stall an interactive prompt, and
   a cold server's first graph query correctly exceeds that. These tests ask
   whether memory crosses sessions, not whether cold-start recall is fast — so
   cold-start deserves its own scenario rather than silently failing this one.

--- a/integrations/tests/tests/e2e/live/test_cross_session_recall.py
+++ b/integrations/tests/tests/e2e/live/test_cross_session_recall.py
@@ -99,8 +99,8 @@ def test_paxos_then_byzantine_recalled_in_a_fresh_session(
 #   real question. Doing it honestly means populating *two* datasets and showing
 #   neither surfaces the other's nonce — a second cognify, so it belongs in its
 #   own test rather than bolted onto this file.
-# * Cold-start recall. With production timeouts (COGNEE_RECALL_TIMEOUT 2.5s,
-#   COGNEE_RECALL_BUDGET 4s) the first graph query against a freshly booted
+# * Cold-start recall. With production timeouts (COGNEE_RECALL_TIMEOUT 6s,
+#   COGNEE_RECALL_BUDGET 8s) the first graph query against a freshly booted
 #   server times out and is correctly reported as "slow", so the prompt gets no
 #   memory. This tier raises those limits to ask its own question, which means
 #   the cold-start behaviour is currently untested. It deserves pinning: first

--- a/integrations/tests/tests/e2e/live/test_resilience.py
+++ b/integrations/tests/tests/e2e/live/test_resilience.py
@@ -173,10 +173,11 @@ def test_buffered_turns_are_replayed_once_the_server_returns(
 def test_a_slow_cold_query_is_classified_slow_not_down(
     started_session, live_env, live_suite, live_home, graph, nonce
 ):
-    """Production recall timeouts are tight on purpose; exceeding them is not an outage.
+    """Recall timeouts are tight on purpose; exceeding them is not an outage.
 
-    With ``COGNEE_RECALL_TIMEOUT`` at its real 2.5s default, the first graph query
-    against a freshly booted server does not finish in time. The plugin must treat
+    With ``COGNEE_RECALL_TIMEOUT`` pinned to a tight 2.5s (the pre-1.5.1 default;
+    production now ships 6s/8s), the first graph query against a freshly booted
+    server does not finish in time. The plugin must treat
     that as "slow" — no memory this prompt, no breaker trip, no failure state that
     would redden the status line — rather than concluding the server is down.
 
@@ -191,9 +192,9 @@ def test_a_slow_cold_query_is_classified_slow_not_down(
     assert writer.wait_for_sync(deadline=600.0) is not None
     graph.wait_until_recalled(f"What did we choose for {nonce}?", "paxos", deadline=600.0)
 
-    # Now restore the production budget for a fresh session's first prompt. The
-    # env dict is shared with the sessions, so mutating it here is what a real
-    # deployment's defaults would give us.
+    # Now pin a tight budget for a fresh session's first prompt. The env dict
+    # is shared with the sessions, so mutating it here is what a deployment
+    # with these values would give us.
     live_env["COGNEE_RECALL_TIMEOUT"] = "2.5"
     live_env["COGNEE_RECALL_BUDGET"] = "4"
 

--- a/integrations/tests/utils/live.py
+++ b/integrations/tests/utils/live.py
@@ -240,8 +240,8 @@ def build_live_env(
             "COGNEE_IDLE_DISABLED": "1",
             "COGNEE_SYNC_START_DELAY": "0.5",
             # Test-only patience for the per-prompt recall. In production these
-            # are deliberately tight (COGNEE_RECALL_TIMEOUT 2.5s per scope,
-            # COGNEE_RECALL_BUDGET 4s overall) so memory can never stall an
+            # are deliberately tight (COGNEE_RECALL_TIMEOUT 6s per scope,
+            # COGNEE_RECALL_BUDGET 8s overall) so memory can never stall an
             # interactive prompt — and on a *cold* server the first graph query
             # exceeds that and is correctly dropped as "slow". These tests ask
             # "does memory cross sessions", not "is cold-start recall fast", so


### PR DESCRIPTION
This PR raises recall budgets for claude, codex, and openclaw, in order to account for very large graphs where some recall hits to the graph might take longer.