### PR TITLE
fix: handle users having python 3.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.5.5",
+      "version": "1.5.4",
       "author": {
         "name": "Cognee"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "author": {
         "name": "Cognee"
       },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,39 @@ jobs:
         working-directory: integrations/${{ matrix.integration }}
         run: uv run pytest tests/ -v
 
+  # The hook-based plugins (claude-code, codex, antigravity) must run under the
+  # oldest python3 users commonly have on PATH — macOS's Xcode Command Line Tools
+  # ship 3.9.6 — because the hooks run under it before (and, in cloud mode,
+  # instead of) the plugin's own uv-managed 3.12 venv. A `X | None` annotation
+  # without `from __future__ import annotations` breaks every hook at import time
+  # on 3.9 and nothing else catches it (SDK-617). The shared suite's pyproject
+  # pins 3.10+ for its own tooling, so this cell builds an ad-hoc 3.9 environment.
+  test-hooks-python39:
+    needs: detect-changes
+    if: ${{ contains(needs.detect-changes.outputs.python, '"tests"') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Run the shared hook suite on Python 3.9
+        working-directory: integrations/tests
+        run: >-
+          uv run --no-project --python 3.9
+          --with "pytest>=8" --with "pytest-httpserver>=1.0"
+          pytest tests/unit tests/integration tests/e2e -q
+
   test-typescript:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.typescript != '[]' }}
@@ -173,13 +206,14 @@ jobs:
   claude-review:
     name: Claude Code Review
     timeout-minutes: 15
-    needs: [ detect-changes, test-python, test-typescript ]
+    needs: [ detect-changes, test-python, test-hooks-python39, test-typescript ]
     if: >-
       ${{ !cancelled()
           && github.event_name == 'pull_request'
           && github.event.pull_request.head.repo.full_name == github.repository
           && needs.detect-changes.result == 'success'
           && needs.test-python.result != 'failure'
+          && needs.test-hooks-python39.result != 'failure'
           && needs.test-typescript.result != 'failure' }}
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ The Claude Code integration is a **plugin** — it gives Claude Code persistent 
 across sessions with no code to write. It auto-captures your prompts, tool traces, and
 responses, and auto-recalls relevant context on every prompt.
 
+**Requirements:** any Python 3.9+ as `python3` on PATH (the hooks are stdlib-only HTTP
+clients; macOS's Xcode Command Line Tools Python is enough). In local mode the plugin
+fetches [uv](https://docs.astral.sh/uv/) and builds its own Python 3.12 virtualenv for
+the Cognee server, so cognee's 3.10+ floor never applies to your system Python — except
+when uv is unavailable and cannot be downloaded, in which case the fallback needs a
+3.10+ `python3` and the plugin says so at session start. The SDK packages in the table
+above import cognee in-process and need Python 3.10+ (3.12+ for Dify, 3.13+ for the
+Claude Agent SDK); see [`integrations/CONFIGURATION.md`](integrations/CONFIGURATION.md#python-version-requirements).
+
 **1. Install the Claude Code plugin**
 
 Run these slash commands directly in the Claude Code chat:

--- a/integrations/CONFIGURATION.md
+++ b/integrations/CONFIGURATION.md
@@ -10,6 +10,23 @@ Default session dataset: `agent_sessions`. Default local server port: `8011`.
 
 Tests live in the shared Claude/Codex suite, Hermes `test_config_contract.py`, and OpenClaw unit tests. This replaces the obsolete config-file contract proposed in #169.
 
+## Python version requirements
+
+cognee itself requires Python 3.10 or newer (up to 3.14). What that means for each
+integration depends on whether it imports cognee in-process or only talks to a server:
+
+| Integration | Host Python floor | Why |
+|---|---|---|
+| Claude Code / Codex / Antigravity plugins | **3.9+** for the hooks; **3.10+** only for the uv-less fallback | Hooks are stdlib HTTP clients. In local mode they build a uv-managed **Python 3.12** venv for the Cognee server (fetching uv, and a ~66 MB standalone 3.12 when none is on the machine). Without uv the fallback builds the venv from the host `python3`, which then must be 3.10+; an older host is refused with `host_python_too_old_for_venv` in `hook.log` and a session-start message. |
+| OpenClaw | **3.9+** for the bootstrap script; **3.10+** only for the uv-less fallback | Same runtime scheme, driven from TypeScript. A refused fallback is recorded in `~/.cognee-plugin/.venv-error.json` and quoted in the gateway's "server did not become ready" warning. |
+| Hermes, LangGraph, CrewAI, Strands, Google ADK, Aider, Obsidian, chat-memory, Slack, Telegram, second-brain, web-widget | **3.10+** | `requires-python = ">=3.10"`; `pip`/`uv` refuse to install on 3.9. |
+| Dify, Dify SDK | **3.12+** | Dify plugin runtime requirement. |
+| Claude Agent SDK | **3.13+** | Follows `claude-agent-sdk`. |
+
+macOS's Xcode Command Line Tools install Python 3.9.6 as `/usr/bin/python3`. That is
+enough for the hook-based plugins and OpenClaw; for the SDK packages install a 3.10+
+interpreter (Homebrew, python.org or `uv python install 3.12`).
+
 ## Extraction models and authentication
 
 Cognee's backend configures extraction independently of the host assistant.

--- a/integrations/antigravity/CHANGELOG.md
+++ b/integrations/antigravity/CHANGELOG.md
@@ -7,31 +7,27 @@ package version.
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.5.2]
+## [1.5.1]
 
 ### Fixed
-- **The hooks run on Python 3.9 again (SDK-617).** Every hook script failed at
-  import time under a 3.9 `python3` — the one macOS ships with the Xcode Command
-  Line Tools — with `TypeError: unsupported operand type(s) for |`, because
-  `X | None` annotations are evaluated when a function is defined. Nothing in the
-  hooks needs 3.10 at runtime: they are stdlib HTTP clients, and cognee runs in
-  the uv-managed Python 3.12 venv the bootstrap builds. Every script now carries
-  `from __future__ import annotations`, so the plugin works on any Python
-  3.9+ host; the shared suite runs on 3.9 in CI to keep it that way.
-- **The uv-less install fallback refuses a host python older than 3.10.** When uv
-  is unavailable and cannot be downloaded, the bootstrap builds the runtime venv
-  from the host interpreter, which then inherits cognee's 3.10+ floor. Instead of
-  building a venv cognee cannot install into, it now logs
+- **Hotfix: the hooks run on Python 3.9 again (SDK-617).** Every hook script
+  failed at import time under a 3.9 `python3` — the one macOS ships with the
+  Xcode Command Line Tools — with `TypeError: unsupported operand type(s) for |`,
+  because `X | None` annotations are evaluated when a function is defined.
+  Nothing in the hooks needs 3.10 at runtime: they are stdlib HTTP clients, and
+  cognee runs in the uv-managed Python 3.12 venv the bootstrap builds. Every
+  script now carries `from __future__ import annotations`, so the plugin works
+  on any Python 3.9+ host; the shared suite runs on 3.9 in CI to keep it that
+  way. Shipped in place, without a version bump.
+- **The uv-less install fallback refuses a host python older than 3.10.** When
+  uv is unavailable and cannot be downloaded, the bootstrap builds the runtime
+  venv from the host interpreter, which then inherits cognee's 3.10+ floor.
+  Instead of building a venv cognee cannot install into, it now logs
   `host_python_too_old_for_venv` to `~/.cognee-plugin/antigravity/hook.log`, prints the interpreter path and
   version to stderr, and leaves a marker that every following SessionStart turns
-  into a systemMessage naming the fix (install uv or a 3.10+ python3) until a venv
-  is built.
-
-### Changed
-- README states the Python requirement up front: 3.9+ for the hooks, 3.10+ only
-  for the uv-less fallback; SDK-based integrations keep their 3.10+ floor.
-
-## [1.5.1]
+  into a systemMessage naming the fix (install uv or a 3.10+ python3) until a
+  venv is built. README states the requirement up front: 3.9+ for the hooks,
+  3.10+ only for that fallback.
 
 ### Changed
 - **Per-prompt recall dispatches every scope at once.** The scopes (`session`,

--- a/integrations/antigravity/CHANGELOG.md
+++ b/integrations/antigravity/CHANGELOG.md
@@ -7,6 +7,30 @@ package version.
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.2]
+
+### Fixed
+- **The hooks run on Python 3.9 again (SDK-617).** Every hook script failed at
+  import time under a 3.9 `python3` — the one macOS ships with the Xcode Command
+  Line Tools — with `TypeError: unsupported operand type(s) for |`, because
+  `X | None` annotations are evaluated when a function is defined. Nothing in the
+  hooks needs 3.10 at runtime: they are stdlib HTTP clients, and cognee runs in
+  the uv-managed Python 3.12 venv the bootstrap builds. Every script now carries
+  `from __future__ import annotations`, so the plugin works on any Python
+  3.9+ host; the shared suite runs on 3.9 in CI to keep it that way.
+- **The uv-less install fallback refuses a host python older than 3.10.** When uv
+  is unavailable and cannot be downloaded, the bootstrap builds the runtime venv
+  from the host interpreter, which then inherits cognee's 3.10+ floor. Instead of
+  building a venv cognee cannot install into, it now logs
+  `host_python_too_old_for_venv` to `~/.cognee-plugin/antigravity/hook.log`, prints the interpreter path and
+  version to stderr, and leaves a marker that every following SessionStart turns
+  into a systemMessage naming the fix (install uv or a 3.10+ python3) until a venv
+  is built.
+
+### Changed
+- README states the Python requirement up front: 3.9+ for the hooks, 3.10+ only
+  for the uv-less fallback; SDK-based integrations keep their 3.10+ floor.
+
 ## [1.5.1]
 
 ### Changed

--- a/integrations/antigravity/EVENTS.md
+++ b/integrations/antigravity/EVENTS.md
@@ -116,6 +116,10 @@ Names cover current hooks, configuration, transcript cleanup, and both watchers.
 | `hook:final_sync_once_pruned` | `sync.sync_once_pruned` |
 | `hook:find_claude_parent_failed` | `find.claude_parent_failed` |
 | `hook:find_codex_parent_failed` | `find.codex_parent_failed` |
+| `hook:host_python_marker_read_failed` | `host_python.marker_read_failed` |
+| `hook:host_python_marker_unlink_failed` | `host_python.marker_unlink_failed` |
+| `hook:host_python_marker_write_failed` | `host_python.marker_write_failed` |
+| `hook:host_python_too_old_for_venv` | `host_python.too_old_for_venv` |
 | `hook:https_context_no_ca_bundle` | `https.context_no_ca_bundle` |
 | `hook:idle_watcher_kill_failed` | `idle.watcher_kill_failed` |
 | `hook:idle_watcher_restart_failed` | `idle.watcher_restart_failed` |

--- a/integrations/antigravity/README.md
+++ b/integrations/antigravity/README.md
@@ -6,6 +6,8 @@ completed turns for later retrieval.
 
 ## Install
 
+**Requirements.** Any Python 3.9 or newer available as `python3` (or `python`) on PATH — the hooks are stdlib-only HTTP clients and never import cognee, so the Python 3.9.6 that ships with macOS's Xcode Command Line Tools is enough. In local mode the plugin brings its own runtime for the Cognee server: it fetches [uv](https://docs.astral.sh/uv/) into `~/.cognee-plugin/uv` and builds a Python 3.12 virtualenv with it (reusing a 3.12 already on the machine, otherwise downloading a ~66 MB standalone build). Only when uv is absent *and* cannot be downloaded does the plugin fall back to the host interpreter, and that fallback needs Python 3.10 or newer: on an older host it refuses, logs `host_python_too_old_for_venv` to `hook.log`, and every session start says so until uv or a newer python3 is installed. Cloud mode never builds a runtime. (SDK-based integrations such as LangGraph or CrewAI import cognee in-process and need Python 3.10+; see [`CONFIGURATION.md`](../CONFIGURATION.md#python-version-requirements).)
+
 From a checkout of this repository, validate the package before installing it:
 
 ```bash

--- a/integrations/antigravity/plugin.json
+++ b/integrations/antigravity/plugin.json
@@ -1,4 +1,4 @@
 {
   "name": "cognee",
-  "version": "1.5.2"
+  "version": "1.5.1"
 }

--- a/integrations/antigravity/plugin.json
+++ b/integrations/antigravity/plugin.json
@@ -1,4 +1,4 @@
 {
   "name": "cognee",
-  "version": "1.5.1"
+  "version": "1.5.2"
 }

--- a/integrations/antigravity/scripts/_capture_policy.py
+++ b/integrations/antigravity/scripts/_capture_policy.py
@@ -1,5 +1,7 @@
 """Client-side automatic capture controls. Explicit remember is independent."""
 
+from __future__ import annotations
+
 import fnmatch
 import json
 import os

--- a/integrations/antigravity/scripts/_code_graph.py
+++ b/integrations/antigravity/scripts/_code_graph.py
@@ -63,6 +63,8 @@ identical-looking results, which is why the skills tell the agent to say which
 one it is answering from when the work is in progress.
 """
 
+from __future__ import annotations
+
 import hashlib
 import json
 import os

--- a/integrations/antigravity/scripts/_cognee_client.py
+++ b/integrations/antigravity/scripts/_cognee_client.py
@@ -15,6 +15,8 @@ short-lived process, so in-memory state (as a long-lived provider like Hermes
 uses) would not survive between calls. State lives in the plugin state dir.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import pathlib

--- a/integrations/antigravity/scripts/_dataset_access.py
+++ b/integrations/antigravity/scripts/_dataset_access.py
@@ -1,5 +1,7 @@
 """Dataset UUIDs are authoritative; names are only for owned datasets."""
 
+from __future__ import annotations
+
 import json
 import os
 from uuid import UUID

--- a/integrations/antigravity/scripts/_deadlines.py
+++ b/integrations/antigravity/scripts/_deadlines.py
@@ -1,5 +1,7 @@
 """Elapsed-time bounds for read-only calls, without blocking interpreter exit."""
 
+from __future__ import annotations
+
 import math
 import queue
 import threading

--- a/integrations/antigravity/scripts/_env_file.py
+++ b/integrations/antigravity/scripts/_env_file.py
@@ -29,6 +29,8 @@ Loading must never break a hook: any parse or IO problem results in the file
 being (partially) ignored, never an exception.
 """
 
+from __future__ import annotations
+
 import os
 import stat
 import sys

--- a/integrations/antigravity/scripts/_file_lock.py
+++ b/integrations/antigravity/scripts/_file_lock.py
@@ -1,5 +1,7 @@
 """Small cross-process lock with bounded acquisition on POSIX and Windows."""
 
+from __future__ import annotations
+
 import os
 import time
 from contextlib import contextmanager

--- a/integrations/antigravity/scripts/_plugin_common.py
+++ b/integrations/antigravity/scripts/_plugin_common.py
@@ -5,6 +5,8 @@ single log-to-disk helper. Hook scripts shouldn't grow heavy because
 they run on every user prompt / tool call.
 """
 
+from __future__ import annotations
+
 import asyncio
 import errno
 import hashlib

--- a/integrations/antigravity/scripts/_proc.py
+++ b/integrations/antigravity/scripts/_proc.py
@@ -8,6 +8,8 @@ on Windows, where signal 0 raises ``OSError`` (``WinError 87``), so the check
 needs a native Windows path.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 

--- a/integrations/antigravity/scripts/_project_memory.py
+++ b/integrations/antigravity/scripts/_project_memory.py
@@ -1,5 +1,7 @@
 """Opt-in project tags and server-verified companion routing, pinned per session."""
 
+from __future__ import annotations
+
 import hashlib
 import os
 import re

--- a/integrations/antigravity/scripts/_recall_http.py
+++ b/integrations/antigravity/scripts/_recall_http.py
@@ -25,6 +25,8 @@ Contract — what gets printed to stdout:
 Diagnostics also go to stderr so the caller can surface them.
 """
 
+from __future__ import annotations
+
 import errno
 import json
 import os

--- a/integrations/antigravity/scripts/_remember_http.py
+++ b/integrations/antigravity/scripts/_remember_http.py
@@ -18,6 +18,8 @@ Contract — what gets printed to stdout:
 Diagnostics also go to stderr so the caller can surface them.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import socket

--- a/integrations/antigravity/scripts/cognee_statusline_render.py
+++ b/integrations/antigravity/scripts/cognee_statusline_render.py
@@ -9,6 +9,8 @@ calls, no ``_plugin_common`` import.
 Output: ``cognee: <dataset-name> · local`` or ``cognee: <dataset-name> · cloud``
 """
 
+from __future__ import annotations
+
 import json
 import os
 import sys

--- a/integrations/antigravity/scripts/config.py
+++ b/integrations/antigravity/scripts/config.py
@@ -27,6 +27,8 @@ Supports three modes:
   - Server: Legacy — direct base_url (kept for backward compat)
 """
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/integrations/antigravity/scripts/credits-refresh.py
+++ b/integrations/antigravity/scripts/credits-refresh.py
@@ -13,6 +13,8 @@ rendered as ``last turn ~$X.XX``. ``refresh_credits`` never raises and no-ops
 entirely on a local server, so this hook is safe to fire unconditionally.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 

--- a/integrations/antigravity/scripts/doctor.py
+++ b/integrations/antigravity/scripts/doctor.py
@@ -12,6 +12,8 @@ Never modifies configuration, initialises databases, registers
 resources, writes files, or mutates state.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import pathlib

--- a/integrations/antigravity/scripts/event_names.py
+++ b/integrations/antigravity/scripts/event_names.py
@@ -1,5 +1,7 @@
 """Canonical log names. Keep legacy `event` readers working during migration."""
 
+from __future__ import annotations
+
 import os
 
 EVENT_NAMES = {
@@ -142,6 +144,10 @@ EVENT_NAMES = {
     "hook:final_sync_once_pruned": "sync.sync_once_pruned",
     "hook:find_claude_parent_failed": "find.claude_parent_failed",
     "hook:find_codex_parent_failed": "find.codex_parent_failed",
+    "hook:host_python_marker_read_failed": "host_python.marker_read_failed",
+    "hook:host_python_marker_unlink_failed": "host_python.marker_unlink_failed",
+    "hook:host_python_marker_write_failed": "host_python.marker_write_failed",
+    "hook:host_python_too_old_for_venv": "host_python.too_old_for_venv",
     "hook:https_context_no_ca_bundle": "https.context_no_ca_bundle",
     "hook:idle_watcher_kill_failed": "idle.watcher_kill_failed",
     "hook:idle_watcher_restart_failed": "idle.watcher_restart_failed",

--- a/integrations/antigravity/scripts/exit-watcher.py
+++ b/integrations/antigravity/scripts/exit-watcher.py
@@ -7,6 +7,8 @@ does nothing while Antigravity is alive; once that PID disappears, it starts the
 normal detached graph sync worker and exits.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/integrations/antigravity/scripts/idle-watcher.py
+++ b/integrations/antigravity/scripts/idle-watcher.py
@@ -14,6 +14,8 @@ Stops cleanly on:
 Survives Antigravity crashes better than foreground hooks.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/integrations/antigravity/scripts/pre-compact.py
+++ b/integrations/antigravity/scripts/pre-compact.py
@@ -10,6 +10,8 @@ query at compact time, and deriving one from recalled/compacted context can feed
 synthetic text back into Cognee as if it were a user question.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/integrations/antigravity/scripts/session-context-lookup.py
+++ b/integrations/antigravity/scripts/session-context-lookup.py
@@ -11,6 +11,8 @@ Configuration:
     Resolves session state via Cognee HTTP endpoints.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/integrations/antigravity/scripts/session-start.py
+++ b/integrations/antigravity/scripts/session-start.py
@@ -9,6 +9,8 @@ Runs on the SessionStart hook. Responsibilities:
   5. Register the current Antigravity conversation as an active agent connection
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os
@@ -102,11 +104,20 @@ _LAZY_BOOTSTRAP = os.environ.get("COGNEE_LAZY_BOOTSTRAP", "1").strip().lower() n
 # uv + a uv-managed Python guarantee a cognee-compatible runtime (3.10-3.14)
 # regardless of what's on the machine. All paths sit under the shared
 # ~/.cognee-plugin root so every host plugin installs once and reuses one venv.
+# The hooks themselves need only a stdlib python3 of 3.9+ (see SDK-617): the
+# host interpreter never imports cognee, it only builds and talks to the venv.
 _UV_DIR = _GLOBAL_STATE_DIR / "uv"
 _UV_BIN = _UV_DIR / ("uv.exe" if os.name == "nt" else "uv")
 _UV_PYTHON_DIR = _GLOBAL_STATE_DIR / "python"
 _UV_INSTALL_URL = "https://astral.sh/uv/install.sh"
 _PINNED_PYTHON = os.environ.get("COGNEE_PLUGIN_PYTHON", "") or "3.12"
+# Floor for the HOST interpreter, enforced only on the uv-less fallback, which
+# builds the runtime venv from sys.executable and so inherits its version.
+_FALLBACK_VENV_MIN_PYTHON = (3, 10)
+# Written when that fallback is refused; read by the next SessionStart so the
+# refusal reaches the user as a systemMessage (the worker that hits it runs
+# detached, with nothing it prints visible). Cleared once a venv is ready.
+_HOST_PYTHON_MARKER = _GLOBAL_STATE_DIR / "host-python-unsupported.json"
 _PINNED_COGNEE_VERSION = "1.5.4"
 _INSTALL_TIMEOUT_SECONDS = float(os.environ.get("COGNEE_INSTALL_TIMEOUT", "") or 600.0)
 
@@ -173,6 +184,72 @@ def _find_uv() -> str:
         return str(_UV_BIN)
     found = shutil.which("uv")
     return found or ""
+
+
+def _host_python_label() -> str:
+    """``<sys.executable> (Python X.Y.Z)`` — names the interpreter a user must replace."""
+    return "{} (Python {}.{}.{})".format(sys.executable, *sys.version_info[:3])
+
+
+def _refuse_fallback_venv() -> None:
+    """Record why the uv-less fallback will not build the runtime venv.
+
+    Three readers: hook.log (forensics), this process's stderr (the bootstrap
+    log when detached, the terminal when not), and the marker the next
+    SessionStart turns into a systemMessage via ``_apply_host_python_warning``.
+    """
+    message = (
+        "Cognee Memory: cannot build the local Cognee runtime. uv is unavailable, and the "
+        "fallback would build the venv from {}, but that needs Python 3.10 or newer. Install "
+        "uv (https://docs.astral.sh/uv/) or a Python 3.10+ python3, then start a new "
+        "session.".format(_host_python_label())
+    )
+    detail = {
+        "python": sys.executable,
+        "version": "{}.{}.{}".format(*sys.version_info[:3]),
+        "required": "{}.{}".format(*_FALLBACK_VENV_MIN_PYTHON),
+    }
+    hook_log("host_python_too_old_for_venv", detail)
+    print(message, file=sys.stderr)
+    try:
+        _HOST_PYTHON_MARKER.parent.mkdir(parents=True, exist_ok=True)
+        _HOST_PYTHON_MARKER.write_text(
+            json.dumps({"message": message, "updated_at": time.time(), **detail}),
+            encoding="utf-8",
+        )
+    except Exception as exc:
+        hook_log("host_python_marker_write_failed", {"error": str(exc)[:200]})
+
+
+def _apply_host_python_warning(output: dict) -> dict:
+    """Append the recorded fallback refusal (if any) to the hook's systemMessage.
+
+    The marker outlives the session that wrote it on purpose: every launch on
+    the broken host repeats the message until a venv is built (which clears it
+    in ``_write_venv_ready``) — this is the loud failure SDK-617 asks for.
+    """
+    try:
+        if not _HOST_PYTHON_MARKER.exists():
+            return output
+        message = str(
+            json.loads(_HOST_PYTHON_MARKER.read_text(encoding="utf-8")).get("message") or ""
+        )
+    except Exception as exc:
+        hook_log("host_python_marker_read_failed", {"error": str(exc)[:200]})
+        return output
+    if not message:
+        return output
+    result = dict(output or {})
+    hso = dict(result.get("hookSpecificOutput") or {})
+    hso.setdefault("hookEventName", "SessionStart")
+    existing = str(hso.get("systemMessage") or "").strip()
+    hso["systemMessage"] = "{}\n\n{}".format(existing, message) if existing else message
+    result["hookSpecificOutput"] = hso
+    # Also at the top level: that is where Claude Code documents the universal
+    # ``systemMessage`` field, and where the Antigravity adapter reads it.
+    top = str(result.get("systemMessage") or "").strip()
+    result["systemMessage"] = "{}\n\n{}".format(top, message) if top else message
+    return result
 
 
 def _install_uv() -> str:
@@ -291,6 +368,11 @@ def _write_venv_ready(version: str) -> None:
         os.replace(tmp, _VENV_READY_MARKER)
     except Exception as exc:
         hook_log("venv_ready_write_failed", {"error": str(exc)[:200]})
+    try:
+        # A usable venv exists, so the host-python refusal (if any) is moot.
+        _HOST_PYTHON_MARKER.unlink(missing_ok=True)
+    except Exception as exc:
+        hook_log("host_python_marker_unlink_failed", {"error": str(exc)[:200]})
 
 
 def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
@@ -422,8 +504,13 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
             except Exception as exc:
                 hook_log("cognee_install_failed", {"via": "uv", "error": str(exc)[:300]})
         elif not venv_present:
-            # Last-resort fallback: stdlib venv + pip. Slower, and relies on the
-            # system python3 being a cognee-compatible version (3.10-3.14).
+            # Last-resort fallback: stdlib venv + pip. Slower, and the venv inherits
+            # this interpreter, so the host python3 must itself satisfy cognee's
+            # floor (3.10-3.14). The hooks run on any 3.9+, so check explicitly
+            # rather than build a venv cognee could never install into.
+            if sys.version_info < _FALLBACK_VENV_MIN_PYTHON:
+                _refuse_fallback_venv()
+                return False
             try:
                 subprocess.run(
                     [sys.executable, "-m", "venv", str(_VENV_DIR)],
@@ -1926,6 +2013,7 @@ def main():
             output = asyncio.run(_start(payload)) or {}
     except Exception as exc:
         hook_log("session_start_exception", {"error": str(exc)[:200]})
+    output = _apply_host_python_warning(output)
     print(json.dumps(output))
 
 

--- a/integrations/antigravity/scripts/store-to-session.py
+++ b/integrations/antigravity/scripts/store-to-session.py
@@ -12,6 +12,8 @@ Configuration:
     Resolves session state via Cognee HTTP endpoints.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/integrations/antigravity/scripts/store-user-prompt.py
+++ b/integrations/antigravity/scripts/store-user-prompt.py
@@ -9,6 +9,8 @@ Configuration:
     Resolves session state via Cognee HTTP endpoints.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/integrations/antigravity/scripts/sync-session-to-graph.py
+++ b/integrations/antigravity/scripts/sync-session-to-graph.py
@@ -9,6 +9,8 @@ Configuration:
     Resolves session identity from Cognee endpoints via API auth.
 """
 
+from __future__ import annotations
+
 import asyncio
 import hashlib
 import json

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.5.5",
+  "version": "1.5.4",
   "author": {
     "name": "Cognee",
     "url": "https://www.cognee.ai"

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "author": {
     "name": "Cognee",
     "url": "https://www.cognee.ai"

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,31 +10,27 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.5.5]
+## [1.5.4]
 
 ### Fixed
-- **The hooks run on Python 3.9 again (SDK-617).** Every hook script failed at
-  import time under a 3.9 `python3` — the one macOS ships with the Xcode Command
-  Line Tools — with `TypeError: unsupported operand type(s) for |`, because
-  `X | None` annotations are evaluated when a function is defined. Nothing in the
-  hooks needs 3.10 at runtime: they are stdlib HTTP clients, and cognee runs in
-  the uv-managed Python 3.12 venv the bootstrap builds. Every script now carries
-  `from __future__ import annotations`, so the plugin works on any Python
-  3.9+ host; the shared suite runs on 3.9 in CI to keep it that way.
-- **The uv-less install fallback refuses a host python older than 3.10.** When uv
-  is unavailable and cannot be downloaded, the bootstrap builds the runtime venv
-  from the host interpreter, which then inherits cognee's 3.10+ floor. Instead of
-  building a venv cognee cannot install into, it now logs
+- **Hotfix: the hooks run on Python 3.9 again (SDK-617).** Every hook script
+  failed at import time under a 3.9 `python3` — the one macOS ships with the
+  Xcode Command Line Tools — with `TypeError: unsupported operand type(s) for |`,
+  because `X | None` annotations are evaluated when a function is defined.
+  Nothing in the hooks needs 3.10 at runtime: they are stdlib HTTP clients, and
+  cognee runs in the uv-managed Python 3.12 venv the bootstrap builds. Every
+  script now carries `from __future__ import annotations`, so the plugin works
+  on any Python 3.9+ host; the shared suite runs on 3.9 in CI to keep it that
+  way. Shipped in place, without a version bump.
+- **The uv-less install fallback refuses a host python older than 3.10.** When
+  uv is unavailable and cannot be downloaded, the bootstrap builds the runtime
+  venv from the host interpreter, which then inherits cognee's 3.10+ floor.
+  Instead of building a venv cognee cannot install into, it now logs
   `host_python_too_old_for_venv` to `~/.cognee-plugin/claude-code/hook.log`, prints the interpreter path and
   version to stderr, and leaves a marker that every following SessionStart turns
-  into a systemMessage naming the fix (install uv or a 3.10+ python3) until a venv
-  is built.
-
-### Changed
-- README states the Python requirement up front: 3.9+ for the hooks, 3.10+ only
-  for the uv-less fallback; SDK-based integrations keep their 3.10+ floor.
-
-## [1.5.4]
+  into a systemMessage naming the fix (install uv or a 3.10+ python3) until a
+  venv is built. README states the requirement up front: 3.9+ for the hooks,
+  3.10+ only for that fallback.
 
 ### Changed
 - **Per-prompt recall dispatches every scope at once.** The scopes (`session`,

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,6 +10,30 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.5]
+
+### Fixed
+- **The hooks run on Python 3.9 again (SDK-617).** Every hook script failed at
+  import time under a 3.9 `python3` — the one macOS ships with the Xcode Command
+  Line Tools — with `TypeError: unsupported operand type(s) for |`, because
+  `X | None` annotations are evaluated when a function is defined. Nothing in the
+  hooks needs 3.10 at runtime: they are stdlib HTTP clients, and cognee runs in
+  the uv-managed Python 3.12 venv the bootstrap builds. Every script now carries
+  `from __future__ import annotations`, so the plugin works on any Python
+  3.9+ host; the shared suite runs on 3.9 in CI to keep it that way.
+- **The uv-less install fallback refuses a host python older than 3.10.** When uv
+  is unavailable and cannot be downloaded, the bootstrap builds the runtime venv
+  from the host interpreter, which then inherits cognee's 3.10+ floor. Instead of
+  building a venv cognee cannot install into, it now logs
+  `host_python_too_old_for_venv` to `~/.cognee-plugin/claude-code/hook.log`, prints the interpreter path and
+  version to stderr, and leaves a marker that every following SessionStart turns
+  into a systemMessage naming the fix (install uv or a 3.10+ python3) until a venv
+  is built.
+
+### Changed
+- README states the Python requirement up front: 3.9+ for the hooks, 3.10+ only
+  for the uv-less fallback; SDK-based integrations keep their 3.10+ floor.
+
 ## [1.5.4]
 
 ### Changed

--- a/integrations/claude-code/EVENTS.md
+++ b/integrations/claude-code/EVENTS.md
@@ -113,6 +113,10 @@ Names cover current hooks, configuration, transcript cleanup, and both watchers.
 | `hook:final_sync_once_pruned` | `sync.sync_once_pruned` |
 | `hook:find_claude_parent_failed` | `find.claude_parent_failed` |
 | `hook:find_codex_parent_failed` | `find.codex_parent_failed` |
+| `hook:host_python_marker_read_failed` | `host_python.marker_read_failed` |
+| `hook:host_python_marker_unlink_failed` | `host_python.marker_unlink_failed` |
+| `hook:host_python_marker_write_failed` | `host_python.marker_write_failed` |
+| `hook:host_python_too_old_for_venv` | `host_python.too_old_for_venv` |
 | `hook:https_context_no_ca_bundle` | `https.context_no_ca_bundle` |
 | `hook:idle_watcher_kill_failed` | `idle.watcher_kill_failed` |
 | `hook:idle_watcher_restart_failed` | `idle.watcher_restart_failed` |

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -21,6 +21,8 @@ The integration:
 
 ## Install
 
+**Requirements.** Any Python 3.9 or newer available as `python3` (or `python`) on PATH — the hooks are stdlib-only HTTP clients and never import cognee, so the Python 3.9.6 that ships with macOS's Xcode Command Line Tools is enough. In local mode the plugin brings its own runtime for the Cognee server: it fetches [uv](https://docs.astral.sh/uv/) into `~/.cognee-plugin/uv` and builds a Python 3.12 virtualenv with it (reusing a 3.12 already on the machine, otherwise downloading a ~66 MB standalone build). Only when uv is absent *and* cannot be downloaded does the plugin fall back to the host interpreter, and that fallback needs Python 3.10 or newer: on an older host it refuses, logs `host_python_too_old_for_venv` to `hook.log`, and every session start says so until uv or a newer python3 is installed. Cloud mode never builds a runtime. (SDK-based integrations such as LangGraph or CrewAI import cognee in-process and need Python 3.10+; see [`CONFIGURATION.md`](../CONFIGURATION.md#python-version-requirements).)
+
 Install from the Claude Code marketplace. The recommended way is from your shell, *before* launching Claude Code, so the first `claude` launch is a clean session that runs the plugin bootstrap automatically — no in-app restart needed:
 
 ```bash

--- a/integrations/claude-code/scripts/_capture_policy.py
+++ b/integrations/claude-code/scripts/_capture_policy.py
@@ -1,5 +1,7 @@
 """Client-side automatic capture controls. Explicit remember is independent."""
 
+from __future__ import annotations
+
 import fnmatch
 import json
 import os

--- a/integrations/claude-code/scripts/_code_graph.py
+++ b/integrations/claude-code/scripts/_code_graph.py
@@ -63,6 +63,8 @@ identical-looking results, which is why the skills tell the agent to say which
 one it is answering from when the work is in progress.
 """
 
+from __future__ import annotations
+
 import hashlib
 import json
 import os

--- a/integrations/claude-code/scripts/_cognee_client.py
+++ b/integrations/claude-code/scripts/_cognee_client.py
@@ -15,6 +15,8 @@ short-lived process, so in-memory state (as a long-lived provider like Hermes
 uses) would not survive between calls. State lives in the plugin state dir.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import pathlib

--- a/integrations/claude-code/scripts/_dataset_access.py
+++ b/integrations/claude-code/scripts/_dataset_access.py
@@ -1,5 +1,7 @@
 """Dataset UUIDs are authoritative; names are only for owned datasets."""
 
+from __future__ import annotations
+
 import json
 import os
 from uuid import UUID

--- a/integrations/claude-code/scripts/_deadlines.py
+++ b/integrations/claude-code/scripts/_deadlines.py
@@ -1,5 +1,7 @@
 """Elapsed-time bounds for read-only calls, without blocking interpreter exit."""
 
+from __future__ import annotations
+
 import math
 import queue
 import threading

--- a/integrations/claude-code/scripts/_env_file.py
+++ b/integrations/claude-code/scripts/_env_file.py
@@ -29,6 +29,8 @@ Loading must never break a hook: any parse or IO problem results in the file
 being (partially) ignored, never an exception.
 """
 
+from __future__ import annotations
+
 import os
 import stat
 import sys

--- a/integrations/claude-code/scripts/_file_lock.py
+++ b/integrations/claude-code/scripts/_file_lock.py
@@ -1,5 +1,7 @@
 """Small cross-process lock with bounded acquisition on POSIX and Windows."""
 
+from __future__ import annotations
+
 import os
 import time
 from contextlib import contextmanager

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -5,6 +5,8 @@ single log-to-disk helper. Hook scripts shouldn't grow heavy because
 they run on every user prompt / tool call.
 """
 
+from __future__ import annotations
+
 import errno
 import hashlib
 import json

--- a/integrations/claude-code/scripts/_proc.py
+++ b/integrations/claude-code/scripts/_proc.py
@@ -8,6 +8,8 @@ on Windows, where signal 0 raises ``OSError`` (``WinError 87``), so the check
 needs a native Windows path.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 

--- a/integrations/claude-code/scripts/_project_memory.py
+++ b/integrations/claude-code/scripts/_project_memory.py
@@ -1,5 +1,7 @@
 """Opt-in project tags and server-verified companion routing, pinned per session."""
 
+from __future__ import annotations
+
 import hashlib
 import os
 import re

--- a/integrations/claude-code/scripts/_recall_http.py
+++ b/integrations/claude-code/scripts/_recall_http.py
@@ -25,6 +25,8 @@ Contract — what gets printed to stdout:
 Diagnostics also go to stderr so the caller can surface them.
 """
 
+from __future__ import annotations
+
 import errno
 import json
 import os

--- a/integrations/claude-code/scripts/_remember_http.py
+++ b/integrations/claude-code/scripts/_remember_http.py
@@ -18,6 +18,8 @@ Contract — what gets printed to stdout:
 Diagnostics also go to stderr so the caller can surface them.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import socket

--- a/integrations/claude-code/scripts/clear-transcript-context.py
+++ b/integrations/claude-code/scripts/clear-transcript-context.py
@@ -6,6 +6,8 @@ Stop hook is the integration-level demo workaround: when enabled, it empties
 the transcript file Claude passes in the hook payload.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import sys

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -9,6 +9,8 @@ no network calls, no ``_plugin_common`` import.
 Output: ``cognee: <dataset-name> · local`` or ``cognee: <dataset-name> · cloud``
 """
 
+from __future__ import annotations
+
 import json
 import os
 import sys

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -26,6 +26,8 @@ Two modes, both over HTTP — the hooks never import cognee in-process:
   - Cloud: connect to a remote Cognee server via COGNEE_BASE_URL + COGNEE_API_KEY
 """
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/integrations/claude-code/scripts/credits-refresh.py
+++ b/integrations/claude-code/scripts/credits-refresh.py
@@ -12,6 +12,8 @@ rendered as ``last turn ~$X.XX``. ``refresh_credits`` never raises and no-ops
 entirely on a local server, so this hook is safe to fire unconditionally.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 

--- a/integrations/claude-code/scripts/doctor.py
+++ b/integrations/claude-code/scripts/doctor.py
@@ -12,6 +12,8 @@ Never modifies configuration, initialises databases, registers
 resources, writes files, or mutates state.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import pathlib

--- a/integrations/claude-code/scripts/event_names.py
+++ b/integrations/claude-code/scripts/event_names.py
@@ -1,5 +1,7 @@
 """Canonical log names. Keep legacy `event` readers working during migration."""
 
+from __future__ import annotations
+
 import os
 
 EVENT_NAMES = {
@@ -110,6 +112,10 @@ EVENT_NAMES = {
     "hook:final_sync_once_pruned": "sync.sync_once_pruned",
     "hook:find_claude_parent_failed": "find.claude_parent_failed",
     "hook:find_codex_parent_failed": "find.codex_parent_failed",
+    "hook:host_python_marker_read_failed": "host_python.marker_read_failed",
+    "hook:host_python_marker_unlink_failed": "host_python.marker_unlink_failed",
+    "hook:host_python_marker_write_failed": "host_python.marker_write_failed",
+    "hook:host_python_too_old_for_venv": "host_python.too_old_for_venv",
     "hook:https_context_no_ca_bundle": "https.context_no_ca_bundle",
     "hook:idle_watcher_kill_failed": "idle.watcher_kill_failed",
     "hook:idle_watcher_restart_failed": "idle.watcher_restart_failed",

--- a/integrations/claude-code/scripts/exit-watcher.py
+++ b/integrations/claude-code/scripts/exit-watcher.py
@@ -7,6 +7,8 @@ does nothing while Codex is alive; once that PID disappears, it starts the
 normal detached graph sync worker and exits.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/integrations/claude-code/scripts/idle-watcher.py
+++ b/integrations/claude-code/scripts/idle-watcher.py
@@ -17,6 +17,8 @@ watcher runs the session's final improve itself (and the exit watcher does
 the same when the host dies without a SessionEnd).
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/integrations/claude-code/scripts/pre-compact.py
+++ b/integrations/claude-code/scripts/pre-compact.py
@@ -11,6 +11,8 @@ Everything goes through the Cognee server over HTTP (``/api/v1/recall`` and
 plugin booted a local server or is connected to a remote one.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -11,6 +11,8 @@ Configuration:
     Resolves session state via Cognee HTTP endpoints.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -9,6 +9,8 @@ Runs on the SessionStart hook. Responsibilities:
   5. Register the current Claude session as an active agent connection
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os
@@ -101,11 +103,20 @@ _LAZY_BOOTSTRAP = os.environ.get("COGNEE_LAZY_BOOTSTRAP", "1").strip().lower() n
 # uv is kept self-contained under ~/.cognee-plugin so we never touch the user's
 # Python or PATH. A uv-managed Python guarantees a cognee-compatible runtime
 # (cognee requires 3.10-3.14) regardless of what's installed on the machine.
+# The hooks themselves need only a stdlib python3 of 3.9+ (see SDK-617): the
+# host interpreter never imports cognee, it only builds and talks to the venv.
 _UV_DIR = _GLOBAL_STATE_DIR / "uv"
 _UV_BIN = _UV_DIR / ("uv.exe" if os.name == "nt" else "uv")
 _UV_PYTHON_DIR = _GLOBAL_STATE_DIR / "python"
 _UV_INSTALL_URL = "https://astral.sh/uv/install.sh"
 _PINNED_PYTHON = os.environ.get("COGNEE_PLUGIN_PYTHON", "") or "3.12"
+# Floor for the HOST interpreter, enforced only on the uv-less fallback, which
+# builds the runtime venv from sys.executable and so inherits its version.
+_FALLBACK_VENV_MIN_PYTHON = (3, 10)
+# Written when that fallback is refused; read by the next SessionStart so the
+# refusal reaches the user as a systemMessage (the worker that hits it runs
+# detached, with nothing it prints visible). Cleared once a venv is ready.
+_HOST_PYTHON_MARKER = _GLOBAL_STATE_DIR / "host-python-unsupported.json"
 _PINNED_COGNEE_VERSION = "1.5.4"
 _INSTALL_TIMEOUT_SECONDS = float(os.environ.get("COGNEE_INSTALL_TIMEOUT", "") or 600.0)
 
@@ -172,6 +183,72 @@ def _find_uv() -> str:
         return str(_UV_BIN)
     found = shutil.which("uv")
     return found or ""
+
+
+def _host_python_label() -> str:
+    """``<sys.executable> (Python X.Y.Z)`` — names the interpreter a user must replace."""
+    return "{} (Python {}.{}.{})".format(sys.executable, *sys.version_info[:3])
+
+
+def _refuse_fallback_venv() -> None:
+    """Record why the uv-less fallback will not build the runtime venv.
+
+    Three readers: hook.log (forensics), this process's stderr (the bootstrap
+    log when detached, the terminal when not), and the marker the next
+    SessionStart turns into a systemMessage via ``_apply_host_python_warning``.
+    """
+    message = (
+        "Cognee Memory: cannot build the local Cognee runtime. uv is unavailable, and the "
+        "fallback would build the venv from {}, but that needs Python 3.10 or newer. Install "
+        "uv (https://docs.astral.sh/uv/) or a Python 3.10+ python3, then start a new "
+        "session.".format(_host_python_label())
+    )
+    detail = {
+        "python": sys.executable,
+        "version": "{}.{}.{}".format(*sys.version_info[:3]),
+        "required": "{}.{}".format(*_FALLBACK_VENV_MIN_PYTHON),
+    }
+    hook_log("host_python_too_old_for_venv", detail)
+    print(message, file=sys.stderr)
+    try:
+        _HOST_PYTHON_MARKER.parent.mkdir(parents=True, exist_ok=True)
+        _HOST_PYTHON_MARKER.write_text(
+            json.dumps({"message": message, "updated_at": time.time(), **detail}),
+            encoding="utf-8",
+        )
+    except Exception as exc:
+        hook_log("host_python_marker_write_failed", {"error": str(exc)[:200]})
+
+
+def _apply_host_python_warning(output: dict) -> dict:
+    """Append the recorded fallback refusal (if any) to the hook's systemMessage.
+
+    The marker outlives the session that wrote it on purpose: every launch on
+    the broken host repeats the message until a venv is built (which clears it
+    in ``_write_venv_ready``) — this is the loud failure SDK-617 asks for.
+    """
+    try:
+        if not _HOST_PYTHON_MARKER.exists():
+            return output
+        message = str(
+            json.loads(_HOST_PYTHON_MARKER.read_text(encoding="utf-8")).get("message") or ""
+        )
+    except Exception as exc:
+        hook_log("host_python_marker_read_failed", {"error": str(exc)[:200]})
+        return output
+    if not message:
+        return output
+    result = dict(output or {})
+    hso = dict(result.get("hookSpecificOutput") or {})
+    hso.setdefault("hookEventName", "SessionStart")
+    existing = str(hso.get("systemMessage") or "").strip()
+    hso["systemMessage"] = "{}\n\n{}".format(existing, message) if existing else message
+    result["hookSpecificOutput"] = hso
+    # Also at the top level: that is where Claude Code documents the universal
+    # ``systemMessage`` field, and where the Antigravity adapter reads it.
+    top = str(result.get("systemMessage") or "").strip()
+    result["systemMessage"] = "{}\n\n{}".format(top, message) if top else message
+    return result
 
 
 def _install_uv() -> str:
@@ -290,6 +367,11 @@ def _write_venv_ready(version: str) -> None:
         os.replace(tmp, _VENV_READY_MARKER)
     except Exception as exc:
         hook_log("venv_ready_write_failed", {"error": str(exc)[:200]})
+    try:
+        # A usable venv exists, so the host-python refusal (if any) is moot.
+        _HOST_PYTHON_MARKER.unlink(missing_ok=True)
+    except Exception as exc:
+        hook_log("host_python_marker_unlink_failed", {"error": str(exc)[:200]})
 
 
 def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
@@ -421,8 +503,13 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
             except Exception as exc:
                 hook_log("cognee_install_failed", {"via": "uv", "error": str(exc)[:300]})
         elif not venv_present:
-            # Last-resort fallback: stdlib venv + pip. Slower, and relies on the
-            # system python3 being a cognee-compatible version (3.10-3.14).
+            # Last-resort fallback: stdlib venv + pip. Slower, and the venv inherits
+            # this interpreter, so the host python3 must itself satisfy cognee's
+            # floor (3.10-3.14). The hooks run on any 3.9+, so check explicitly
+            # rather than build a venv cognee could never install into.
+            if sys.version_info < _FALLBACK_VENV_MIN_PYTHON:
+                _refuse_fallback_venv()
+                return False
             try:
                 subprocess.run(
                     [sys.executable, "-m", "venv", str(_VENV_DIR)],
@@ -2066,6 +2153,7 @@ def main():
         hook_log("session_start_exception", {"error": str(exc)[:200]})
     output = _apply_memory_preference(output)
     output = _apply_update_nudge(output)
+    output = _apply_host_python_warning(output)
     print(json.dumps(output or {}))
 
 

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -12,6 +12,8 @@ Configuration:
     Resolves session state via Cognee HTTP endpoints.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/integrations/claude-code/scripts/store-user-prompt.py
+++ b/integrations/claude-code/scripts/store-user-prompt.py
@@ -9,6 +9,8 @@ Configuration:
     Resolves session state via Cognee HTTP endpoints.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -9,6 +9,8 @@ Configuration:
     Resolves session identity from Cognee endpoints via API auth.
 """
 
+from __future__ import annotations
+
 import asyncio
 import hashlib
 import json

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -22,6 +22,8 @@ The integration:
 
 ## Install
 
+**Requirements.** Any Python 3.9 or newer available as `python3` (or `python`) on PATH — the hooks are stdlib-only HTTP clients and never import cognee, so the Python 3.9.6 that ships with macOS's Xcode Command Line Tools is enough. In local mode the plugin brings its own runtime for the Cognee server: it fetches [uv](https://docs.astral.sh/uv/) into `~/.cognee-plugin/uv` and builds a Python 3.12 virtualenv with it (reusing a 3.12 already on the machine, otherwise downloading a ~66 MB standalone build). Only when uv is absent *and* cannot be downloaded does the plugin fall back to the host interpreter, and that fallback needs Python 3.10 or newer: on an older host it refuses, logs `host_python_too_old_for_venv` to `hook.log`, and every session start says so until uv or a newer python3 is installed. Cloud mode never builds a runtime. (SDK-based integrations such as LangGraph or CrewAI import cognee in-process and need Python 3.10+; see [`CONFIGURATION.md`](../CONFIGURATION.md#python-version-requirements).)
+
 Install via the Codex marketplace. First enable hooks, then run the install commands in your terminal or directly inside a Codex session.
 
 You can enable hooks with:

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.6.5",
+  "version": "1.6.4",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,6 +10,30 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.5]
+
+### Fixed
+- **The hooks run on Python 3.9 again (SDK-617).** Every hook script failed at
+  import time under a 3.9 `python3` — the one macOS ships with the Xcode Command
+  Line Tools — with `TypeError: unsupported operand type(s) for |`, because
+  `X | None` annotations are evaluated when a function is defined. Nothing in the
+  hooks needs 3.10 at runtime: they are stdlib HTTP clients, and cognee runs in
+  the uv-managed Python 3.12 venv the bootstrap builds. Every script now carries
+  `from __future__ import annotations`, so the plugin works on any Python
+  3.9+ host; the shared suite runs on 3.9 in CI to keep it that way.
+- **The uv-less install fallback refuses a host python older than 3.10.** When uv
+  is unavailable and cannot be downloaded, the bootstrap builds the runtime venv
+  from the host interpreter, which then inherits cognee's 3.10+ floor. Instead of
+  building a venv cognee cannot install into, it now logs
+  `host_python_too_old_for_venv` to `~/.cognee-plugin/codex/hook.log`, prints the interpreter path and
+  version to stderr, and leaves a marker that every following SessionStart turns
+  into a systemMessage naming the fix (install uv or a 3.10+ python3) until a venv
+  is built.
+
+### Changed
+- README states the Python requirement up front: 3.9+ for the hooks, 3.10+ only
+  for the uv-less fallback; SDK-based integrations keep their 3.10+ floor.
+
 ## [1.6.4]
 
 ### Changed

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,31 +10,27 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.6.5]
+## [1.6.4]
 
 ### Fixed
-- **The hooks run on Python 3.9 again (SDK-617).** Every hook script failed at
-  import time under a 3.9 `python3` — the one macOS ships with the Xcode Command
-  Line Tools — with `TypeError: unsupported operand type(s) for |`, because
-  `X | None` annotations are evaluated when a function is defined. Nothing in the
-  hooks needs 3.10 at runtime: they are stdlib HTTP clients, and cognee runs in
-  the uv-managed Python 3.12 venv the bootstrap builds. Every script now carries
-  `from __future__ import annotations`, so the plugin works on any Python
-  3.9+ host; the shared suite runs on 3.9 in CI to keep it that way.
-- **The uv-less install fallback refuses a host python older than 3.10.** When uv
-  is unavailable and cannot be downloaded, the bootstrap builds the runtime venv
-  from the host interpreter, which then inherits cognee's 3.10+ floor. Instead of
-  building a venv cognee cannot install into, it now logs
+- **Hotfix: the hooks run on Python 3.9 again (SDK-617).** Every hook script
+  failed at import time under a 3.9 `python3` — the one macOS ships with the
+  Xcode Command Line Tools — with `TypeError: unsupported operand type(s) for |`,
+  because `X | None` annotations are evaluated when a function is defined.
+  Nothing in the hooks needs 3.10 at runtime: they are stdlib HTTP clients, and
+  cognee runs in the uv-managed Python 3.12 venv the bootstrap builds. Every
+  script now carries `from __future__ import annotations`, so the plugin works
+  on any Python 3.9+ host; the shared suite runs on 3.9 in CI to keep it that
+  way. Shipped in place, without a version bump.
+- **The uv-less install fallback refuses a host python older than 3.10.** When
+  uv is unavailable and cannot be downloaded, the bootstrap builds the runtime
+  venv from the host interpreter, which then inherits cognee's 3.10+ floor.
+  Instead of building a venv cognee cannot install into, it now logs
   `host_python_too_old_for_venv` to `~/.cognee-plugin/codex/hook.log`, prints the interpreter path and
   version to stderr, and leaves a marker that every following SessionStart turns
-  into a systemMessage naming the fix (install uv or a 3.10+ python3) until a venv
-  is built.
-
-### Changed
-- README states the Python requirement up front: 3.9+ for the hooks, 3.10+ only
-  for the uv-less fallback; SDK-based integrations keep their 3.10+ floor.
-
-## [1.6.4]
+  into a systemMessage naming the fix (install uv or a 3.10+ python3) until a
+  venv is built. README states the requirement up front: 3.9+ for the hooks,
+  3.10+ only for that fallback.
 
 ### Changed
 - **Per-prompt recall dispatches every scope at once.** The scopes (`session`,

--- a/integrations/codex/plugins/cognee/EVENTS.md
+++ b/integrations/codex/plugins/cognee/EVENTS.md
@@ -113,6 +113,10 @@ Names cover current hooks, configuration, transcript cleanup, and both watchers.
 | `hook:final_sync_once_pruned` | `sync.sync_once_pruned` |
 | `hook:find_claude_parent_failed` | `find.claude_parent_failed` |
 | `hook:find_codex_parent_failed` | `find.codex_parent_failed` |
+| `hook:host_python_marker_read_failed` | `host_python.marker_read_failed` |
+| `hook:host_python_marker_unlink_failed` | `host_python.marker_unlink_failed` |
+| `hook:host_python_marker_write_failed` | `host_python.marker_write_failed` |
+| `hook:host_python_too_old_for_venv` | `host_python.too_old_for_venv` |
 | `hook:https_context_no_ca_bundle` | `https.context_no_ca_bundle` |
 | `hook:idle_watcher_kill_failed` | `idle.watcher_kill_failed` |
 | `hook:idle_watcher_restart_failed` | `idle.watcher_restart_failed` |

--- a/integrations/codex/plugins/cognee/scripts/_capture_policy.py
+++ b/integrations/codex/plugins/cognee/scripts/_capture_policy.py
@@ -1,5 +1,7 @@
 """Client-side automatic capture controls. Explicit remember is independent."""
 
+from __future__ import annotations
+
 import fnmatch
 import json
 import os

--- a/integrations/codex/plugins/cognee/scripts/_code_graph.py
+++ b/integrations/codex/plugins/cognee/scripts/_code_graph.py
@@ -63,6 +63,8 @@ identical-looking results, which is why the skills tell the agent to say which
 one it is answering from when the work is in progress.
 """
 
+from __future__ import annotations
+
 import hashlib
 import json
 import os

--- a/integrations/codex/plugins/cognee/scripts/_cognee_client.py
+++ b/integrations/codex/plugins/cognee/scripts/_cognee_client.py
@@ -15,6 +15,8 @@ short-lived process, so in-memory state (as a long-lived provider like Hermes
 uses) would not survive between calls. State lives in the plugin state dir.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import pathlib

--- a/integrations/codex/plugins/cognee/scripts/_dataset_access.py
+++ b/integrations/codex/plugins/cognee/scripts/_dataset_access.py
@@ -1,5 +1,7 @@
 """Dataset UUIDs are authoritative; names are only for owned datasets."""
 
+from __future__ import annotations
+
 import json
 import os
 from uuid import UUID

--- a/integrations/codex/plugins/cognee/scripts/_deadlines.py
+++ b/integrations/codex/plugins/cognee/scripts/_deadlines.py
@@ -1,5 +1,7 @@
 """Elapsed-time bounds for read-only calls, without blocking interpreter exit."""
 
+from __future__ import annotations
+
 import math
 import queue
 import threading

--- a/integrations/codex/plugins/cognee/scripts/_env_file.py
+++ b/integrations/codex/plugins/cognee/scripts/_env_file.py
@@ -29,6 +29,8 @@ Loading must never break a hook: any parse or IO problem results in the file
 being (partially) ignored, never an exception.
 """
 
+from __future__ import annotations
+
 import os
 import stat
 import sys

--- a/integrations/codex/plugins/cognee/scripts/_file_lock.py
+++ b/integrations/codex/plugins/cognee/scripts/_file_lock.py
@@ -1,5 +1,7 @@
 """Small cross-process lock with bounded acquisition on POSIX and Windows."""
 
+from __future__ import annotations
+
 import os
 import time
 from contextlib import contextmanager

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -5,6 +5,8 @@ single log-to-disk helper. Hook scripts shouldn't grow heavy because
 they run on every user prompt / tool call.
 """
 
+from __future__ import annotations
+
 import errno
 import hashlib
 import json

--- a/integrations/codex/plugins/cognee/scripts/_proc.py
+++ b/integrations/codex/plugins/cognee/scripts/_proc.py
@@ -8,6 +8,8 @@ on Windows, where signal 0 raises ``OSError`` (``WinError 87``), so the check
 needs a native Windows path.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 

--- a/integrations/codex/plugins/cognee/scripts/_project_memory.py
+++ b/integrations/codex/plugins/cognee/scripts/_project_memory.py
@@ -1,5 +1,7 @@
 """Opt-in project tags and server-verified companion routing, pinned per session."""
 
+from __future__ import annotations
+
 import hashlib
 import os
 import re

--- a/integrations/codex/plugins/cognee/scripts/_recall_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_recall_http.py
@@ -25,6 +25,8 @@ Contract — what gets printed to stdout:
 Diagnostics also go to stderr so the caller can surface them.
 """
 
+from __future__ import annotations
+
 import errno
 import json
 import os

--- a/integrations/codex/plugins/cognee/scripts/_remember_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_remember_http.py
@@ -18,6 +18,8 @@ Contract — what gets printed to stdout:
 Diagnostics also go to stderr so the caller can surface them.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import socket

--- a/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
@@ -9,6 +9,8 @@ calls, no ``_plugin_common`` import.
 Output: ``cognee: <dataset-name> · local`` or ``cognee: <dataset-name> · cloud``
 """
 
+from __future__ import annotations
+
 import json
 import os
 import sys

--- a/integrations/codex/plugins/cognee/scripts/config.py
+++ b/integrations/codex/plugins/cognee/scripts/config.py
@@ -26,6 +26,8 @@ Two modes, both over HTTP — the hooks never import cognee in-process:
   - Cloud: connect to a remote Cognee server via COGNEE_BASE_URL + COGNEE_API_KEY
 """
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/integrations/codex/plugins/cognee/scripts/credits-refresh.py
+++ b/integrations/codex/plugins/cognee/scripts/credits-refresh.py
@@ -13,6 +13,8 @@ rendered as ``last turn ~$X.XX``. ``refresh_credits`` never raises and no-ops
 entirely on a local server, so this hook is safe to fire unconditionally.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 

--- a/integrations/codex/plugins/cognee/scripts/doctor.py
+++ b/integrations/codex/plugins/cognee/scripts/doctor.py
@@ -12,6 +12,8 @@ Never modifies configuration, initialises databases, registers
 resources, writes files, or mutates state.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import pathlib

--- a/integrations/codex/plugins/cognee/scripts/event_names.py
+++ b/integrations/codex/plugins/cognee/scripts/event_names.py
@@ -1,5 +1,7 @@
 """Canonical log names. Keep legacy `event` readers working during migration."""
 
+from __future__ import annotations
+
 import os
 
 EVENT_NAMES = {
@@ -110,6 +112,10 @@ EVENT_NAMES = {
     "hook:final_sync_once_pruned": "sync.sync_once_pruned",
     "hook:find_claude_parent_failed": "find.claude_parent_failed",
     "hook:find_codex_parent_failed": "find.codex_parent_failed",
+    "hook:host_python_marker_read_failed": "host_python.marker_read_failed",
+    "hook:host_python_marker_unlink_failed": "host_python.marker_unlink_failed",
+    "hook:host_python_marker_write_failed": "host_python.marker_write_failed",
+    "hook:host_python_too_old_for_venv": "host_python.too_old_for_venv",
     "hook:https_context_no_ca_bundle": "https.context_no_ca_bundle",
     "hook:idle_watcher_kill_failed": "idle.watcher_kill_failed",
     "hook:idle_watcher_restart_failed": "idle.watcher_restart_failed",

--- a/integrations/codex/plugins/cognee/scripts/exit-watcher.py
+++ b/integrations/codex/plugins/cognee/scripts/exit-watcher.py
@@ -7,6 +7,8 @@ does nothing while Codex is alive; once that PID disappears, it starts the
 normal detached graph sync worker and exits.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/integrations/codex/plugins/cognee/scripts/idle-watcher.py
+++ b/integrations/codex/plugins/cognee/scripts/idle-watcher.py
@@ -17,6 +17,8 @@ watcher runs the session's final improve itself (and the exit watcher does
 the same when the host dies without a SessionEnd).
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/integrations/codex/plugins/cognee/scripts/pre-compact.py
+++ b/integrations/codex/plugins/cognee/scripts/pre-compact.py
@@ -14,6 +14,8 @@ Everything goes through the Cognee server over HTTP (``/api/v1/recall`` and
 plugin booted a local server or is connected to a remote one.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -11,6 +11,8 @@ Configuration:
     Resolves session state via Cognee HTTP endpoints.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -9,6 +9,8 @@ Runs on the SessionStart hook. Responsibilities:
   5. Register the current Codex thread as an active agent connection
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os
@@ -100,11 +102,20 @@ _LAZY_BOOTSTRAP = os.environ.get("COGNEE_LAZY_BOOTSTRAP", "1").strip().lower() n
 # uv + a uv-managed Python guarantee a cognee-compatible runtime (3.10-3.14)
 # regardless of what's on the machine. All paths sit under the shared
 # ~/.cognee-plugin root so the two plugins install once and reuse one venv.
+# The hooks themselves need only a stdlib python3 of 3.9+ (see SDK-617): the
+# host interpreter never imports cognee, it only builds and talks to the venv.
 _UV_DIR = _GLOBAL_STATE_DIR / "uv"
 _UV_BIN = _UV_DIR / ("uv.exe" if os.name == "nt" else "uv")
 _UV_PYTHON_DIR = _GLOBAL_STATE_DIR / "python"
 _UV_INSTALL_URL = "https://astral.sh/uv/install.sh"
 _PINNED_PYTHON = os.environ.get("COGNEE_PLUGIN_PYTHON", "") or "3.12"
+# Floor for the HOST interpreter, enforced only on the uv-less fallback, which
+# builds the runtime venv from sys.executable and so inherits its version.
+_FALLBACK_VENV_MIN_PYTHON = (3, 10)
+# Written when that fallback is refused; read by the next SessionStart so the
+# refusal reaches the user as a systemMessage (the worker that hits it runs
+# detached, with nothing it prints visible). Cleared once a venv is ready.
+_HOST_PYTHON_MARKER = _GLOBAL_STATE_DIR / "host-python-unsupported.json"
 _PINNED_COGNEE_VERSION = "1.5.4"
 _INSTALL_TIMEOUT_SECONDS = float(os.environ.get("COGNEE_INSTALL_TIMEOUT", "") or 600.0)
 
@@ -171,6 +182,72 @@ def _find_uv() -> str:
         return str(_UV_BIN)
     found = shutil.which("uv")
     return found or ""
+
+
+def _host_python_label() -> str:
+    """``<sys.executable> (Python X.Y.Z)`` — names the interpreter a user must replace."""
+    return "{} (Python {}.{}.{})".format(sys.executable, *sys.version_info[:3])
+
+
+def _refuse_fallback_venv() -> None:
+    """Record why the uv-less fallback will not build the runtime venv.
+
+    Three readers: hook.log (forensics), this process's stderr (the bootstrap
+    log when detached, the terminal when not), and the marker the next
+    SessionStart turns into a systemMessage via ``_apply_host_python_warning``.
+    """
+    message = (
+        "Cognee Memory: cannot build the local Cognee runtime. uv is unavailable, and the "
+        "fallback would build the venv from {}, but that needs Python 3.10 or newer. Install "
+        "uv (https://docs.astral.sh/uv/) or a Python 3.10+ python3, then start a new "
+        "session.".format(_host_python_label())
+    )
+    detail = {
+        "python": sys.executable,
+        "version": "{}.{}.{}".format(*sys.version_info[:3]),
+        "required": "{}.{}".format(*_FALLBACK_VENV_MIN_PYTHON),
+    }
+    hook_log("host_python_too_old_for_venv", detail)
+    print(message, file=sys.stderr)
+    try:
+        _HOST_PYTHON_MARKER.parent.mkdir(parents=True, exist_ok=True)
+        _HOST_PYTHON_MARKER.write_text(
+            json.dumps({"message": message, "updated_at": time.time(), **detail}),
+            encoding="utf-8",
+        )
+    except Exception as exc:
+        hook_log("host_python_marker_write_failed", {"error": str(exc)[:200]})
+
+
+def _apply_host_python_warning(output: dict) -> dict:
+    """Append the recorded fallback refusal (if any) to the hook's systemMessage.
+
+    The marker outlives the session that wrote it on purpose: every launch on
+    the broken host repeats the message until a venv is built (which clears it
+    in ``_write_venv_ready``) — this is the loud failure SDK-617 asks for.
+    """
+    try:
+        if not _HOST_PYTHON_MARKER.exists():
+            return output
+        message = str(
+            json.loads(_HOST_PYTHON_MARKER.read_text(encoding="utf-8")).get("message") or ""
+        )
+    except Exception as exc:
+        hook_log("host_python_marker_read_failed", {"error": str(exc)[:200]})
+        return output
+    if not message:
+        return output
+    result = dict(output or {})
+    hso = dict(result.get("hookSpecificOutput") or {})
+    hso.setdefault("hookEventName", "SessionStart")
+    existing = str(hso.get("systemMessage") or "").strip()
+    hso["systemMessage"] = "{}\n\n{}".format(existing, message) if existing else message
+    result["hookSpecificOutput"] = hso
+    # Also at the top level: that is where Claude Code documents the universal
+    # ``systemMessage`` field, and where the Antigravity adapter reads it.
+    top = str(result.get("systemMessage") or "").strip()
+    result["systemMessage"] = "{}\n\n{}".format(top, message) if top else message
+    return result
 
 
 def _install_uv() -> str:
@@ -289,6 +366,11 @@ def _write_venv_ready(version: str) -> None:
         os.replace(tmp, _VENV_READY_MARKER)
     except Exception as exc:
         hook_log("venv_ready_write_failed", {"error": str(exc)[:200]})
+    try:
+        # A usable venv exists, so the host-python refusal (if any) is moot.
+        _HOST_PYTHON_MARKER.unlink(missing_ok=True)
+    except Exception as exc:
+        hook_log("host_python_marker_unlink_failed", {"error": str(exc)[:200]})
 
 
 def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
@@ -420,8 +502,13 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
             except Exception as exc:
                 hook_log("cognee_install_failed", {"via": "uv", "error": str(exc)[:300]})
         elif not venv_present:
-            # Last-resort fallback: stdlib venv + pip. Slower, and relies on the
-            # system python3 being a cognee-compatible version (3.10-3.14).
+            # Last-resort fallback: stdlib venv + pip. Slower, and the venv inherits
+            # this interpreter, so the host python3 must itself satisfy cognee's
+            # floor (3.10-3.14). The hooks run on any 3.9+, so check explicitly
+            # rather than build a venv cognee could never install into.
+            if sys.version_info < _FALLBACK_VENV_MIN_PYTHON:
+                _refuse_fallback_venv()
+                return False
             try:
                 subprocess.run(
                     [sys.executable, "-m", "venv", str(_VENV_DIR)],
@@ -1908,6 +1995,7 @@ def main():
             output = asyncio.run(_start(payload)) or {}
     except Exception as exc:
         hook_log("session_start_exception", {"error": str(exc)[:200]})
+    output = _apply_host_python_warning(output)
     print(json.dumps(output))
 
 

--- a/integrations/codex/plugins/cognee/scripts/store-to-session.py
+++ b/integrations/codex/plugins/cognee/scripts/store-to-session.py
@@ -12,6 +12,8 @@ Configuration:
     Resolves session state via Cognee HTTP endpoints.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/integrations/codex/plugins/cognee/scripts/store-user-prompt.py
+++ b/integrations/codex/plugins/cognee/scripts/store-user-prompt.py
@@ -9,6 +9,8 @@ Configuration:
     Resolves session state via Cognee HTTP endpoints.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/integrations/codex/plugins/cognee/scripts/sync-session-to-graph.py
+++ b/integrations/codex/plugins/cognee/scripts/sync-session-to-graph.py
@@ -9,6 +9,8 @@ Configuration:
     Resolves session identity from Cognee endpoints via API auth.
 """
 
+from __future__ import annotations
+
 import asyncio
 import hashlib
 import json

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -53,6 +53,11 @@ Python package with the `hermes_agent.plugins` entry point.
 
 ### Prerequisites
 
+- **Python 3.10 or newer.** This integration imports cognee in-process
+  (`requires-python = ">=3.10"` in `pyproject.toml`), so it inherits cognee's
+  own floor; `pip` refuses to install it on 3.9. Note that macOS's Xcode
+  Command Line Tools ship Python 3.9.6 — use a Homebrew, python.org or
+  [uv](https://docs.astral.sh/uv/)-managed 3.10+ interpreter instead.
 - [Hermes Agent](https://github.com/NousResearch/hermes-agent) installed
   (`curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`).
 - **Local mode:** an LLM API key (e.g. OpenAI) — cognee uses it to build the

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -23,7 +23,7 @@ integrations:
     registry: npm
     package_name: "@cognee/cognee-openclaw"
     cognee_dependency: http-api
-    current_version: "2026.9.8"
+    current_version: "2026.9.10"
     migration_status: done
     notes: "OpenClaw plugin with auto-recall/capture hooks"
 
@@ -34,7 +34,7 @@ integrations:
     registry: none
     package_name: null
     cognee_dependency: sdk
-    current_version: "1.5.4"
+    current_version: "1.5.5"
     migration_status: done
     notes: "Claude Code plugin – session storage via hooks, recall via context lookup, session-to-graph sync"
 
@@ -45,7 +45,7 @@ integrations:
     registry: none
     package_name: null
     cognee_dependency: http-api
-    current_version: "1.5.1"
+    current_version: "1.5.2"
     migration_status: done
     notes: "Native agy plugin – session storage via named hooks, transcript-tail recall, and session-to-graph sync"
 
@@ -67,7 +67,7 @@ integrations:
     registry: codex-marketplace
     package_name: null
     cognee_dependency: cli
-    current_version: "1.6.4"
+    current_version: "1.6.5"
     migration_status: done
     notes: "Codex local plugin marketplace with Cognee CLI skills for setup, memory, codebase ingestion, and UI launch"
 

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -23,7 +23,7 @@ integrations:
     registry: npm
     package_name: "@cognee/cognee-openclaw"
     cognee_dependency: http-api
-    current_version: "2026.9.10"
+    current_version: "2026.9.8"
     migration_status: done
     notes: "OpenClaw plugin with auto-recall/capture hooks"
 
@@ -34,7 +34,7 @@ integrations:
     registry: none
     package_name: null
     cognee_dependency: sdk
-    current_version: "1.5.5"
+    current_version: "1.5.4"
     migration_status: done
     notes: "Claude Code plugin – session storage via hooks, recall via context lookup, session-to-graph sync"
 
@@ -45,7 +45,7 @@ integrations:
     registry: none
     package_name: null
     cognee_dependency: http-api
-    current_version: "1.5.2"
+    current_version: "1.5.1"
     migration_status: done
     notes: "Native agy plugin – session storage via named hooks, transcript-tail recall, and session-to-graph sync"
 
@@ -67,7 +67,7 @@ integrations:
     registry: codex-marketplace
     package_name: null
     cognee_dependency: cli
-    current_version: "1.6.5"
+    current_version: "1.6.4"
     migration_status: done
     notes: "Codex local plugin marketplace with Cognee CLI skills for setup, memory, codebase ingestion, and UI launch"
 

--- a/integrations/openclaw/CHANGELOG.md
+++ b/integrations/openclaw/CHANGELOG.md
@@ -11,26 +11,22 @@ reports an update only when the published npm version changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/). Versions are
 date-based (`YYYY.M.D`), matching the OpenClaw plugin ecosystem.
 
-## [2026.9.10]
+## [2026.9.8]
 
 ### Fixed
-- **The uv-less install fallback refuses a host python older than 3.10 (SDK-617).**
-  The bootstrap script (`~/.cognee-plugin/ensure_and_boot.py`) runs under the
-  system `python3` — `/usr/bin/python3`, which is 3.9.6 on macOS with the Xcode
-  Command Line Tools — and that is fine: it only needs the standard library, and
-  cognee runs in the uv-managed Python 3.12 venv it builds. But when uv is
-  unavailable and cannot be downloaded, the fallback `python3 -m venv` inherits
-  the host version, and a 3.9 venv can never hold cognee. The script now refuses
-  in that case and, since it daemonizes with its output closed, records the
-  reason in `~/.cognee-plugin/.venv-error.json`; the gateway's "server did not
-  become ready" warning quotes it (`readBootError`). The marker is cleared once
-  an install succeeds.
-
-### Changed
-- README gains a Requirements section: Python 3.9+ for the bootstrap, 3.10+ only
-  for the uv-less fallback, none in cloud mode.
-
-## [2026.9.8]
+- **Hotfix: the uv-less install fallback refuses a host python older than 3.10
+  (SDK-617).** The bootstrap script (`~/.cognee-plugin/ensure_and_boot.py`) runs
+  under the system `python3` — `/usr/bin/python3`, which is 3.9.6 on macOS with
+  the Xcode Command Line Tools — and that is fine: it only needs the standard
+  library, and cognee runs in the uv-managed Python 3.12 venv it builds. But when
+  uv is unavailable and cannot be downloaded, the fallback `python3 -m venv`
+  inherits the host version, and a 3.9 venv can never hold cognee. The script
+  now refuses in that case and, since it daemonizes with its output closed,
+  records the reason in `~/.cognee-plugin/.venv-error.json`; the gateway's
+  "server did not become ready" warning quotes it (`readBootError`). The marker
+  is cleared once an install succeeds. README gains a Requirements section:
+  Python 3.9+ for the bootstrap, 3.10+ only for the uv-less fallback, none in
+  cloud mode. Shipped in place, without a version bump.
 
 ### Changed
 - **Per-prompt recall waits long enough for growing graphs.** `recallTimeoutMs`

--- a/integrations/openclaw/CHANGELOG.md
+++ b/integrations/openclaw/CHANGELOG.md
@@ -11,6 +11,25 @@ reports an update only when the published npm version changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/). Versions are
 date-based (`YYYY.M.D`), matching the OpenClaw plugin ecosystem.
 
+## [2026.9.10]
+
+### Fixed
+- **The uv-less install fallback refuses a host python older than 3.10 (SDK-617).**
+  The bootstrap script (`~/.cognee-plugin/ensure_and_boot.py`) runs under the
+  system `python3` — `/usr/bin/python3`, which is 3.9.6 on macOS with the Xcode
+  Command Line Tools — and that is fine: it only needs the standard library, and
+  cognee runs in the uv-managed Python 3.12 venv it builds. But when uv is
+  unavailable and cannot be downloaded, the fallback `python3 -m venv` inherits
+  the host version, and a 3.9 venv can never hold cognee. The script now refuses
+  in that case and, since it daemonizes with its output closed, records the
+  reason in `~/.cognee-plugin/.venv-error.json`; the gateway's "server did not
+  become ready" warning quotes it (`readBootError`). The marker is cleared once
+  an install succeeds.
+
+### Changed
+- README gains a Requirements section: Python 3.9+ for the bootstrap, 3.10+ only
+  for the uv-less fallback, none in cloud mode.
+
 ## [2026.9.8]
 
 ### Changed

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -56,6 +56,13 @@ Without this, any plugin found in your environment could be loaded automatically
 
 ## Installation
 
+### Requirements
+
+- Node.js, as required by your OpenClaw gateway.
+- **Python 3.9 or newer** as `python3` — only the standard library is used. On first use in local mode the plugin writes a small bootstrap script to `~/.cognee-plugin/` and runs it with the system `python3` (`/usr/bin/python3` on macOS, which is 3.9.6 with the Xcode Command Line Tools). That script fetches [uv](https://docs.astral.sh/uv/) and builds a Python 3.12 virtualenv for the Cognee server (reusing a 3.12 already on the machine, otherwise downloading a ~66 MB standalone build); cognee itself never runs under the system interpreter.
+- If uv is unavailable *and* cannot be downloaded, the bootstrap falls back to `python3 -m venv`, and that fallback needs **Python 3.10 or newer**. On an older host it refuses instead of building a venv cognee cannot install into, records the reason in `~/.cognee-plugin/.venv-error.json`, and the gateway log's "server did not become ready" warning quotes it.
+- Cloud mode (`COGNEE_BASE_URL` pointing at Cognee Cloud or a remote server) builds no runtime and has no Python requirement beyond running the bootstrap script.
+
 ### Published package
 
 ```bash

--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cognee/cognee-openclaw",
-  "version": "2026.9.8",
+  "version": "2026.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cognee/cognee-openclaw",
-      "version": "2026.9.8",
+      "version": "2026.9.10",
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^20.0.0",

--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cognee/cognee-openclaw",
-  "version": "2026.9.10",
+  "version": "2026.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cognee/cognee-openclaw",
-      "version": "2026.9.10",
+      "version": "2026.9.8",
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^20.0.0",

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/cognee-openclaw",
-  "version": "2026.9.8",
+  "version": "2026.9.10",
   "type": "module",
   "description": "OpenClaw Cognee-backed memory plugin with auto-recall/capture",
   "author": {

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognee/cognee-openclaw",
-  "version": "2026.9.10",
+  "version": "2026.9.8",
   "type": "module",
   "description": "OpenClaw Cognee-backed memory plugin with auto-recall/capture",
   "author": {

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -44,7 +44,7 @@ import { describeImprove, renderSessionLayerSections } from "./recall-layers.js"
 import { DigestTracker, formatFooter, sourceLabel } from "./digest.js";
 import { cogneeSessionId, datasetNameForScope, isMultiScopeEnabled, normalizeAgentId, routeFileToScope } from "./scope.js";
 import { syncFiles, syncFilesScoped } from "./sync.js";
-import { bootServerIfNeeded, waitForServerHealth, isLocalUrl, resolveOrMintApiKey, spawnExitWatcher, exitWatcherPidfilePath } from "./server.js";
+import { bootServerIfNeeded, waitForServerHealth, isLocalUrl, readBootError, resolveOrMintApiKey, spawnExitWatcher, exitWatcherPidfilePath } from "./server.js";
 
 /** Expand a leading `~` in a workspace path to the user's home directory. */
 function expandHome(p: string | undefined): string | undefined {
@@ -1218,7 +1218,14 @@ const memoryCogneePlugin = {
           // can legitimately take several minutes.
           await waitForServerHealth(cfg.baseUrl, 600_000);
         } catch (e) {
-          logger.warn?.(`cognee-openclaw: server did not become ready: ${String(e)}`);
+          // The boot script daemonizes with its output closed; when its install
+          // step failed (e.g. no uv and a host python3 older than 3.10) the only
+          // trace is the marker it leaves, so surface that alongside the timeout.
+          const reason = await readBootError();
+          logger.warn?.(
+            `cognee-openclaw: server did not become ready: ${String(e)}` +
+              (reason ? ` — boot script reported: ${reason}` : ""),
+          );
           return;
         }
       }

--- a/integrations/openclaw/src/server.ts
+++ b/integrations/openclaw/src/server.ts
@@ -6,6 +6,23 @@ import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/sandbox";
 
 const COGNEE_PLUGIN_BASE = join(homedir(), ".cognee-plugin");
 const API_KEY_CACHE_PATH = join(COGNEE_PLUGIN_BASE, "api_key.json");
+const BOOT_ERROR_MARKER_PATH = join(COGNEE_PLUGIN_BASE, ".venv-error.json");
+
+/**
+ * Why the last ensure_and_boot.py install attempt failed, or "" when it did not
+ * (or nothing recorded one). The boot script daemonizes with stdout/stderr
+ * closed, so this marker is the only channel for its failure reason — e.g. a
+ * host python3 too old to build the fallback venv when uv is unavailable.
+ */
+export async function readBootError(): Promise<string> {
+  try {
+    const raw = await readFile(BOOT_ERROR_MARKER_PATH, "utf-8");
+    const parsed = JSON.parse(raw) as { error?: unknown };
+    return typeof parsed.error === "string" ? parsed.error : "";
+  } catch {
+    return "";
+  }
+}
 
 // Combined install-and-boot script written to ~/.cognee-plugin/ensure_and_boot.py on first use.
 // Handles: (1) creating the venv + installing cognee if absent, (2) booting uvicorn.
@@ -24,6 +41,7 @@ const ENSURE_SCRIPT_CONTENT = [
   "UV_DIR = os.path.join(BASE, 'uv')",
   "UV_BIN = os.path.join(UV_DIR, 'uv' + _ext)",
   "READY_MARKER = os.path.join(BASE, '.venv-ready.json')",
+  "ERROR_MARKER = os.path.join(BASE, '.venv-error.json')",
   "INSTALL_LOCK = os.path.join(BASE, 'venv-install.lock')",
   "COGNEE_VERSION = '1.5.3'",
   "",
@@ -92,6 +110,14 @@ const ENSURE_SCRIPT_CONTENT = [
   "                env=uv_env, check=True, capture_output=True, timeout=600,",
   "            )",
   "        elif not os.path.exists(VENV_PYTHON):",
+  "            # No uv: the venv inherits this interpreter, so it must satisfy",
+  "            # cognee's own floor (3.10+). The script itself runs on any 3.9+.",
+  "            if sys.version_info < (3, 10):",
+  "                raise RuntimeError(",
+  "                    'uv is unavailable and %s is Python %d.%d.%d; building the cognee '",
+  "                    'runtime without uv requires Python 3.10 or newer. Install uv '",
+  "                    '(https://docs.astral.sh/uv/) or a newer python3 and restart the gateway.'",
+  "                    % (sys.executable, sys.version_info[0], sys.version_info[1], sys.version_info[2]))",
   "            subprocess.run(",
   "                [sys.executable, '-m', 'venv', VENV_DIR],",
   "                check=True, capture_output=True, timeout=120,",
@@ -105,8 +131,19 @@ const ENSURE_SCRIPT_CONTENT = [
   "            json.dump({'cognee_version': COGNEE_VERSION, 'python': VENV_PYTHON,",
   "                       'updated_at': time.time()}, f)",
   "        os.replace(tmp, READY_MARKER)",
+  "        try: os.unlink(ERROR_MARKER)",
+  "        except Exception: pass",
   "        return True",
-  "    except Exception: return False",
+  "    except Exception as exc:",
+  "        # The daemon has no stdout/stderr; leave the reason where the gateway",
+  "        # (readBootError) and a human (cat the file) can find it.",
+  "        try:",
+  "            with open(ERROR_MARKER, 'w') as f:",
+  "                json.dump({'error': str(exc)[:500], 'python': sys.executable,",
+  "                           'python_version': '%d.%d.%d' % sys.version_info[:3],",
+  "                           'updated_at': time.time()}, f)",
+  "        except Exception: pass",
+  "        return False",
   "    finally: release_lock(INSTALL_LOCK)",
   "",
   "def boot_server():",
@@ -140,7 +177,11 @@ const ENSURE_SCRIPT_CONTENT = [
 ].join("\n");
 
 // System Python candidates for running ensure_and_boot.py on a cold machine
-// (before the plugin venv exists). Only stdlib is needed so any Python 3 works.
+// (before the plugin venv exists). Only stdlib is needed, so any Python 3.9+
+// works: cognee itself runs in the uv-managed 3.12 venv the script builds.
+// The one exception is the uv-less fallback, which inherits this interpreter
+// and therefore needs 3.10+ — the script refuses and records why (see
+// readBootError) rather than building a venv cognee cannot install into.
 const SYSTEM_PYTHON_CANDIDATES = [
   "/usr/bin/python3",          // macOS Xcode CLT + most Linux
   "/usr/local/bin/python3",    // some Linux, older Homebrew

--- a/integrations/openclaw/src/version.ts
+++ b/integrations/openclaw/src/version.ts
@@ -26,7 +26,7 @@ import { UPDATE_CHECK_PATH } from "./persistence.js";
  * Fallback version used when api.version is unset. The drift-guard test in
  * __tests__/unit/test_version.ts asserts this stays equal to package.json.
  */
-export const PLUGIN_VERSION = "2026.9.8";
+export const PLUGIN_VERSION = "2026.9.10";
 
 const NPM_LATEST_URL = "https://registry.npmjs.org/@cognee/cognee-openclaw/latest";
 const DEFAULT_INTERVAL_SECONDS = 86_400; // 24h

--- a/integrations/openclaw/src/version.ts
+++ b/integrations/openclaw/src/version.ts
@@ -26,7 +26,7 @@ import { UPDATE_CHECK_PATH } from "./persistence.js";
  * Fallback version used when api.version is unset. The drift-guard test in
  * __tests__/unit/test_version.ts asserts this stays equal to package.json.
  */
-export const PLUGIN_VERSION = "2026.9.10";
+export const PLUGIN_VERSION = "2026.9.8";
 
 const NPM_LATEST_URL = "https://registry.npmjs.org/@cognee/cognee-openclaw/latest";
 const DEFAULT_INTERVAL_SECONDS = 86_400; // 24h

--- a/integrations/tests/tests/unit/test_antigravity_hooks_contract.py
+++ b/integrations/tests/tests/unit/test_antigravity_hooks_contract.py
@@ -147,7 +147,7 @@ def test_plugin_manifest_identifies_cognee_with_a_version_string(plugin_root):
     spec = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
 
     assert spec["name"] == "cognee"
-    assert spec["version"] == "1.5.1"
+    assert spec["version"] == "1.5.2"
 
 
 def test_hooks_manifest_is_at_plugin_root_not_claude_hooks_directory(manifest):

--- a/integrations/tests/tests/unit/test_antigravity_hooks_contract.py
+++ b/integrations/tests/tests/unit/test_antigravity_hooks_contract.py
@@ -147,7 +147,7 @@ def test_plugin_manifest_identifies_cognee_with_a_version_string(plugin_root):
     spec = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
 
     assert spec["name"] == "cognee"
-    assert spec["version"] == "1.5.2"
+    assert spec["version"] == "1.5.1"
 
 
 def test_hooks_manifest_is_at_plugin_root_not_claude_hooks_directory(manifest):

--- a/integrations/tests/tests/unit/test_python39_compat.py
+++ b/integrations/tests/tests/unit/test_python39_compat.py
@@ -1,0 +1,234 @@
+"""The hook layer runs on Python 3.9; only the uv-less venv fallback needs 3.10 (SDK-617).
+
+The hooks are launched as ``python3 <script>`` under whatever python3 the host
+has on PATH — 3.9.6 on a Mac with just the Xcode Command Line Tools. They never
+import cognee (cognee runs in the uv-managed 3.12 venv the bootstrap builds), so
+nothing in them needs 3.10 at runtime. What broke on 3.9 was ``X | None`` in
+annotations, which Python evaluates when it defines a function unless the module
+defers annotations with ``from __future__ import annotations``. One missing
+import in a shared module took every hook down at import time, and the failure
+was a ``TypeError`` traceback in a log nobody reads.
+
+Two invariants, asserted for every suite:
+
+1. Every script in the scripts dir defers annotation evaluation and parses under
+   the 3.9 grammar (no ``match``, no parenthesized context managers). This is
+   the cheap guard that runs on every interpreter; the 3.9 CI cell proves the
+   suite as a whole.
+2. The one place the host version truly matters — the stdlib ``venv`` fallback
+   in ``ensure_cognee_installed`` when uv is unavailable — refuses a host older
+   than 3.10 loudly: ``hook.log`` event, stderr line naming the interpreter, and
+   a marker that ``session-start.py`` turns into a systemMessage on every launch
+   until a venv exists.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from utils.hooklog import hook_events
+from utils.suites import plugin_root
+
+_FUTURE = "annotations"
+_MARKER_NAME = "host-python-unsupported.json"
+
+
+# --- 1. source-level invariant -----------------------------------------------
+
+
+def _defers_annotations(tree: ast.Module) -> bool:
+    return any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "__future__"
+        and any(alias.name == _FUTURE for alias in node.names)
+        for node in tree.body
+    )
+
+
+def test_every_script_parses_on_39_and_defers_annotations(suite):
+    """No hook may reintroduce a 3.10-only construct; the import must stay."""
+    scripts = sorted(suite.scripts_dir.glob("*.py"))
+    assert scripts, f"{suite.name}: no scripts found under {suite.scripts_dir}"
+    offenders: list[str] = []
+    for path in scripts:
+        source = path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(source, filename=str(path), feature_version=(3, 9))
+        except SyntaxError as exc:
+            offenders.append(f"{path.name}: not valid Python 3.9 (line {exc.lineno}: {exc.msg})")
+            continue
+        if not _defers_annotations(tree):
+            offenders.append(f"{path.name}: missing `from __future__ import annotations`")
+    assert not offenders, f"{suite.name}:\n  " + "\n  ".join(offenders)
+
+
+# --- 2. the uv-less fallback gate --------------------------------------------
+
+
+@pytest.fixture
+def ss(suite, hook_module, monkeypatch):
+    module = hook_module(suite, "session-start.py")
+    # No uv anywhere, and no network to fetch it: the only remaining install
+    # path is the stdlib venv built from the host interpreter.
+    monkeypatch.setattr(module, "_find_uv", lambda: "")
+    monkeypatch.setattr(module, "_install_uv", lambda: "")
+    return module
+
+
+def _marker(temp_home: Path) -> Path:
+    return plugin_root(temp_home) / _MARKER_NAME
+
+
+def _events(suite, temp_home: Path, name: str) -> list[dict]:
+    return [detail for event, detail in hook_events(suite, temp_home) if event == name]
+
+
+def test_fallback_refuses_host_python_below_310(suite, ss, temp_home, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "version_info", (3, 9, 6, "final", 0))
+
+    def _no_subprocess(*args, **kwargs):  # pragma: no cover - asserts the gate held
+        raise AssertionError(f"venv build attempted on a 3.9 host: {args[0]!r}")
+
+    monkeypatch.setattr(ss.subprocess, "run", _no_subprocess)
+
+    assert ss.ensure_cognee_installed() is False
+
+    # stderr names the interpreter, its version and the floor — the acceptance
+    # criteria of SDK-617 for a "loud" failure.
+    err = capsys.readouterr().err
+    assert "Python 3.10 or newer" in err
+    assert sys.executable in err
+    assert "3.9.6" in err
+    assert "uv" in err
+
+    # hook.log carries the same facts for forensics.
+    logged = _events(suite, temp_home, "host_python_too_old_for_venv")
+    assert logged, f"{suite.name}: no host_python_too_old_for_venv event in hook.log"
+    assert logged[-1]["python"] == sys.executable
+    assert logged[-1]["version"] == "3.9.6"
+    assert logged[-1]["required"] == "3.10"
+
+    # And the marker the next SessionStart reads (shared root: the venv is shared).
+    marker = _marker(temp_home)
+    assert marker.exists(), f"{suite.name}: {marker} not written"
+    recorded = json.loads(marker.read_text(encoding="utf-8"))
+    assert recorded["python"] == sys.executable
+    assert "Python 3.10 or newer" in recorded["message"]
+
+    # A refusal must not leave a venv-ready marker behind.
+    assert not ss._VENV_READY_MARKER.exists()
+
+
+def test_fallback_proceeds_on_310_host(suite, ss, temp_home, monkeypatch):
+    """The gate is specific to < 3.10: a 3.10 host reaches the venv build."""
+    monkeypatch.setattr(sys, "version_info", (3, 10, 0, "final", 0))
+    calls: list[list[str]] = []
+
+    def _record(cmd, *args, **kwargs):
+        calls.append([str(c) for c in cmd])
+        raise OSError("hermetic: no real venv build")  # the install then fails cleanly
+
+    monkeypatch.setattr(ss.subprocess, "run", _record)
+
+    assert ss.ensure_cognee_installed() is False  # no venv came out of the fake build
+    assert calls, f"{suite.name}: 3.10 host never reached the venv build"
+    assert calls[0][:3] == [sys.executable, "-m", "venv"]
+    assert not _marker(temp_home).exists()
+    assert not _events(suite, temp_home, "host_python_too_old_for_venv")
+
+
+def test_venv_ready_clears_the_marker(suite, ss, temp_home):
+    marker = _marker(temp_home)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(json.dumps({"message": "stale"}), encoding="utf-8")
+
+    ss._write_venv_ready("1.5.4")
+
+    assert not marker.exists(), f"{suite.name}: marker survived a successful venv build"
+    assert ss._VENV_READY_MARKER.exists()
+
+
+# --- 3. the refusal reaches the user ------------------------------------------
+
+
+def test_session_start_output_carries_the_warning(suite, ss, temp_home):
+    marker = _marker(temp_home)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(
+        json.dumps({"message": "Cognee Memory: host python too old"}), encoding="utf-8"
+    )
+
+    fresh = ss._apply_host_python_warning({})
+    assert fresh["systemMessage"] == "Cognee Memory: host python too old"
+    assert fresh["hookSpecificOutput"]["systemMessage"] == "Cognee Memory: host python too old"
+    assert fresh["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+
+    # Appended after, never replacing, whatever the hook already had to say.
+    existing = {
+        "hookSpecificOutput": {"hookEventName": "SessionStart", "systemMessage": "## Connected"}
+    }
+    merged = ss._apply_host_python_warning(existing)
+    assert merged["hookSpecificOutput"]["systemMessage"] == (
+        "## Connected\n\nCognee Memory: host python too old"
+    )
+    assert merged["systemMessage"] == "Cognee Memory: host python too old"
+    # The input is not mutated.
+    assert existing["hookSpecificOutput"]["systemMessage"] == "## Connected"
+
+
+def test_session_start_output_untouched_without_marker(suite, ss, temp_home):
+    assert not _marker(temp_home).exists()
+    original = {"hookSpecificOutput": {"hookEventName": "SessionStart", "systemMessage": "hi"}}
+    assert ss._apply_host_python_warning(original) == original
+    assert ss._apply_host_python_warning({}) == {}
+
+
+# --- 4. a real 3.9 interpreter, when the machine has one -----------------------
+
+
+def _find_python39() -> str:
+    """A Python 3.9 on this machine, or '' — the CI cell guarantees coverage."""
+    candidates = [shutil.which("python3.9") or ""]
+    if sys.platform == "darwin":
+        candidates.append("/Library/Developer/CommandLineTools/usr/bin/python3")
+    for candidate in candidates:
+        if not candidate or not os.path.exists(candidate):
+            continue
+        try:
+            probe = subprocess.run(
+                [candidate, "-c", "import sys; print(sys.version_info[:2] == (3, 9))"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except Exception:
+            continue
+        if probe.returncode == 0 and probe.stdout.strip() == "True":
+            return candidate
+    return ""
+
+
+_PY39 = _find_python39()
+
+
+@pytest.mark.skipif(not _PY39, reason="no Python 3.9 interpreter on this machine")
+@pytest.mark.parametrize("script", ["credits-refresh.py", "clear-transcript-context.py"])
+def test_hook_runs_under_real_python39(suite, run_hook, script):
+    """The regression as a user saw it: `python3 <hook>` under 3.9.6 exits 0.
+
+    ``clear-transcript-context.py`` is Claude Code only; the other suites skip it.
+    Both hooks are cheap and network-free, so this stays hermetic.
+    """
+    if not (suite.scripts_dir / script).exists():
+        pytest.skip(f"{suite.name} has no {script}")
+    result = run_hook(suite, script, stdin={}, python=_PY39, timeout=60)
+    assert result.returncode == 0, result.stderr
+    assert "TypeError" not in result.stderr
+    assert "unsupported operand" not in result.stderr


### PR DESCRIPTION
This PR fixes issues users reported when trying to use plugins like Claude and Codex with the default python 3.9 interpreter that comes with macOS.