### PR TITLE
fix(plugins): recall header reports buffered writes apart from saves

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "author": {
         "name": "Cognee"
       },

--- a/integrations/antigravity/CHANGELOG.md
+++ b/integrations/antigravity/CHANGELOG.md
@@ -7,6 +7,42 @@ package version.
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.2]
+
+### Fixed
+- **The recall header no longer reports buffered writes as saved (SDK-467).** The
+  store hook bumped the same save counter whether a trace or answer reached the
+  server or was diverted to the warmup buffer, so an outage read as a normal run
+  of saves — `saved last turn 1 prompt / 6 trace / 1 answer` on every prompt
+  while nothing reached the server. Buffered writes now have their own counter
+  kinds (`trace_buffered`, `answer_buffered`) and the header shows them as their
+  own segment, followed by what still waits for replay across every session on
+  the machine and how long the oldest entry has waited:
+
+  ```
+  Cognee memory: 0 memory hits · memory warming up (3 turns) · saved last turn 1 prompt / 0 trace / 0 answer · buffered last turn 6 trace / 1 answer (not saved yet) · 7 awaiting replay, oldest 20d
+  ```
+
+  Nothing is added when nothing was buffered and nothing awaits replay, so the
+  healthy header reads exactly as before. To make the age visible, every buffered
+  entry now carries a `_buffered_at` stamp in `~/.cognee-plugin/antigravity/bridge/`;
+  like the ambiguous-replay marker it is stripped before the entry is sent, so
+  nothing new reaches the server. Entries buffered before this release take their
+  file's mtime, a lower bound on their age.
+- **A prompt whose recall is skipped because the server is known bad now gets a
+  header too.** It used to return nothing — no header, no sign that memory was
+  off — and because the save counter was only read on a successful recall, the
+  first header after recovery presented weeks of buffered writes as one turn's
+  saves. The header now reads `Cognee memory: recall skipped (server unreachable)`
+  (or `auth failed` / `server error` / `server not responding`), followed by the
+  saved, buffered and awaiting-replay segments, and the counter is read and reset
+  on every prompt. The model receives the same line as its context.
+- **`cognee-plugin metrics` reports buffered writes apart from saves.** The
+  offline rollup added warmup-buffered writes to the saved totals and ignored the
+  after-error buffering entirely. It now has a `buffered` section (`trace` /
+  `answer`) fed by `store_buffered_warming`, `trace_buffered_after_error` and
+  `store_buffered_after_error`, and `saves` counts only what the server received.
+
 ## [1.5.1]
 
 ### Fixed

--- a/integrations/antigravity/plugin.json
+++ b/integrations/antigravity/plugin.json
@@ -1,4 +1,4 @@
 {
   "name": "cognee",
-  "version": "1.5.1"
+  "version": "1.5.2"
 }

--- a/integrations/antigravity/scripts/_plugin_common.py
+++ b/integrations/antigravity/scripts/_plugin_common.py
@@ -97,6 +97,14 @@ _SESSIONS_MAP_DIR = _PLUGIN_DIR / "sessions"
 
 # Save-kinds tracked per turn. Keep this tuple in sync with bump_save_counter callers.
 SAVE_KINDS = ("prompt", "trace", "answer")
+# A write the server never received is not a save. When a store hook diverts a
+# trace/answer to the warmup buffer (server down, or a retryable send failure)
+# it is counted under the kind's buffered twin so the recall header can show it
+# as buffered instead of folding it into the saved count — through a 2.5-week
+# outage every prompt read "saved last turn 1 prompt / 6 trace / 1 answer"
+# while nothing reached the server (SDK-467).
+BUFFERED_SAVE_KINDS = ("trace_buffered", "answer_buffered")
+ALL_SAVE_KINDS = SAVE_KINDS + BUFFERED_SAVE_KINDS
 
 # Cap the per-line log size so a noisy tool output doesn't bloat the file.
 _LOG_LINE_CAP = 600
@@ -1520,14 +1528,18 @@ def quiet_hook_output(label: str):
         os.close(log_fd)
 
 
-def bump_save_counter(session_id: str, kind: str) -> None:
+def bump_save_counter(session_id: str, kind: str, *, buffered: bool = False) -> None:
     """Record a save of ``kind`` (one of ``SAVE_KINDS``) for this session.
 
-    Used to surface per-turn save volume back to the user through the
-    next UserPromptSubmit's injected context. Cheap, best-effort file IO —
-    never raises.
+    ``buffered=True`` records it under ``<kind>_buffered`` instead: the entry
+    went to the warmup buffer, not the server, and the recall header must not
+    report it as saved. Used to surface per-turn save volume back to the user
+    through the next UserPromptSubmit's injected context. Cheap, best-effort
+    file IO — never raises.
     """
-    if not session_id or kind not in SAVE_KINDS:
+    if buffered:
+        kind = f"{kind}_buffered"
+    if not session_id or kind not in ALL_SAVE_KINDS:
         return
     try:
         data = (
@@ -1536,7 +1548,7 @@ def bump_save_counter(session_id: str, kind: str) -> None:
     except Exception as exc:
         hook_log("save_counter_read_failed", {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]})
         data = {}
-    sess = data.get(session_id) or {k: 0 for k in SAVE_KINDS}
+    sess = data.get(session_id) or {k: 0 for k in ALL_SAVE_KINDS}
     sess[kind] = int(sess.get(kind, 0)) + 1
     data[session_id] = sess
     try:
@@ -1547,8 +1559,11 @@ def bump_save_counter(session_id: str, kind: str) -> None:
 
 
 def read_and_reset_save_counter(session_id: str) -> dict:
-    """Return the save-kind counts accumulated since the last reset, then zero them."""
-    zero = {k: 0 for k in SAVE_KINDS}
+    """Return the save-kind counts accumulated since the last reset, then zero them.
+
+    Keyed by ``ALL_SAVE_KINDS``: the persisted kinds plus their buffered twins.
+    """
+    zero = {k: 0 for k in ALL_SAVE_KINDS}
     if not session_id:
         return zero
     try:
@@ -1569,7 +1584,142 @@ def read_and_reset_save_counter(session_id: str) -> dict:
         hook_log(
             "save_counter_reset_write_failed", {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]}
         )
-    return {k: int(sess.get(k, 0)) for k in SAVE_KINDS}
+    return {k: int(sess.get(k, 0)) for k in ALL_SAVE_KINDS}
+
+
+def warmup_backlog() -> dict:
+    """Entries still waiting in the warmup buffers, across every session on this machine.
+
+    Returns ``{"pending": n, "oldest_age_seconds": float | None}``.
+    Read-only and best-effort: a file that cannot be parsed is skipped and the
+    scan never raises — it runs on the keystroke->answer path.
+
+    Every per-session bridge file is scanned, not just the current session's: a
+    buffer left behind by an earlier session drains only when that session runs
+    again, so its entries can sit for weeks with nothing pointing at them — the
+    machine that motivated this held entries from three weeks earlier (SDK-467).
+    An entry written before the timestamp existed takes its file's mtime, a
+    lower bound on its age.
+    """
+    result = {"pending": 0, "oldest_age_seconds": None}
+    try:
+        paths = list(_BRIDGE_DIR.glob("*.json")) if _BRIDGE_DIR.is_dir() else []
+    except Exception:
+        return result
+    now = time.time()
+    oldest = None
+    for path in paths:
+        try:
+            cache = json.loads(path.read_text(encoding="utf-8"))
+            fallback_ts = path.stat().st_mtime
+        except Exception:
+            continue
+        if not isinstance(cache, dict):
+            continue
+        for state in cache.values():
+            if not isinstance(state, dict):
+                continue
+            for entry in state.get("pending_entries") or []:
+                result["pending"] += 1
+                stamp = entry.get(_BUFFERED_AT_KEY) if isinstance(entry, dict) else None
+                try:
+                    buffered_at = float(stamp) if stamp else fallback_ts
+                except (TypeError, ValueError):
+                    buffered_at = fallback_ts
+                age = max(0.0, now - buffered_at)
+                if oldest is None or age > oldest:
+                    oldest = age
+    result["oldest_age_seconds"] = oldest
+    return result
+
+
+def format_age(seconds: float) -> str:
+    """``45s`` / ``12m`` / ``3h`` / ``20d`` — coarse, for a one-line header."""
+    seconds = max(0, int(seconds))
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86400}d"
+
+
+def buffered_saves_segments(saves: dict, backlog: dict | None = None) -> list:
+    """Header segments that make a buffering outage visible; empty when healthy.
+
+    ``saves`` is a ``read_and_reset_save_counter`` result and ``backlog`` a
+    ``warmup_backlog`` result. The recall headers append these after
+    ``saved last turn …`` (Claude Code joins with ``; ``, Codex with `` · ``)::
+
+        buffered last turn 6 trace / 1 answer (not saved yet)
+        7 awaiting replay, oldest 20d
+
+    Nothing is added when nothing was buffered and nothing awaits replay, so
+    the healthy header reads exactly as before.
+    """
+    segments: list = []
+    trace_buffered = int(saves.get("trace_buffered", 0) or 0)
+    answer_buffered = int(saves.get("answer_buffered", 0) or 0)
+    if trace_buffered or answer_buffered:
+        segments.append(
+            f"buffered last turn {trace_buffered} trace / {answer_buffered} answer (not saved yet)"
+        )
+    backlog = backlog or {}
+    pending = int(backlog.get("pending", 0) or 0)
+    if pending > 0:
+        segment = f"{pending} awaiting replay"
+        oldest = backlog.get("oldest_age_seconds")
+        if oldest is not None:
+            segment += f", oldest {format_age(oldest)}"
+        segments.append(segment)
+    return segments
+
+
+def saves_segment(saves: dict) -> str:
+    """``saved last turn 1 prompt / 3 trace / 1 answer`` — persisted writes only."""
+    return (
+        "saved last turn "
+        f"{saves.get('prompt', 0)} prompt / {saves.get('trace', 0)} trace / "
+        f"{saves.get('answer', 0)} answer"
+    )
+
+
+# Probe verdicts that settle the server's recorded state. ``slow`` and ``unknown``
+# are not verdicts: they leave the recorded state untouched.
+DEFINITIVE_FAILURE_STATES = ("auth_failed", "unreachable", "server_error")
+
+_FAILURE_LABELS = {
+    "unreachable": "server unreachable",
+    "server_error": "server error",
+    "auth_failed": "auth failed",
+    "not_responding": "server not responding",
+}
+
+
+def describe_connection_failure(state: str) -> str:
+    """A recorded connection state as the header names it, e.g. ``server unreachable``."""
+    state = str(state or "unknown")
+    return _FAILURE_LABELS.get(state, f"server {state.replace('_', ' ')}")
+
+
+def outage_header(state: str, saves: dict, backlog: dict | None, joiner: str) -> str:
+    """The one-line header for a prompt whose recall was skipped: the server is known bad.
+
+    An empty recall used to be the only sign of an outage. The lookup hook returned
+    nothing, so no header was shown, and because the save counter was only read on
+    a successful recall, the first header after recovery reported weeks of buffered
+    writes as one turn's saves (SDK-467). The buffered writes and the replay backlog
+    are the whole story here, so this names the outage and reports them and nothing
+    else. ``joiner`` is the host's segment separator (``"; "`` or ``" · "``)::
+
+        Cognee memory: recall skipped (server unreachable); saved last turn 1 prompt
+        / 0 trace / 0 answer; buffered last turn 6 trace / 1 answer (not saved yet);
+        7 awaiting replay, oldest 20d
+    """
+    parts = [f"recall skipped ({describe_connection_failure(state)})", saves_segment(saves)]
+    parts.extend(buffered_saves_segments(saves, backlog))
+    return "Cognee memory: " + joiner.join(parts)
 
 
 def _pending_keys(session_id: str, turn_id: str = "") -> tuple[str, str]:
@@ -4451,6 +4601,11 @@ def _improve_submit_timeout() -> float:
 
 
 _AMBIGUOUS_KEY = "_replay_ambiguous"
+# Epoch seconds at which the entry was buffered. Read back by ``warmup_backlog``
+# so the recall header can say how long the oldest unreplayed entry has waited.
+_BUFFERED_AT_KEY = "_buffered_at"
+# Buffer-internal bookkeeping, stripped before an entry is sent to the server.
+_BUFFER_META_KEYS = (_AMBIGUOUS_KEY, _BUFFERED_AT_KEY)
 
 
 def append_warmup_entry(
@@ -4471,10 +4626,10 @@ def append_warmup_entry(
     """
     if not dataset or not session_id or not isinstance(entry, dict):
         return
-    entry = _sanitize_value(entry)
+    entry = dict(_sanitize_value(entry))
     if ambiguous:
-        entry = dict(entry)
         entry[_AMBIGUOUS_KEY] = True
+    entry[_BUFFERED_AT_KEY] = time.time()
     with _buffer_lock():
         cache = _load_json_file(_bridge_file(session_id))
         key = _bridge_cache_key(dataset, session_id)
@@ -4689,9 +4844,9 @@ def drain_warmup_entries(
                 break
             send_entry = entry
             ambiguous = False
-            if isinstance(entry, dict) and _AMBIGUOUS_KEY in entry:
-                send_entry = {k: v for k, v in entry.items() if k != _AMBIGUOUS_KEY}
-                ambiguous = True
+            if isinstance(entry, dict):
+                ambiguous = bool(entry.get(_AMBIGUOUS_KEY))
+                send_entry = {k: v for k, v in entry.items() if k not in _BUFFER_META_KEYS}
             if ambiguous and verified and _entry_fingerprint(send_entry) in server_prints:
                 # The original send committed after all — consume the buffered
                 # copy without re-sending it.

--- a/integrations/antigravity/scripts/cognee_plugin.py
+++ b/integrations/antigravity/scripts/cognee_plugin.py
@@ -82,6 +82,7 @@ def _compute_metrics(plugin_dir: Path) -> dict:
     cloud_decisions = 0
     breaker_open_events = 0
     saves_from_log = {"prompt": 0, "trace": 0, "answer": 0}
+    buffered_from_log = {"trace": 0, "answer": 0}
 
     for line in hook_lines:
         ev = line.get("event", "")
@@ -109,9 +110,12 @@ def _compute_metrics(plugin_dir: Path) -> dict:
         if ev == "recall_breaker_open":
             breaker_open_events += 1
 
-        # Save events recorded in hook.log. Warmup-buffered trace/answer saves
-        # log "store_buffered_warming" (tagged with the originating hook) rather
-        # than trace_stored/stop_stored, so count those too for a full total.
+        # Save events recorded in hook.log. A write the server never received is
+        # not a save: a trace/answer diverted to the warmup buffer — logged as
+        # store_buffered_warming (tagged with the originating hook) or as
+        # trace_/store_buffered_after_error — is reported apart, under
+        # "buffered", so an outage does not read as a normal run of saves
+        # (SDK-467; the recall header draws the same line).
         if ev == "prompt_pending":
             saves_from_log["prompt"] += 1
         elif ev == "trace_stored":
@@ -120,9 +124,13 @@ def _compute_metrics(plugin_dir: Path) -> dict:
             saves_from_log["answer"] += 1
         elif ev == "store_buffered_warming":
             if detail.get("hook") == "tool":
-                saves_from_log["trace"] += 1
+                buffered_from_log["trace"] += 1
             elif detail.get("hook") == "stop":
-                saves_from_log["answer"] += 1
+                buffered_from_log["answer"] += 1
+        elif ev == "trace_buffered_after_error":
+            buffered_from_log["trace"] += 1
+        elif ev == "store_buffered_after_error":
+            buffered_from_log["answer"] += 1
 
     # -----------------------------------------------------------------------
     # 2. save_counter.json - session ids only
@@ -174,6 +182,7 @@ def _compute_metrics(plugin_dir: Path) -> dict:
             "hit_rate_pct": hit_rate_pct,
         },
         "saves": total_saves,
+        "buffered": dict(buffered_from_log),
         "mode_split": {
             "local_pct": local_pct,
             "cloud_pct": cloud_pct,
@@ -192,6 +201,7 @@ def _compute_metrics(plugin_dir: Path) -> dict:
 def _print_rollup(metrics: dict, plugin: str) -> None:
     r = metrics["recalls"]
     s = metrics["saves"]
+    b = metrics["buffered"]
     ms = metrics["mode_split"]
 
     print(f"cognee-plugin metrics  [{plugin}]")
@@ -206,6 +216,7 @@ def _print_rollup(metrics: dict, plugin: str) -> None:
     print(f"  Saves (trace)       : {s['trace']}")
     print(f"  Saves (answer)      : {s['answer']}")
     print(f"  Saves (total)       : {sum(s.values())}")
+    print(f"  Buffered, not saved : {b['trace']} trace / {b['answer']} answer")
     print()
     print(f"  Mode - local        : {ms['local_pct']}%  ({ms['local_count']} decisions)")
     print(f"  Mode - cloud        : {ms['cloud_pct']}%  ({ms['cloud_count']} decisions)")

--- a/integrations/antigravity/scripts/session-context-lookup.py
+++ b/integrations/antigravity/scripts/session-context-lookup.py
@@ -22,9 +22,11 @@ import time
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
+    DEFINITIVE_FAILURE_STATES,
     _float_env,
     authed_liveness,
     bounded_dim_mismatch_hint,
+    buffered_saves_segments,
     clear_slow_streak,
     elapsed_ms,
     get_session_key,
@@ -32,6 +34,7 @@ from _plugin_common import (
     load_resolved,
     mark_server_ready,
     notify,
+    outage_header,
     probe_health,
     quiet_hook_output,
     read_and_reset_save_counter,
@@ -43,10 +46,12 @@ from _plugin_common import (
     resolve_session_key_from_payload,
     resolve_user,
     same_connection_target,
+    saves_segment,
     server_ready_hint,
     service_url_is_local,
     set_session_key,
     slow_streak_threshold,
+    warmup_backlog,
     write_connection_state,
 )
 from _recall_http import DOWN, SLOW, classify_transport_exception
@@ -165,7 +170,12 @@ def _plural(n: int, word: str) -> str:
 
 
 def _memory_summary(
-    total: int, cross_session: int, totals: dict, saves: dict, code_facts: int | None = None
+    total: int,
+    cross_session: int,
+    totals: dict,
+    saves: dict,
+    code_facts: int | None = None,
+    backlog: dict | None = None,
 ) -> str:
     """The one-line ``Cognee memory: …`` header, in plain words.
 
@@ -182,6 +192,13 @@ def _memory_summary(
     a bare ``0/7``. When the repo code lane is armed, ``N code facts`` follows
     the hit count (they are part of the total) so an indexed repo is visibly in
     play even at zero.
+
+    Writes the server never received are not saves. When the previous turn's
+    trace/answer went to the warmup buffer, or entries still wait for replay
+    (``backlog``, a ``warmup_backlog`` result), that follows as its own
+    segments — ``buffered last turn 6 trace / 1 answer (not saved yet) · 7
+    awaiting replay, oldest 20d`` — and is absent when there is nothing to
+    say (SDK-467).
     """
     parts = [_plural(total, "memory hit")]
     if code_facts is not None:
@@ -198,12 +215,21 @@ def _memory_summary(
             parts.append(f"{with_hits}/{turns} turns had hits this session")
         else:
             parts.append(f"memory warming up ({_plural(turns, 'turn')})")
-    parts.append(
-        "saved last turn "
-        f"{saves.get('prompt', 0)} prompt / {saves.get('trace', 0)} trace / "
-        f"{saves.get('answer', 0)} answer"
-    )
+    parts.append(saves_segment(saves))
+    parts.extend(buffered_saves_segments(saves, backlog))
     return "Cognee memory: " + " · ".join(parts)
+
+
+def _outage_output(state: str) -> dict:
+    """Envelope for a prompt whose recall was skipped: see ``outage_header``."""
+    session_id = _load_session_id()
+    saves = read_and_reset_save_counter(session_id) if session_id else {}
+    summary = outage_header(state, saves, warmup_backlog(), " · ")
+    header = f"{render_status_for_host(get_session_key())}\n{summary}"
+    return {
+        "systemMessage": header,
+        "hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": header},
+    }
 
 
 def _has_entry_content(entry: dict) -> bool:
@@ -298,14 +324,16 @@ async def _run(prompt: str, cwd: str = "") -> dict | None:
             clear_slow_streak(service_url)
             # fall through to recall below
         else:
-            if state in ("auth_failed", "unreachable", "server_error"):
+            if state in DEFINITIVE_FAILURE_STATES:
                 # A definitive verdict: refresh/replace the recorded failure.
                 write_connection_state(state, service_url, detail="authed liveness probe")
                 clear_slow_streak(service_url)
             # "slow"/"unknown" from the probe is NO verdict — keep the recorded
             # state untouched rather than promote a timeout to a failure.
             hook_log("recall_skipped_not_ready", {"base_url": service_url, "state": state})
-            return None
+            # Report the outage instead of going quiet: the recorded failure
+            # names it when the probe itself was inconclusive.
+            return _outage_output(state if state in DEFINITIVE_FAILURE_STATES else prior_state)
 
     if not cloud_mode:
         await ensure_cognee_ready(config)
@@ -742,6 +770,7 @@ async def _run(prompt: str, cwd: str = "") -> dict | None:
         _totals,
         saves_last_turn,
         code_facts=counts.get("code", 0) if code_lane else None,
+        backlog=warmup_backlog(),
     )
 
     section_lines = []

--- a/integrations/antigravity/scripts/store-to-session.py
+++ b/integrations/antigravity/scripts/store-to-session.py
@@ -210,7 +210,7 @@ async def _store_tool_call(payload: dict) -> None:
         # for a later /remember/entry replay (improve bridges only what the
         # server session cache holds).
         append_warmup_entry(dataset, session_id, entry)
-        bump_save_counter(session_id, "trace")
+        bump_save_counter(session_id, "trace", buffered=True)
         hook_log("store_buffered_warming", {"hook": "tool", "tool": tool_name})
         return
     if not use_http:
@@ -247,7 +247,7 @@ async def _store_tool_call(payload: dict) -> None:
             # /remember/entry has no idempotency, and a blind replay of a
             # committed write duplicates the trace into the next improve.
             append_warmup_entry(dataset, session_id, entry, ambiguous=write_outcome_ambiguous(exc))
-            bump_save_counter(session_id, "trace")
+            bump_save_counter(session_id, "trace", buffered=True)
             hook_log(
                 "trace_buffered_after_error",
                 {"tool": tool_name, "status": status_code, "error": str(exc)[:200]},
@@ -329,7 +329,7 @@ async def _store_assistant_stop(payload: dict) -> None:
         # structured entry for a later /remember/entry replay (improve bridges
         # only what the server session cache holds).
         append_warmup_entry(dataset, session_id, entry)
-        bump_save_counter(session_id, "answer")
+        bump_save_counter(session_id, "answer", buffered=True)
         hook_log("store_buffered_warming", {"hook": "stop"})
         return
     if not use_http:
@@ -372,7 +372,7 @@ async def _store_assistant_stop(payload: dict) -> None:
             # went out) are verified against the server before replay — see
             # write_outcome_ambiguous.
             append_warmup_entry(dataset, session_id, entry, ambiguous=write_outcome_ambiguous(exc))
-            bump_save_counter(session_id, "answer")
+            bump_save_counter(session_id, "answer", buffered=True)
             hook_log(
                 "store_buffered_after_error",
                 {"hook": "stop", "status": status, "error": str(exc)[:200]},

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "author": {
     "name": "Cognee",
     "url": "https://www.cognee.ai"

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,6 +10,43 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.5]
+
+### Fixed
+- **The recall header no longer reports buffered writes as saved (SDK-467).** While
+  the server was unreachable for two and a half weeks, every prompt's header kept
+  reading `saved last turn 1 prompt / 6 trace / 1 answer` — the store hooks
+  diverted every trace and answer to the warmup buffer and bumped the same save
+  counter as a real write, so a durable outage produced no visible signal at all.
+  Buffered writes now have their own counter kinds (`trace_buffered`,
+  `answer_buffered`) and the header shows them as their own segment, followed by
+  what still waits for replay across every session on the machine and how long
+  the oldest entry has waited:
+
+  ```
+  Cognee memory: recall 0 session / 0 trace / 0 graph / 0 agent; saved last turn 1 prompt / 0 trace / 0 answer; buffered last turn 6 trace / 1 answer (not saved yet); 7 awaiting replay, oldest 20d
+  ```
+
+  Nothing is added when nothing was buffered and nothing awaits
+  replay, so the healthy header reads exactly as before. To make the age
+  visible, every buffered entry now carries a `_buffered_at` stamp in
+  `~/.cognee-plugin/claude-code/bridge/`; like the ambiguous-replay marker it is
+  stripped before the entry is sent, so nothing new reaches the server. Entries
+  buffered before this release take their file's mtime, a lower bound on their age.
+- **A prompt whose recall is skipped because the server is known bad now gets a
+  header too.** It used to return nothing — no header, no sign that memory was
+  off — and because the save counter was only read on a successful recall, the
+  first header after recovery presented weeks of buffered writes as one turn's
+  saves. The header now reads `Cognee memory: recall skipped (server unreachable)`
+  (or `auth failed` / `server error` / `server not responding`), followed by the saved,
+  buffered and awaiting-replay segments, and the counter is read and reset on
+  every prompt. The model receives the same line as its context.
+- **`cognee-plugin metrics` reports buffered writes apart from saves.** The
+  offline rollup added warmup-buffered writes to the saved totals and ignored the
+  after-error buffering entirely. It now has a `buffered` section (`trace` /
+  `answer`) fed by `store_buffered_warming`, `trace_buffered_after_error` and
+  `store_buffered_after_error`, and `saves` counts only what the server received.
+
 ## [1.5.4]
 
 ### Fixed

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -87,6 +87,14 @@ _SESSIONS_MAP_DIR = _PLUGIN_DIR / "sessions"
 
 # Save-kinds tracked per turn. Keep this tuple in sync with bump_save_counter callers.
 SAVE_KINDS = ("prompt", "trace", "answer")
+# A write the server never received is not a save. When a store hook diverts a
+# trace/answer to the warmup buffer (server down, or a retryable send failure)
+# it is counted under the kind's buffered twin so the recall header can show it
+# as buffered instead of folding it into the saved count — through a 2.5-week
+# outage every prompt read "saved last turn 1 prompt / 6 trace / 1 answer"
+# while nothing reached the server (SDK-467).
+BUFFERED_SAVE_KINDS = ("trace_buffered", "answer_buffered")
+ALL_SAVE_KINDS = SAVE_KINDS + BUFFERED_SAVE_KINDS
 
 # Cap the per-line log size so a noisy tool output doesn't bloat the file.
 _LOG_LINE_CAP = 600
@@ -1355,14 +1363,18 @@ def quiet_hook_output(label: str):
         os.close(log_fd)
 
 
-def bump_save_counter(session_id: str, kind: str) -> None:
+def bump_save_counter(session_id: str, kind: str, *, buffered: bool = False) -> None:
     """Record a save of ``kind`` (one of ``SAVE_KINDS``) for this session.
 
-    Used to surface per-turn save volume back to the user through the
-    next UserPromptSubmit's injected context. Cheap, best-effort file IO —
-    never raises.
+    ``buffered=True`` records it under ``<kind>_buffered`` instead: the entry
+    went to the warmup buffer, not the server, and the recall header must not
+    report it as saved. Used to surface per-turn save volume back to the user
+    through the next UserPromptSubmit's injected context. Cheap, best-effort
+    file IO — never raises.
     """
-    if not session_id or kind not in SAVE_KINDS:
+    if buffered:
+        kind = f"{kind}_buffered"
+    if not session_id or kind not in ALL_SAVE_KINDS:
         return
     try:
         data = (
@@ -1371,7 +1383,7 @@ def bump_save_counter(session_id: str, kind: str) -> None:
     except Exception as exc:
         hook_log("save_counter_read_failed", {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]})
         data = {}
-    sess = data.get(session_id) or {k: 0 for k in SAVE_KINDS}
+    sess = data.get(session_id) or {k: 0 for k in ALL_SAVE_KINDS}
     sess[kind] = int(sess.get(kind, 0)) + 1
     data[session_id] = sess
     try:
@@ -1382,8 +1394,11 @@ def bump_save_counter(session_id: str, kind: str) -> None:
 
 
 def read_and_reset_save_counter(session_id: str) -> dict:
-    """Return the save-kind counts accumulated since the last reset, then zero them."""
-    zero = {k: 0 for k in SAVE_KINDS}
+    """Return the save-kind counts accumulated since the last reset, then zero them.
+
+    Keyed by ``ALL_SAVE_KINDS``: the persisted kinds plus their buffered twins.
+    """
+    zero = {k: 0 for k in ALL_SAVE_KINDS}
     if not session_id:
         return zero
     try:
@@ -1404,7 +1419,142 @@ def read_and_reset_save_counter(session_id: str) -> dict:
         hook_log(
             "save_counter_reset_write_failed", {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]}
         )
-    return {k: int(sess.get(k, 0)) for k in SAVE_KINDS}
+    return {k: int(sess.get(k, 0)) for k in ALL_SAVE_KINDS}
+
+
+def warmup_backlog() -> dict:
+    """Entries still waiting in the warmup buffers, across every session on this machine.
+
+    Returns ``{"pending": n, "oldest_age_seconds": float | None}``.
+    Read-only and best-effort: a file that cannot be parsed is skipped and the
+    scan never raises — it runs on the keystroke->answer path.
+
+    Every per-session bridge file is scanned, not just the current session's: a
+    buffer left behind by an earlier session drains only when that session runs
+    again, so its entries can sit for weeks with nothing pointing at them — the
+    machine that motivated this held entries from three weeks earlier (SDK-467).
+    An entry written before the timestamp existed takes its file's mtime, a
+    lower bound on its age.
+    """
+    result = {"pending": 0, "oldest_age_seconds": None}
+    try:
+        paths = list(_BRIDGE_DIR.glob("*.json")) if _BRIDGE_DIR.is_dir() else []
+    except Exception:
+        return result
+    now = time.time()
+    oldest = None
+    for path in paths:
+        try:
+            cache = json.loads(path.read_text(encoding="utf-8"))
+            fallback_ts = path.stat().st_mtime
+        except Exception:
+            continue
+        if not isinstance(cache, dict):
+            continue
+        for state in cache.values():
+            if not isinstance(state, dict):
+                continue
+            for entry in state.get("pending_entries") or []:
+                result["pending"] += 1
+                stamp = entry.get(_BUFFERED_AT_KEY) if isinstance(entry, dict) else None
+                try:
+                    buffered_at = float(stamp) if stamp else fallback_ts
+                except (TypeError, ValueError):
+                    buffered_at = fallback_ts
+                age = max(0.0, now - buffered_at)
+                if oldest is None or age > oldest:
+                    oldest = age
+    result["oldest_age_seconds"] = oldest
+    return result
+
+
+def format_age(seconds: float) -> str:
+    """``45s`` / ``12m`` / ``3h`` / ``20d`` — coarse, for a one-line header."""
+    seconds = max(0, int(seconds))
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86400}d"
+
+
+def buffered_saves_segments(saves: dict, backlog: dict | None = None) -> list:
+    """Header segments that make a buffering outage visible; empty when healthy.
+
+    ``saves`` is a ``read_and_reset_save_counter`` result and ``backlog`` a
+    ``warmup_backlog`` result. The recall headers append these after
+    ``saved last turn …`` (Claude Code joins with ``; ``, Codex with `` · ``)::
+
+        buffered last turn 6 trace / 1 answer (not saved yet)
+        7 awaiting replay, oldest 20d
+
+    Nothing is added when nothing was buffered and nothing awaits replay, so
+    the healthy header reads exactly as before.
+    """
+    segments: list = []
+    trace_buffered = int(saves.get("trace_buffered", 0) or 0)
+    answer_buffered = int(saves.get("answer_buffered", 0) or 0)
+    if trace_buffered or answer_buffered:
+        segments.append(
+            f"buffered last turn {trace_buffered} trace / {answer_buffered} answer (not saved yet)"
+        )
+    backlog = backlog or {}
+    pending = int(backlog.get("pending", 0) or 0)
+    if pending > 0:
+        segment = f"{pending} awaiting replay"
+        oldest = backlog.get("oldest_age_seconds")
+        if oldest is not None:
+            segment += f", oldest {format_age(oldest)}"
+        segments.append(segment)
+    return segments
+
+
+def saves_segment(saves: dict) -> str:
+    """``saved last turn 1 prompt / 3 trace / 1 answer`` — persisted writes only."""
+    return (
+        "saved last turn "
+        f"{saves.get('prompt', 0)} prompt / {saves.get('trace', 0)} trace / "
+        f"{saves.get('answer', 0)} answer"
+    )
+
+
+# Probe verdicts that settle the server's recorded state. ``slow`` and ``unknown``
+# are not verdicts: they leave the recorded state untouched.
+DEFINITIVE_FAILURE_STATES = ("auth_failed", "unreachable", "server_error")
+
+_FAILURE_LABELS = {
+    "unreachable": "server unreachable",
+    "server_error": "server error",
+    "auth_failed": "auth failed",
+    "not_responding": "server not responding",
+}
+
+
+def describe_connection_failure(state: str) -> str:
+    """A recorded connection state as the header names it, e.g. ``server unreachable``."""
+    state = str(state or "unknown")
+    return _FAILURE_LABELS.get(state, f"server {state.replace('_', ' ')}")
+
+
+def outage_header(state: str, saves: dict, backlog: dict | None, joiner: str) -> str:
+    """The one-line header for a prompt whose recall was skipped: the server is known bad.
+
+    An empty recall used to be the only sign of an outage. The lookup hook returned
+    nothing, so no header was shown, and because the save counter was only read on
+    a successful recall, the first header after recovery reported weeks of buffered
+    writes as one turn's saves (SDK-467). The buffered writes and the replay backlog
+    are the whole story here, so this names the outage and reports them and nothing
+    else. ``joiner`` is the host's segment separator (``"; "`` or ``" · "``)::
+
+        Cognee memory: recall skipped (server unreachable); saved last turn 1 prompt
+        / 0 trace / 0 answer; buffered last turn 6 trace / 1 answer (not saved yet);
+        7 awaiting replay, oldest 20d
+    """
+    parts = [f"recall skipped ({describe_connection_failure(state)})", saves_segment(saves)]
+    parts.extend(buffered_saves_segments(saves, backlog))
+    return "Cognee memory: " + joiner.join(parts)
 
 
 def _pending_keys(session_id: str, turn_id: str = "") -> tuple[str, str]:
@@ -4204,6 +4354,11 @@ def _backend_reachable(base_url: str, timeout: float = 1.5) -> bool:
 
 
 _AMBIGUOUS_KEY = "_replay_ambiguous"
+# Epoch seconds at which the entry was buffered. Read back by ``warmup_backlog``
+# so the recall header can say how long the oldest unreplayed entry has waited.
+_BUFFERED_AT_KEY = "_buffered_at"
+# Buffer-internal bookkeeping, stripped before an entry is sent to the server.
+_BUFFER_META_KEYS = (_AMBIGUOUS_KEY, _BUFFERED_AT_KEY)
 
 
 def append_warmup_entry(
@@ -4224,10 +4379,10 @@ def append_warmup_entry(
     """
     if not dataset or not session_id or not isinstance(entry, dict):
         return
-    entry = _sanitize_value(entry)
+    entry = dict(_sanitize_value(entry))
     if ambiguous:
-        entry = dict(entry)
         entry[_AMBIGUOUS_KEY] = True
+    entry[_BUFFERED_AT_KEY] = time.time()
     with _buffer_lock():
         cache = _load_json_file(_bridge_file(session_id))
         key = _bridge_cache_key(dataset, session_id)
@@ -4442,9 +4597,9 @@ def drain_warmup_entries(
                 break
             send_entry = entry
             ambiguous = False
-            if isinstance(entry, dict) and _AMBIGUOUS_KEY in entry:
-                send_entry = {k: v for k, v in entry.items() if k != _AMBIGUOUS_KEY}
-                ambiguous = True
+            if isinstance(entry, dict):
+                ambiguous = bool(entry.get(_AMBIGUOUS_KEY))
+                send_entry = {k: v for k, v in entry.items() if k not in _BUFFER_META_KEYS}
             if ambiguous and verified and _entry_fingerprint(send_entry) in server_prints:
                 # The original send committed after all — consume the buffered
                 # copy without re-sending it.

--- a/integrations/claude-code/scripts/cognee_plugin.py
+++ b/integrations/claude-code/scripts/cognee_plugin.py
@@ -82,6 +82,7 @@ def _compute_metrics(plugin_dir: Path) -> dict:
     cloud_decisions = 0
     breaker_open_events = 0
     saves_from_log = {"prompt": 0, "trace": 0, "answer": 0}
+    buffered_from_log = {"trace": 0, "answer": 0}
 
     for line in hook_lines:
         ev = line.get("event", "")
@@ -110,9 +111,12 @@ def _compute_metrics(plugin_dir: Path) -> dict:
         if ev == "recall_breaker_open":
             breaker_open_events += 1
 
-        # Save events recorded in hook.log. Warmup-buffered trace/answer saves
-        # log "store_buffered_warming" (tagged with the originating hook) rather
-        # than trace_stored/stop_stored, so count those too for a full total.
+        # Save events recorded in hook.log. A write the server never received is
+        # not a save: a trace/answer diverted to the warmup buffer — logged as
+        # store_buffered_warming (tagged with the originating hook) or as
+        # trace_/store_buffered_after_error — is reported apart, under
+        # "buffered", so an outage does not read as a normal run of saves
+        # (SDK-467; the recall header draws the same line).
         if ev == "prompt_pending":
             saves_from_log["prompt"] += 1
         elif ev == "trace_stored":
@@ -121,9 +125,13 @@ def _compute_metrics(plugin_dir: Path) -> dict:
             saves_from_log["answer"] += 1
         elif ev == "store_buffered_warming":
             if detail.get("hook") == "tool":
-                saves_from_log["trace"] += 1
+                buffered_from_log["trace"] += 1
             elif detail.get("hook") == "stop":
-                saves_from_log["answer"] += 1
+                buffered_from_log["answer"] += 1
+        elif ev == "trace_buffered_after_error":
+            buffered_from_log["trace"] += 1
+        elif ev == "store_buffered_after_error":
+            buffered_from_log["answer"] += 1
 
     # -----------------------------------------------------------------------
     # 2. save_counter.json - session ids only
@@ -175,6 +183,7 @@ def _compute_metrics(plugin_dir: Path) -> dict:
             "hit_rate_pct": hit_rate_pct,
         },
         "saves": total_saves,
+        "buffered": dict(buffered_from_log),
         "mode_split": {
             "local_pct": local_pct,
             "cloud_pct": cloud_pct,
@@ -193,6 +202,7 @@ def _compute_metrics(plugin_dir: Path) -> dict:
 def _print_rollup(metrics: dict, plugin: str) -> None:
     r = metrics["recalls"]
     s = metrics["saves"]
+    b = metrics["buffered"]
     ms = metrics["mode_split"]
 
     print(f"cognee-plugin metrics  [{plugin}]")
@@ -207,6 +217,7 @@ def _print_rollup(metrics: dict, plugin: str) -> None:
     print(f"  Saves (trace)       : {s['trace']}")
     print(f"  Saves (answer)      : {s['answer']}")
     print(f"  Saves (total)       : {sum(s.values())}")
+    print(f"  Buffered, not saved : {b['trace']} trace / {b['answer']} answer")
     print()
     print(f"  Mode - local        : {ms['local_pct']}%  ({ms['local_count']} decisions)")
     print(f"  Mode - cloud        : {ms['cloud_pct']}%  ({ms['cloud_count']} decisions)")

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -22,8 +22,10 @@ import time
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
+    DEFINITIVE_FAILURE_STATES,
     _float_env,
     authed_liveness,
+    buffered_saves_segments,
     clear_slow_streak,
     elapsed_ms,
     get_session_key,
@@ -31,6 +33,7 @@ from _plugin_common import (
     load_resolved,
     mark_server_ready,
     notify,
+    outage_header,
     probe_health,
     quiet_hook_output,
     read_and_reset_save_counter,
@@ -41,9 +44,11 @@ from _plugin_common import (
     resolve_runtime_mode,
     resolve_session_key_from_payload,
     same_connection_target,
+    saves_segment,
     server_ready_hint,
     set_session_key,
     slow_streak_threshold,
+    warmup_backlog,
     write_connection_state,
 )
 from _recall_http import DOWN, SLOW, classify_transport_exception
@@ -151,6 +156,20 @@ def _count_cross_session_hits(by_source: dict, session_id: str) -> int:
     return count
 
 
+def _outage_output(state: str) -> dict:
+    """Envelope for a prompt whose recall was skipped: see ``outage_header``."""
+    session_id = _load_session_id()
+    saves = read_and_reset_save_counter(session_id) if session_id else {}
+    header = outage_header(state, saves, warmup_backlog(), "; ")
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": header,
+            "systemMessage": header,
+        }
+    }
+
+
 def _has_entry_content(entry: dict) -> bool:
     """Return True when a recall entry has useful content to inject."""
     source = entry.get("source", "")
@@ -218,14 +237,16 @@ async def _run(prompt: str, cwd: str = "") -> dict | None:
             clear_slow_streak(service_url)
             # fall through to recall below
         else:
-            if state in ("auth_failed", "unreachable", "server_error"):
+            if state in DEFINITIVE_FAILURE_STATES:
                 # A definitive verdict: refresh/replace the recorded failure.
                 write_connection_state(state, service_url, detail="authed liveness probe")
                 clear_slow_streak(service_url)
             # "slow"/"unknown" from the probe is NO verdict — keep the recorded
             # state untouched rather than promote a timeout to a failure.
             hook_log("recall_skipped_not_ready", {"base_url": service_url, "state": state})
-            return None
+            # Report the outage instead of going quiet: the recorded failure
+            # names it when the probe itself was inconclusive.
+            return _outage_output(state if state in DEFINITIVE_FAILURE_STATES else prior_state)
 
     session_id = _load_session_id()
     if not session_id:
@@ -617,10 +638,13 @@ async def _run(prompt: str, cwd: str = "") -> dict | None:
         f"{counts['session']} session / {counts['trace']} trace / "
         f"{counts['graph_context']} graph / {counts['session_context']} agent"
         + (f" / {counts['code']} code" if code_lane else "")
-        + "; saved last turn "
-        f"{saves_last_turn['prompt']} prompt / {saves_last_turn['trace']} trace / "
-        f"{saves_last_turn['answer']} answer"
+        + "; "
+        + saves_segment(saves_last_turn)
     )
+    # Writes the server never received are not saves: a buffering outage gets
+    # its own segment, plus whatever still waits for replay (SDK-467).
+    for segment in buffered_saves_segments(saves_last_turn, warmup_backlog()):
+        header += f"; {segment}"
 
     section_lines = []
     if by_source.get("session_context"):

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -215,7 +215,7 @@ async def _store_tool_call(payload: dict) -> None:
         # for a later /remember/entry replay (improve bridges only what the
         # server session cache holds).
         append_warmup_entry(dataset, session_id, entry)
-        bump_save_counter(session_id, "trace")
+        bump_save_counter(session_id, "trace", buffered=True)
         hook_log("store_buffered_warming", {"hook": "tool", "tool": tool_name})
         return
 
@@ -236,7 +236,7 @@ async def _store_tool_call(payload: dict) -> None:
             # /remember/entry has no idempotency, and a blind replay of a
             # committed write duplicates the trace into the next improve.
             append_warmup_entry(dataset, session_id, entry, ambiguous=write_outcome_ambiguous(exc))
-            bump_save_counter(session_id, "trace")
+            bump_save_counter(session_id, "trace", buffered=True)
             hook_log(
                 "trace_buffered_after_error",
                 {"tool": tool_name, "status": status_code, "error": str(exc)[:200]},
@@ -327,7 +327,7 @@ async def _store_assistant_stop(payload: dict) -> None:
         # structured entry for a later /remember/entry replay (improve bridges
         # only what the server session cache holds).
         append_warmup_entry(dataset, session_id, entry)
-        bump_save_counter(session_id, "answer")
+        bump_save_counter(session_id, "answer", buffered=True)
         hook_log("store_buffered_warming", {"hook": "stop"})
         return
 
@@ -354,7 +354,7 @@ async def _store_assistant_stop(payload: dict) -> None:
             # went out) are verified against the server before replay — see
             # write_outcome_ambiguous.
             append_warmup_entry(dataset, session_id, entry, ambiguous=write_outcome_ambiguous(exc))
-            bump_save_counter(session_id, "answer")
+            bump_save_counter(session_id, "answer", buffered=True)
             hook_log(
                 "store_buffered_after_error",
                 {"hook": "stop", "status": status, "error": str(exc)[:200]},

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -115,7 +115,9 @@ Every prompt's recalled context opens with a one-line memory header:
 Cognee memory: 5 memory hits (3 from past sessions) · 12/40 turns had hits this session · saved last turn 1 prompt / 3 trace / 1 answer
 ```
 
-`5 memory hits` is how many memories this turn's lookup found and injected (across session turns, traces, graph context and agent guidance); `3 from past sessions` is the part the model could not have known from this conversation — knowledge-graph passages from an earlier session or a `remember`-ed document (omitted when zero); `12/40 turns had hits this session` is the running total, reading `memory warming up (7 turns)` until the first hit; `saved last turn` is what the previous turn persisted. The counts are also written to `~/.cognee-plugin/codex/last_recall.json`.
+`5 memory hits` is how many memories this turn's lookup found and injected (across session turns, traces, graph context and agent guidance); `3 from past sessions` is the part the model could not have known from this conversation — knowledge-graph passages from an earlier session or a `remember`-ed document (omitted when zero); `12/40 turns had hits this session` is the running total, reading `memory warming up (7 turns)` until the first hit; `saved last turn` is what the previous turn persisted — on the server. The counts are also written to `~/.cognee-plugin/codex/last_recall.json`.
+
+When the server cannot be reached, traces and answers are buffered locally and replayed later; those are never counted as saved. Instead the header grows two segments — `buffered last turn 6 trace / 1 answer (not saved yet) · 7 awaiting replay, oldest 20d` — so an outage is visible on every prompt, including prompts whose recall was skipped because the server is known to be down (`Cognee memory: recall skipped (server unreachable) · …`). Both segments disappear once the buffer has drained.
 
 ## Auth
 

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,6 +10,43 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.5]
+
+### Fixed
+- **The recall header no longer reports buffered writes as saved (SDK-467).** While
+  the server was unreachable for two and a half weeks, every prompt's header kept
+  reading `saved last turn 1 prompt / 6 trace / 1 answer` — the store hooks
+  diverted every trace and answer to the warmup buffer and bumped the same save
+  counter as a real write, so a durable outage produced no visible signal at all.
+  Buffered writes now have their own counter kinds (`trace_buffered`,
+  `answer_buffered`) and the header shows them as their own segment, followed by
+  what still waits for replay across every session on the machine and how long
+  the oldest entry has waited:
+
+  ```
+  Cognee memory: 0 memory hits · memory warming up (3 turns) · saved last turn 1 prompt / 0 trace / 0 answer · buffered last turn 6 trace / 1 answer (not saved yet) · 7 awaiting replay, oldest 20d
+  ```
+
+  Nothing is added when nothing was buffered and nothing awaits
+  replay, so the healthy header reads exactly as before. To make the age
+  visible, every buffered entry now carries a `_buffered_at` stamp in
+  `~/.cognee-plugin/codex/bridge/`; like the ambiguous-replay marker it is
+  stripped before the entry is sent, so nothing new reaches the server. Entries
+  buffered before this release take their file's mtime, a lower bound on their age.
+- **A prompt whose recall is skipped because the server is known bad now gets a
+  header too.** It used to return nothing — no header, no sign that memory was
+  off — and because the save counter was only read on a successful recall, the
+  first header after recovery presented weeks of buffered writes as one turn's
+  saves. The header now reads `Cognee memory: recall skipped (server unreachable)`
+  (or `auth failed` / `server error` / `server not responding`), followed by the saved,
+  buffered and awaiting-replay segments, and the counter is read and reset on
+  every prompt. The model receives the same line as its context.
+- **`cognee-plugin metrics` reports buffered writes apart from saves.** The
+  offline rollup added warmup-buffered writes to the saved totals and ignored the
+  after-error buffering entirely. It now has a `buffered` section (`trace` /
+  `answer`) fed by `store_buffered_warming`, `trace_buffered_after_error` and
+  `store_buffered_after_error`, and `saves` counts only what the server received.
+
 ## [1.6.4]
 
 ### Fixed

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -88,6 +88,14 @@ _SESSIONS_MAP_DIR = _PLUGIN_DIR / "sessions"
 
 # Save-kinds tracked per turn. Keep this tuple in sync with bump_save_counter callers.
 SAVE_KINDS = ("prompt", "trace", "answer")
+# A write the server never received is not a save. When a store hook diverts a
+# trace/answer to the warmup buffer (server down, or a retryable send failure)
+# it is counted under the kind's buffered twin so the recall header can show it
+# as buffered instead of folding it into the saved count — through a 2.5-week
+# outage every prompt read "saved last turn 1 prompt / 6 trace / 1 answer"
+# while nothing reached the server (SDK-467).
+BUFFERED_SAVE_KINDS = ("trace_buffered", "answer_buffered")
+ALL_SAVE_KINDS = SAVE_KINDS + BUFFERED_SAVE_KINDS
 
 # Cap the per-line log size so a noisy tool output doesn't bloat the file.
 _LOG_LINE_CAP = 600
@@ -1331,14 +1339,18 @@ def quiet_hook_output(label: str):
         os.close(log_fd)
 
 
-def bump_save_counter(session_id: str, kind: str) -> None:
+def bump_save_counter(session_id: str, kind: str, *, buffered: bool = False) -> None:
     """Record a save of ``kind`` (one of ``SAVE_KINDS``) for this session.
 
-    Used to surface per-turn save volume back to the user through the
-    next UserPromptSubmit's injected context. Cheap, best-effort file IO —
-    never raises.
+    ``buffered=True`` records it under ``<kind>_buffered`` instead: the entry
+    went to the warmup buffer, not the server, and the recall header must not
+    report it as saved. Used to surface per-turn save volume back to the user
+    through the next UserPromptSubmit's injected context. Cheap, best-effort
+    file IO — never raises.
     """
-    if not session_id or kind not in SAVE_KINDS:
+    if buffered:
+        kind = f"{kind}_buffered"
+    if not session_id or kind not in ALL_SAVE_KINDS:
         return
     try:
         data = (
@@ -1347,7 +1359,7 @@ def bump_save_counter(session_id: str, kind: str) -> None:
     except Exception as exc:
         hook_log("save_counter_read_failed", {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]})
         data = {}
-    sess = data.get(session_id) or {k: 0 for k in SAVE_KINDS}
+    sess = data.get(session_id) or {k: 0 for k in ALL_SAVE_KINDS}
     sess[kind] = int(sess.get(kind, 0)) + 1
     data[session_id] = sess
     try:
@@ -1358,8 +1370,11 @@ def bump_save_counter(session_id: str, kind: str) -> None:
 
 
 def read_and_reset_save_counter(session_id: str) -> dict:
-    """Return the save-kind counts accumulated since the last reset, then zero them."""
-    zero = {k: 0 for k in SAVE_KINDS}
+    """Return the save-kind counts accumulated since the last reset, then zero them.
+
+    Keyed by ``ALL_SAVE_KINDS``: the persisted kinds plus their buffered twins.
+    """
+    zero = {k: 0 for k in ALL_SAVE_KINDS}
     if not session_id:
         return zero
     try:
@@ -1380,7 +1395,142 @@ def read_and_reset_save_counter(session_id: str) -> dict:
         hook_log(
             "save_counter_reset_write_failed", {"path": str(_SAVE_COUNTER), "error": str(exc)[:200]}
         )
-    return {k: int(sess.get(k, 0)) for k in SAVE_KINDS}
+    return {k: int(sess.get(k, 0)) for k in ALL_SAVE_KINDS}
+
+
+def warmup_backlog() -> dict:
+    """Entries still waiting in the warmup buffers, across every session on this machine.
+
+    Returns ``{"pending": n, "oldest_age_seconds": float | None}``.
+    Read-only and best-effort: a file that cannot be parsed is skipped and the
+    scan never raises — it runs on the keystroke->answer path.
+
+    Every per-session bridge file is scanned, not just the current session's: a
+    buffer left behind by an earlier session drains only when that session runs
+    again, so its entries can sit for weeks with nothing pointing at them — the
+    machine that motivated this held entries from three weeks earlier (SDK-467).
+    An entry written before the timestamp existed takes its file's mtime, a
+    lower bound on its age.
+    """
+    result = {"pending": 0, "oldest_age_seconds": None}
+    try:
+        paths = list(_BRIDGE_DIR.glob("*.json")) if _BRIDGE_DIR.is_dir() else []
+    except Exception:
+        return result
+    now = time.time()
+    oldest = None
+    for path in paths:
+        try:
+            cache = json.loads(path.read_text(encoding="utf-8"))
+            fallback_ts = path.stat().st_mtime
+        except Exception:
+            continue
+        if not isinstance(cache, dict):
+            continue
+        for state in cache.values():
+            if not isinstance(state, dict):
+                continue
+            for entry in state.get("pending_entries") or []:
+                result["pending"] += 1
+                stamp = entry.get(_BUFFERED_AT_KEY) if isinstance(entry, dict) else None
+                try:
+                    buffered_at = float(stamp) if stamp else fallback_ts
+                except (TypeError, ValueError):
+                    buffered_at = fallback_ts
+                age = max(0.0, now - buffered_at)
+                if oldest is None or age > oldest:
+                    oldest = age
+    result["oldest_age_seconds"] = oldest
+    return result
+
+
+def format_age(seconds: float) -> str:
+    """``45s`` / ``12m`` / ``3h`` / ``20d`` — coarse, for a one-line header."""
+    seconds = max(0, int(seconds))
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86400}d"
+
+
+def buffered_saves_segments(saves: dict, backlog: dict | None = None) -> list:
+    """Header segments that make a buffering outage visible; empty when healthy.
+
+    ``saves`` is a ``read_and_reset_save_counter`` result and ``backlog`` a
+    ``warmup_backlog`` result. The recall headers append these after
+    ``saved last turn …`` (Claude Code joins with ``; ``, Codex with `` · ``)::
+
+        buffered last turn 6 trace / 1 answer (not saved yet)
+        7 awaiting replay, oldest 20d
+
+    Nothing is added when nothing was buffered and nothing awaits replay, so
+    the healthy header reads exactly as before.
+    """
+    segments: list = []
+    trace_buffered = int(saves.get("trace_buffered", 0) or 0)
+    answer_buffered = int(saves.get("answer_buffered", 0) or 0)
+    if trace_buffered or answer_buffered:
+        segments.append(
+            f"buffered last turn {trace_buffered} trace / {answer_buffered} answer (not saved yet)"
+        )
+    backlog = backlog or {}
+    pending = int(backlog.get("pending", 0) or 0)
+    if pending > 0:
+        segment = f"{pending} awaiting replay"
+        oldest = backlog.get("oldest_age_seconds")
+        if oldest is not None:
+            segment += f", oldest {format_age(oldest)}"
+        segments.append(segment)
+    return segments
+
+
+def saves_segment(saves: dict) -> str:
+    """``saved last turn 1 prompt / 3 trace / 1 answer`` — persisted writes only."""
+    return (
+        "saved last turn "
+        f"{saves.get('prompt', 0)} prompt / {saves.get('trace', 0)} trace / "
+        f"{saves.get('answer', 0)} answer"
+    )
+
+
+# Probe verdicts that settle the server's recorded state. ``slow`` and ``unknown``
+# are not verdicts: they leave the recorded state untouched.
+DEFINITIVE_FAILURE_STATES = ("auth_failed", "unreachable", "server_error")
+
+_FAILURE_LABELS = {
+    "unreachable": "server unreachable",
+    "server_error": "server error",
+    "auth_failed": "auth failed",
+    "not_responding": "server not responding",
+}
+
+
+def describe_connection_failure(state: str) -> str:
+    """A recorded connection state as the header names it, e.g. ``server unreachable``."""
+    state = str(state or "unknown")
+    return _FAILURE_LABELS.get(state, f"server {state.replace('_', ' ')}")
+
+
+def outage_header(state: str, saves: dict, backlog: dict | None, joiner: str) -> str:
+    """The one-line header for a prompt whose recall was skipped: the server is known bad.
+
+    An empty recall used to be the only sign of an outage. The lookup hook returned
+    nothing, so no header was shown, and because the save counter was only read on
+    a successful recall, the first header after recovery reported weeks of buffered
+    writes as one turn's saves (SDK-467). The buffered writes and the replay backlog
+    are the whole story here, so this names the outage and reports them and nothing
+    else. ``joiner`` is the host's segment separator (``"; "`` or ``" · "``)::
+
+        Cognee memory: recall skipped (server unreachable); saved last turn 1 prompt
+        / 0 trace / 0 answer; buffered last turn 6 trace / 1 answer (not saved yet);
+        7 awaiting replay, oldest 20d
+    """
+    parts = [f"recall skipped ({describe_connection_failure(state)})", saves_segment(saves)]
+    parts.extend(buffered_saves_segments(saves, backlog))
+    return "Cognee memory: " + joiner.join(parts)
 
 
 def _pending_keys(session_id: str, turn_id: str = "") -> tuple[str, str]:
@@ -4112,6 +4262,11 @@ def _backend_reachable(base_url: str, timeout: float = 1.5) -> bool:
 
 
 _AMBIGUOUS_KEY = "_replay_ambiguous"
+# Epoch seconds at which the entry was buffered. Read back by ``warmup_backlog``
+# so the recall header can say how long the oldest unreplayed entry has waited.
+_BUFFERED_AT_KEY = "_buffered_at"
+# Buffer-internal bookkeeping, stripped before an entry is sent to the server.
+_BUFFER_META_KEYS = (_AMBIGUOUS_KEY, _BUFFERED_AT_KEY)
 
 
 def append_warmup_entry(
@@ -4132,10 +4287,10 @@ def append_warmup_entry(
     """
     if not dataset or not session_id or not isinstance(entry, dict):
         return
-    entry = _sanitize_value(entry)
+    entry = dict(_sanitize_value(entry))
     if ambiguous:
-        entry = dict(entry)
         entry[_AMBIGUOUS_KEY] = True
+    entry[_BUFFERED_AT_KEY] = time.time()
     with _buffer_lock():
         cache = _load_json_file(_bridge_file(session_id))
         key = _bridge_cache_key(dataset, session_id)
@@ -4350,9 +4505,9 @@ def drain_warmup_entries(
                 break
             send_entry = entry
             ambiguous = False
-            if isinstance(entry, dict) and _AMBIGUOUS_KEY in entry:
-                send_entry = {k: v for k, v in entry.items() if k != _AMBIGUOUS_KEY}
-                ambiguous = True
+            if isinstance(entry, dict):
+                ambiguous = bool(entry.get(_AMBIGUOUS_KEY))
+                send_entry = {k: v for k, v in entry.items() if k not in _BUFFER_META_KEYS}
             if ambiguous and verified and _entry_fingerprint(send_entry) in server_prints:
                 # The original send committed after all — consume the buffered
                 # copy without re-sending it.

--- a/integrations/codex/plugins/cognee/scripts/cognee_plugin.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_plugin.py
@@ -83,6 +83,7 @@ def _compute_metrics(plugin_dir: Path) -> dict:
     cloud_decisions = 0
     breaker_open_events = 0
     saves_from_log = {"prompt": 0, "trace": 0, "answer": 0}
+    buffered_from_log = {"trace": 0, "answer": 0}
 
     for line in hook_lines:
         ev = line.get("event", "")
@@ -111,9 +112,12 @@ def _compute_metrics(plugin_dir: Path) -> dict:
         if ev == "recall_breaker_open":
             breaker_open_events += 1
 
-        # Save events recorded in hook.log. Warmup-buffered trace/answer saves
-        # log "store_buffered_warming" (tagged with the originating hook) rather
-        # than trace_stored/stop_stored, so count those too for a full total.
+        # Save events recorded in hook.log. A write the server never received is
+        # not a save: a trace/answer diverted to the warmup buffer — logged as
+        # store_buffered_warming (tagged with the originating hook) or as
+        # trace_/store_buffered_after_error — is reported apart, under
+        # "buffered", so an outage does not read as a normal run of saves
+        # (SDK-467; the recall header draws the same line).
         if ev == "prompt_pending":
             saves_from_log["prompt"] += 1
         elif ev == "trace_stored":
@@ -122,9 +126,13 @@ def _compute_metrics(plugin_dir: Path) -> dict:
             saves_from_log["answer"] += 1
         elif ev == "store_buffered_warming":
             if detail.get("hook") == "tool":
-                saves_from_log["trace"] += 1
+                buffered_from_log["trace"] += 1
             elif detail.get("hook") == "stop":
-                saves_from_log["answer"] += 1
+                buffered_from_log["answer"] += 1
+        elif ev == "trace_buffered_after_error":
+            buffered_from_log["trace"] += 1
+        elif ev == "store_buffered_after_error":
+            buffered_from_log["answer"] += 1
 
     # -----------------------------------------------------------------------
     # 2. save_counter.json - session ids only
@@ -176,6 +184,7 @@ def _compute_metrics(plugin_dir: Path) -> dict:
             "hit_rate_pct": hit_rate_pct,
         },
         "saves": total_saves,
+        "buffered": dict(buffered_from_log),
         "mode_split": {
             "local_pct": local_pct,
             "cloud_pct": cloud_pct,
@@ -194,6 +203,7 @@ def _compute_metrics(plugin_dir: Path) -> dict:
 def _print_rollup(metrics: dict, plugin: str) -> None:
     r = metrics["recalls"]
     s = metrics["saves"]
+    b = metrics["buffered"]
     ms = metrics["mode_split"]
 
     print(f"cognee-plugin metrics  [{plugin}]")
@@ -208,6 +218,7 @@ def _print_rollup(metrics: dict, plugin: str) -> None:
     print(f"  Saves (trace)       : {s['trace']}")
     print(f"  Saves (answer)      : {s['answer']}")
     print(f"  Saves (total)       : {sum(s.values())}")
+    print(f"  Buffered, not saved : {b['trace']} trace / {b['answer']} answer")
     print()
     print(f"  Mode - local        : {ms['local_pct']}%  ({ms['local_count']} decisions)")
     print(f"  Mode - cloud        : {ms['cloud_pct']}%  ({ms['cloud_count']} decisions)")

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -22,8 +22,10 @@ import time
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
+    DEFINITIVE_FAILURE_STATES,
     _float_env,
     authed_liveness,
+    buffered_saves_segments,
     clear_slow_streak,
     elapsed_ms,
     get_session_key,
@@ -31,6 +33,7 @@ from _plugin_common import (
     load_resolved,
     mark_server_ready,
     notify,
+    outage_header,
     probe_health,
     quiet_hook_output,
     read_and_reset_save_counter,
@@ -41,9 +44,11 @@ from _plugin_common import (
     resolve_runtime_mode,
     resolve_session_key_from_payload,
     same_connection_target,
+    saves_segment,
     server_ready_hint,
     set_session_key,
     slow_streak_threshold,
+    warmup_backlog,
     write_connection_state,
 )
 from _recall_http import DOWN, SLOW, classify_transport_exception
@@ -157,7 +162,12 @@ def _plural(n: int, word: str) -> str:
 
 
 def _memory_summary(
-    total: int, cross_session: int, totals: dict, saves: dict, code_facts: int | None = None
+    total: int,
+    cross_session: int,
+    totals: dict,
+    saves: dict,
+    code_facts: int | None = None,
+    backlog: dict | None = None,
 ) -> str:
     """The one-line ``Cognee memory: …`` header, in plain words.
 
@@ -174,6 +184,13 @@ def _memory_summary(
     a bare ``0/7``. When the repo code lane is armed, ``N code facts`` follows
     the hit count (they are part of the total) so an indexed repo is visibly in
     play even at zero.
+
+    Writes the server never received are not saves. When the previous turn's
+    trace/answer went to the warmup buffer, or entries still wait for replay
+    (``backlog``, a ``warmup_backlog`` result), that follows as its own
+    segments — ``buffered last turn 6 trace / 1 answer (not saved yet) · 7
+    awaiting replay, oldest 20d`` — and is absent when there is nothing to
+    say (SDK-467).
     """
     parts = [_plural(total, "memory hit")]
     if code_facts is not None:
@@ -190,12 +207,21 @@ def _memory_summary(
             parts.append(f"{with_hits}/{turns} turns had hits this session")
         else:
             parts.append(f"memory warming up ({_plural(turns, 'turn')})")
-    parts.append(
-        "saved last turn "
-        f"{saves.get('prompt', 0)} prompt / {saves.get('trace', 0)} trace / "
-        f"{saves.get('answer', 0)} answer"
-    )
+    parts.append(saves_segment(saves))
+    parts.extend(buffered_saves_segments(saves, backlog))
     return "Cognee memory: " + " · ".join(parts)
+
+
+def _outage_output(state: str) -> dict:
+    """Envelope for a prompt whose recall was skipped: see ``outage_header``."""
+    session_id = _load_session_id()
+    saves = read_and_reset_save_counter(session_id) if session_id else {}
+    summary = outage_header(state, saves, warmup_backlog(), " · ")
+    header = f"{render_status_for_host(get_session_key())}\n{summary}"
+    return {
+        "systemMessage": header,
+        "hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": header},
+    }
 
 
 def _has_entry_content(entry: dict) -> bool:
@@ -254,14 +280,16 @@ async def _run(prompt: str, cwd: str = "") -> dict | None:
             clear_slow_streak(service_url)
             # fall through to recall below
         else:
-            if state in ("auth_failed", "unreachable", "server_error"):
+            if state in DEFINITIVE_FAILURE_STATES:
                 # A definitive verdict: refresh/replace the recorded failure.
                 write_connection_state(state, service_url, detail="authed liveness probe")
                 clear_slow_streak(service_url)
             # "slow"/"unknown" from the probe is NO verdict — keep the recorded
             # state untouched rather than promote a timeout to a failure.
             hook_log("recall_skipped_not_ready", {"base_url": service_url, "state": state})
-            return None
+            # Report the outage instead of going quiet: the recorded failure
+            # names it when the probe itself was inconclusive.
+            return _outage_output(state if state in DEFINITIVE_FAILURE_STATES else prior_state)
 
     session_id = _load_session_id()
     if not session_id:
@@ -655,6 +683,7 @@ async def _run(prompt: str, cwd: str = "") -> dict | None:
         _totals,
         saves_last_turn,
         code_facts=counts.get("code", 0) if code_lane else None,
+        backlog=warmup_backlog(),
     )
 
     section_lines = []

--- a/integrations/codex/plugins/cognee/scripts/store-to-session.py
+++ b/integrations/codex/plugins/cognee/scripts/store-to-session.py
@@ -196,7 +196,7 @@ async def _store_tool_call(payload: dict) -> None:
         # for a later /remember/entry replay (improve bridges only what the
         # server session cache holds).
         append_warmup_entry(dataset, session_id, entry)
-        bump_save_counter(session_id, "trace")
+        bump_save_counter(session_id, "trace", buffered=True)
         hook_log("store_buffered_warming", {"hook": "tool", "tool": tool_name})
         return
 
@@ -217,7 +217,7 @@ async def _store_tool_call(payload: dict) -> None:
             # /remember/entry has no idempotency, and a blind replay of a
             # committed write duplicates the trace into the next improve.
             append_warmup_entry(dataset, session_id, entry, ambiguous=write_outcome_ambiguous(exc))
-            bump_save_counter(session_id, "trace")
+            bump_save_counter(session_id, "trace", buffered=True)
             hook_log(
                 "trace_buffered_after_error",
                 {"tool": tool_name, "status": status_code, "error": str(exc)[:200]},
@@ -297,7 +297,7 @@ async def _store_assistant_stop(payload: dict) -> None:
         # structured entry for a later /remember/entry replay (improve bridges
         # only what the server session cache holds).
         append_warmup_entry(dataset, session_id, entry)
-        bump_save_counter(session_id, "answer")
+        bump_save_counter(session_id, "answer", buffered=True)
         hook_log("store_buffered_warming", {"hook": "stop"})
         return
 
@@ -324,7 +324,7 @@ async def _store_assistant_stop(payload: dict) -> None:
             # went out) are verified against the server before replay — see
             # write_outcome_ambiguous.
             append_warmup_entry(dataset, session_id, entry, ambiguous=write_outcome_ambiguous(exc))
-            bump_save_counter(session_id, "answer")
+            bump_save_counter(session_id, "answer", buffered=True)
             hook_log(
                 "store_buffered_after_error",
                 {"hook": "stop", "status": status, "error": str(exc)[:200]},

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -34,7 +34,7 @@ integrations:
     registry: none
     package_name: null
     cognee_dependency: sdk
-    current_version: "1.5.4"
+    current_version: "1.5.5"
     migration_status: done
     notes: "Claude Code plugin – session storage via hooks, recall via context lookup, session-to-graph sync"
 
@@ -45,7 +45,7 @@ integrations:
     registry: none
     package_name: null
     cognee_dependency: http-api
-    current_version: "1.5.1"
+    current_version: "1.5.2"
     migration_status: done
     notes: "Native agy plugin – session storage via named hooks, transcript-tail recall, and session-to-graph sync"
 
@@ -67,7 +67,7 @@ integrations:
     registry: codex-marketplace
     package_name: null
     cognee_dependency: cli
-    current_version: "1.6.4"
+    current_version: "1.6.5"
     migration_status: done
     notes: "Codex local plugin marketplace with Cognee CLI skills for setup, memory, codebase ingestion, and UI launch"
 

--- a/integrations/tests/tests/unit/test_antigravity_hooks_contract.py
+++ b/integrations/tests/tests/unit/test_antigravity_hooks_contract.py
@@ -147,7 +147,7 @@ def test_plugin_manifest_identifies_cognee_with_a_version_string(plugin_root):
     spec = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
 
     assert spec["name"] == "cognee"
-    assert spec["version"] == "1.5.1"
+    assert spec["version"] == "1.5.2"
 
 
 def test_hooks_manifest_is_at_plugin_root_not_claude_hooks_directory(manifest):

--- a/integrations/tests/tests/unit/test_buffered_saves_visibility.py
+++ b/integrations/tests/tests/unit/test_buffered_saves_visibility.py
@@ -1,0 +1,372 @@
+"""A write the server never received is not a save (SDK-467).
+
+While the backend was unreachable for two and a half weeks, every prompt's
+recall header kept reading ``saved last turn 1 prompt / 6 trace / 1 answer``:
+the store hooks diverted every trace and answer to the warmup buffer and bumped
+the same save counter as a real write, so a durable outage produced no visible
+signal at all. What these tests pin:
+
+  * the counter keeps buffered writes apart from persisted ones, and the store
+    hooks record every buffered branch (warming spillway, retryable failure)
+    under the buffered kind — and only those;
+  * the buffer stamps each entry with when it was buffered, strips the stamp
+    before the entry reaches the server, and can report how many entries wait
+    across every session on the machine and how long the oldest has waited;
+  * every host's header shows buffered writes and the replay backlog as their
+    own segments, and reads exactly as before when there is nothing to say;
+  * a prompt whose recall is skipped because the server is known bad still gets
+    a header — it names the outage and reads (and resets) the save counter, so
+    the first header after recovery does not present weeks of buffered writes
+    as one turn's saves.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+import urllib.error
+
+import pytest
+from utils.recall import HIT, URL, drive_recall, load_lookup
+
+_SID = "sid"
+
+
+# ── the counter ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def pc(suite, isolated_modules, tmp_path, monkeypatch):
+    """_plugin_common with the save counter, bridge dir and locks in a temp dir."""
+    common = isolated_modules(suite, "_plugin_common")
+    monkeypatch.setattr(common, "_SAVE_COUNTER", tmp_path / "save_counter.json")
+    monkeypatch.setattr(common, "_BRIDGE_DIR", tmp_path / "bridge")
+    monkeypatch.setattr(common, "_bridge_file", lambda sid="": tmp_path / "bridge" / f"{sid}.json")
+    monkeypatch.setattr(common, "_DRAIN_LOCK", tmp_path / "drain.lock")
+    monkeypatch.setattr(common, "_BUFFER_LOCK", tmp_path / "buffer.lock")
+    monkeypatch.setattr(common, "hook_log", lambda *a, **k: None)
+    return common
+
+
+def test_buffered_bumps_land_under_their_own_kind(pc):
+    pc.bump_save_counter(_SID, "prompt")
+    pc.bump_save_counter(_SID, "trace")
+    pc.bump_save_counter(_SID, "trace", buffered=True)
+    pc.bump_save_counter(_SID, "trace", buffered=True)
+    pc.bump_save_counter(_SID, "answer", buffered=True)
+    pc.bump_save_counter(_SID, "prompt", buffered=True)  # prompts are never buffered: ignored
+
+    assert pc.read_and_reset_save_counter(_SID) == {
+        "prompt": 1,
+        "trace": 1,
+        "answer": 0,
+        "trace_buffered": 2,
+        "answer_buffered": 1,
+    }
+    # Reset zeroes every kind, buffered ones included.
+    assert set(pc.read_and_reset_save_counter(_SID).values()) == {0}
+
+
+# ── the store hook: which branch bumps what ─────────────────────────────────
+
+
+@pytest.fixture
+def store(suite, hook_module, monkeypatch):
+    """The store hook with its write seams stubbed; returns ``(module, bumps)``."""
+    module = hook_module(suite, "store-to-session.py")
+    bumps: list[tuple] = []
+    monkeypatch.setattr(module, "hook_log", lambda *a, **k: None)
+    monkeypatch.setattr(module, "notify", lambda *a, **k: None)
+    monkeypatch.setattr(module, "resolve_runtime_mode", lambda: {"mode": "http", "base_url": URL})
+    monkeypatch.setattr(module, "_load_session", lambda: (_SID, "ds", "uid"))
+    monkeypatch.setattr(module, "append_warmup_entry", lambda *a, **k: None)
+    monkeypatch.setattr(module, "touch_activity", lambda: None)
+    monkeypatch.setattr(module, "bump_turn_counter", lambda sid: (1, False))
+    monkeypatch.setattr(module, "pop_pending_prompt", lambda sid, **k: {"prompt": "q"})
+    monkeypatch.setattr(
+        module,
+        "bump_save_counter",
+        lambda sid, kind, buffered=False: bumps.append((kind, buffered)),
+    )
+    return module, bumps
+
+
+_TOOL = {"tool_name": "Read", "tool_input": {"file_path": "/x"}, "tool_output": "ok"}
+_STOP = {"assistant_message": "done", "turn_id": "t1"}
+_PATHS = [("_store_tool_call", _TOOL, "trace"), ("_store_assistant_stop", _STOP, "answer")]
+
+
+def _raising(code: int):
+    def _boom(*a, **k):
+        raise urllib.error.HTTPError(URL, code, "boom", hdrs=None, fp=None)
+
+    return _boom
+
+
+@pytest.mark.parametrize("run, payload, kind", _PATHS)
+def test_stored_write_bumps_the_plain_kind(store, monkeypatch, run, payload, kind):
+    module, bumps = store
+    monkeypatch.setattr(module, "server_usable", lambda url="": True)
+    monkeypatch.setattr(module, "remember_entry_via_http", lambda *a, **k: {"entry_id": "e"})
+    asyncio.run(getattr(module, run)(payload))
+    assert bumps == [(kind, False)]
+
+
+@pytest.mark.parametrize("run, payload, kind", _PATHS)
+def test_warming_spillway_bumps_the_buffered_kind(store, monkeypatch, run, payload, kind):
+    module, bumps = store
+    monkeypatch.setattr(module, "server_usable", lambda url="": False)
+    asyncio.run(getattr(module, run)(payload))
+    assert bumps == [(kind, True)]
+
+
+@pytest.mark.parametrize("run, payload, kind", _PATHS)
+def test_retryable_failure_bumps_the_buffered_kind(store, monkeypatch, run, payload, kind):
+    module, bumps = store
+    monkeypatch.setattr(module, "server_usable", lambda url="": True)
+    monkeypatch.setattr(module, "remember_entry_via_http", _raising(503))
+    asyncio.run(getattr(module, run)(payload))
+    assert bumps == [(kind, True)]
+
+
+@pytest.mark.parametrize("run, payload, kind", _PATHS)
+def test_dropped_4xx_bumps_nothing(store, monkeypatch, run, payload, kind):
+    """A rejected write is neither saved nor buffered, so it must not count as either."""
+    module, bumps = store
+    monkeypatch.setattr(module, "server_usable", lambda url="": True)
+    monkeypatch.setattr(module, "remember_entry_via_http", _raising(422))
+    asyncio.run(getattr(module, run)(payload))
+    assert bumps == []
+
+
+# ── the buffer: stamp, strip, backlog ───────────────────────────────────────
+
+_TRACE = {"type": "trace", "origin_function": "Bash", "status": "success"}
+
+
+def _pending(pc, sid: str = _SID) -> list:
+    cache = pc._load_json_file(pc._bridge_file(sid))
+    return (cache.get(pc._bridge_cache_key("ds", sid)) or {}).get("pending_entries") or []
+
+
+def test_buffered_entry_is_stamped_with_when_it_was_buffered(pc):
+    before = time.time()
+    pc.append_warmup_entry("ds", _SID, dict(_TRACE))
+    (entry,) = _pending(pc)
+    assert before <= entry[pc._BUFFERED_AT_KEY] <= time.time()
+    # The caller's dict is left alone.
+    assert pc._BUFFERED_AT_KEY not in _TRACE
+
+
+def test_stamp_never_reaches_the_server(pc, monkeypatch):
+    pc.append_warmup_entry("ds", _SID, dict(_TRACE))
+    pc.append_warmup_entry("ds", _SID, dict(_TRACE), ambiguous=True)
+    monkeypatch.setattr(
+        pc, "get_session_detail_via_http", lambda sid, **k: {"traces": [], "qas": []}
+    )
+    sent: list = []
+    monkeypatch.setattr(pc, "remember_entry_via_http", lambda d, s, e, **k: sent.append(e) or {})
+
+    assert pc.drain_warmup_entries("ds", _SID) == (2, 0)
+    assert sent == [_TRACE, _TRACE], "buffer bookkeeping must be stripped before the send"
+
+
+def test_backlog_is_empty_without_a_bridge_dir(pc):
+    assert pc.warmup_backlog() == {"pending": 0, "oldest_age_seconds": None}
+
+
+def test_backlog_counts_every_session_and_reports_the_oldest_entry(pc, monkeypatch):
+    now = 1_800_000_000.0
+    monkeypatch.setattr(pc.time, "time", lambda: now - 20 * 86400)
+    pc.append_warmup_entry("ds", "old-session", dict(_TRACE))
+    monkeypatch.setattr(pc.time, "time", lambda: now - 90)
+    pc.append_warmup_entry("ds", _SID, dict(_TRACE))
+    pc.append_warmup_entry("ds", _SID, {"type": "qa", "question": "q", "answer": "a"})
+    monkeypatch.setattr(pc.time, "time", lambda: now)
+
+    backlog = pc.warmup_backlog()
+    assert backlog["pending"] == 3
+    assert backlog["oldest_age_seconds"] == pytest.approx(20 * 86400)
+
+
+def test_backlog_skips_drained_sessions_and_unreadable_files(pc):
+    pc.append_warmup_entry("ds", _SID, dict(_TRACE))
+    drained = pc._bridge_file("drained")
+    pc._write_json_file(drained, {pc._bridge_cache_key("ds", "drained"): {"pending_entries": []}})
+    (pc._BRIDGE_DIR / "corrupt.json").write_text("{not json", encoding="utf-8")
+
+    assert pc.warmup_backlog()["pending"] == 1
+
+
+def test_unstamped_legacy_entry_takes_the_file_mtime(pc):
+    """Entries buffered before the stamp existed still get an age — a lower bound."""
+    path = pc._bridge_file(_SID)
+    pc._write_json_file(
+        path, {pc._bridge_cache_key("ds", _SID): {"pending_entries": [dict(_TRACE)]}}
+    )
+    week_ago = time.time() - 7 * 86400
+    os.utime(path, (week_ago, week_ago))
+
+    backlog = pc.warmup_backlog()
+    assert backlog["pending"] == 1
+    assert backlog["oldest_age_seconds"] == pytest.approx(7 * 86400, abs=5)
+
+
+def test_format_age_is_coarse(pc):
+    assert [pc.format_age(s) for s in (0, 45, 61, 3599, 3600, 86399, 86400, 20 * 86400)] == [
+        "0s",
+        "45s",
+        "1m",
+        "59m",
+        "1h",
+        "23h",
+        "1d",
+        "20d",
+    ]
+
+
+def test_segments_are_silent_when_healthy(pc):
+    saves = {"prompt": 1, "trace": 3, "answer": 1, "trace_buffered": 0, "answer_buffered": 0}
+    assert pc.buffered_saves_segments(saves, None) == []
+    assert pc.buffered_saves_segments(saves, {"pending": 0, "oldest_age_seconds": None}) == []
+    # A stub that predates the buffered kinds is fine too.
+    assert pc.buffered_saves_segments({"prompt": 0, "trace": 0, "answer": 0}) == []
+
+
+def test_segments_name_buffered_writes_and_the_backlog(pc):
+    saves = {"prompt": 1, "trace": 0, "answer": 0, "trace_buffered": 6, "answer_buffered": 1}
+    backlog = {"pending": 7, "oldest_age_seconds": 20 * 86400}
+    assert pc.buffered_saves_segments(saves, backlog) == [
+        "buffered last turn 6 trace / 1 answer (not saved yet)",
+        "7 awaiting replay, oldest 20d",
+    ]
+    # Either half stands on its own.
+    assert pc.buffered_saves_segments(saves, None) == [
+        "buffered last turn 6 trace / 1 answer (not saved yet)"
+    ]
+    assert pc.buffered_saves_segments({"trace_buffered": 0}, {"pending": 2}) == [
+        "2 awaiting replay"
+    ]
+
+
+def test_outage_header_names_the_failure_and_uses_the_hosts_joiner(pc):
+    saves = {"prompt": 1, "trace": 0, "answer": 0, "trace_buffered": 6, "answer_buffered": 1}
+    backlog = {"pending": 7, "oldest_age_seconds": 20 * 86400}
+    assert pc.outage_header("unreachable", saves, backlog, "; ") == (
+        "Cognee memory: recall skipped (server unreachable)"
+        "; saved last turn 1 prompt / 0 trace / 0 answer"
+        "; buffered last turn 6 trace / 1 answer (not saved yet)"
+        "; 7 awaiting replay, oldest 20d"
+    )
+    assert pc.outage_header("server_error", {}, None, " · ") == (
+        "Cognee memory: recall skipped (server error)"
+        " · saved last turn 0 prompt / 0 trace / 0 answer"
+    )
+    assert [pc.describe_connection_failure(s) for s in pc.DEFINITIVE_FAILURE_STATES] == [
+        "auth failed",
+        "server unreachable",
+        "server error",
+    ]
+    assert pc.describe_connection_failure("not_responding") == "server not responding"
+    assert pc.describe_connection_failure("") == "server unknown"
+
+
+# ── the headers, per host ───────────────────────────────────────────────────
+
+_OUTAGE_SAVES = {
+    "prompt": 1,
+    "trace": 0,
+    "answer": 0,
+    "trace_buffered": 6,
+    "answer_buffered": 1,
+}
+_BACKLOG = {"pending": 7, "oldest_age_seconds": 20 * 86400}
+
+
+@pytest.fixture
+def lookup(suite, hook_module, monkeypatch):
+    module = load_lookup(suite, hook_module, monkeypatch)
+    monkeypatch.setattr(module, "warmup_backlog", lambda: dict(_BACKLOG))
+    return module
+
+
+def _joiner(suite) -> str:
+    return "; " if suite.name == "claude-code" else " · "
+
+
+def _message(suite, output: dict) -> str:
+    """The hook's terminal message, wherever this host carries it."""
+    if suite.name == "claude-code":
+        return output["hookSpecificOutput"]["systemMessage"]
+    return output["systemMessage"]
+
+
+def _header(suite, output: dict) -> str:
+    """The ``Cognee memory: …`` line of the terminal message."""
+    message = _message(suite, output)
+    return next(line for line in message.splitlines() if line.startswith("Cognee memory:"))
+
+
+def test_header_shows_buffered_writes_and_the_backlog(suite, lookup, monkeypatch):
+    run = drive_recall(lookup, monkeypatch, recall=HIT, saves_last_turn=_OUTAGE_SAVES)
+    header = _header(suite, run.output)
+    j = _joiner(suite)
+    assert header.endswith(
+        f"{j}saved last turn 1 prompt / 0 trace / 0 answer"
+        f"{j}buffered last turn 6 trace / 1 answer (not saved yet)"
+        f"{j}7 awaiting replay, oldest 20d"
+    )
+    # The buffered writes are NOT folded into the saved count.
+    assert "6 trace / 1 answer" not in header.split("buffered")[0]
+
+
+def test_header_reads_as_before_when_nothing_was_buffered(suite, lookup, monkeypatch):
+    monkeypatch.setattr(
+        lookup, "warmup_backlog", lambda: {"pending": 0, "oldest_age_seconds": None}
+    )
+    run = drive_recall(lookup, monkeypatch, recall=HIT)
+    header = _header(suite, run.output)
+    assert header.endswith("saved last turn 0 prompt / 0 trace / 0 answer")
+    assert "buffered" not in header and "awaiting replay" not in header
+
+
+def test_skipped_recall_still_reports_the_outage(suite, lookup, monkeypatch):
+    """A known-bad server used to mean no header at all — and an unread counter."""
+    monkeypatch.setattr(lookup, "authed_liveness", lambda url, timeout=1.0: "unreachable")
+    monkeypatch.setattr(lookup, "probe_health", lambda url, timeout=1.0: "down")
+    run = drive_recall(
+        lookup,
+        monkeypatch,
+        recall=HIT,
+        prior_state={"state": "unreachable", "base_url": URL},
+        saves_last_turn=_OUTAGE_SAVES,
+    )
+    assert run.fired("recall_skipped_not_ready")
+    assert run.calls == [], "no scope was requested against a known-bad server"
+
+    j = _joiner(suite)
+    assert _header(suite, run.output) == (
+        f"Cognee memory: recall skipped (server unreachable)"
+        f"{j}saved last turn 1 prompt / 0 trace / 0 answer"
+        f"{j}buffered last turn 6 trace / 1 answer (not saved yet)"
+        f"{j}7 awaiting replay, oldest 20d"
+    )
+    # The model sees exactly what the terminal shows.
+    assert run.output["hookSpecificOutput"]["additionalContext"] == _message(suite, run.output)
+    assert run.output["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+    # Codex-derived hosts keep their plain status line on top.
+    if suite.name != "claude-code":
+        assert run.output["systemMessage"].startswith("cognee: ds · local\n")
+
+
+def test_inconclusive_probe_names_the_recorded_failure(suite, lookup, monkeypatch):
+    monkeypatch.setattr(lookup, "authed_liveness", lambda url, timeout=1.0: "unknown")
+    monkeypatch.setattr(lookup, "probe_health", lambda url, timeout=1.0: "slow")
+    run = drive_recall(
+        lookup,
+        monkeypatch,
+        recall=HIT,
+        prior_state={"state": "server_error", "base_url": URL},
+    )
+    assert _header(suite, run.output).startswith("Cognee memory: recall skipped (server error)")

--- a/integrations/tests/tests/unit/test_metrics.py
+++ b/integrations/tests/tests/unit/test_metrics.py
@@ -4,8 +4,9 @@ Everything is derived from mock local files in a temp dir — no network, no rea
 plugin state. Fixtures use the SAME schemas the plugin actually writes: hook.log
 lines are {ts, pid, event, detail}; mode_decision.detail.mode is "http" (or
 "local_sdk" in logs written before the in-process path was removed);
-warmup-buffered saves log "store_buffered_warming"; recall-audit.log /
-save_counter.json / last_recall.json match their writers.
+warmup-buffered writes log "store_buffered_warming" / "*_buffered_after_error" and
+are reported apart from saves; recall-audit.log / save_counter.json /
+last_recall.json match their writers.
 
 Migrated from {claude-code,codex}/tests/test_metrics.py.
 """
@@ -56,6 +57,7 @@ def test_empty_dir_returns_zeros(cognee_plugin, state_dir):
         "sessions": 0,
         "recalls": {"total": 0, "hits": 0, "hit_rate_pct": 0.0},
         "saves": {"prompt": 0, "trace": 0, "answer": 0},
+        "buffered": {"trace": 0, "answer": 0},
         "mode_split": {"local_pct": 0.0, "cloud_pct": 0.0, "local_count": 0, "cloud_count": 0},
         "breaker_open_events": 0,
     }
@@ -95,18 +97,21 @@ def test_saves_counted_once_from_hook_log(cognee_plugin, state_dir):
     assert saves == {"prompt": 2, "trace": 1, "answer": 1}
 
 
-def test_saves_include_warmup_buffered(cognee_plugin, state_dir):
-    # Warmup-buffered trace/answer saves log store_buffered_warming, not
-    # trace_stored/stop_stored, and must still be counted.
+def test_buffered_writes_are_reported_apart_from_saves(cognee_plugin, state_dir):
+    # A write the server never received is not a save (SDK-467): the warming
+    # spillway and the after-error buffering land under "buffered", never "saves".
     _write_jsonl(
         state_dir / "hook.log",
         _hook("trace_stored", tool="Bash", status="ok"),
         _hook("store_buffered_warming", hook="tool", tool="Read"),
         _hook("store_buffered_warming", hook="stop"),
+        _hook("trace_buffered_after_error", tool="Edit", status=503),
+        _hook("store_buffered_after_error", hook="stop", status=None),
         _hook("stop_stored", chars=5),
     )
-    saves = cognee_plugin._compute_metrics(state_dir)["saves"]
-    assert saves == {"prompt": 0, "trace": 2, "answer": 2}
+    metrics = cognee_plugin._compute_metrics(state_dir)
+    assert metrics["saves"] == {"prompt": 0, "trace": 1, "answer": 1}
+    assert metrics["buffered"] == {"trace": 2, "answer": 2}
 
 
 def test_sessions_union_across_files(cognee_plugin, state_dir):
@@ -172,7 +177,14 @@ def test_cli_json_output(cognee_plugin, state_dir):
     rc, out = _run_cli(cognee_plugin, ["metrics", "--json"])
     assert rc == 0
     parsed = json.loads(out)
-    assert set(parsed) == {"sessions", "recalls", "saves", "mode_split", "breaker_open_events"}
+    assert set(parsed) == {
+        "sessions",
+        "recalls",
+        "saves",
+        "buffered",
+        "mode_split",
+        "breaker_open_events",
+    }
     assert parsed["mode_split"]["local_count"] == 1
 
 

--- a/integrations/tests/tests/unit/test_recall_session_totals.py
+++ b/integrations/tests/tests/unit/test_recall_session_totals.py
@@ -31,26 +31,14 @@ import json
 from pathlib import Path
 
 import pytest
-from utils.recall import SCOPES, drive_recall
+from utils.recall import HIT, SCOPES, SESSION_KEY, drive_recall, load_lookup
 
-_KEY = "fde122ae-07db-431d-b5af-acba353e4e3e"
-_HIT = {
-    "session": [{"question": "q1", "answer": "a1"}],
-    "trace": [],
-    "graph": [],
-    "session_context": [],
-}
 _MISS = {scope: [] for scope in SCOPES}
 
 
 @pytest.fixture
 def lookup(suite, hook_module, monkeypatch):
-    module = hook_module(suite, "session-context-lookup.py")
-    monkeypatch.setattr(module, "get_session_key", lambda: _KEY)
-    if suite.name == "codex":
-        # codex prefixes the header with the plain status line; keep it inert.
-        monkeypatch.setattr(module, "render_status_for_host", lambda key: "cognee: ds · local")
-    return module
+    return load_lookup(suite, hook_module, monkeypatch)
 
 
 @pytest.fixture
@@ -62,7 +50,7 @@ def state(suite, temp_home) -> Path:
 def per_session(suite, state):
     """Read the marker this suite's total lives in (see module docstring)."""
 
-    def _read(key: str = _KEY) -> dict:
+    def _read(key: str = SESSION_KEY) -> dict:
         path = state / "last_recall.json"
         if suite.name == "claude-code":
             path = state / "recall" / f"{key}.json"
@@ -75,7 +63,7 @@ def _shared(state: Path) -> dict:
     return json.loads((state / "last_recall.json").read_text(encoding="utf-8"))
 
 
-def _seed(state: Path, suite, payload: dict, key: str = _KEY) -> None:
+def _seed(state: Path, suite, payload: dict, key: str = SESSION_KEY) -> None:
     """Pre-write the marker a previous prompt of session ``key`` would have left."""
     path = state / "last_recall.json"
     if suite.name == "claude-code":
@@ -85,7 +73,7 @@ def _seed(state: Path, suite, payload: dict, key: str = _KEY) -> None:
 
 
 def test_first_prompt_starts_the_count(lookup, monkeypatch, per_session):
-    drive_recall(lookup, monkeypatch, recall=_HIT)
+    drive_recall(lookup, monkeypatch, recall=HIT)
     assert per_session()["session_totals"] == {"turns": 1, "turns_with_hits": 1}
 
 
@@ -95,7 +83,7 @@ def test_a_miss_counts_the_turn_but_not_a_hit(lookup, monkeypatch, per_session):
 
 
 def test_totals_accumulate_across_prompts(lookup, monkeypatch, per_session):
-    for results in (_HIT, _MISS, _HIT, _HIT, _MISS):
+    for results in (HIT, _MISS, HIT, HIT, _MISS):
         drive_recall(lookup, monkeypatch, recall=results)
     marker = per_session()
     assert marker["session_totals"] == {"turns": 5, "turns_with_hits": 3}
@@ -119,10 +107,10 @@ def test_another_sessions_marker_is_not_the_source_of_the_total(
         ),
         encoding="utf-8",
     )
-    drive_recall(lookup, monkeypatch, recall=_HIT)
+    drive_recall(lookup, monkeypatch, recall=HIT)
     assert per_session()["session_totals"] == {"turns": 1, "turns_with_hits": 1}
     # ...and the shared copy now carries ours, stamped with our key.
-    assert _shared(state)["session_key"] == _KEY
+    assert _shared(state)["session_key"] == SESSION_KEY
     assert _shared(state)["session_totals"] == {"turns": 1, "turns_with_hits": 1}
 
 
@@ -132,16 +120,20 @@ def test_codex_continues_its_own_shared_marker(lookup, monkeypatch, suite, state
     _seed(
         state,
         suite,
-        {"session_key": _KEY, "hits": {}, "session_totals": {"turns": 4, "turns_with_hits": 2}},
+        {
+            "session_key": SESSION_KEY,
+            "hits": {},
+            "session_totals": {"turns": 4, "turns_with_hits": 2},
+        },
     )
-    drive_recall(lookup, monkeypatch, recall=_HIT)
+    drive_recall(lookup, monkeypatch, recall=HIT)
     assert per_session()["session_totals"] == {"turns": 5, "turns_with_hits": 3}
 
 
 def test_a_legacy_marker_without_totals_restarts_the_count(
     lookup, monkeypatch, suite, state, per_session
 ):
-    _seed(state, suite, {"session_key": _KEY, "hits": {"session": 2}})
+    _seed(state, suite, {"session_key": SESSION_KEY, "hits": {"session": 2}})
     drive_recall(lookup, monkeypatch, recall=_MISS)
     assert per_session()["session_totals"] == {"turns": 1, "turns_with_hits": 0}
 
@@ -150,7 +142,7 @@ def test_a_corrupt_marker_restarts_the_count_instead_of_failing(
     lookup, monkeypatch, suite, state, per_session
 ):
     _seed(state, suite, "not json{{{")
-    run = drive_recall(lookup, monkeypatch, recall=_HIT)
+    run = drive_recall(lookup, monkeypatch, recall=HIT)
     assert run.detail("last_recall_write_failed") is None, run.events
     assert per_session()["session_totals"] == {"turns": 1, "turns_with_hits": 1}
 
@@ -160,12 +152,12 @@ def test_negative_or_garbage_totals_are_clamped(lookup, monkeypatch, suite, stat
         state,
         suite,
         {
-            "session_key": _KEY,
+            "session_key": SESSION_KEY,
             "hits": {},
             "session_totals": {"turns": -4, "turns_with_hits": "x"},
         },
     )
-    run = drive_recall(lookup, monkeypatch, recall=_HIT)
+    run = drive_recall(lookup, monkeypatch, recall=HIT)
     assert run.detail("last_recall_write_failed") is None, run.events
     assert per_session()["session_totals"] == {"turns": 1, "turns_with_hits": 1}
 
@@ -174,7 +166,7 @@ def test_path_unsafe_session_key_writes_no_per_session_copy(lookup, monkeypatch,
     if suite.name != "claude-code":
         pytest.skip("codex has no per-session copy")
     monkeypatch.setattr(lookup, "get_session_key", lambda: "../escape")
-    run = drive_recall(lookup, monkeypatch, recall=_HIT)
+    run = drive_recall(lookup, monkeypatch, recall=HIT)
     assert run.detail("last_recall_write_failed") is None, run.events
     recall_dir = state / "recall"
     assert not recall_dir.exists() or not any(recall_dir.iterdir())
@@ -297,5 +289,5 @@ def test_codex_header_says_warming_up_until_the_first_hit(codex, lookup, monkeyp
 
 
 def test_codex_header_omits_past_sessions_at_zero(codex, lookup, monkeypatch, state):
-    drive_recall(lookup, monkeypatch, recall=_HIT)
+    drive_recall(lookup, monkeypatch, recall=HIT)
     assert _codex_header(state).startswith("Cognee memory: 1 memory hit · 1/1 turns had hits")

--- a/integrations/tests/tests/unit/test_warmup_drain.py
+++ b/integrations/tests/tests/unit/test_warmup_drain.py
@@ -54,6 +54,11 @@ def _pending(pc) -> list:
     return _session_state(pc).get("pending_entries") or []
 
 
+def _pending_content(pc) -> list:
+    """Buffered entries without the buffer's own bookkeeping (the buffered-at stamp)."""
+    return [{k: v for k, v in e.items() if k != pc._BUFFERED_AT_KEY} for e in _pending(pc)]
+
+
 def _replay_into(pc, monkeypatch, sink: list):
     monkeypatch.setattr(
         pc, "remember_entry_via_http", lambda d, s, entry, **k: sink.append(entry) or {}
@@ -118,7 +123,7 @@ def test_concurrent_append_during_drain_survives(pc, monkeypatch):
     monkeypatch.setattr(pc, "remember_entry_via_http", _replay)
     # Both originals replayed; the mid-drain arrival remains.
     assert pc.drain_warmup_entries("ds", "sid") == (2, 1)
-    assert _pending(pc) == [{"type": "qa", "question": "new", "answer": "x"}]
+    assert _pending_content(pc) == [{"type": "qa", "question": "new", "answer": "x"}]
 
 
 def test_drain_skipped_when_lock_busy(pc, monkeypatch):

--- a/integrations/tests/utils/recall.py
+++ b/integrations/tests/utils/recall.py
@@ -33,6 +33,39 @@ SCOPES = ("session", "trace", "session_context", "graph")
 #: (SDK-356), so assertions need the exact value the hook was handed.
 URL = "https://cloud.example"
 
+#: A session key in the shape the hooks accept, shared by the header tests.
+SESSION_KEY = "fde122ae-07db-431d-b5af-acba353e4e3e"
+
+#: One session hit and nothing else — the smallest recall that counts as a hit.
+HIT = {
+    "session": [{"question": "q1", "answer": "a1"}],
+    "trace": [],
+    "graph": [],
+    "session_context": [],
+}
+
+
+def load_lookup(
+    suite,
+    hook_module,
+    monkeypatch,
+    *,
+    session_key: str = SESSION_KEY,
+    status_line: str = "cognee: ds · local",
+):
+    """``session-context-lookup.py`` with the session key pinned.
+
+    Hosts that prefix the memory header with their plain status line (the
+    Codex-derived cores) get that line held inert, so header assertions see a
+    fixed prefix instead of whatever the renderer reads from the temp HOME.
+    """
+    module = hook_module(suite, "session-context-lookup.py")
+    monkeypatch.setattr(module, "get_session_key", lambda: session_key)
+    if hasattr(module, "render_status_for_host"):
+        monkeypatch.setattr(module, "render_status_for_host", lambda key: status_line)
+    return module
+
+
 #: A connection-state marker standing for "this server has answered before",
 #: which is what separates a real outage from an ordinary cold start.
 READY_PRIOR = {"state": "ready", "base_url": URL, "checked_at": 1.0}
@@ -86,6 +119,7 @@ def drive_recall(
     cwd: str = "",
     mode: str = "http",
     sdk_recall: Callable[..., Any] | dict[str, list] | None = None,
+    saves_last_turn: dict | None = None,
 ) -> RecallRun:
     """Run ``module._run(prompt)`` with every seam captured.
 
@@ -94,6 +128,9 @@ def drive_recall(
     ``prior_state``/``ready_hint`` set what the hook believes about the server
     before the attempt; ``slow_streak``/``slow_threshold`` drive timeout
     escalation without touching real streak files.
+
+    ``saves_last_turn`` is what the hook reads back from the save counter (all
+    kinds zero by default), so a header test can hand it buffered writes.
 
     ``mode="http"`` (the default) drives cloud/HTTP mode, the only mode where
     the health accounting runs. ``mode="local_sdk"`` drives the in-process SDK
@@ -150,7 +187,9 @@ def drive_recall(
         "record_slow_probe": lambda url: slow_streak,
         "slow_streak_threshold": lambda: slow_threshold,
         "_load_session_id": lambda: "sid",
-        "read_and_reset_save_counter": lambda sid: {"prompt": 0, "trace": 0, "answer": 0},
+        "read_and_reset_save_counter": lambda sid: dict(
+            saves_last_turn or {"prompt": 0, "trace": 0, "answer": 0}
+        ),
         "recall_via_http": _recall,
     }
     for name, impl in seams.items():


### PR DESCRIPTION
While the server was unreachable for ~2.5 weeks, every prompt's header kept
reading `saved last turn 1 prompt / 6 trace / 1 answer` — the store hooks
diverted every write to the warmup buffer but bumped the save counter as if
it had landed. An outage produced no visible signal at all.

### What changes

- **Buffered writes are counted apart.** New `trace_buffered` / `answer_buffered`
  counter kinds; all four buffering branches in the store hook use them.
- **Headers show the outage.** Claude Code, Codex and Antigravity append
  `buffered last turn 6 trace / 1 answer (not saved yet); 7 awaiting replay, oldest 20d`
  when there is anything to say. The healthy header is unchanged.
- **Buffer age is measurable.** Each buffered entry carries a `_buffered_at` stamp,
  stripped before replay. `warmup_backlog()` scans every session's bridge file.
- **Skipped recalls are no longer silent.** A known-bad server now yields
  `Cognee memory: recall skipped (server unreachable); …` and resets the counter,
  so the first header after recovery does not report weeks of buffering as one turn.
- **`cognee-plugin metrics`** gains a `buffered` section; `saves` counts only what
  the server received.

Shared header pieces (`saves_segment`, `outage_header`,
`describe_connection_failure`, `DEFINITIVE_FAILURE_STATES`) live in
`_plugin_common.py` and are used by all three hooks.

### Versions

Claude Code 1.5.5 · Codex 1.6.5 · Antigravity 1.5.2

### Tests

Unit: 2067 passed · Integration: 522 passed · Ruff clean.
New `test_buffered_saves_visibility.py` covers the counter, every store-hook
branch, stamping/stripping, backlog scanning, and all three hosts' headers.

Follow-ups (not in this PR): drop the mtime fallback for pre-upgrade buffer
entries after one release; the three-way `_plugin_common.py` duplication.