### PR TITLE
fix(plugins): prefer the server over the CLI, and follow collection redirects

### DIFF
--- a/integrations/antigravity/CHANGELOG.md
+++ b/integrations/antigravity/CHANGELOG.md
@@ -42,6 +42,55 @@ project adheres to [Semantic Versioning](https://semver.org/).
   after-error buffering entirely. It now has a `buffered` section (`trace` /
   `answer`) fed by `store_buffered_warming`, `trace_buffered_after_error` and
   `store_buffered_after_error`, and `saves` counts only what the server received.
+- **Skills reached for the `cognee-cli` before the server, and the CLI paths were
+  unreachable anyway (SDK-622).** The `setup` and `local-ui` skills — shipped
+  identically to the Codex plugin's — declared `uv run cognee-cli ...` the
+  "primary interface"/"primary launcher", contradicting `memory`'s own
+  server-first rule. Both assumed a cognee **source checkout**:
+  `scripts/cognee-cli.sh` exits 64 anywhere else, and bare `uv run cognee-cli`
+  bypassed even that wrapper while never using the plugin's own venv, which in
+  cloud mode is never built at all.
+  - `setup` is now **Cognee Connection And Status**, answering from
+    `scripts/doctor.py --json` and an HTTP `/health` probe, with the CLI demoted
+    to a last resort gated on *local mode plus a checkout*. Dropped `uv sync
+    --dev --all-extras --reinstall` and `serve --logout`.
+  - `local-ui` **checks the mode first and stops on cloud**, and no longer
+    competes with `setup` for "is Cognee running?".
+  - Every remaining CLI invocation routes through `scripts/cognee-cli.sh`.
+- **The recommended "server-first" `curl` 401'd in local mode**, because
+  `${COGNEE_API_KEY:-}` is empty there — the key is minted into
+  `~/.cognee-plugin/api_key.json` and never exported. Recall now goes through
+  `scripts/cognee-search.sh`, and the raw-endpoint form resolves credentials with
+  `eval "$(scripts/cognee-forget.sh env)"` first.
+- **`memory`'s Forget section was CLI-only.** It offered only `cognee-cli forget
+  --dataset ...`, despite the plugin shipping `scripts/cognee-forget.sh`. It now
+  walks the guided server-side flow (sync, resolve dataset id, judge candidates
+  by raw content grouped by session, confirm, delete) with the CLI as fallback.
+- **A local server's redirect broke every by-name dataset switch (SDK-622).**
+  `switch-dataset.py` failed with a bare `307` for any dataset named rather than
+  addressed by UUID, so the dataset picker could not switch at all. Real Cognee
+  servers disagree about the trailing slash on `/api/v1/datasets` and answer 307
+  to the spelling they do not serve — in **opposite** directions: cloud tenants
+  redirect the bare path to the slashed one, a local server redirects the slashed
+  path to the bare one. The clients hard-coded the slash for the cloud's benefit,
+  and urllib's `HTTPRedirectHandler` refuses to replay a POST across a 307 (it
+  raises `HTTPError` instead), so the create surfaced as a 307 the caller treated
+  as a failure. Because `ensure_dataset_ready_via_api` runs unconditionally on the
+  by-name path, an *existing* dataset failed exactly like a new one.
+
+  Both HTTP helpers (`_json_http_request` and `config._cloud_http_request`) now
+  replay a 307/308 themselves, preserving method and body, so either spelling
+  works against either server shape. The replay is **same-origin only** — these
+  requests carry `X-Api-Key`, which must never be sent to another host — and
+  bounded to two hops, so a redirect loop cannot spin a hook. A cross-origin
+  target, a missing `Location`, or any other status leaves the original error
+  untouched. The two `# trailing slash on purpose` workarounds are gone.
+
+  The suite missed this because the mock server accepted both spellings
+  unconditionally. It can now redirect either way
+  (`set_collection_redirect`), and the regression tests assert dataset creation
+  through both helpers in both directions, plus the same-origin gate and the
+  refusals.
 
 ## [1.5.1]
 

--- a/integrations/antigravity/scripts/_plugin_common.py
+++ b/integrations/antigravity/scripts/_plugin_common.py
@@ -4120,7 +4120,14 @@ def urlopen_following_307(req, *, timeout: float, context=None):
             target = urllib.parse.urljoin(req.full_url, location)
             if not _same_origin(req.full_url, target):
                 raise
-            exc.close()
+            try:
+                exc.close()
+            except Exception:
+                # Best-effort connection release. An HTTPError carrying no body
+                # never initialized its underlying file, and closing that raises
+                # (KeyError on Python 3.9, the hooks' floor). The replay does not
+                # depend on the close, and a raise here would mask the HTTP error.
+                pass
             replay = urllib.request.Request(
                 target, data=req.data, headers=dict(req.headers), method=req.get_method()
             )

--- a/integrations/antigravity/scripts/_plugin_common.py
+++ b/integrations/antigravity/scripts/_plugin_common.py
@@ -2318,8 +2318,9 @@ def list_datasets_via_http(api_key: str, *, timeout: float = 15.0) -> list[dict]
 
 def create_dataset_via_http(api_key: str, name: str) -> dict:
     """POST /api/v1/datasets/ as ``api_key``: the (new or existing) dataset row, or {}."""
-    # Trailing slash on purpose: cloud tenants 307-redirect the bare path and
-    # urllib will not replay a POST across a redirect.
+    # Either spelling works: the request helper replays a same-origin 307/308,
+    # which is how cloud (bare -> slashed) and local (slashed -> bare) servers
+    # disagree about this route.
     status, body = _control_plane_request(
         "/api/v1/datasets/", {"name": name}, api_key=api_key, timeout=30.0
     )
@@ -4070,6 +4071,63 @@ def set_agent_registration(registered: bool, session_key: str = "") -> None:
     _ = (registered, session_key)
 
 
+_REDIRECT_REPLAY_CODES = (307, 308)
+_MAX_REDIRECT_REPLAYS = 2
+
+
+def _same_origin(first: str, second: str) -> bool:
+    """Same scheme, host and effective port — the gate for replaying a keyed request."""
+    import urllib.parse
+
+    def origin(url):
+        parts = urllib.parse.urlsplit(url)
+        port = parts.port or (443 if parts.scheme == "https" else 80)
+        return (parts.scheme, (parts.hostname or "").lower(), port)
+
+    return origin(first) == origin(second)
+
+
+def urlopen_following_307(req, *, timeout: float, context=None):
+    """``urlopen`` that replays a method-preserving redirect (307/308).
+
+    urllib refuses to replay a POST across a 307/308 — ``HTTPRedirectHandler``
+    raises ``HTTPError`` instead — so a server that redirects between the two
+    spellings of a collection route (``/api/v1/datasets`` and
+    ``/api/v1/datasets/``) fails every POST to it. Both spellings occur in the
+    wild and they redirect in *opposite* directions: cloud tenants 307 the bare
+    path to the slashed one, while a local server 307s the slashed path to the
+    bare one. No single spelling works everywhere, so the redirect has to be
+    followed rather than guessed.
+
+    Only a **same-origin** target is followed: these requests carry
+    ``X-Api-Key``, which must never be replayed to another host. A cross-origin
+    target, a missing ``Location``, or any other status leaves the original
+    ``HTTPError`` to the caller untouched.
+    """
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    for _ in range(_MAX_REDIRECT_REPLAYS):
+        try:
+            return urllib.request.urlopen(req, timeout=timeout, context=context)
+        except urllib.error.HTTPError as exc:
+            if exc.code not in _REDIRECT_REPLAY_CODES:
+                raise
+            location = exc.headers.get("Location") if exc.headers else ""
+            if not location:
+                raise
+            target = urllib.parse.urljoin(req.full_url, location)
+            if not _same_origin(req.full_url, target):
+                raise
+            exc.close()
+            replay = urllib.request.Request(
+                target, data=req.data, headers=dict(req.headers), method=req.get_method()
+            )
+            req = replay
+    return urllib.request.urlopen(req, timeout=timeout, context=context)
+
+
 def _json_http_request(
     path: str,
     payload: dict | None = None,
@@ -4100,7 +4158,7 @@ def _json_http_request(
         headers=headers,
         method=method,
     )
-    with urllib.request.urlopen(req, timeout=timeout, context=_https_context()) as resp:
+    with urlopen_following_307(req, timeout=timeout, context=_https_context()) as resp:
         body = resp.read().decode("utf-8")
         if not body:
             return None

--- a/integrations/antigravity/scripts/config.py
+++ b/integrations/antigravity/scripts/config.py
@@ -262,7 +262,7 @@ def _cloud_http_request(
     import urllib.parse
     import urllib.request
 
-    from _plugin_common import _https_context
+    from _plugin_common import _https_context, urlopen_following_307
 
     headers: dict[str, str] = {}
     data: bytes | None = None
@@ -279,7 +279,7 @@ def _cloud_http_request(
 
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
     try:
-        with urllib.request.urlopen(req, timeout=timeout, context=_https_context()) as resp:
+        with urlopen_following_307(req, timeout=timeout, context=_https_context()) as resp:
             return resp.status, resp.read().decode("utf-8")
     except urllib.error.HTTPError as exc:
         try:
@@ -335,7 +335,10 @@ async def ensure_dataset_ready_via_api(service_url: str, api_key: str, dataset: 
             raise RuntimeError("403: no verified write permission on selected dataset")
         return
     status, text = _cloud_http_request(
-        f"{base}/api/v1/datasets/",  # trailing slash: cloud tenants 307-redirect the bare path
+        # Either spelling works: _cloud_http_request replays a same-origin
+        # 307/308, which is how cloud (bare -> slashed) and local
+        # (slashed -> bare) servers disagree about this route.
+        f"{base}/api/v1/datasets/",
         method="POST",
         api_key=api_key,
         json_body={"name": dataset},

--- a/integrations/antigravity/skills/local-ui/SKILL.md
+++ b/integrations/antigravity/skills/local-ui/SKILL.md
@@ -1,47 +1,88 @@
 ---
 name: local-ui
-description: Use when launching, checking, or reporting on the local Cognee UI/backend through cognee-cli -ui.
+description: Use only when the user explicitly asks to launch or inspect the LOCAL Cognee UI (the cognee-cli dev UI). For "is Cognee running/connected" or any configuration question, use the setup skill instead. Does not apply in cloud mode.
 ---
 
-# Cognee CLI Local UI
+# Cognee Local UI
 
-Use this skill when the user asks to launch the local Cognee UI, check whether
-Cognee is running, or report how well the UI/backend work.
+Use this skill only when the user explicitly asks to launch or inspect the
+**local** Cognee UI — the development UI that `cognee-cli -ui` serves from a
+cognee source checkout.
+
+This skill does **not** answer "is Cognee running?" or "is Cognee connected?".
+Those are connection questions: use the **setup** skill, which reads the
+plugin's own diagnostic and probes the resolved server.
 
 ## Rules
 
-- Use `uv run cognee-cli -ui` as the primary launcher.
-- Do not use MCP for this plugin.
+- **Check the mode first.** The local UI exists only in local mode; see step 1.
+  Never launch or probe it before confirming the mode.
+- **Server first for status.** The plugin's server is the source of truth for
+  whether Cognee works. The UI is a viewer on top of it, not the thing to test.
+- **`cognee-cli -ui` requires a cognee source checkout.** It is not available on
+  a normal plugin install. Establish that prerequisite before attempting it.
 - Keep the process running when the user wants the UI available.
-- If ports are already occupied, inspect the running services before starting another copy.
+- If ports are already occupied, inspect the running services before starting
+  another copy.
 - Do not kill user processes without explicit approval.
+- Do not use MCP for this plugin.
 
-## Launch
-
-From the Cognee repository root:
+## 1. Check the mode — stop here on cloud
 
 ```bash
-uv run cognee-cli -ui
+python3 "${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/doctor.py" --json
 ```
 
-Expected local surfaces:
+If `mode` is **`Cloud`**, there is no local UI to launch and nothing here
+applies. Tell the user their instance is remote, that its dashboard lives at
+their Cognee Cloud URL, and report the connection facts from the same output
+(`server_url`, `reachable`, `latency_ms`, `api_key_source`). Do **not** start a
+local server or probe localhost — a local UI would be a second, empty instance
+holding none of their memory.
+
+If `mode` is **`Local`**, the plugin's own server is already running at
+`server_url` (normally `http://localhost:8011`). Confirm the state the user
+actually cares about there first:
+
+```bash
+curl -sS -i "${COGNEE_BASE_URL:-http://localhost:8011}/health"
+```
+
+That is the server the plugin reads and writes. The `cognee-cli -ui` surfaces
+below are a **separate** dev instance on different ports — launching them does
+not affect, and does not report on, the plugin's memory.
+
+## 2. Launch the dev UI (local mode, cognee checkout required)
+
+Only when the user explicitly wants the UI, and only from a cognee source
+checkout:
+
+```bash
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" -ui
+```
+
+The wrapper exits 64 ("Run this from the Cognee repository root or set
+COGNEE_REPO_ROOT") when there is no checkout. That is expected on a normal
+plugin install — report it as "the local dev UI needs a cognee source checkout",
+not as a Cognee failure, and fall back to reporting the plugin server's health
+from step 1.
+
+Expected surfaces for that dev instance:
 
 ```text
-Backend: http://localhost:8000
+Backend:  http://localhost:8000
 Frontend: http://localhost:3000
 ```
 
-## Health Checks
+These are `cognee-cli -ui`'s own defaults and are unrelated to the plugin's
+`:8011` server — do not use them to judge whether the plugin's memory works.
 
-Backend:
+## 3. Health checks for the dev UI
+
+Only for a UI launched in step 2:
 
 ```bash
 curl -i http://localhost:8000/health
-```
-
-Frontend:
-
-```bash
 curl -i http://localhost:3000/
 ```
 
@@ -61,8 +102,13 @@ credentials only when appropriate and do not expose real user credentials.
 
 Report:
 
-- which process or command is running;
-- backend health and any warnings;
+- the resolved **mode** and the plugin server's health first — that is what
+  determines whether memory works;
+- which process or command is running, if a UI was launched;
+- dev-UI backend health and any warnings;
 - frontend route availability;
 - working authenticated flows, if checked;
 - broken or suspicious behavior with file references when possible.
+
+Never present a healthy dev UI as proof that the plugin's memory is working, or
+an absent dev UI as proof that it is broken — they are different instances.

--- a/integrations/antigravity/skills/memory/SKILL.md
+++ b/integrations/antigravity/skills/memory/SKILL.md
@@ -11,8 +11,17 @@ memory.
 
 ## Rules
 
-- Prefer the server-first paths below (HTTP to the running Cognee server).
-- Use `uv run cognee-cli ...` only when the server is genuinely unreachable.
+- **Server first.** Every operation below goes to the running Cognee server over
+  HTTP, through the plugin's own scripts. That is the authoritative path in both
+  local and cloud mode.
+- **`cognee-cli` is a last resort, not an alternative.** It is reachable only on a
+  machine holding a cognee **source checkout**: `scripts/cognee-cli.sh` exits 64
+  anywhere else, and in cloud mode the plugin's venv is never built at all. Use it
+  only when the server is genuinely unreachable *and* that checkout exists. Unsure
+  which mode you are in? `python3 "${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/doctor.py" --json`
+  reports `mode`, `server_url` and `reachable` without importing cognee.
+- **Empty CLI output is never proof of absence.** Ground-truth against the server
+  before concluding anything (see *The server is the source of truth* below).
 - Choose a clear dataset name with `-d` or `--dataset-name`; ask only if the dataset boundary is genuinely ambiguous.
 - Do not ingest secrets, credentials, `.env` files, private keys, token dumps, or unrelated generated artifacts.
 - Before destructive commands such as `forget`, `delete`, or `--everything`, get explicit user confirmation.
@@ -22,10 +31,18 @@ memory.
 **Server-first (one-step ingestion):**
 
 ```bash
-"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-remember.sh" "<text>" --node-set user_context
+${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-remember.sh "<text>" --node-set user_context
 ```
 
-Use `--node-set project_docs` for project/code content, `--node-set agent_actions` for agent notes. The script POSTs directly to `/api/v1/remember`. A `{"ok": true}` response means the server accepted the data. An error response means the server rejected or failed the request — check `COGNEE_API_KEY` and server logs; do **not** re-run or conclude the data wasn't stored without confirming against the server.
+Use `--node-set project_docs` for project/code content, `--node-set agent_actions` for agent notes.
+
+To store a **file** under its real filename (so code files ride the zero-LLM code path instead of being ingested as prose), pass `--file`:
+
+```bash
+${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-remember.sh --file src/payments.py --node-set project_docs
+```
+
+For a whole repository (cross-file calls/imports, impact analysis), use the **codebase** skill instead. The script POSTs directly to `/api/v1/remember`. A `{"ok": true}` response means the server accepted the data. An error response means the server rejected or failed the request — check `COGNEE_API_KEY` and server logs; do **not** re-run or conclude the data wasn't stored without confirming against the server.
 
 **Background by default + eventual consistency**: the wrapper submits with `run_in_background=true` (so a large cognify never holds one request open past the cloud's ~10-min request ceiling). The POST returns once the work is **enqueued**, with `dataset_id` and `pipeline_run_id`; `status: "running"` means *submitted, not yet in the permanent graph*. The session cache is searchable immediately, but the graph is queryable only after the cognify pipeline **completes**.
 
@@ -34,53 +51,73 @@ By default the wrapper then waits a short, bounded time (`COGNEE_REMEMBER_WAIT_S
 **Fallback only — server unreachable:**
 
 ```bash
-uv run cognee-cli remember <text-or-path> -d <dataset-name>
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" remember <text-or-path> -d <dataset-name>
 ```
 
-For staged work (no HTTP equivalent — CLI only):
+For staged work there is no HTTP equivalent, so it is available **only** with a
+cognee source checkout. Prefer the one-step server path above; mention this
+limitation rather than switching to the CLI when no checkout exists:
 
 ```bash
-uv run cognee-cli add <text-or-path> -d <dataset-name>
-uv run cognee-cli cognify -d <dataset-name>
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" add <text-or-path> -d <dataset-name>
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" cognify -d <dataset-name>
 ```
 
 For long processing:
 
 ```bash
-uv run cognee-cli remember <text-or-path> -d <dataset-name> --background
-uv run cognee-cli cognify -d <dataset-name> --background
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" remember <text-or-path> -d <dataset-name> --background
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" cognify -d <dataset-name> --background
 ```
 
 ## Recall And Search
 
-**Server-first (authoritative):**
+**Server-first (authoritative) — use the wrapper:**
 
 ```bash
-curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
+${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-search.sh "<question>" 10 --graph
+```
+
+It resolves the endpoint, the session and the API key the way the hooks do
+(launch record → `COGNEE_API_KEY` → the auto-minted `api_key.json`), so it
+authenticates correctly in **both** local and cloud mode. Drop `--graph` to
+search the session cache and the graph, or pass `--session` for the session only.
+
+An empty result from the server is authoritative — the server searched and found
+nothing.
+
+**Do not hand-roll the `curl` with `-H "X-Api-Key: ${COGNEE_API_KEY:-}"`.** In
+local mode that variable is empty — the key is minted into
+`~/.cognee-plugin/api_key.json` and never exported to your shell — so the request
+401s and looks like a server problem when nothing is wrong. When you genuinely
+need the raw endpoint (to pass `node_name`, say), resolve the credentials first,
+in the **same** shell invocation:
+
+```bash
+eval "$(${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-forget.sh env)" && \
+curl -s -X POST "${COGNEE_BASE_URL}/api/v1/recall" \
   -H "Content-Type: application/json" \
-  -H "X-Api-Key: ${COGNEE_API_KEY:-}" \
+  -H "X-Api-Key: ${COGNEE_API_KEY}" \
   -d '{"query": "<question>", "top_k": 10, "only_context": true, "scope": ["graph"]}'
 ```
 
-Omit `-H "X-Api-Key: ..."` for a local single-user server (auth is optional). An empty list `[]` from the server is authoritative — the server searched and found nothing.
+A `401` after that resolver means the key really is wrong for that server; a
+`401` without it means nothing.
 
 **Fallback only — server unreachable:**
 
 ```bash
-uv run cognee-cli recall "<question>" -d <dataset-name> -f pretty
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" recall "<question>" -d <dataset-name> -f pretty
 ```
 
-Search modes (CLI only):
+These search modes have no HTTP equivalent, so they are available **only** with a
+cognee source checkout. They are not a reason to leave the server path: if no
+checkout exists, say the mode is unavailable and use the server search above.
 
 ```bash
-uv run cognee-cli search "<question>" -d <dataset-name> -t GRAPH_COMPLETION -f pretty
-uv run cognee-cli search "<exact passage or citation need>" -d <dataset-name> -t CHUNKS -k 10 -f pretty
-```
-
-For code structure, use the codebase skill and the server's code graph:
-
-```bash
-"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-search.sh" "<symbol>" 10 --code
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" search "<question>" -d <dataset-name> -t GRAPH_COMPLETION -f pretty
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" search "<exact passage or citation need>" -d <dataset-name> -t CHUNKS -k 10 -f pretty
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" search "<code question>" -d <dataset-name> -t CODE -k 10 -f pretty
 ```
 
 ### The server is the source of truth
@@ -101,29 +138,48 @@ python3 "${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/
 **Fallback only — server unreachable:**
 
 ```bash
-uv run cognee-cli improve -d <dataset-name>
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" improve -d <dataset-name>
 ```
 
 Bridge session feedback or Q&A into the graph:
 
 ```bash
-uv run cognee-cli improve -d <dataset-name> -s <session-id>
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" improve -d <dataset-name> -s <session-id>
 ```
 
 For targeted enrichment:
 
 ```bash
-uv run cognee-cli improve -d <dataset-name> --node-name <entity-name>
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" improve -d <dataset-name> --node-name <entity-name>
 ```
 
 ## Forget
 
-Use the narrowest deletion command possible and confirm first:
+When the user asks to forget or delete something from memory, walk the guided
+flow below through the wrapper: sync the live session (so unsynced content
+becomes a deletable document), find the dataset id, judge candidate documents by
+their raw content — by meaning, not just keywords, and grouped by session, since
+one session produces several documents carrying the same content in different
+forms — confirm with the user, then delete each match:
 
 ```bash
-uv run cognee-cli forget --dataset <dataset-name>
-uv run cognee-cli forget --dataset <dataset-name> --data-id <data-uuid>
+${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-forget.sh sync
+${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-forget.sh datasets
+${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-forget.sh data <dataset_id>
+${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-forget.sh raw <dataset_id> <data_id>
+${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-forget.sh forget <dataset_id> <data_id>
 ```
 
-Avoid `uv run cognee-cli forget --everything` unless the user explicitly asks
-to delete all Cognee data.
+The wrapper always authenticates (env → `~/.cognee/.env` → the auto-minted
+local `api_key.json`) and prints an `HTTP <status>` trailer per call. Deletion
+is irreversible — use the narrowest scope possible and confirm first.
+
+**Fallback only — server unreachable:**
+
+```bash
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" forget --dataset <dataset-name> --data-id <data-uuid>
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" forget --dataset <dataset-name>
+```
+
+Avoid the CLI's `forget --everything` unless the user explicitly asks to delete
+all Cognee data.

--- a/integrations/antigravity/skills/setup/SKILL.md
+++ b/integrations/antigravity/skills/setup/SKILL.md
@@ -1,85 +1,153 @@
 ---
 name: setup
-description: Use when setting up, checking, or connecting Cognee through the cognee CLI from Antigravity.
+description: Use when configuring the Cognee connection, checking whether Cognee is ready or connected, or diagnosing a local or cloud Cognee instance from Antigravity.
 ---
 
-# Cognee CLI Setup
+# Cognee Connection And Status
 
 Use this skill when the user asks to configure Cognee, check whether Cognee is
-ready, connect to a local or cloud Cognee instance, or inspect CLI capability.
+ready or connected, switch between local and cloud mode, or diagnose a
+connection problem.
 
 ## Rules
 
-- Use `uv run cognee-cli ...` as the primary interface.
+- **Server first.** Answer every question here from the plugin's own diagnostic
+  and the running Cognee server over HTTP. That is the authoritative path in
+  both local and cloud mode.
+- **`cognee-cli` is a last resort, not an alternative.** It is reachable only on
+  a machine holding a cognee **source checkout**: `scripts/cognee-cli.sh` exits
+  64 ("Run this from the Cognee repository root or set COGNEE_REPO_ROOT")
+  anywhere else, and in cloud mode the plugin's venv is never built at all. Never
+  reach for it before the two steps below have actually failed.
+- **Never run `uv sync` or any dependency install.** On a plugin install there is
+  no cognee repository to sync, and in the user's own project it would rebuild
+  their dependencies.
+- Do not print secret values from `.env`, config files, shell history, or command
+  output. Report whether a key *appears configured*, never the value.
+- If a command may create, delete, or overwrite durable Cognee state, say what it
+  will affect before running it.
 - Do not use MCP for this plugin.
-- Work from the Cognee repository root when available.
-- Do not print secret values from `.env`, config files, shell history, or command output.
-- If a command may create, delete, or overwrite durable Cognee state, say what it will affect before running it.
 
-## Checks
+## 1. Check the mode and the connection
 
-Start with the local command surface:
-
-```bash
-uv run cognee-cli --help
-uv run cognee-cli --version
-```
-
-If dependencies are missing, use the repository command:
+One command answers "is Cognee ready?", "which mode am I in?", and "what is
+wrong?" — it imports no cognee, makes one `/health` probe, and works from any
+directory:
 
 ```bash
-uv sync --dev --all-extras --reinstall
+python3 "${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/doctor.py" --json
 ```
 
-Inspect configuration without exposing values:
+The JSON carries:
+
+| Field | Meaning |
+|-------|---------|
+| `mode` | `Local` or `Cloud`, plus an annotation naming what forced the decision (e.g. `forced by COGNEE_BACKEND=local`) |
+| `server_url` | The endpoint this terminal actually resolved |
+| `reachable` | Whether the health probe succeeded |
+| `latency_ms` | Round-trip time, or `null` when unreachable |
+| `api_key_source` | Which credential the plugin is using (plugin identity, env var, cached, minted) |
+| `memory_sharing` | Shared-agent-memory state |
+| `circuit_breaker` | Whether recall is currently short-circuited |
+
+Read `mode` **before** doing anything mode-specific. In particular: in `Cloud`
+mode there is no local server to start and no local UI to launch — see the
+**local-ui** skill, which stops on cloud by design.
+
+Drop `--json` for a human-readable table when reporting to the user.
+
+## 2. Probe the server directly (optional)
+
+When you need to confirm the endpoint yourself, or the doctor's verdict looks
+stale:
 
 ```bash
-uv run cognee-cli config list
+curl -sS -i "${COGNEE_BASE_URL:-http://localhost:8011}/health"
 ```
 
-Use `config get <KEY>` only for non-secret settings. For secret-like keys,
-report whether the key appears configured rather than showing the value.
+`http://localhost:8011` is the plugin's local server. Do **not** substitute
+`:8000` — that is the `cognee-cli`'s own default for a server it would start
+itself, unrelated to the one the plugin runs and talks to.
 
-## Connect
-
-For a local backend:
+For an authenticated check of the resolved credential (cloud, or any server with
+auth enabled), use the forget helper's credential resolver rather than guessing
+where the key lives:
 
 ```bash
-uv run cognee-cli serve --url http://localhost:8000
+eval "$(${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-forget.sh env)" && \
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  -H "X-Api-Key: ${COGNEE_API_KEY}" "${COGNEE_BASE_URL}/api/v1/users/me"
 ```
 
-For a hosted instance with an API key, do not paste the key into the transcript.
-Use an environment variable or an already configured credential.
+`200` means the key is accepted; `401`/`403` means it was rejected by that
+server. In local mode the key is never exported to the shell, so a raw request
+without this resolver will 401 misleadingly.
 
-For the plugin itself, durable configuration (`COGNEE_BASE_URL`,
-`COGNEE_API_KEY`, `LLM_API_KEY`, ...) belongs in `~/.cognee/.env` — a one-time
-setup file shared with existing Cognee plugins, loaded at session start. Shell
-exports still override it per terminal. Guide the user to edit that file
-rather than exporting in every shell; never echo its secret values.
+## Configure the connection
 
-The file may hold both modes' variables at once: with nothing exported, cloud
-wins (`COGNEE_BASE_URL` routes the connection). To pin one terminal to a mode,
-the user exports `COGNEE_BACKEND=local` or `COGNEE_BACKEND=cloud` before
-launching — that beats the URL rule, and `unset COGNEE_BASE_URL` is NOT a way
-to go local (the file re-injects the URL on the next launch).
+Durable configuration (`COGNEE_BASE_URL`, `COGNEE_API_KEY`, `LLM_API_KEY`, ...)
+belongs in `~/.cognee/.env` — a one-time setup file shared with existing Cognee
+plugins, loaded at session start. Guide the user to edit that file rather than
+exporting in every shell; never echo its secret values. Shell exports still
+override it per terminal. Changes apply on the next `antigravity` launch.
 
-To disconnect:
+**Cloud or a remote server** — both values:
 
 ```bash
-uv run cognee-cli serve --logout
+mkdir -p ~/.cognee
+cat >> ~/.cognee/.env <<'EOF'
+COGNEE_BASE_URL="https://your-instance.cognee.ai"
+COGNEE_API_KEY="ck_..."
+EOF
+chmod 600 ~/.cognee/.env
 ```
 
-## Multi-Agent Or API Mode
-
-When the user wants concurrent or multi-agent use, prefer a running Cognee API
-server and pass:
+**Local** (default when `COGNEE_BASE_URL` is unset) — the plugin bootstraps a
+local Cognee API on `http://localhost:8011` and auto-mints `COGNEE_API_KEY`, so
+only the LLM key is required:
 
 ```bash
-uv run cognee-cli --api-url http://localhost:8000 <command>
+mkdir -p ~/.cognee
+cat >> ~/.cognee/.env <<'EOF'
+LLM_API_KEY="sk-..."
+EOF
+chmod 600 ~/.cognee/.env
 ```
 
-For isolated session history and permissions, include:
+Re-pasting either block is safe — the last value of a repeated key wins.
+
+### Which mode wins
+
+The file may hold **both** modes' variables at once. The mode is then decided
+per terminal, in this order:
+
+1. An exported `COGNEE_BACKEND` (or the plugin-specific `COGNEE_ANTIGRAVITY_BACKEND`,
+   which beats it) pins that terminal: `local` or `cloud`.
+2. Otherwise cloud wins when `COGNEE_BASE_URL` is set anywhere.
+3. Otherwise local.
+
+A forced mode is **pinned**: `COGNEE_BACKEND=cloud` with no URL configured stays
+cloud and fails visibly (`✕ (missing_cognee_base_url)`) rather than silently
+falling back. `unset COGNEE_BASE_URL` is **not** a way to go local — the env file
+re-injects it on the next launch; use the switch.
+
+`COGNEE_BACKEND` may also live in `~/.cognee/.env` to make a mode the durable
+default. The doctor's `mode` field always reports what the terminal actually
+resolved, with the cause.
+
+## Fallback — `cognee-cli`, local mode with a cognee checkout only
+
+Only if steps 1 and 2 both failed, the mode is `Local`, **and** the machine has a
+cognee source checkout. Route it through the wrapper so a missing checkout fails
+with a clear message instead of an opaque `uv` error:
 
 ```bash
-uv run cognee-cli --user-id <uuid> <command>
+"${COGNEE_ANTIGRAVITY_PLUGIN_ROOT:-$HOME/.gemini/config/plugins/cognee}/scripts/cognee-cli.sh" config list
 ```
+
+Set `COGNEE_REPO_ROOT` to the checkout path if the wrapper cannot find it. Use
+`config get <KEY>` only for non-secret settings.
+
+Exit code 64 means there is no cognee checkout here — that is expected on a
+normal install, and it is **not** a Cognee fault to report. Say the server is
+unreachable and give the user the doctor output instead.

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -46,6 +46,53 @@ project adheres to [Semantic Versioning](https://semver.org/).
   after-error buffering entirely. It now has a `buffered` section (`trace` /
   `answer`) fed by `store_buffered_warming`, `trace_buffered_after_error` and
   `store_buffered_after_error`, and `saves` counts only what the server received.
+- **The recommended "server-first" `curl` 401'd in local mode, which read as a
+  server fault (SDK-622).** `cognee-search`'s category-filter and
+  ground-truth examples sent `-H "X-Api-Key: ${COGNEE_API_KEY:-}"`, but in local
+  mode that variable is empty: the key is minted into
+  `~/.cognee-plugin/api_key.json` and never exported to the shell. The
+  authoritative path therefore failed with a misleading 401, and the skill's own
+  rule then sent the agent to the `cognee-cli` fallback. Both forms now resolve
+  credentials with `eval "$(scripts/cognee-forget.sh env)"` in the same shell
+  invocation, and the skill states that a `401` without the resolver proves
+  nothing.
+- **`cognee-cli` fallbacks read as an equal alternative.** `cognee-search` and
+  `cognee-remember` now carry the same explicit rules block: the server is first
+  in both modes, and the CLI is a last resort reachable only on a machine holding
+  a cognee **source checkout** (in cloud mode the plugin's venv is never built at
+  all). A missing CLI is documented as "not a Cognee fault to report" — say the
+  server is unreachable and show `scripts/cognee-doctor.sh` instead, and never
+  report a write as saved when neither path persisted it.
+- **`cognee-switch-datasets` pointed at a slash command that does not exist.**
+  Error code 2 told the agent to run `/cognee-memory:cognee-doctor`; the plugin
+  ships no doctor skill. It now names `scripts/cognee-doctor.sh` — as
+  `cognee-forget` already did — and mentions `--session-key <host session id>`
+  for directories shared by several launches.
+- **A local server's redirect broke every by-name dataset switch (SDK-622).**
+  `switch-dataset.py` failed with a bare `307` for any dataset named rather than
+  addressed by UUID, so the dataset picker could not switch at all. Real Cognee
+  servers disagree about the trailing slash on `/api/v1/datasets` and answer 307
+  to the spelling they do not serve — in **opposite** directions: cloud tenants
+  redirect the bare path to the slashed one, a local server redirects the slashed
+  path to the bare one. The clients hard-coded the slash for the cloud's benefit,
+  and urllib's `HTTPRedirectHandler` refuses to replay a POST across a 307 (it
+  raises `HTTPError` instead), so the create surfaced as a 307 the caller treated
+  as a failure. Because `ensure_dataset_ready_via_api` runs unconditionally on the
+  by-name path, an *existing* dataset failed exactly like a new one.
+
+  Both HTTP helpers (`_json_http_request` and `config._cloud_http_request`) now
+  replay a 307/308 themselves, preserving method and body, so either spelling
+  works against either server shape. The replay is **same-origin only** — these
+  requests carry `X-Api-Key`, which must never be sent to another host — and
+  bounded to two hops, so a redirect loop cannot spin a hook. A cross-origin
+  target, a missing `Location`, or any other status leaves the original error
+  untouched. The two `# trailing slash on purpose` workarounds are gone.
+
+  The suite missed this because the mock server accepted both spellings
+  unconditionally. It can now redirect either way
+  (`set_collection_redirect`), and the regression tests assert dataset creation
+  through both helpers in both directions, plus the same-origin gate and the
+  refusals.
 
 ## [1.5.4]
 

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -3948,7 +3948,14 @@ def urlopen_following_307(req, *, timeout: float, context=None):
             target = urllib.parse.urljoin(req.full_url, location)
             if not _same_origin(req.full_url, target):
                 raise
-            exc.close()
+            try:
+                exc.close()
+            except Exception:
+                # Best-effort connection release. An HTTPError carrying no body
+                # never initialized its underlying file, and closing that raises
+                # (KeyError on Python 3.9, the hooks' floor). The replay does not
+                # depend on the close, and a raise here would mask the HTTP error.
+                pass
             replay = urllib.request.Request(
                 target, data=req.data, headers=dict(req.headers), method=req.get_method()
             )

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -2073,8 +2073,9 @@ def list_datasets_via_http(api_key: str, *, timeout: float = 15.0) -> list[dict]
 
 def create_dataset_via_http(api_key: str, name: str) -> dict:
     """POST /api/v1/datasets/ as ``api_key``: the (new or existing) dataset row, or {}."""
-    # Trailing slash on purpose: cloud tenants 307-redirect the bare path and
-    # urllib will not replay a POST across a redirect.
+    # Either spelling works: the request helper replays a same-origin 307/308,
+    # which is how cloud (bare -> slashed) and local (slashed -> bare) servers
+    # disagree about this route.
     status, body = _control_plane_request(
         "/api/v1/datasets/", {"name": name}, api_key=api_key, timeout=30.0
     )
@@ -3898,6 +3899,63 @@ def set_agent_registration(registered: bool, session_key: str = "") -> None:
     _ = (registered, session_key)
 
 
+_REDIRECT_REPLAY_CODES = (307, 308)
+_MAX_REDIRECT_REPLAYS = 2
+
+
+def _same_origin(first: str, second: str) -> bool:
+    """Same scheme, host and effective port — the gate for replaying a keyed request."""
+    import urllib.parse
+
+    def origin(url):
+        parts = urllib.parse.urlsplit(url)
+        port = parts.port or (443 if parts.scheme == "https" else 80)
+        return (parts.scheme, (parts.hostname or "").lower(), port)
+
+    return origin(first) == origin(second)
+
+
+def urlopen_following_307(req, *, timeout: float, context=None):
+    """``urlopen`` that replays a method-preserving redirect (307/308).
+
+    urllib refuses to replay a POST across a 307/308 — ``HTTPRedirectHandler``
+    raises ``HTTPError`` instead — so a server that redirects between the two
+    spellings of a collection route (``/api/v1/datasets`` and
+    ``/api/v1/datasets/``) fails every POST to it. Both spellings occur in the
+    wild and they redirect in *opposite* directions: cloud tenants 307 the bare
+    path to the slashed one, while a local server 307s the slashed path to the
+    bare one. No single spelling works everywhere, so the redirect has to be
+    followed rather than guessed.
+
+    Only a **same-origin** target is followed: these requests carry
+    ``X-Api-Key``, which must never be replayed to another host. A cross-origin
+    target, a missing ``Location``, or any other status leaves the original
+    ``HTTPError`` to the caller untouched.
+    """
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    for _ in range(_MAX_REDIRECT_REPLAYS):
+        try:
+            return urllib.request.urlopen(req, timeout=timeout, context=context)
+        except urllib.error.HTTPError as exc:
+            if exc.code not in _REDIRECT_REPLAY_CODES:
+                raise
+            location = exc.headers.get("Location") if exc.headers else ""
+            if not location:
+                raise
+            target = urllib.parse.urljoin(req.full_url, location)
+            if not _same_origin(req.full_url, target):
+                raise
+            exc.close()
+            replay = urllib.request.Request(
+                target, data=req.data, headers=dict(req.headers), method=req.get_method()
+            )
+            req = replay
+    return urllib.request.urlopen(req, timeout=timeout, context=context)
+
+
 def _json_http_request(
     path: str,
     payload: dict | None = None,
@@ -3928,7 +3986,7 @@ def _json_http_request(
         headers=headers,
         method=method,
     )
-    with urllib.request.urlopen(req, timeout=timeout, context=_https_context()) as resp:
+    with urlopen_following_307(req, timeout=timeout, context=_https_context()) as resp:
         body = resp.read().decode("utf-8")
         if not body:
             return None

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -242,7 +242,7 @@ def _cloud_http_request(
     import urllib.parse
     import urllib.request
 
-    from _plugin_common import _https_context
+    from _plugin_common import _https_context, urlopen_following_307
 
     headers: dict[str, str] = {}
     data: bytes | None = None
@@ -259,7 +259,7 @@ def _cloud_http_request(
 
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
     try:
-        with urllib.request.urlopen(req, timeout=timeout, context=_https_context()) as resp:
+        with urlopen_following_307(req, timeout=timeout, context=_https_context()) as resp:
             return resp.status, resp.read().decode("utf-8")
     except urllib.error.HTTPError as exc:
         try:
@@ -314,7 +314,10 @@ async def ensure_dataset_ready_via_api(service_url: str, api_key: str, dataset: 
             raise RuntimeError("403: no verified write permission on selected dataset")
         return
     status, text = _cloud_http_request(
-        f"{base}/api/v1/datasets/",  # trailing slash: cloud tenants 307-redirect the bare path
+        # Either spelling works: _cloud_http_request replays a same-origin
+        # 307/308, which is how cloud (bare -> slashed) and local
+        # (slashed -> bare) servers disagree about this route.
+        f"{base}/api/v1/datasets/",
         method="POST",
         api_key=api_key,
         json_body={"name": dataset},

--- a/integrations/claude-code/skills/cognee-remember/SKILL.md
+++ b/integrations/claude-code/skills/cognee-remember/SKILL.md
@@ -7,6 +7,19 @@ description: Store data permanently in the Cognee knowledge graph. Accepts a dat
 
 Store data permanently in the Cognee knowledge graph with category tagging.
 
+## Rules
+
+- **Server first.** Writes go to the running Cognee server over HTTP through the
+  wrapper below — the authoritative path in both local and cloud mode.
+- **`cognee-cli` is a last resort, not an alternative.** It is reachable only on a
+  machine holding a cognee **source checkout**, and in cloud mode the plugin's
+  venv is never built at all. Use it only when the server is genuinely
+  unreachable *and* that checkout exists. Unsure which mode you are in?
+  `${CLAUDE_PLUGIN_ROOT}/scripts/cognee-doctor.sh --json` reports `mode`,
+  `server_url` and `reachable` without importing cognee.
+- **Empty CLI output is never proof that a write landed.** Confirm against the
+  server before reporting success.
+
 ## Data categories
 
 Cognee organizes knowledge into three categories via `node_set` tagging:
@@ -56,13 +69,20 @@ By default the wrapper then waits a short, bounded time (`COGNEE_REMEMBER_WAIT_S
 
 ## Fallback only — server unreachable
 
-`cognee-cli` is a thin client over the same server. Use it only when the server is genuinely down:
+`cognee-cli` is a thin client over the same server, and it requires a cognee
+source checkout — on a normal install it is simply unavailable, which is not a
+Cognee fault to report. Use it only when the server is genuinely down *and* that
+checkout exists:
 
 ```bash
 cognee-cli remember "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-agent_sessions}" --node-set user_context
 ```
 
 **Empty or clean CLI output does NOT confirm the data was stored.** Verify via the server directly once it is back up.
+
+If the CLI is missing too, say the write could not be persisted and show the user
+`${CLAUDE_PLUGIN_ROOT}/scripts/cognee-doctor.sh` output — do not report the
+memory as saved.
 
 ## When to use
 

--- a/integrations/claude-code/skills/cognee-search/SKILL.md
+++ b/integrations/claude-code/skills/cognee-search/SKILL.md
@@ -21,9 +21,23 @@ Knowledge is organized into three categories via `node_set`:
 | **project** | `project_docs` | Repository docs, code context, architecture decisions |
 | **agent** | `agent_actions` | Tool call logs, reasoning traces, generated artifacts |
 
+## Rules
+
+- **Server first.** Search goes through the **running Cognee server**
+  (`POST /api/v1/recall`) via the wrapper below — the source of truth in both
+  local and cloud mode.
+- **`cognee-cli` is a last resort, not an alternative.** It is reachable only on a
+  machine holding a cognee **source checkout**, and in cloud mode the plugin's
+  venv is never built at all. Use it only when the server is genuinely
+  unreachable *and* that checkout exists. Unsure which mode you are in?
+  `${CLAUDE_PLUGIN_ROOT}/scripts/cognee-doctor.sh --json` reports `mode`,
+  `server_url` and `reachable` without importing cognee.
+- **Empty CLI output is never proof of absence.** Ground-truth against the server
+  before concluding anything.
+
 ## Instructions
 
-Search goes through the **running Cognee server** (`POST /api/v1/recall`) — the source of truth. Use the wrapper below: it queries the server first, scoped to the **plugin's dataset** (`$COGNEE_PLUGIN_DATASET`, default `agent_sessions` — the same dataset all plugin writes target, so unrelated datasets don't bleed in), and falls back to `cognee-cli` only if the server is unreachable.
+Use the wrapper below: it queries the server, scoped to the **plugin's dataset** (`$COGNEE_PLUGIN_DATASET`, default `agent_sessions` — the same dataset all plugin writes target, so unrelated datasets don't bleed in), and resolves the endpoint, session and API key the way the hooks do.
 
 **One broad search is usually enough** — the `UserPromptSubmit` hook already injects session/trace/graph context every turn, so avoid running many targeted searches (each is an extra permission prompt for the user).
 
@@ -51,35 +65,42 @@ conceptual questions that name no symbol ("how does auth work here?").
 
 ### Filter by category (optional)
 
-Categories (`user_context` / `project_docs` / `agent_actions`) filter by node set. `cognee-cli recall` does **not** expose this — pass `node_name` to the server directly:
+Categories (`user_context` / `project_docs` / `agent_actions`) filter by node set. The wrapper does not expose this — pass `node_name` to the server directly.
+
+**Resolve credentials first.** In local mode `$COGNEE_API_KEY` is empty (the key is minted into `~/.cognee-plugin/api_key.json` and never exported to your shell), so a hand-rolled `curl` with `-H "X-Api-Key: ${COGNEE_API_KEY:-}"` 401s and looks like a server fault when nothing is wrong. Use the forget helper's resolver in the **same** shell invocation — exports do not persist across separate Bash calls:
 
 ```bash
-curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
+eval "$(${CLAUDE_PLUGIN_ROOT}/scripts/cognee-forget.sh env)" && \
+curl -s -X POST "${COGNEE_BASE_URL}/api/v1/recall" \
   -H "Content-Type: application/json" \
-  -H "X-Api-Key: ${COGNEE_API_KEY:-}" \
+  -H "X-Api-Key: ${COGNEE_API_KEY}" \
   -d '{"query": "...", "top_k": 5, "only_context": true, "scope": ["graph"], "node_name": ["project_docs"], "datasets": ["'"${COGNEE_PLUGIN_DATASET:-agent_sessions}"'"]}'
 ```
 
 ### Ground-truth a suspicious result (debugging)
 
-The server is authoritative. If a search returns empty but you expect content, confirm directly — **do not** conclude "not found" from empty CLI output:
+The server is authoritative. If a search returns empty but you expect content, confirm directly — **do not** conclude "not found" from empty CLI output. Resolve credentials in the same invocation, as above:
 
 ```bash
-curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
+eval "$(${CLAUDE_PLUGIN_ROOT}/scripts/cognee-forget.sh env)" && \
+curl -s -X POST "${COGNEE_BASE_URL}/api/v1/recall" \
   -H "Content-Type: application/json" \
-  -H "X-Api-Key: ${COGNEE_API_KEY:-}" \
+  -H "X-Api-Key: ${COGNEE_API_KEY}" \
   -d '{"query": "...", "top_k": 5, "only_context": true, "scope": ["graph"], "datasets": ["'"${COGNEE_PLUGIN_DATASET:-agent_sessions}"'"]}'
 ```
 
-(An authed/cloud server needs `COGNEE_API_KEY`; a local single-user server ignores an empty key. If the response is an `{"error": ...}` object rather than a list, the server was reachable but rejected/failed the request — that's an error, **not** "no results".)
+(The server enforces auth in both modes, which is why the resolver is not optional. If the response is an `{"error": ...}` object rather than a list, the server was reachable but rejected/failed the request — that's an error, **not** "no results". A `401` *after* the resolver means the key really is wrong for that server; a `401` without it means nothing.)
 
 ### Fallback only — server unreachable
 
-`cognee-cli` is a thin client over the same server and can print **empty stdout even when content exists**. Use it only when the server is down, and treat empty output as *inconclusive*, never as "no results":
+`cognee-cli` is a thin client over the same server and can print **empty stdout even when content exists**. It also requires a cognee source checkout, so on a normal install it is simply unavailable — an absent CLI is not a Cognee fault to report. Use it only when the server is down *and* a checkout exists, and treat empty output as *inconclusive*, never as "no results":
 
 ```bash
 cognee-cli recall "$ARGUMENTS" -k 5 -f json
 ```
+
+If the CLI is missing, say the server is unreachable and show the user
+`${CLAUDE_PLUGIN_ROOT}/scripts/cognee-doctor.sh` output instead.
 
 ## Understanding results
 
@@ -99,4 +120,4 @@ Session entries tagged with `[category:agent]` are automatic tool call logs.
 | "what does the codebase do" / "what did we do last time" | `cognee-search.sh "<query>" 10 --graph` |
 | Need a specific category | use the `node_name` curl form above (`["user_context"\|"project_docs"\|"agent_actions"]`) |
 | Auto context insufficient | `cognee-search.sh "<query>" 10 --session` |
-| **Result empty but you expect content** | **Ground-truth via the `curl` above before concluding "not found"** |
+| **Result empty but you expect content** | **Ground-truth via the credential-resolving `curl` above before concluding "not found"** |

--- a/integrations/claude-code/skills/cognee-switch-datasets/SKILL.md
+++ b/integrations/claude-code/skills/cognee-switch-datasets/SKILL.md
@@ -56,7 +56,7 @@ On failure the JSON is `{"error", "code"}`:
 
 | code | meaning | what to do |
 |------|---------|------------|
-| 2 | launch record not found | the plugin did not initialise this session; run `/cognee-memory:cognee-doctor` |
+| 2 | launch record not found | the plugin did not initialise this session; run `${CLAUDE_PLUGIN_ROOT}/scripts/cognee-doctor.sh`. If several Claude Code sessions share this directory, rerun with `--session-key <host session id>` |
 | 3 | syncing the current session failed | nothing was changed; show the error. Re-run with `--force` **only if the user explicitly accepts** that unsynced entries of the current session are retried at session end instead |
 | 4 | registering the new session failed | nothing was changed; the server rejected the registration — check the connection |
 | 5 | dataset not writable | the name is readable but owned by another principal; pick from `--list` |

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee",
   "version": "1.6.5",
-  "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
+  "description": "Cognee memory for Codex: automatic capture and recall over the Cognee server's HTTP API, with knowledge-graph and codebase skills.",
   "author": {
     "name": "Topoteretes",
     "url": "https://github.com/topoteretes"
@@ -13,7 +13,7 @@
     "memory",
     "knowledge-graph",
     "rag",
-    "cli",
+    "codex",
     "agents"
   ],
   "skills": "./skills/",
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "Cognee",
     "shortDescription": "Use Cognee from Codex with automatic memory capture and recall.",
-    "longDescription": "Reusable Codex skills for running Cognee's CLI workflows plus hooks that automatically capture Codex session starts, user prompts, tool results, and assistant stops into Cognee session memory, then recall relevant context on each prompt. This plugin intentionally does not configure MCP.",
+    "longDescription": "Reusable Codex skills that talk to a local or cloud Cognee server over its HTTP API, plus hooks that automatically capture Codex session starts, user prompts, tool results, and assistant stops into Cognee session memory, then recall relevant context on each prompt. The cognee CLI is only a fallback for an unreachable server. This plugin intentionally does not configure MCP.",
     "developerName": "Topoteretes",
     "category": "Engineering",
     "capabilities": [
@@ -31,8 +31,8 @@
     ],
     "websiteURL": "https://docs.cognee.ai",
     "defaultPrompt": [
-      "Use Cognee CLI to remember the important context in this repo.",
-      "Use Cognee CLI to recall what we know about this feature.",
+      "Remember the important context in this repo with Cognee.",
+      "Recall what we know about this feature from Cognee memory.",
       "Check that Codex session events are reaching Cognee."
     ],
     "brandColor": "#BC9BFF"

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -46,6 +46,79 @@ project adheres to [Semantic Versioning](https://semver.org/).
   after-error buffering entirely. It now has a `buffered` section (`trace` /
   `answer`) fed by `store_buffered_warming`, `trace_buffered_after_error` and
   `store_buffered_after_error`, and `saves` counts only what the server received.
+- **Skills reached for the `cognee-cli` before the server, and the CLI paths were
+  unreachable anyway (SDK-622).** The `setup` and `local-ui` skills declared
+  `uv run cognee-cli ...` the "primary interface"/"primary launcher", directly
+  contradicting `memory`'s own rule ("Prefer the server-first paths"). Both also
+  assumed a cognee **source checkout**: `scripts/cognee-cli.sh` exits 64 ("Run
+  this from the Cognee repository root") anywhere else, and the skills bypassed
+  even that wrapper with bare `uv run cognee-cli`, which inherits uv's
+  project-directory requirement and never uses the plugin's own venv — a venv
+  that in cloud mode is never built at all. So on any normal install the
+  "primary" path could not run, and the behaviour was masked on developer
+  machines that happen to have `cognee-cli` on PATH.
+  - `setup` is now **Cognee Connection And Status**: it answers from
+    `scripts/doctor.py --json` (mode, resolved URL, reachability, key source) and
+    an HTTP `/health` probe, with the CLI demoted to a last resort gated on
+    *local mode plus a checkout*. Dropped `uv sync --dev --all-extras
+    --reinstall` (there is no cognee repo to sync on a plugin install, and in the
+    user's own project it rebuilds their dependencies) and `serve --logout`.
+    The env-file / `COGNEE_BACKEND` material is now the configuration section
+    rather than a paragraph buried under CLI content.
+  - `local-ui` now **checks the mode first and stops on cloud**, where there is
+    no local UI and launching one would create a second, empty instance holding
+    none of the user's memory. Its description no longer competes with `setup`
+    for "is Cognee running?". `cognee-cli -ui`'s own `:8000`/`:3000` surfaces are
+    kept but marked as a separate dev instance, explicitly not evidence about the
+    plugin's `:8011` server.
+  - Every remaining CLI invocation routes through `scripts/cognee-cli.sh`, so a
+    missing checkout fails with a clear message instead of an opaque `uv` error,
+    and exit 64 is documented as "not a Cognee fault to report".
+  - `memory`'s "CLI only" extras (staged `add`+`cognify`, the `-t
+    GRAPH_COMPLETION/CHUNKS/CODE` search modes, `improve --node-name`) are
+    reframed as *unavailable without a checkout* rather than as a reason to leave
+    the server path.
+- **The recommended "server-first" `curl` 401'd in local mode — and pushed the
+  agent to the CLI.** `memory`'s authoritative recall example sent
+  `-H "X-Api-Key: ${COGNEE_API_KEY:-}"`, but in local mode that variable is
+  empty: the key is minted into `~/.cognee-plugin/api_key.json` and never
+  exported to the shell. The server-first path therefore failed with a 401 that
+  looked like a server fault, and the skill's own fallback rule then sent the
+  agent to the CLI. Recall now goes through `scripts/cognee-search.sh` (which
+  resolves endpoint, session and key the way the hooks do), and the raw-endpoint
+  form is shown with `eval "$(scripts/cognee-forget.sh env)"` in the same shell
+  invocation.
+- **The plugin manifest advertised itself as CLI-first.** `plugin.json`'s
+  description ("CLI-first Cognee workflows"), long description ("skills for
+  running Cognee's CLI workflows") and default prompts ("Use Cognee CLI to
+  remember ...") pointed users and the agent at the CLI before any skill body was
+  read. All three now describe the HTTP/server path, with the CLI named as the
+  fallback it is.
+- **A local server's redirect broke every by-name dataset switch (SDK-622).**
+  `switch-dataset.py` failed with a bare `307` for any dataset named rather than
+  addressed by UUID, so the dataset picker could not switch at all. Real Cognee
+  servers disagree about the trailing slash on `/api/v1/datasets` and answer 307
+  to the spelling they do not serve — in **opposite** directions: cloud tenants
+  redirect the bare path to the slashed one, a local server redirects the slashed
+  path to the bare one. The clients hard-coded the slash for the cloud's benefit,
+  and urllib's `HTTPRedirectHandler` refuses to replay a POST across a 307 (it
+  raises `HTTPError` instead), so the create surfaced as a 307 the caller treated
+  as a failure. Because `ensure_dataset_ready_via_api` runs unconditionally on the
+  by-name path, an *existing* dataset failed exactly like a new one.
+
+  Both HTTP helpers (`_json_http_request` and `config._cloud_http_request`) now
+  replay a 307/308 themselves, preserving method and body, so either spelling
+  works against either server shape. The replay is **same-origin only** — these
+  requests carry `X-Api-Key`, which must never be sent to another host — and
+  bounded to two hops, so a redirect loop cannot spin a hook. A cross-origin
+  target, a missing `Location`, or any other status leaves the original error
+  untouched. The two `# trailing slash on purpose` workarounds are gone.
+
+  The suite missed this because the mock server accepted both spellings
+  unconditionally. It can now redirect either way
+  (`set_collection_redirect`), and the regression tests assert dataset creation
+  through both helpers in both directions, plus the same-origin gate and the
+  refusals.
 
 ## [1.6.4]
 

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -2051,8 +2051,9 @@ def list_datasets_via_http(api_key: str, *, timeout: float = 15.0) -> list[dict]
 
 def create_dataset_via_http(api_key: str, name: str) -> dict:
     """POST /api/v1/datasets/ as ``api_key``: the (new or existing) dataset row, or {}."""
-    # Trailing slash on purpose: cloud tenants 307-redirect the bare path and
-    # urllib will not replay a POST across a redirect.
+    # Either spelling works: the request helper replays a same-origin 307/308,
+    # which is how cloud (bare -> slashed) and local (slashed -> bare) servers
+    # disagree about this route.
     status, body = _control_plane_request(
         "/api/v1/datasets/", {"name": name}, api_key=api_key, timeout=30.0
     )
@@ -3806,6 +3807,63 @@ def set_agent_registration(registered: bool, session_key: str = "") -> None:
     _ = (registered, session_key)
 
 
+_REDIRECT_REPLAY_CODES = (307, 308)
+_MAX_REDIRECT_REPLAYS = 2
+
+
+def _same_origin(first: str, second: str) -> bool:
+    """Same scheme, host and effective port — the gate for replaying a keyed request."""
+    import urllib.parse
+
+    def origin(url):
+        parts = urllib.parse.urlsplit(url)
+        port = parts.port or (443 if parts.scheme == "https" else 80)
+        return (parts.scheme, (parts.hostname or "").lower(), port)
+
+    return origin(first) == origin(second)
+
+
+def urlopen_following_307(req, *, timeout: float, context=None):
+    """``urlopen`` that replays a method-preserving redirect (307/308).
+
+    urllib refuses to replay a POST across a 307/308 — ``HTTPRedirectHandler``
+    raises ``HTTPError`` instead — so a server that redirects between the two
+    spellings of a collection route (``/api/v1/datasets`` and
+    ``/api/v1/datasets/``) fails every POST to it. Both spellings occur in the
+    wild and they redirect in *opposite* directions: cloud tenants 307 the bare
+    path to the slashed one, while a local server 307s the slashed path to the
+    bare one. No single spelling works everywhere, so the redirect has to be
+    followed rather than guessed.
+
+    Only a **same-origin** target is followed: these requests carry
+    ``X-Api-Key``, which must never be replayed to another host. A cross-origin
+    target, a missing ``Location``, or any other status leaves the original
+    ``HTTPError`` to the caller untouched.
+    """
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    for _ in range(_MAX_REDIRECT_REPLAYS):
+        try:
+            return urllib.request.urlopen(req, timeout=timeout, context=context)
+        except urllib.error.HTTPError as exc:
+            if exc.code not in _REDIRECT_REPLAY_CODES:
+                raise
+            location = exc.headers.get("Location") if exc.headers else ""
+            if not location:
+                raise
+            target = urllib.parse.urljoin(req.full_url, location)
+            if not _same_origin(req.full_url, target):
+                raise
+            exc.close()
+            replay = urllib.request.Request(
+                target, data=req.data, headers=dict(req.headers), method=req.get_method()
+            )
+            req = replay
+    return urllib.request.urlopen(req, timeout=timeout, context=context)
+
+
 def _json_http_request(
     path: str,
     payload: dict | None = None,
@@ -3836,7 +3894,7 @@ def _json_http_request(
         headers=headers,
         method=method,
     )
-    with urllib.request.urlopen(req, timeout=timeout, context=_https_context()) as resp:
+    with urlopen_following_307(req, timeout=timeout, context=_https_context()) as resp:
         body = resp.read().decode("utf-8")
         if not body:
             return None

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -3856,7 +3856,14 @@ def urlopen_following_307(req, *, timeout: float, context=None):
             target = urllib.parse.urljoin(req.full_url, location)
             if not _same_origin(req.full_url, target):
                 raise
-            exc.close()
+            try:
+                exc.close()
+            except Exception:
+                # Best-effort connection release. An HTTPError carrying no body
+                # never initialized its underlying file, and closing that raises
+                # (KeyError on Python 3.9, the hooks' floor). The replay does not
+                # depend on the close, and a raise here would mask the HTTP error.
+                pass
             replay = urllib.request.Request(
                 target, data=req.data, headers=dict(req.headers), method=req.get_method()
             )

--- a/integrations/codex/plugins/cognee/scripts/config.py
+++ b/integrations/codex/plugins/cognee/scripts/config.py
@@ -230,7 +230,7 @@ def _cloud_http_request(
     import urllib.parse
     import urllib.request
 
-    from _plugin_common import _https_context
+    from _plugin_common import _https_context, urlopen_following_307
 
     headers: dict[str, str] = {}
     data: bytes | None = None
@@ -247,7 +247,7 @@ def _cloud_http_request(
 
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
     try:
-        with urllib.request.urlopen(req, timeout=timeout, context=_https_context()) as resp:
+        with urlopen_following_307(req, timeout=timeout, context=_https_context()) as resp:
             return resp.status, resp.read().decode("utf-8")
     except urllib.error.HTTPError as exc:
         try:
@@ -302,7 +302,10 @@ async def ensure_dataset_ready_via_api(service_url: str, api_key: str, dataset: 
             raise RuntimeError("403: no verified write permission on selected dataset")
         return
     status, text = _cloud_http_request(
-        f"{base}/api/v1/datasets/",  # trailing slash: cloud tenants 307-redirect the bare path
+        # Either spelling works: _cloud_http_request replays a same-origin
+        # 307/308, which is how cloud (bare -> slashed) and local
+        # (slashed -> bare) servers disagree about this route.
+        f"{base}/api/v1/datasets/",
         method="POST",
         api_key=api_key,
         json_body={"name": dataset},

--- a/integrations/codex/plugins/cognee/skills/local-ui/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/local-ui/SKILL.md
@@ -1,47 +1,88 @@
 ---
 name: local-ui
-description: Use when launching, checking, or reporting on the local Cognee UI/backend through cognee-cli -ui.
+description: Use only when the user explicitly asks to launch or inspect the LOCAL Cognee UI (the cognee-cli dev UI). For "is Cognee running/connected" or any configuration question, use the setup skill instead. Does not apply in cloud mode.
 ---
 
-# Cognee CLI Local UI
+# Cognee Local UI
 
-Use this skill when the user asks to launch the local Cognee UI, check whether
-Cognee is running, or report how well the UI/backend work.
+Use this skill only when the user explicitly asks to launch or inspect the
+**local** Cognee UI — the development UI that `cognee-cli -ui` serves from a
+cognee source checkout.
+
+This skill does **not** answer "is Cognee running?" or "is Cognee connected?".
+Those are connection questions: use the **setup** skill, which reads the
+plugin's own diagnostic and probes the resolved server.
 
 ## Rules
 
-- Use `uv run cognee-cli -ui` as the primary launcher.
-- Do not use MCP for this plugin.
+- **Check the mode first.** The local UI exists only in local mode; see step 1.
+  Never launch or probe it before confirming the mode.
+- **Server first for status.** The plugin's server is the source of truth for
+  whether Cognee works. The UI is a viewer on top of it, not the thing to test.
+- **`cognee-cli -ui` requires a cognee source checkout.** It is not available on
+  a normal plugin install. Establish that prerequisite before attempting it.
 - Keep the process running when the user wants the UI available.
-- If ports are already occupied, inspect the running services before starting another copy.
+- If ports are already occupied, inspect the running services before starting
+  another copy.
 - Do not kill user processes without explicit approval.
+- Do not use MCP for this plugin.
 
-## Launch
-
-From the Cognee repository root:
+## 1. Check the mode — stop here on cloud
 
 ```bash
-uv run cognee-cli -ui
+python3 "${CODEX_PLUGIN_ROOT}/scripts/doctor.py" --json
 ```
 
-Expected local surfaces:
+If `mode` is **`Cloud`**, there is no local UI to launch and nothing here
+applies. Tell the user their instance is remote, that its dashboard lives at
+their Cognee Cloud URL, and report the connection facts from the same output
+(`server_url`, `reachable`, `latency_ms`, `api_key_source`). Do **not** start a
+local server or probe localhost — a local UI would be a second, empty instance
+holding none of their memory.
+
+If `mode` is **`Local`**, the plugin's own server is already running at
+`server_url` (normally `http://localhost:8011`). Confirm the state the user
+actually cares about there first:
+
+```bash
+curl -sS -i "${COGNEE_BASE_URL:-http://localhost:8011}/health"
+```
+
+That is the server the plugin reads and writes. The `cognee-cli -ui` surfaces
+below are a **separate** dev instance on different ports — launching them does
+not affect, and does not report on, the plugin's memory.
+
+## 2. Launch the dev UI (local mode, cognee checkout required)
+
+Only when the user explicitly wants the UI, and only from a cognee source
+checkout:
+
+```bash
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" -ui
+```
+
+The wrapper exits 64 ("Run this from the Cognee repository root or set
+COGNEE_REPO_ROOT") when there is no checkout. That is expected on a normal
+plugin install — report it as "the local dev UI needs a cognee source checkout",
+not as a Cognee failure, and fall back to reporting the plugin server's health
+from step 1.
+
+Expected surfaces for that dev instance:
 
 ```text
-Backend: http://localhost:8000
+Backend:  http://localhost:8000
 Frontend: http://localhost:3000
 ```
 
-## Health Checks
+These are `cognee-cli -ui`'s own defaults and are unrelated to the plugin's
+`:8011` server — do not use them to judge whether the plugin's memory works.
 
-Backend:
+## 3. Health checks for the dev UI
+
+Only for a UI launched in step 2:
 
 ```bash
 curl -i http://localhost:8000/health
-```
-
-Frontend:
-
-```bash
 curl -i http://localhost:3000/
 ```
 
@@ -61,8 +102,13 @@ credentials only when appropriate and do not expose real user credentials.
 
 Report:
 
-- which process or command is running;
-- backend health and any warnings;
+- the resolved **mode** and the plugin server's health first — that is what
+  determines whether memory works;
+- which process or command is running, if a UI was launched;
+- dev-UI backend health and any warnings;
 - frontend route availability;
 - working authenticated flows, if checked;
 - broken or suspicious behavior with file references when possible.
+
+Never present a healthy dev UI as proof that the plugin's memory is working, or
+an absent dev UI as proof that it is broken — they are different instances.

--- a/integrations/codex/plugins/cognee/skills/memory/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/memory/SKILL.md
@@ -11,8 +11,17 @@ memory.
 
 ## Rules
 
-- Prefer the server-first paths below (HTTP to the running Cognee server).
-- Use `uv run cognee-cli ...` only when the server is genuinely unreachable.
+- **Server first.** Every operation below goes to the running Cognee server over
+  HTTP, through the plugin's own scripts. That is the authoritative path in both
+  local and cloud mode.
+- **`cognee-cli` is a last resort, not an alternative.** It is reachable only on a
+  machine holding a cognee **source checkout**: `scripts/cognee-cli.sh` exits 64
+  anywhere else, and in cloud mode the plugin's venv is never built at all. Use it
+  only when the server is genuinely unreachable *and* that checkout exists. Unsure
+  which mode you are in? `python3 "${CODEX_PLUGIN_ROOT}/scripts/doctor.py" --json`
+  reports `mode`, `server_url` and `reachable` without importing cognee.
+- **Empty CLI output is never proof of absence.** Ground-truth against the server
+  before concluding anything (see *The server is the source of truth* below).
 - Choose a clear dataset name with `-d` or `--dataset-name`; ask only if the dataset boundary is genuinely ambiguous.
 - Do not ingest secrets, credentials, `.env` files, private keys, token dumps, or unrelated generated artifacts.
 - Before destructive commands such as `forget`, `delete`, or `--everything`, get explicit user confirmation.
@@ -42,48 +51,73 @@ By default the wrapper then waits a short, bounded time (`COGNEE_REMEMBER_WAIT_S
 **Fallback only — server unreachable:**
 
 ```bash
-uv run cognee-cli remember <text-or-path> -d <dataset-name>
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" remember <text-or-path> -d <dataset-name>
 ```
 
-For staged work (no HTTP equivalent — CLI only):
+For staged work there is no HTTP equivalent, so it is available **only** with a
+cognee source checkout. Prefer the one-step server path above; mention this
+limitation rather than switching to the CLI when no checkout exists:
 
 ```bash
-uv run cognee-cli add <text-or-path> -d <dataset-name>
-uv run cognee-cli cognify -d <dataset-name>
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" add <text-or-path> -d <dataset-name>
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" cognify -d <dataset-name>
 ```
 
 For long processing:
 
 ```bash
-uv run cognee-cli remember <text-or-path> -d <dataset-name> --background
-uv run cognee-cli cognify -d <dataset-name> --background
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" remember <text-or-path> -d <dataset-name> --background
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" cognify -d <dataset-name> --background
 ```
 
 ## Recall And Search
 
-**Server-first (authoritative):**
+**Server-first (authoritative) — use the wrapper:**
 
 ```bash
-curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
+${CODEX_PLUGIN_ROOT}/scripts/cognee-search.sh "<question>" 10 --graph
+```
+
+It resolves the endpoint, the session and the API key the way the hooks do
+(launch record → `COGNEE_API_KEY` → the auto-minted `api_key.json`), so it
+authenticates correctly in **both** local and cloud mode. Drop `--graph` to
+search the session cache and the graph, or pass `--session` for the session only.
+
+An empty result from the server is authoritative — the server searched and found
+nothing.
+
+**Do not hand-roll the `curl` with `-H "X-Api-Key: ${COGNEE_API_KEY:-}"`.** In
+local mode that variable is empty — the key is minted into
+`~/.cognee-plugin/api_key.json` and never exported to your shell — so the request
+401s and looks like a server problem when nothing is wrong. When you genuinely
+need the raw endpoint (to pass `node_name`, say), resolve the credentials first,
+in the **same** shell invocation:
+
+```bash
+eval "$(${CODEX_PLUGIN_ROOT}/scripts/cognee-forget.sh env)" && \
+curl -s -X POST "${COGNEE_BASE_URL}/api/v1/recall" \
   -H "Content-Type: application/json" \
-  -H "X-Api-Key: ${COGNEE_API_KEY:-}" \
+  -H "X-Api-Key: ${COGNEE_API_KEY}" \
   -d '{"query": "<question>", "top_k": 10, "only_context": true, "scope": ["graph"]}'
 ```
 
-Omit `-H "X-Api-Key: ..."` for a local single-user server (auth is optional). An empty list `[]` from the server is authoritative — the server searched and found nothing.
+A `401` after that resolver means the key really is wrong for that server; a
+`401` without it means nothing.
 
 **Fallback only — server unreachable:**
 
 ```bash
-uv run cognee-cli recall "<question>" -d <dataset-name> -f pretty
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" recall "<question>" -d <dataset-name> -f pretty
 ```
 
-Search modes (CLI only):
+These search modes have no HTTP equivalent, so they are available **only** with a
+cognee source checkout. They are not a reason to leave the server path: if no
+checkout exists, say the mode is unavailable and use the server search above.
 
 ```bash
-uv run cognee-cli search "<question>" -d <dataset-name> -t GRAPH_COMPLETION -f pretty
-uv run cognee-cli search "<exact passage or citation need>" -d <dataset-name> -t CHUNKS -k 10 -f pretty
-uv run cognee-cli search "<code question>" -d <dataset-name> -t CODE -k 10 -f pretty
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" search "<question>" -d <dataset-name> -t GRAPH_COMPLETION -f pretty
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" search "<exact passage or citation need>" -d <dataset-name> -t CHUNKS -k 10 -f pretty
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" search "<code question>" -d <dataset-name> -t CODE -k 10 -f pretty
 ```
 
 ### The server is the source of truth
@@ -104,19 +138,19 @@ python3 "${CODEX_PLUGIN_ROOT}/scripts/sync-session-to-graph.py"
 **Fallback only — server unreachable:**
 
 ```bash
-uv run cognee-cli improve -d <dataset-name>
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" improve -d <dataset-name>
 ```
 
 Bridge session feedback or Q&A into the graph:
 
 ```bash
-uv run cognee-cli improve -d <dataset-name> -s <session-id>
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" improve -d <dataset-name> -s <session-id>
 ```
 
 For targeted enrichment:
 
 ```bash
-uv run cognee-cli improve -d <dataset-name> --node-name <entity-name>
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" improve -d <dataset-name> --node-name <entity-name>
 ```
 
 ## Forget
@@ -141,9 +175,9 @@ is irreversible — use the narrowest scope possible and confirm first.
 **Fallback only — server unreachable:**
 
 ```bash
-uv run cognee-cli forget --dataset <dataset-name> --data-id <data-uuid>
-uv run cognee-cli forget --dataset <dataset-name>
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" forget --dataset <dataset-name> --data-id <data-uuid>
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" forget --dataset <dataset-name>
 ```
 
-Avoid `uv run cognee-cli forget --everything` unless the user explicitly asks
-to delete all Cognee data.
+Avoid the CLI's `forget --everything` unless the user explicitly asks to delete
+all Cognee data.

--- a/integrations/codex/plugins/cognee/skills/setup/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/setup/SKILL.md
@@ -1,85 +1,153 @@
 ---
 name: setup
-description: Use when setting up, checking, or connecting Cognee through the cognee CLI from Codex.
+description: Use when configuring the Cognee connection, checking whether Cognee is ready or connected, or diagnosing a local or cloud Cognee instance from Codex.
 ---
 
-# Cognee CLI Setup
+# Cognee Connection And Status
 
 Use this skill when the user asks to configure Cognee, check whether Cognee is
-ready, connect to a local or cloud Cognee instance, or inspect CLI capability.
+ready or connected, switch between local and cloud mode, or diagnose a
+connection problem.
 
 ## Rules
 
-- Use `uv run cognee-cli ...` as the primary interface.
+- **Server first.** Answer every question here from the plugin's own diagnostic
+  and the running Cognee server over HTTP. That is the authoritative path in
+  both local and cloud mode.
+- **`cognee-cli` is a last resort, not an alternative.** It is reachable only on
+  a machine holding a cognee **source checkout**: `scripts/cognee-cli.sh` exits
+  64 ("Run this from the Cognee repository root or set COGNEE_REPO_ROOT")
+  anywhere else, and in cloud mode the plugin's venv is never built at all. Never
+  reach for it before the two steps below have actually failed.
+- **Never run `uv sync` or any dependency install.** On a plugin install there is
+  no cognee repository to sync, and in the user's own project it would rebuild
+  their dependencies.
+- Do not print secret values from `.env`, config files, shell history, or command
+  output. Report whether a key *appears configured*, never the value.
+- If a command may create, delete, or overwrite durable Cognee state, say what it
+  will affect before running it.
 - Do not use MCP for this plugin.
-- Work from the Cognee repository root when available.
-- Do not print secret values from `.env`, config files, shell history, or command output.
-- If a command may create, delete, or overwrite durable Cognee state, say what it will affect before running it.
 
-## Checks
+## 1. Check the mode and the connection
 
-Start with the local command surface:
-
-```bash
-uv run cognee-cli --help
-uv run cognee-cli --version
-```
-
-If dependencies are missing, use the repository command:
+One command answers "is Cognee ready?", "which mode am I in?", and "what is
+wrong?" — it imports no cognee, makes one `/health` probe, and works from any
+directory:
 
 ```bash
-uv sync --dev --all-extras --reinstall
+python3 "${CODEX_PLUGIN_ROOT}/scripts/doctor.py" --json
 ```
 
-Inspect configuration without exposing values:
+The JSON carries:
+
+| Field | Meaning |
+|-------|---------|
+| `mode` | `Local` or `Cloud`, plus an annotation naming what forced the decision (e.g. `forced by COGNEE_BACKEND=local`) |
+| `server_url` | The endpoint this terminal actually resolved |
+| `reachable` | Whether the health probe succeeded |
+| `latency_ms` | Round-trip time, or `null` when unreachable |
+| `api_key_source` | Which credential the plugin is using (plugin identity, env var, cached, minted) |
+| `memory_sharing` | Shared-agent-memory state |
+| `circuit_breaker` | Whether recall is currently short-circuited |
+
+Read `mode` **before** doing anything mode-specific. In particular: in `Cloud`
+mode there is no local server to start and no local UI to launch — see the
+**local-ui** skill, which stops on cloud by design.
+
+Drop `--json` for a human-readable table when reporting to the user.
+
+## 2. Probe the server directly (optional)
+
+When you need to confirm the endpoint yourself, or the doctor's verdict looks
+stale:
 
 ```bash
-uv run cognee-cli config list
+curl -sS -i "${COGNEE_BASE_URL:-http://localhost:8011}/health"
 ```
 
-Use `config get <KEY>` only for non-secret settings. For secret-like keys,
-report whether the key appears configured rather than showing the value.
+`http://localhost:8011` is the plugin's local server. Do **not** substitute
+`:8000` — that is the `cognee-cli`'s own default for a server it would start
+itself, unrelated to the one the plugin runs and talks to.
 
-## Connect
-
-For a local backend:
+For an authenticated check of the resolved credential (cloud, or any server with
+auth enabled), use the forget helper's credential resolver rather than guessing
+where the key lives:
 
 ```bash
-uv run cognee-cli serve --url http://localhost:8000
+eval "$(${CODEX_PLUGIN_ROOT}/scripts/cognee-forget.sh env)" && \
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  -H "X-Api-Key: ${COGNEE_API_KEY}" "${COGNEE_BASE_URL}/api/v1/users/me"
 ```
 
-For a hosted instance with an API key, do not paste the key into the transcript.
-Use an environment variable or an already configured credential.
+`200` means the key is accepted; `401`/`403` means it was rejected by that
+server. In local mode the key is never exported to the shell, so a raw request
+without this resolver will 401 misleadingly.
 
-For the plugin itself, durable configuration (`COGNEE_BASE_URL`,
-`COGNEE_API_KEY`, `LLM_API_KEY`, ...) belongs in `~/.cognee/.env` — a one-time
-setup file shared with the Claude Code plugin, loaded at session start. Shell
-exports still override it per terminal. Guide the user to edit that file
-rather than exporting in every shell; never echo its secret values.
+## Configure the connection
 
-The file may hold both modes' variables at once: with nothing exported, cloud
-wins (`COGNEE_BASE_URL` routes the connection). To pin one terminal to a mode,
-the user exports `COGNEE_BACKEND=local` or `COGNEE_BACKEND=cloud` before
-launching — that beats the URL rule, and `unset COGNEE_BASE_URL` is NOT a way
-to go local (the file re-injects the URL on the next launch).
+Durable configuration (`COGNEE_BASE_URL`, `COGNEE_API_KEY`, `LLM_API_KEY`, ...)
+belongs in `~/.cognee/.env` — a one-time setup file shared with the Claude Code
+plugin, loaded at session start. Guide the user to edit that file rather than
+exporting in every shell; never echo its secret values. Shell exports still
+override it per terminal. Changes apply on the next `codex` launch.
 
-To disconnect:
+**Cloud or a remote server** — both values:
 
 ```bash
-uv run cognee-cli serve --logout
+mkdir -p ~/.cognee
+cat >> ~/.cognee/.env <<'EOF'
+COGNEE_BASE_URL="https://your-instance.cognee.ai"
+COGNEE_API_KEY="ck_..."
+EOF
+chmod 600 ~/.cognee/.env
 ```
 
-## Multi-Agent Or API Mode
-
-When the user wants concurrent or multi-agent use, prefer a running Cognee API
-server and pass:
+**Local** (default when `COGNEE_BASE_URL` is unset) — the plugin bootstraps a
+local Cognee API on `http://localhost:8011` and auto-mints `COGNEE_API_KEY`, so
+only the LLM key is required:
 
 ```bash
-uv run cognee-cli --api-url http://localhost:8000 <command>
+mkdir -p ~/.cognee
+cat >> ~/.cognee/.env <<'EOF'
+LLM_API_KEY="sk-..."
+EOF
+chmod 600 ~/.cognee/.env
 ```
 
-For isolated session history and permissions, include:
+Re-pasting either block is safe — the last value of a repeated key wins.
+
+### Which mode wins
+
+The file may hold **both** modes' variables at once. The mode is then decided
+per terminal, in this order:
+
+1. An exported `COGNEE_BACKEND` (or the plugin-specific `COGNEE_CODEX_BACKEND`,
+   which beats it) pins that terminal: `local` or `cloud`.
+2. Otherwise cloud wins when `COGNEE_BASE_URL` is set anywhere.
+3. Otherwise local.
+
+A forced mode is **pinned**: `COGNEE_BACKEND=cloud` with no URL configured stays
+cloud and fails visibly (`✕ (missing_cognee_base_url)`) rather than silently
+falling back. `unset COGNEE_BASE_URL` is **not** a way to go local — the env file
+re-injects it on the next launch; use the switch.
+
+`COGNEE_BACKEND` may also live in `~/.cognee/.env` to make a mode the durable
+default. The doctor's `mode` field always reports what the terminal actually
+resolved, with the cause.
+
+## Fallback — `cognee-cli`, local mode with a cognee checkout only
+
+Only if steps 1 and 2 both failed, the mode is `Local`, **and** the machine has a
+cognee source checkout. Route it through the wrapper so a missing checkout fails
+with a clear message instead of an opaque `uv` error:
 
 ```bash
-uv run cognee-cli --user-id <uuid> <command>
+"${CODEX_PLUGIN_ROOT}/scripts/cognee-cli.sh" config list
 ```
+
+Set `COGNEE_REPO_ROOT` to the checkout path if the wrapper cannot find it. Use
+`config get <KEY>` only for non-secret settings.
+
+Exit code 64 means there is no cognee checkout here — that is expected on a
+normal install, and it is **not** a Cognee fault to report. Say the server is
+unreachable and give the user the doctor output instead.

--- a/integrations/tests/tests/unit/test_collection_redirect_replay.py
+++ b/integrations/tests/tests/unit/test_collection_redirect_replay.py
@@ -1,0 +1,215 @@
+"""Method-preserving redirects (307/308) on the dataset collection route.
+
+Real Cognee servers disagree about the trailing slash on ``/api/v1/datasets``
+and answer 307 to the spelling they do not serve — in *opposite* directions:
+cloud tenants redirect the bare path to the slashed one, a local server
+redirects the slashed path to the bare one. urllib's ``HTTPRedirectHandler``
+refuses to replay a POST across a 307 (it raises ``HTTPError`` instead), so
+whichever spelling a client hard-codes, it fails against one of the two
+server shapes.
+
+That is SDK-622: the clients hard-coded the trailing slash for the cloud's
+benefit, so every by-name dataset create against a *local* server surfaced as
+a bare ``307`` — which broke ``switch-dataset.py`` entirely, since
+``ensure_dataset_ready_via_api`` runs unconditionally on the by-name path.
+The suite missed it because the mock server accepted both spellings.
+
+Covers, for every suite:
+  * ``_same_origin``: the gate that decides whether a keyed request may be replayed
+  * the replay itself, in both redirect directions, through both HTTP helpers
+  * the refusals: cross-origin, missing ``Location``, non-redirect statuses
+  * a bounded number of hops, so a redirect loop cannot spin
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+
+import pytest
+from utils.fixtures import DEFAULT_TEST_API_KEY
+
+
+@pytest.fixture
+def pc(suite, isolated_modules, monkeypatch):
+    common = isolated_modules(suite, "_plugin_common")
+    monkeypatch.setattr(common, "hook_log", lambda *a, **k: None)
+    return common
+
+
+@pytest.fixture
+def pc_on_server(pc, mock_server, monkeypatch):
+    """``_plugin_common`` pointed at the mock server, for helpers that resolve
+    their own base URL (``create_dataset_via_http`` via ``_json_http_request``)."""
+    monkeypatch.setenv("COGNEE_BASE_URL", mock_server.url)
+    return pc
+
+
+# ── the same-origin gate ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("source", "target", "same"),
+    [
+        # The two spellings of one route on one origin: the case that must replay.
+        ("http://localhost:8011/api/v1/datasets/", "http://localhost:8011/api/v1/datasets", True),
+        ("https://t.cognee.ai/api/v1/datasets", "https://t.cognee.ai/api/v1/datasets/", True),
+        # An explicit default port is the same origin as an implicit one.
+        ("https://t.cognee.ai/a", "https://t.cognee.ai:443/a", True),
+        ("http://localhost/a", "http://localhost:80/a", True),
+        # Everything else is a different origin — these carry X-Api-Key.
+        ("https://t.cognee.ai/a", "https://evil.example/a", False),
+        ("https://t.cognee.ai/a", "http://t.cognee.ai/a", False),
+        ("http://localhost:8011/a", "http://localhost:9999/a", False),
+    ],
+)
+def test_same_origin_gate(pc, source, target, same):
+    assert pc._same_origin(source, target) is same
+
+
+# ── the replay ──────────────────────────────────────────────────────────────
+
+
+def _post(url, *, key="k", body=None):
+    return urllib.request.Request(
+        url,
+        data=json.dumps(body if body is not None else {"name": "ds"}).encode("utf-8"),
+        headers={"Content-Type": "application/json", "X-Api-Key": key},
+        method="POST",
+    )
+
+
+@pytest.mark.parametrize("mode", ["to_slashed", "to_bare"])
+@pytest.mark.parametrize("spelling", ["/api/v1/datasets", "/api/v1/datasets/"])
+def test_dataset_create_survives_either_redirect_direction(pc, mock_server, mode, spelling):
+    """Both spellings work against both server shapes, POST body intact."""
+    mock_server.set_collection_redirect(mode)
+
+    with pc.urlopen_following_307(
+        _post(f"{mock_server.url}{spelling}", body={"name": "ds-redirect"}),
+        timeout=5.0,
+        context=None,
+    ) as resp:
+        assert resp.status in (200, 201)
+        created = json.loads(resp.read().decode("utf-8"))
+
+    # The replayed request kept its method AND its body: the dataset is named.
+    assert created.get("name") == "ds-redirect"
+    mock_server.assert_called("POST", "/api/v1/datasets", name="ds-redirect")
+
+
+@pytest.mark.parametrize("mode", ["to_slashed", "to_bare"])
+def test_ensure_dataset_ready_survives_either_redirect_direction(
+    suite, isolated_modules, mock_server, mode
+):
+    """``config.ensure_dataset_ready_via_api`` — the path switch-dataset.py uses."""
+    import asyncio
+
+    config = isolated_modules(suite, "config")
+    mock_server.set_collection_redirect(mode)
+
+    # Must not raise: a bare 307 here is what blocked every by-name switch.
+    asyncio.run(
+        config.ensure_dataset_ready_via_api(mock_server.url, DEFAULT_TEST_API_KEY, "ds-ensure")
+    )
+    mock_server.assert_called("POST", "/api/v1/datasets", name="ds-ensure")
+
+    # Runs unconditionally on every switch, so it has to stay idempotent.
+    asyncio.run(
+        config.ensure_dataset_ready_via_api(mock_server.url, DEFAULT_TEST_API_KEY, "ds-ensure")
+    )
+
+
+@pytest.mark.parametrize("mode", ["to_slashed", "to_bare"])
+def test_create_dataset_via_http_survives_either_redirect_direction(
+    pc_on_server, mock_server, mode
+):
+    """The other client of this route, reached through ``_json_http_request``."""
+    mock_server.set_collection_redirect(mode)
+
+    row = pc_on_server.create_dataset_via_http(DEFAULT_TEST_API_KEY, "ds-helper")
+
+    assert row.get("name") == "ds-helper"
+    assert row.get("id")
+
+
+# ── the refusals ────────────────────────────────────────────────────────────
+
+
+def test_cross_origin_redirect_is_not_followed(pc, mock_server, monkeypatch):
+    """A keyed request must never be replayed to another host."""
+    replayed: list[str] = []
+    real_urlopen = urllib.request.urlopen
+
+    def spy(req, *args, **kwargs):
+        replayed.append(req.full_url if hasattr(req, "full_url") else str(req))
+        url = replayed[-1]
+        if url.startswith(mock_server.url):
+            raise urllib.error.HTTPError(
+                url, 307, "Temporary Redirect", {"Location": "https://evil.example/steal"}, None
+            )
+        return real_urlopen(req, *args, **kwargs)
+
+    monkeypatch.setattr(urllib.request, "urlopen", spy)
+
+    with pytest.raises(urllib.error.HTTPError) as raised:
+        pc.urlopen_following_307(
+            _post(f"{mock_server.url}/api/v1/datasets", key="secret-key"),
+            timeout=5.0,
+            context=None,
+        )
+
+    # The original 307 reaches the caller, and the other host was never called.
+    assert raised.value.code == 307
+    assert not any("evil.example" in url for url in replayed)
+
+
+def test_redirect_without_location_is_not_followed(pc, monkeypatch):
+    def spy(req, *args, **kwargs):
+        raise urllib.error.HTTPError(req.full_url, 307, "Temporary Redirect", {}, None)
+
+    monkeypatch.setattr(urllib.request, "urlopen", spy)
+
+    with pytest.raises(urllib.error.HTTPError) as raised:
+        pc.urlopen_following_307(_post("http://localhost:8011/x"), timeout=5.0, context=None)
+    assert raised.value.code == 307
+
+
+@pytest.mark.parametrize("code", [400, 401, 403, 404, 409, 500, 503])
+def test_non_redirect_statuses_pass_through_untouched(pc, monkeypatch, code):
+    calls: list[str] = []
+
+    def spy(req, *args, **kwargs):
+        calls.append(req.full_url)
+        raise urllib.error.HTTPError(req.full_url, code, "boom", {}, None)
+
+    monkeypatch.setattr(urllib.request, "urlopen", spy)
+
+    with pytest.raises(urllib.error.HTTPError) as raised:
+        pc.urlopen_following_307(_post("http://localhost:8011/x"), timeout=5.0, context=None)
+
+    assert raised.value.code == code
+    assert len(calls) == 1, "a non-redirect status must not be retried"
+
+
+def test_redirect_loop_is_bounded(pc, monkeypatch):
+    """A server that redirects forever must not spin the hook."""
+    calls: list[str] = []
+
+    def spy(req, *args, **kwargs):
+        calls.append(req.full_url)
+        # Always point at the other spelling: an endless ping-pong.
+        target = req.full_url.rstrip("/") if req.full_url.endswith("/") else req.full_url + "/"
+        raise urllib.error.HTTPError(
+            req.full_url, 307, "Temporary Redirect", {"Location": target}, None
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", spy)
+
+    with pytest.raises(urllib.error.HTTPError):
+        pc.urlopen_following_307(
+            _post("http://localhost:8011/api/v1/datasets"), timeout=5.0, context=None
+        )
+
+    assert len(calls) <= pc._MAX_REDIRECT_REPLAYS + 1

--- a/integrations/tests/utils/mock_cognee.py
+++ b/integrations/tests/utils/mock_cognee.py
@@ -78,6 +78,9 @@ class MockCogneeServer:
         # (method, path) -> (status, body): short-circuits the normal handler.
         self._forced: dict[tuple[str, str], tuple[int, Any]] = {}
         self.calls: list[dict[str, Any]] = []
+        #: Collection-route redirect mode, mirroring how real servers disagree
+        #: about the trailing slash: see ``set_collection_redirect``.
+        self._collection_redirect = None
         self._register_routes()
 
     # -- public surface ----------------------------------------------------
@@ -136,6 +139,23 @@ class MockCogneeServer:
         entry answers with that HTTP status instead of a body.
         """
         self._credits_overview = overview
+
+    def set_collection_redirect(self, mode: str | None) -> None:
+        """Make POST /api/v1/datasets redirect between its two spellings.
+
+        Real servers disagree about the trailing slash and answer 307 to the
+        spelling they do not serve — in *opposite* directions:
+
+          * ``"to_slashed"`` — cloud tenants: ``/datasets`` -> ``/datasets/``
+          * ``"to_bare"``    — a local server: ``/datasets/`` -> ``/datasets``
+          * ``None``         — accept both (the default)
+
+        urllib refuses to replay a POST across a 307, so a client that does not
+        follow the redirect itself fails against one of the two. Accepting both
+        spellings unconditionally is what hid that from this suite.
+        """
+        assert mode in (None, "to_slashed", "to_bare"), mode
+        self._collection_redirect = mode
 
     def force_response(self, method: str, path: str, status: int, body: Any = None) -> None:
         """Force one route to answer (status, body), bypassing its handler.
@@ -297,9 +317,9 @@ class MockCogneeServer:
         route("/api/v1/remember/entry", "POST", self._remember_entry)
         route("/api/v1/recall", "POST", self._recall)
         route("/api/v1/improve", "POST", self._improve)
-        # POST accepts both spellings: the clients send the trailing slash because
-        # cloud tenants 307-redirect the bare path, and urllib will not replay a
-        # POST across a 307.
+        # POST serves both spellings by default; ``set_collection_redirect``
+        # makes one of them 307 to the other, as real servers do (in opposite
+        # directions on cloud vs local).
         route(re.compile(r"^/api/v1/datasets/?$"), "POST", self._datasets)
         route("/api/v1/datasets", "GET", self._datasets_list)
         route("/api/v1/datasets/", "GET", self._datasets_list)
@@ -512,7 +532,23 @@ class MockCogneeServer:
         _, ds = self.identity.datasets_create(dataset)
         return _json(200, {"dataset_id": ds["id"], "status": "submitted"})
 
+    def _redirect_target(self, path: str) -> str:
+        """Absolute Location for a collection request in the wrong spelling, else ""."""
+        mode = self._collection_redirect
+        if mode is None:
+            return ""
+        slashed = path.endswith("/")
+        if mode == "to_slashed" and not slashed:
+            return f"{self.url}{path}/"
+        if mode == "to_bare" and slashed:
+            return f"{self.url}{path.rstrip('/')}"
+        return ""
+
     def _datasets(self, req: Request) -> Response:
+        redirect_to = self._redirect_target(req.path)
+        if redirect_to:
+            self._record(req)
+            return Response("", status=307, headers={"Location": redirect_to})
         self._record(req)
         body_in = req.get_json(silent=True) or {}
         status, body = self.identity.datasets_create(


### PR DESCRIPTION
## What

Two fixes found while manually testing the plugins against Cognee Cloud, across
all three plugins (claude-code, codex, antigravity). No version bumps — entries
go into the current 1.5.5 / 1.6.5 / 1.5.2 changelog sections.

**1. Skills favoured the CLI over the server, and the CLI was unreachable.**
`setup` and `local-ui` declared `uv run cognee-cli` the "primary
interface"/"primary launcher", contradicting `memory`'s own server-first rule.
Both assumed a cognee source checkout — `cognee-cli.sh` exits 64 without one,
and cloud mode never builds the plugin venv — so on a normal install the
"primary" path could not run. Masked on dev machines that have `cognee-cli` on
PATH.

The preferred path was also broken: the recommended `curl` sent
`-H "X-Api-Key: ${COGNEE_API_KEY:-}"`, which is empty in local mode (the key is
minted into `~/.cognee-plugin/api_key.json`, never exported), so it 401'd and
the fallback rule then sent the agent to the CLI.

**2. A local server's 307 broke every by-name dataset switch.**
Servers disagree about the trailing slash on `/api/v1/datasets` and answer 307
in *opposite* directions — cloud: bare → slashed; local: slashed → bare. The
clients hard-coded the slash for the cloud, and urllib refuses to replay a POST
across a 307, so `switch-dataset.py` failed with a bare `307` for any dataset
named rather than addressed by UUID. `ensure_dataset_ready_via_api` runs
unconditionally, so existing datasets failed like new ones.

## How

- `setup` → server-first status skill: `doctor.py --json`, then `/health`, CLI
  last and gated on local mode plus a checkout. `local-ui` stops on cloud.
- One rules block wherever the CLI appears; CLI calls go through
  `cognee-cli.sh`; credentials resolve via `cognee-forget.sh env`.
- New `urlopen_following_307` behind both HTTP helpers: replays 307/308 with
  method and body intact, **same-origin only** (these requests carry
  `X-Api-Key`) and bounded to two hops.

## Testing

2748 passed, 255 skipped, 2 xfailed; `check_version_consistency.py` clean.

New `test_collection_redirect_replay.py` (75 tests across the three suites)
covers the replay through both helpers in both directions, the same-origin
gate, the refusals, and the hop bound. The mock server accepted both spellings
unconditionally — that is why CI never caught this — and now redirects either
way via `set_collection_redirect`.

Verified against a real local server: the slashed POST goes 307 → 200,
`ensure_dataset_ready_via_api` succeeds and is idempotent, and plain
`urllib.request.urlopen` still raises `HTTPError 307` on the same request.
Reverting just the two call sites makes the `to_bare` tests fail while
`to_slashed` passes — the exact asymmetry that let this ship.